### PR TITLE
ci(deploy-web): bump GitHub Actions to Node-24 majors

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -59,10 +59,10 @@ jobs:
         run: npm run build-web
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: web/dist-web
 
@@ -75,5 +75,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
   


### PR DESCRIPTION
## Summary
- Bump every pinned first-party action in [.github/workflows/deploy-web.yml](.github/workflows/deploy-web.yml) to its newest major running on Node 24.
- Silences the Node 20 deprecation annotations that appear on every run, and future-proofs ahead of the 2026-09-16 Node 20 removal date.
- Workflow-only change; no Rust/TS source touched.

## Version table

| Action | Before | After | Runtime verified |
|---|---|---|---|
| `actions/checkout` | `v4` | `v6` | `node24` |
| `actions/setup-node` | `v4` | `v6` | `node24` |
| `actions/configure-pages` | `v4` | `v6` | `node24` |
| `actions/upload-pages-artifact` | `v3` | `v5` | composite → `actions/upload-artifact@v7.0.0` (`node24`) |
| `actions/deploy-pages` | `v4` | `v5` | `node24` |

Runtimes were verified by reading `action.yml` at each tag's tip and grepping for the `using:` field.

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` is **not** set — all five actions now have a Node-24 major available, so the transitional env var is unnecessary.

The `node-version: '20'` input on `actions/setup-node` is the project's Node target (for \`npm ci\` + vite build) and is independent of the action's runtime — left alone intentionally.

## Test plan
- [ ] Build job runs on this PR branch (the deploy job only runs on push-to-main, so PR validation is limited to build, which is where the updated actions actually execute).
- [ ] No deprecation annotations on the PR run.
- [ ] Build artifact (\`web/dist-web\`) produced at the same step count and path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)