### PR TITLE
perf(harmony): coalesce per-group hint stream into batched WS messages

### DIFF
--- a/pir-sdk-client/src/connection.rs
+++ b/pir-sdk-client/src/connection.rs
@@ -186,6 +186,18 @@ pub struct WsConnection {
     /// Backend label passed to the recorder's callbacks. Defaults to the
     /// empty string; the owning client overrides via `set_metrics_recorder`.
     metrics_backend: &'static str,
+    /// Leftover bytes from the last WS Binary message — populated when a
+    /// message arrives carrying more than one length-prefixed record.
+    /// `recv()` drains records out of this buffer one at a time before
+    /// reaching for the next WS message.
+    ///
+    /// Used to consume coalesced HarmonyPIR hint batches (a server-side
+    /// optimisation that flushes ~750 KB of length-prefixed hint records
+    /// per WS message — see `HINT_BATCH_BYTES` in
+    /// `runtime/src/bin/unified_server.rs`). For any server that still
+    /// emits one record per WS message, this buffer never holds residual
+    /// bytes, so the path is a no-op for non-coalesced traffic.
+    recv_buf: Vec<u8>,
 }
 
 /// Install the `ring` crypto provider for rustls exactly once per process.
@@ -302,6 +314,7 @@ impl WsConnection {
                         retry_policy: policy,
                         metrics_recorder: None,
                         metrics_backend: "",
+                        recv_buf: Vec::new(),
                     });
                 }
                 Err(err) if err.is_connection_error() => {
@@ -378,6 +391,10 @@ impl WsConnection {
                 Ok((sink, stream)) => {
                     self.sink = sink;
                     self.stream = stream;
+                    // Drop any half-consumed coalesced hint batch from the
+                    // previous connection — its records belonged to a
+                    // request whose response can never complete.
+                    self.recv_buf.clear();
                     return Ok(());
                 }
                 Err(err) if err.is_connection_error() => {
@@ -513,20 +530,40 @@ impl WsConnection {
         Ok(())
     }
 
-    /// Receive a binary message, handling ping/pong automatically,
-    /// subject to the per-request deadline.
+    /// Receive one length-prefixed record, handling ping/pong
+    /// automatically, subject to the per-request deadline.
+    ///
+    /// A single WebSocket Binary message may carry one record (the
+    /// historical shape) or several records concatenated back-to-back
+    /// (the HarmonyPIR hint coalescing introduced 2026-05-20 — see
+    /// `HINT_BATCH_BYTES` on the server side). This method peels one
+    /// `[4B len][payload of len bytes]` record off the head of the
+    /// internal buffer and stashes any tail bytes for the next call,
+    /// reading a fresh WS message only when the buffer is empty.
+    ///
+    /// `fire_bytes_received` is invoked once per WS message read (with
+    /// the message's full size) — not per record — so the metrics
+    /// recorder sees the same byte count a wire observer would see.
     pub async fn recv(&mut self) -> PirResult<Vec<u8>> {
+        if let Some(record) = Self::take_record_from_buf(&mut self.recv_buf)? {
+            return Ok(record);
+        }
+
         let request_timeout = self.request_timeout;
         let url = self.url.clone();
         let recv_fut = self.recv_inner();
         match tokio::time::timeout(request_timeout, recv_fut).await {
-            Ok(Ok(frame)) => {
-                // Report the raw frame length (including any length
-                // prefix the PIR protocol adds on top of the WebSocket
-                // payload — matches what a wire-level observer would
-                // see).
-                self.fire_bytes_received(frame.len());
-                Ok(frame)
+            Ok(Ok(ws_msg)) => {
+                // Report the size of the raw WS message (or reassembled
+                // chunked message) — matches what a wire-level observer
+                // would see.
+                self.fire_bytes_received(ws_msg.len());
+                self.recv_buf = ws_msg;
+                Self::take_record_from_buf(&mut self.recv_buf)?.ok_or_else(|| {
+                    PirError::Protocol(
+                        "recv: WS message shorter than one length-prefixed record".into(),
+                    )
+                })
             }
             Ok(Err(e)) => Err(e),
             Err(_) => Err(PirError::Timeout(format!(
@@ -534,6 +571,54 @@ impl WsConnection {
                 url, request_timeout,
             ))),
         }
+    }
+
+    /// Pop one `[4B len][payload of len bytes]` record off the head of
+    /// `buf`, leaving any trailing bytes in place. Returns:
+    ///  * `Ok(Some(record))` — one full record was drained.
+    ///  * `Ok(None)`         — `buf` is empty (or holds fewer than 4
+    ///    bytes — treated as "no more records yet" so the caller will
+    ///    read another WS message).
+    ///  * `Err(...)`         — `buf` claims more bytes than it has
+    ///    (malformed length prefix), which would otherwise hang the
+    ///    caller waiting for bytes that will never arrive.
+    fn take_record_from_buf(buf: &mut Vec<u8>) -> PirResult<Option<Vec<u8>>> {
+        if buf.len() < 4 {
+            if !buf.is_empty() {
+                // A partial length prefix that never completed across
+                // messages is a protocol violation — coalescing is
+                // strictly within one WS message, so the buffer is
+                // expected to drain to empty between WS reads.
+                let leftover = buf.len();
+                buf.clear();
+                return Err(PirError::Protocol(format!(
+                    "recv: WS message ended mid-record (leftover {} bytes)",
+                    leftover
+                )));
+            }
+            return Ok(None);
+        }
+        let payload_len = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+        let record_len = 4 + payload_len;
+        if buf.len() < record_len {
+            let leftover = buf.len();
+            buf.clear();
+            return Err(PirError::Protocol(format!(
+                "recv: truncated record (len prefix {} > {} buffered bytes)",
+                payload_len, leftover
+            )));
+        }
+        let record = buf[..record_len].to_vec();
+        if record_len == buf.len() {
+            buf.clear();
+        } else {
+            // Compact the tail down. For typical hint batches this
+            // happens ~10 times per WS message; the resulting copies
+            // are still far cheaper than the per-frame WS receive
+            // overhead the coalescing eliminates.
+            buf.drain(..record_len);
+        }
+        Ok(Some(record))
     }
 
     /// Inner recv loop — same behaviour as the old `recv`, no timeout.
@@ -563,9 +648,7 @@ impl WsConnection {
                         let seq = u16::from_le_bytes([b[5], b[6]]);
                         let total = u16::from_le_bytes([b[7], b[8]]);
                         if total == 0 {
-                            return Err(PirError::Protocol(
-                                "chunk frame with total=0".into(),
-                            ));
+                            return Err(PirError::Protocol("chunk frame with total=0".into()));
                         }
                         if seq != chunk_expected {
                             return Err(PirError::Protocol(format!(
@@ -747,6 +830,119 @@ mod tests {
         };
         assert_eq!(policy.backoff_delay(64), policy.max_delay);
         assert_eq!(policy.backoff_delay(1_000), policy.max_delay);
+    }
+
+    /// Build a `[4B len LE][body]` record from `body`.
+    fn make_record(body: &[u8]) -> Vec<u8> {
+        let mut r = Vec::with_capacity(4 + body.len());
+        r.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        r.extend_from_slice(body);
+        r
+    }
+
+    #[test]
+    fn take_record_from_buf_empty_buf_returns_none() {
+        let mut buf: Vec<u8> = Vec::new();
+        let out = WsConnection::take_record_from_buf(&mut buf).expect("ok");
+        assert!(out.is_none());
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn take_record_from_buf_single_record_drains_to_empty() {
+        let mut buf = make_record(&[0x41, 0xaa, 0xbb]);
+        let out = WsConnection::take_record_from_buf(&mut buf)
+            .expect("ok")
+            .expect("some");
+        assert_eq!(out, make_record(&[0x41, 0xaa, 0xbb]));
+        assert!(buf.is_empty());
+        // Next call sees an empty buffer.
+        assert!(WsConnection::take_record_from_buf(&mut buf)
+            .expect("ok")
+            .is_none());
+    }
+
+    #[test]
+    fn take_record_from_buf_demuxes_two_records() {
+        let r1 = make_record(b"first");
+        let r2 = make_record(b"second-payload");
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&r1);
+        buf.extend_from_slice(&r2);
+
+        let out1 = WsConnection::take_record_from_buf(&mut buf)
+            .expect("ok")
+            .expect("some");
+        assert_eq!(out1, r1, "first record byte-identical");
+        let out2 = WsConnection::take_record_from_buf(&mut buf)
+            .expect("ok")
+            .expect("some");
+        assert_eq!(out2, r2, "second record byte-identical");
+        assert!(buf.is_empty());
+        assert!(WsConnection::take_record_from_buf(&mut buf)
+            .expect("ok")
+            .is_none());
+    }
+
+    #[test]
+    fn take_record_from_buf_truncated_length_errors() {
+        // Length prefix claims 100 bytes but only 5 trailing bytes
+        // present — must error so the caller doesn't hang waiting for
+        // more buffer.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(100u32).to_le_bytes());
+        buf.extend_from_slice(b"short");
+        let err = WsConnection::take_record_from_buf(&mut buf).expect_err("err");
+        match err {
+            PirError::Protocol(msg) => {
+                assert!(msg.contains("truncated"), "msg = {}", msg);
+            }
+            other => panic!("expected Protocol, got {:?}", other),
+        }
+        assert!(buf.is_empty(), "buf cleared after error");
+    }
+
+    #[test]
+    fn take_record_from_buf_partial_prefix_errors() {
+        // Fewer than 4 bytes of length prefix can only happen if a
+        // previous record ate the first 3 bytes — that's a protocol
+        // violation, so we error rather than silently dropping it.
+        let mut buf: Vec<u8> = vec![1, 2, 3];
+        let err = WsConnection::take_record_from_buf(&mut buf).expect_err("err");
+        match err {
+            PirError::Protocol(msg) => {
+                assert!(msg.contains("ended mid-record"), "msg = {}", msg);
+            }
+            other => panic!("expected Protocol, got {:?}", other),
+        }
+    }
+
+    /// Server-side coalescing-then-client-side demux round-trip check.
+    ///
+    /// Mirrors what `send_resp_batch` produces in
+    /// `runtime/src/bin/unified_server.rs` for the no-channel case: a
+    /// `Vec` of `[4B len][body]` records concatenated back-to-back into
+    /// one buffer. Demuxing must return the exact same records in
+    /// order — this is the strongest argument the coalescing doesn't
+    /// change protocol semantics.
+    #[test]
+    fn batch_round_trip_demuxes_to_original_records() {
+        let originals: Vec<Vec<u8>> = (0u8..7)
+            .map(|i| make_record(&vec![i, 0x41, 0xaa, 0xbb, 0xcc, i.wrapping_add(0x10)]))
+            .collect();
+        // Concat: simulates one WS Binary message carrying all 7 records.
+        let mut batch = Vec::new();
+        for r in &originals {
+            batch.extend_from_slice(r);
+        }
+        // Drain: simulates the client's recv-loop pulling one record
+        // per recv() call.
+        let mut drained = Vec::new();
+        while let Some(r) = WsConnection::take_record_from_buf(&mut batch).expect("ok") {
+            drained.push(r);
+        }
+        assert_eq!(drained, originals, "round-tripped records match");
+        assert!(batch.is_empty());
     }
 
     /// Small helper: run `fut` and panic if it returns `Ok` — `WsConnection`

--- a/pir-sdk-client/src/wasm_transport.rs
+++ b/pir-sdk-client/src/wasm_transport.rs
@@ -136,6 +136,42 @@ enum IncomingFrame {
     Closed(String),
 }
 
+/// Pop one `[4B len][payload of len bytes]` record off the head of `buf`,
+/// leaving any trailing bytes in place. Mirrors
+/// `WsConnection::take_record_from_buf` in
+/// [`crate::connection`](crate::connection) — see that function for the
+/// rationale (HarmonyPIR hint coalescing).
+fn take_record_from_buf(buf: &mut Vec<u8>) -> PirResult<Option<Vec<u8>>> {
+    if buf.len() < 4 {
+        if !buf.is_empty() {
+            let leftover = buf.len();
+            buf.clear();
+            return Err(PirError::Protocol(format!(
+                "recv: WS message ended mid-record (leftover {} bytes)",
+                leftover
+            )));
+        }
+        return Ok(None);
+    }
+    let payload_len = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+    let record_len = 4 + payload_len;
+    if buf.len() < record_len {
+        let leftover = buf.len();
+        buf.clear();
+        return Err(PirError::Protocol(format!(
+            "recv: truncated record (len prefix {} > {} buffered bytes)",
+            payload_len, leftover
+        )));
+    }
+    let record = buf[..record_len].to_vec();
+    if record_len == buf.len() {
+        buf.clear();
+    } else {
+        buf.drain(..record_len);
+    }
+    Ok(Some(record))
+}
+
 /// Owning handles for the four JS-side callbacks.
 ///
 /// `Closure<dyn FnMut(...)>` is the idiomatic `wasm-bindgen` shape for a
@@ -183,6 +219,15 @@ pub struct WasmWebSocketTransport {
     /// Backend label passed to the recorder's callbacks. Defaults to
     /// `""`; owning clients override via `set_metrics_recorder`.
     metrics_backend: &'static str,
+    /// Leftover bytes from the last WS Binary message — populated when
+    /// the message carries multiple length-prefixed records (the
+    /// HarmonyPIR hint coalescing introduced 2026-05-20; see
+    /// `HINT_BATCH_BYTES` in `runtime/src/bin/unified_server.rs`).
+    /// `recv()` peels one record per call before reaching for the next
+    /// WS message. For any server that emits one record per WS message,
+    /// this buffer is always empty between calls, so the path is a
+    /// no-op for non-coalesced traffic.
+    recv_buf: Vec<u8>,
 }
 
 impl WasmWebSocketTransport {
@@ -229,9 +274,8 @@ fn build_transport(
 )> {
     // `WebSocket::new` throws on invalid URLs; convert the JS exception
     // to a PirError.
-    let ws = WebSocket::new(url).map_err(|e| {
-        PirError::ConnectionFailed(format!("WebSocket constructor threw: {:?}", e))
-    })?;
+    let ws = WebSocket::new(url)
+        .map_err(|e| PirError::ConnectionFailed(format!("WebSocket constructor threw: {:?}", e)))?;
     // Messages arrive as `ArrayBuffer`. The alternative (`Blob`) needs an
     // async FileReader step per message — wasted work for our binary-only
     // protocol.
@@ -340,6 +384,7 @@ fn build_transport(
         closed: Wasm32Shim::new(closed),
         metrics_recorder: None,
         metrics_backend: "",
+        recv_buf: Vec::new(),
     };
 
     Ok((open_rx, transport))
@@ -405,18 +450,31 @@ impl PirTransport for WasmWebSocketTransport {
     }
 
     async fn recv(&mut self) -> PirResult<Vec<u8>> {
+        // First try to peel one record off any tail from the previous
+        // WS message (HarmonyPIR hint coalescing — see `recv_buf` doc).
+        if let Some(record) = take_record_from_buf(&mut self.recv_buf)? {
+            return Ok(record);
+        }
+
         // The `next()` future resolves when the next callback-pushed
         // `IncomingFrame` lands on the channel — could be a message,
         // error, or close.
         match self.rx.next().await {
             Some(IncomingFrame::Binary(bytes)) => {
+                // `fire_bytes_received` fires once per WS message
+                // (matching the wire-level observer count), not per
+                // record — so a coalesced batch still reports its full
+                // size on the message that delivered it.
                 self.fire_bytes_received(bytes.len());
-                Ok(bytes)
+                self.recv_buf = bytes;
+                take_record_from_buf(&mut self.recv_buf)?.ok_or_else(|| {
+                    PirError::Protocol(
+                        "recv: WS message shorter than one length-prefixed record".into(),
+                    )
+                })
             }
             Some(IncomingFrame::Error(msg)) => Err(PirError::ConnectionFailed(msg)),
-            Some(IncomingFrame::Closed(reason)) => {
-                Err(PirError::ConnectionClosed(reason))
-            }
+            Some(IncomingFrame::Closed(reason)) => Err(PirError::ConnectionClosed(reason)),
             None => Err(PirError::ConnectionClosed(
                 "WebSocket receiver dropped".into(),
             )),

--- a/runtime/src/bin/harmonypir_hint_server.rs
+++ b/runtime/src/bin/harmonypir_hint_server.rs
@@ -24,6 +24,23 @@ use harmonypir::prp::hoang::HoangPrp;
  // for find_best_t, pad_n_for_t, compute_rounds
 use rand::RngCore;
 
+/// Target accumulation size before flushing a coalesced hint batch as one
+/// WebSocket Binary message. Per-group hint records (~74 KB each on the
+/// public deployment) are concatenated into this buffer; once the
+/// threshold is crossed the buffer is flushed and a fresh one started.
+///
+/// Wire-format inside the buffer is unchanged — each record is still the
+/// pre-existing `[4B len][RESP_HARMONY_HINTS][group_id][n][t][m][hints]`
+/// frame. Only WS message boundaries are reduced (a HarmonyPIR query that
+/// previously emitted ~622 RX HARMONY_HINTS frames now emits ~32).
+///
+/// Kept below 1 MiB so the message survives the Cloudflare WebSocket
+/// proxy (~1 MB ceiling — see docs/PIR1_REGISTER_KEYS_TRUNCATION.md). The
+/// standalone hint server isn't deployed behind Cloudflare, but a shared
+/// constant keeps the framing identical across the unified-server V2 /
+/// V2-half paths.
+const HINT_BATCH_BYTES: usize = 768 * 1024;
+
 // ─── Server data ────────────────────────────────────────────────────────────
 
 use runtime::table::CuckooTablePair;
@@ -271,27 +288,48 @@ async fn main() {
                         });
 
                         // Receive and stream hints to client as they arrive.
+                        // Coalesce per-group records into ~HINT_BATCH_BYTES
+                        // chunks so the client sees ~32 WS messages
+                        // (one onmessage event each) instead of `num`
+                        // (~155). Each record inside the buffer is the
+                        // same `[4B len][RESP_HARMONY_HINTS][...]` frame
+                        // the client was already parsing — only WS
+                        // message boundaries change.
                         let mut sent = 0;
+                        let mut batches = 0usize;
+                        let mut buf: Vec<u8> = Vec::with_capacity(HINT_BATCH_BYTES + 128 * 1024);
                         while let Some((group_id, n, t, m, flat_hints)) = rx.recv().await {
                             let hint_payload_len = 1 + 1 + 4 + 4 + 4 + flat_hints.len();
-                            let mut resp = Vec::with_capacity(4 + hint_payload_len);
-                            resp.extend_from_slice(&(hint_payload_len as u32).to_le_bytes());
-                            resp.push(RESP_HARMONY_HINTS);
-                            resp.push(group_id);
-                            resp.extend_from_slice(&n.to_le_bytes());
-                            resp.extend_from_slice(&t.to_le_bytes());
-                            resp.extend_from_slice(&m.to_le_bytes());
-                            resp.extend_from_slice(&flat_hints);
+                            buf.extend_from_slice(&(hint_payload_len as u32).to_le_bytes());
+                            buf.push(RESP_HARMONY_HINTS);
+                            buf.push(group_id);
+                            buf.extend_from_slice(&n.to_le_bytes());
+                            buf.extend_from_slice(&t.to_le_bytes());
+                            buf.extend_from_slice(&m.to_le_bytes());
+                            buf.extend_from_slice(&flat_hints);
 
-                            if let Err(e) = sink.send(Message::Binary(resp)).await {
-                                eprintln!("[{}] Send error: {}", peer, e);
-                                break;
+                            if buf.len() >= HINT_BATCH_BYTES {
+                                let batch = std::mem::take(&mut buf);
+                                if let Err(e) = sink.send(Message::Binary(batch)).await {
+                                    eprintln!("[{}] Send error: {}", peer, e);
+                                    break;
+                                }
+                                buf.reserve(HINT_BATCH_BYTES + 128 * 1024);
+                                batches += 1;
                             }
                             sent += 1;
                         }
+                        // Flush the final partial batch.
+                        if !buf.is_empty() {
+                            if let Err(e) = sink.send(Message::Binary(buf)).await {
+                                eprintln!("[{}] Final-batch send error: {}", peer, e);
+                            } else {
+                                batches += 1;
+                            }
+                        }
 
-                        println!("[{}] Hints streamed: level={} {}/{} groups in {:.2?}",
-                            peer, level, sent, num, t_start.elapsed());
+                        println!("[{}] Hints streamed: level={} {}/{} groups in {:.2?} ({} WS batches)",
+                            peer, level, sent, num, t_start.elapsed(), batches);
                     }
                     Request::HarmonyHintsV2(_v2_req) => {
                         // V2: server generates PRP key, sends ALL groups for both
@@ -345,28 +383,45 @@ async fn main() {
                             });
                         });
 
-                        // Stream frames as they arrive.
+                        // Stream frames as they arrive — coalesced into
+                        // ~HINT_BATCH_BYTES-sized WS messages. See the V1
+                        // path above for the rationale; the inner
+                        // length-prefixed record stream is unchanged.
                         let mut sent = 0usize;
+                        let mut batches = 0usize;
+                        let mut buf: Vec<u8> = Vec::with_capacity(HINT_BATCH_BYTES + 128 * 1024);
                         while let Some((group_id, n, t, m, flat_hints)) = rx.recv().await {
                             let hint_payload_len: u32 = 1 + 1 + 4 + 4 + 4 + flat_hints.len() as u32;
-                            let mut resp = Vec::with_capacity(4 + hint_payload_len as usize);
-                            resp.extend_from_slice(&hint_payload_len.to_le_bytes());
-                            resp.push(RESP_HARMONY_HINTS);
-                            resp.push(group_id);
-                            resp.extend_from_slice(&n.to_le_bytes());
-                            resp.extend_from_slice(&t.to_le_bytes());
-                            resp.extend_from_slice(&m.to_le_bytes());
-                            resp.extend_from_slice(&flat_hints);
+                            buf.extend_from_slice(&hint_payload_len.to_le_bytes());
+                            buf.push(RESP_HARMONY_HINTS);
+                            buf.push(group_id);
+                            buf.extend_from_slice(&n.to_le_bytes());
+                            buf.extend_from_slice(&t.to_le_bytes());
+                            buf.extend_from_slice(&m.to_le_bytes());
+                            buf.extend_from_slice(&flat_hints);
 
-                            if let Err(e) = sink.send(Message::Binary(resp)).await {
-                                eprintln!("[{}] V2 hint send error: {}", peer, e);
-                                break;
+                            if buf.len() >= HINT_BATCH_BYTES {
+                                let batch = std::mem::take(&mut buf);
+                                if let Err(e) = sink.send(Message::Binary(batch)).await {
+                                    eprintln!("[{}] V2 hint send error: {}", peer, e);
+                                    break;
+                                }
+                                buf.reserve(HINT_BATCH_BYTES + 128 * 1024);
+                                batches += 1;
                             }
                             sent += 1;
                         }
+                        // Flush the final partial batch.
+                        if !buf.is_empty() {
+                            if let Err(e) = sink.send(Message::Binary(buf)).await {
+                                eprintln!("[{}] V2 final-batch send error: {}", peer, e);
+                            } else {
+                                batches += 1;
+                            }
+                        }
 
-                        println!("[{}] V2 hints streamed: {}/{} groups in {:.2?}",
-                            peer, sent, total_groups, t_start.elapsed());
+                        println!("[{}] V2 hints streamed: {}/{} groups in {:.2?} ({} WS batches)",
+                            peer, sent, total_groups, t_start.elapsed(), batches);
                     }
                     _ => {
                         let resp = Response::Error("unsupported request on hint server".into());

--- a/runtime/src/bin/unified_server.rs
+++ b/runtime/src/bin/unified_server.rs
@@ -1261,49 +1261,74 @@ where
     sink.send(Message::Binary(to_send)).await
 }
 
-/// Feed-only variant of [`send_resp`] — push the payload into the WS sink
-/// without flushing. Lets the caller batch N frames into the kernel send
-/// buffer with one final [`SinkExt::flush`] instead of paying an await
-/// per frame.
+// `feed_resp` (a per-frame `sink.feed()` variant of `send_resp`) was
+// removed when the V2 / V2-half hint paths switched from one
+// `Message::Binary` per group to a coalesced ~768 KB batch — see
+// `HINT_BATCH_BYTES` below. The coalesced path uses `send_resp_batch`,
+// which seals each record individually (preserving per-record framing
+// the client demuxes) and emits the concatenated buffer as one
+// `Sink::send`-flushed Binary message per batch.
+
+/// Send a batch of `[4B len][body]` records as ONE WebSocket Binary
+/// message. Each record retains its own `[4B len][body_or_sealed]`
+/// framing inside the buffer so the client's transport layer can demux
+/// them one-by-one via [`WsConnection::recv`] (which peels one record
+/// per call, buffering any tail).
 ///
-/// Used by the V2 hint pool path to stream ~155 frames (~20 MB) without
-/// stalling on per-frame backpressure. Equivalent to `send_resp` on the
-/// wire — the receiver sees identical bytes; only the
-/// application-layer flushing changes.
+/// When the channel session is active, each record is sealed
+/// individually with a fresh sequence number — the seal pattern is
+/// byte-identical to N back-to-back `send_resp` calls, just emitted as
+/// one WS Binary message instead of N.
 ///
-/// Caller MUST `sink.flush().await` (or call `send_resp` for the final
-/// frame) before considering the batch complete — otherwise the last
-/// few frames may sit unsent in the local sink buffer.
-async fn feed_resp<S>(
+/// Used by the HarmonyPIR hint paths (V1, V2, V2-half) to coalesce the
+/// per-group hint records into ~`HINT_BATCH_BYTES`-sized batches; see
+/// the call sites for the surrounding loops.
+async fn send_resp_batch<S>(
     sink: &mut S,
-    session: Option<&mut pir_runtime_core::channel::Session>,
-    payload: Vec<u8>,
+    mut session: Option<&mut pir_runtime_core::channel::Session>,
+    records: Vec<Vec<u8>>,
 ) -> tokio_tungstenite::tungstenite::Result<()>
 where
     S: futures_util::SinkExt<tokio_tungstenite::tungstenite::Message, Error = tokio_tungstenite::tungstenite::Error>
         + Unpin,
 {
     use tokio_tungstenite::tungstenite::{Error as TungError, Message};
-    let to_send = match session {
-        Some(s) => {
-            if payload.len() < 4 {
-                payload
-            } else {
-                let inner = &payload[4..];
-                let sealed = s
-                    .seal(pir_runtime_core::channel::Direction::ServerToClient, inner)
-                    .map_err(|e| {
-                        TungError::Io(std::io::Error::other(format!("channel seal: {}", e)))
-                    })?;
-                let mut framed = Vec::with_capacity(4 + sealed.len());
-                framed.extend_from_slice(&(sealed.len() as u32).to_le_bytes());
-                framed.extend_from_slice(&sealed);
-                framed
+    if records.is_empty() {
+        return Ok(());
+    }
+    // Pre-size the output buffer. For the no-channel case we know the
+    // exact size; for the channel case each sealed body is
+    // `body.len() + 1 (magic) + 8 (seq) + 16 (tag) = body.len() + 25`,
+    // so a tight upper-bound stays correct without re-allocating.
+    let total_estimate: usize = records
+        .iter()
+        .map(|r| if r.len() < 4 { r.len() } else { 4 + (r.len() - 4) + 25 })
+        .sum();
+    let mut buf: Vec<u8> = Vec::with_capacity(total_estimate);
+    for payload in records {
+        match session.as_deref_mut() {
+            Some(s) => {
+                if payload.len() < 4 {
+                    // Defensive: malformed (no length prefix). Pass
+                    // through — matches `send_resp` behaviour.
+                    buf.extend_from_slice(&payload);
+                } else {
+                    let inner = &payload[4..];
+                    let sealed = s
+                        .seal(pir_runtime_core::channel::Direction::ServerToClient, inner)
+                        .map_err(|e| {
+                            TungError::Io(std::io::Error::other(format!("channel seal: {}", e)))
+                        })?;
+                    buf.extend_from_slice(&(sealed.len() as u32).to_le_bytes());
+                    buf.extend_from_slice(&sealed);
+                }
+            }
+            None => {
+                buf.extend_from_slice(&payload);
             }
         }
-        None => payload,
-    };
-    sink.feed(Message::Binary(to_send)).await
+    }
+    sink.send(Message::Binary(buf)).await
 }
 
 // ─── Transport-level message chunking (Cloudflare large-message workaround) ──
@@ -1319,6 +1344,23 @@ const CHUNK_MAGIC: u8 = 0xc7;
 const CHUNK_SIZE: usize = 256 * 1024;
 const CHUNK_HDR: usize = 1 + 2 + 2; // magic + seq + total
 const MAX_REASSEMBLED: usize = 64 * 1024 * 1024;
+
+/// Target accumulation size before flushing a coalesced HarmonyPIR hint
+/// batch as one WebSocket Binary message. Per-group hint records
+/// (~74 KB each on the public deployment) are concatenated into a buffer
+/// until the threshold is crossed, then flushed.
+///
+/// Wire-format inside the buffer is unchanged — each record is still the
+/// pre-existing `[4B len][RESP_HARMONY_HINTS][group_id][n][t][m][hints]`
+/// frame. Only WS message boundaries are reduced (a HarmonyPIR query that
+/// previously emitted ~622 RX HARMONY_HINTS frames across two sockets now
+/// emits ~32).
+///
+/// Sized below 1 MiB so the message survives the Cloudflare WebSocket
+/// proxy (~1 MB ceiling — see docs/PIR1_REGISTER_KEYS_TRUNCATION.md).
+/// Mirrors `HINT_BATCH_BYTES` in
+/// `runtime/src/bin/harmonypir_hint_server.rs`.
+const HINT_BATCH_BYTES: usize = 768 * 1024;
 
 /// Like [`send_resp`], but when `allow_chunk` is set and the framed
 /// message exceeds `CHUNK_SIZE`, splits it into chunk frames the client
@@ -3034,24 +3076,51 @@ async fn main() {
                                 });
                             });
 
+                            // Coalesce per-group records into ~HINT_BATCH_BYTES
+                            // WS messages so the browser sees ~30 onmessage
+                            // events instead of `num` (~155). Each record
+                            // retains its per-record `[4B len][body]`
+                            // framing inside the buffer (sealed
+                            // individually if the channel is active) so
+                            // the client's existing one-record-per-recv()
+                            // contract holds — see `send_resp_batch` and
+                            // `WsConnection::recv` for the demux.
                             let mut sent = 0;
+                            let mut batches = 0usize;
+                            let mut pending: Vec<Vec<u8>> = Vec::new();
+                            let mut pending_bytes = 0usize;
                             while let Some((group_id, n, t, m, flat_hints)) = rx.recv().await {
                                 let hint_len = 1 + 1 + 4 + 4 + 4 + flat_hints.len();
-                                let mut resp = Vec::with_capacity(4 + hint_len);
-                                resp.extend_from_slice(&(hint_len as u32).to_le_bytes());
-                                resp.push(RESP_HARMONY_HINTS);
-                                resp.push(group_id);
-                                resp.extend_from_slice(&n.to_le_bytes());
-                                resp.extend_from_slice(&t.to_le_bytes());
-                                resp.extend_from_slice(&m.to_le_bytes());
-                                resp.extend_from_slice(&flat_hints);
-                                if let Err(e) = send_resp(&mut sink, channel_session.as_mut(), resp).await {
-                                    eprintln!("[{}] Send error: {}", peer, e);
-                                    break;
+                                let mut record = Vec::with_capacity(4 + hint_len);
+                                record.extend_from_slice(&(hint_len as u32).to_le_bytes());
+                                record.push(RESP_HARMONY_HINTS);
+                                record.push(group_id);
+                                record.extend_from_slice(&n.to_le_bytes());
+                                record.extend_from_slice(&t.to_le_bytes());
+                                record.extend_from_slice(&m.to_le_bytes());
+                                record.extend_from_slice(&flat_hints);
+                                pending_bytes += record.len();
+                                pending.push(record);
+                                if pending_bytes >= HINT_BATCH_BYTES {
+                                    let batch = std::mem::take(&mut pending);
+                                    pending_bytes = 0;
+                                    if let Err(e) = send_resp_batch(&mut sink, channel_session.as_mut(), batch).await {
+                                        eprintln!("[{}] Send error: {}", peer, e);
+                                        break;
+                                    }
+                                    batches += 1;
                                 }
                                 sent += 1;
                             }
-                            println!("[harmony-hint] db={} L{} {}/{} groups in {:.2?}", db_id, level, sent, num, t_start.elapsed());
+                            if !pending.is_empty() {
+                                if let Err(e) = send_resp_batch(&mut sink, channel_session.as_mut(), pending).await {
+                                    eprintln!("[{}] Final-batch send error: {}", peer, e);
+                                } else {
+                                    batches += 1;
+                                }
+                            }
+                            println!("[harmony-hint] db={} L{} {}/{} groups in {:.2?} ({} WS batches)",
+                                db_id, level, sent, num, t_start.elapsed(), batches);
                         }
                     }
                     REQ_HARMONY_HINTS_V2 => {
@@ -3097,45 +3166,58 @@ async fn main() {
                             }
                         };
 
-                        // 1. Feed key preamble frame (no flush — see (4) below).
-                        if let Err(e) = feed_resp(&mut sink, channel_session.as_mut(), entry.key_preamble.clone()).await {
-                            eprintln!("[{}] V2 preamble feed error: {}", peer, e);
+                        // 1. Send key preamble as its own (small) WS Binary
+                        //    message — keeps the existing wire shape for the
+                        //    preamble + makes the client's first recv()
+                        //    return just the preamble. (The client picks the
+                        //    PRP key out of it before building HarmonyGroup
+                        //    instances.)
+                        if let Err(e) = send_resp(&mut sink, channel_session.as_mut(), entry.key_preamble.clone()).await {
+                            eprintln!("[{}] V2 preamble send error: {}", peer, e);
                             continue;
                         }
 
-                        // 2. Feed all INDEX frames. `feed` pushes into the
-                        //    WS sink's local buffer without forcing a flush
-                        //    per frame — so the ~155 frames in a typical
-                        //    pool entry don't pay 155× await + flush
-                        //    backpressure overhead. The kernel TCP buffer
-                        //    sees one large pipelined write loop and
-                        //    schedules segments much more efficiently.
-                        //    Measured: ~2.3 MB/s → ~6 MB/s on the public
-                        //    deployment.
+                        // 2. Coalesce INDEX + CHUNK frames into
+                        //    ~HINT_BATCH_BYTES WS messages. Each record
+                        //    retains its per-record `[4B len][body]`
+                        //    framing (sealed individually if the channel
+                        //    is on) so the client's
+                        //    one-record-per-recv() contract holds — see
+                        //    `send_resp_batch` + `WsConnection::recv`
+                        //    for the demux. A typical pool entry's ~155
+                        //    frames now flush as ~10 WS messages
+                        //    instead of 155.
                         let mut sent = 0usize;
-                        for frame in &entry.index_frames {
-                            if let Err(e) = feed_resp(&mut sink, channel_session.as_mut(), frame.clone()).await {
-                                eprintln!("[{}] V2 index frame feed error: {}", peer, e);
-                                break;
+                        let mut batches = 0usize;
+                        let mut pending: Vec<Vec<u8>> = Vec::new();
+                        let mut pending_bytes = 0usize;
+                        let frame_iter = entry.index_frames.iter().chain(entry.chunk_frames.iter());
+                        for frame in frame_iter {
+                            pending_bytes += frame.len();
+                            pending.push(frame.clone());
+                            if pending_bytes >= HINT_BATCH_BYTES {
+                                let batch = std::mem::take(&mut pending);
+                                pending_bytes = 0;
+                                if let Err(e) = send_resp_batch(&mut sink, channel_session.as_mut(), batch).await {
+                                    eprintln!("[{}] V2 frame batch send error: {}", peer, e);
+                                    break;
+                                }
+                                batches += 1;
                             }
                             sent += 1;
                         }
-
-                        // 3. Feed all CHUNK frames.
-                        for frame in &entry.chunk_frames {
-                            if let Err(e) = feed_resp(&mut sink, channel_session.as_mut(), frame.clone()).await {
-                                eprintln!("[{}] V2 chunk frame feed error: {}", peer, e);
-                                break;
+                        if !pending.is_empty() {
+                            if let Err(e) = send_resp_batch(&mut sink, channel_session.as_mut(), pending).await {
+                                eprintln!("[{}] V2 final-batch send error: {}", peer, e);
+                            } else {
+                                batches += 1;
                             }
-                            sent += 1;
                         }
 
-                        // 4. Terminal sentinel: group_id=0xFF signals
-                        //    end-of-stream. Use `send_resp` here (not
-                        //    `feed_resp`) so the underlying
-                        //    `Sink::send` flushes the entire batched
-                        //    stream — preamble + 155 frames + sentinel
-                        //    all hit the wire in one final flush.
+                        // 3. Terminal sentinel: group_id=0xFF signals
+                        //    end-of-stream. Sent as its own (small) message
+                        //    so the client's last recv() returns just the
+                        //    sentinel, matching the legacy unbatched shape.
                         let terminal_len: u32 = 1 + 1; // variant + group_id
                         let mut terminal = Vec::with_capacity(4 + terminal_len as usize);
                         terminal.extend_from_slice(&terminal_len.to_le_bytes());
@@ -3145,9 +3227,10 @@ async fn main() {
 
                         let elapsed = t_start.elapsed();
                         println!(
-                            "[harmony-hint-v2] db={} {} groups served from pool (prp_key={:02x?}...) in {:.2?}",
+                            "[harmony-hint-v2] db={} {} groups served from pool ({} WS batches, prp_key={:02x?}...) in {:.2?}",
                             db_id,
                             sent,
+                            batches,
                             &entry.prp_key[..4],
                             elapsed,
                         );
@@ -3270,9 +3353,11 @@ async fn main() {
                             }
                         };
 
-                        // 1. Feed key preamble (same for both halves
-                        //    since they share the entry).
-                        if let Err(e) = feed_resp(
+                        // 1. Send key preamble (same for both halves
+                        //    since they share the entry). Kept as its own
+                        //    small WS Binary message so the client's first
+                        //    recv() returns just the preamble.
+                        if let Err(e) = send_resp(
                             &mut sink,
                             channel_session.as_mut(),
                             entry_arc.key_preamble.clone(),
@@ -3280,37 +3365,71 @@ async fn main() {
                         .await
                         {
                             eprintln!(
-                                "[{}] V2-half preamble feed error: {}",
+                                "[{}] V2-half preamble send error: {}",
                                 peer, e
                             );
                             continue;
                         }
 
-                        // 2. Feed the selected half's frames.
+                        // 2. Coalesce the selected half's frames into
+                        //    ~HINT_BATCH_BYTES WS messages. Each record
+                        //    retains its per-record `[4B len][body]`
+                        //    framing (sealed individually if the
+                        //    channel is on) so the client's
+                        //    one-record-per-recv() contract holds. A
+                        //    typical half (~78 INDEX or ~77 CHUNK
+                        //    frames @ ~74 KB) now flushes as ~5 WS
+                        //    messages instead of ~78.
                         let frames: &[Vec<u8>] = if side == 0 {
                             &entry_arc.index_frames
                         } else {
                             &entry_arc.chunk_frames
                         };
                         let mut sent = 0usize;
+                        let mut batches = 0usize;
+                        let mut pending: Vec<Vec<u8>> = Vec::new();
+                        let mut pending_bytes = 0usize;
                         for frame in frames {
-                            if let Err(e) = feed_resp(
+                            pending_bytes += frame.len();
+                            pending.push(frame.clone());
+                            if pending_bytes >= HINT_BATCH_BYTES {
+                                let batch = std::mem::take(&mut pending);
+                                pending_bytes = 0;
+                                if let Err(e) = send_resp_batch(
+                                    &mut sink,
+                                    channel_session.as_mut(),
+                                    batch,
+                                )
+                                .await
+                                {
+                                    eprintln!(
+                                        "[{}] V2-half frame batch send error (side={}, group={}): {}",
+                                        peer, side, sent, e
+                                    );
+                                    break;
+                                }
+                                batches += 1;
+                            }
+                            sent += 1;
+                        }
+                        if !pending.is_empty() {
+                            if let Err(e) = send_resp_batch(
                                 &mut sink,
                                 channel_session.as_mut(),
-                                frame.clone(),
+                                pending,
                             )
                             .await
                             {
                                 eprintln!(
-                                    "[{}] V2-half frame feed error (side={}, group={}): {}",
-                                    peer, side, sent, e
+                                    "[{}] V2-half final-batch send error (side={}): {}",
+                                    peer, side, e
                                 );
-                                break;
+                            } else {
+                                batches += 1;
                             }
-                            sent += 1;
                         }
 
-                        // 3. Send terminal sentinel (flushes the batch).
+                        // 3. Send terminal sentinel.
                         let terminal_len: u32 = 1 + 1;
                         let mut terminal = Vec::with_capacity(4 + terminal_len as usize);
                         terminal.extend_from_slice(&terminal_len.to_le_bytes());
@@ -3326,10 +3445,11 @@ async fn main() {
                         let elapsed = t_start.elapsed();
                         let side_name = if side == 0 { "INDEX" } else { "CHUNK" };
                         println!(
-                            "[harmony-hint-v2-half] db={} side={} {} groups served from pool (prp_key={:02x?}..., token={:02x?}...) in {:.2?}",
+                            "[harmony-hint-v2-half] db={} side={} {} groups served from pool ({} WS batches, prp_key={:02x?}..., token={:02x?}...) in {:.2?}",
                             db_id,
                             side_name,
                             sent,
+                            batches,
                             &entry_arc.prp_key[..4],
                             &token[..4],
                             elapsed,

--- a/web/src/__tests__/ws.test.ts
+++ b/web/src/__tests__/ws.test.ts
@@ -84,9 +84,14 @@ describe('ManagedWebSocket', () => {
     const p1 = ws.sendRaw(new Uint8Array([1]));
     const p2 = ws.sendRaw(new Uint8Array([2]));
 
-    // Reply to first, then second
-    const resp1 = new Uint8Array([5, 0, 0, 0, 0x01, 0xAA]);
-    const resp2 = new Uint8Array([5, 0, 0, 0, 0x01, 0xBB]);
+    // Reply to first, then second. Each response is a proper
+    // length-prefixed record: `[2, 0, 0, 0, 0x01, 0xAA]` = len=2,
+    // body=[variant=0x01, 0xAA]. (Pre-coalesce the test used
+    // `[5, 0, 0, 0, ...]` with a mismatched length — fine when
+    // `deliver` just shoved the whole message at the next caller, but
+    // the demux now actually parses the prefix.)
+    const resp1 = new Uint8Array([2, 0, 0, 0, 0x01, 0xAA]);
+    const resp2 = new Uint8Array([2, 0, 0, 0, 0x01, 0xBB]);
     mock.receiveMessage(resp1);
     mock.receiveMessage(resp2);
 
@@ -106,8 +111,9 @@ describe('ManagedWebSocket', () => {
     // Send pong (should be filtered)
     mock.receivePong();
 
-    // Send real response (should resolve p1)
-    const realResp = new Uint8Array([5, 0, 0, 0, 0x01, 0xFF]);
+    // Send real response (should resolve p1). Length-prefix matches
+    // body — see the FIFO test above for why this changed.
+    const realResp = new Uint8Array([2, 0, 0, 0, 0x01, 0xFF]);
     mock.receiveMessage(realResp);
 
     expect(await p1).toEqual(realResp);
@@ -183,5 +189,88 @@ describe('ManagedWebSocket', () => {
   it('isOpen returns false before connect', () => {
     const ws = new ManagedWebSocket({ url: 'ws://test' });
     expect(ws.isOpen()).toBe(false);
+  });
+
+  // ─── Coalesced (multi-record) WS messages ─────────────────────────────
+  //
+  // The HarmonyPIR hint server may flush several length-prefixed records
+  // back-to-back inside a single WS Binary message (~768 KB target — see
+  // `HINT_BATCH_BYTES` in `runtime/src/bin/unified_server.rs`). The
+  // delivery loop must peel one record per pending caller, in order,
+  // without dropping records or hanging.
+
+  it('demuxes two length-prefixed records from one onmessage', async () => {
+    const ws = new ManagedWebSocket({ url: 'ws://test' });
+    await ws.connect();
+    const mock = MockWebSocket.instances[0];
+
+    const p1 = ws.sendRaw(new Uint8Array([1]));
+    const p2 = ws.sendRaw(new Uint8Array([2]));
+
+    // Two records concatenated into ONE WS message. Each is the legacy
+    // `[4B len LE][variant=0x01][body]` shape the server has always
+    // emitted; only the WS framing changes — len=5 body=[0x01, 0xAA].
+    const concat = new Uint8Array([
+      5, 0, 0, 0, 0x01, 0xAA, 0xA1, 0xA2, 0xA3,
+      5, 0, 0, 0, 0x01, 0xBB, 0xB1, 0xB2, 0xB3,
+    ]);
+    mock.receiveMessage(concat);
+
+    const r1 = await p1;
+    const r2 = await p2;
+    expect(r1).toEqual(new Uint8Array([5, 0, 0, 0, 0x01, 0xAA, 0xA1, 0xA2, 0xA3]));
+    expect(r2).toEqual(new Uint8Array([5, 0, 0, 0, 0x01, 0xBB, 0xB1, 0xB2, 0xB3]));
+
+    ws.disconnect();
+  });
+
+  it('demuxes records across coalesced messages while honouring FIFO', async () => {
+    const ws = new ManagedWebSocket({ url: 'ws://test' });
+    await ws.connect();
+    const mock = MockWebSocket.instances[0];
+
+    const p1 = ws.sendRaw(new Uint8Array([1]));
+    const p2 = ws.sendRaw(new Uint8Array([2]));
+    const p3 = ws.sendRaw(new Uint8Array([3]));
+
+    // First WS message carries two records (records 1 + 2). Second
+    // WS message carries one record (record 3). The caller should see
+    // each record arrive in order.
+    const msg1 = new Uint8Array([
+      5, 0, 0, 0, 0x01, 0x11, 0x22, 0x33, 0x44,
+      5, 0, 0, 0, 0x01, 0x55, 0x66, 0x77, 0x88,
+    ]);
+    const msg2 = new Uint8Array([5, 0, 0, 0, 0x01, 0x99, 0xAA, 0xBB, 0xCC]);
+    mock.receiveMessage(msg1);
+    mock.receiveMessage(msg2);
+
+    expect(await p1).toEqual(new Uint8Array([5, 0, 0, 0, 0x01, 0x11, 0x22, 0x33, 0x44]));
+    expect(await p2).toEqual(new Uint8Array([5, 0, 0, 0, 0x01, 0x55, 0x66, 0x77, 0x88]));
+    expect(await p3).toEqual(new Uint8Array([5, 0, 0, 0, 0x01, 0x99, 0xAA, 0xBB, 0xCC]));
+
+    ws.disconnect();
+  });
+
+  it('filters pong records inside coalesced WS messages', async () => {
+    // The hint server's coalesced buffer can include any payload —
+    // including (in pathological cases) a pong-shaped record. The
+    // pong-filter must run per-record, not just on whole WS messages.
+    const ws = new ManagedWebSocket({ url: 'ws://test' });
+    await ws.connect();
+    const mock = MockWebSocket.instances[0];
+
+    const p = ws.sendRaw(new Uint8Array([1]));
+
+    // [pong][real] concatenated. Pong: [1,0,0,0, 0x00]. Real: same as
+    // earlier tests.
+    const concat = new Uint8Array([
+      1, 0, 0, 0, 0x00,
+      5, 0, 0, 0, 0x01, 0xFF, 0xFE, 0xFD, 0xFC,
+    ]);
+    mock.receiveMessage(concat);
+
+    expect(await p).toEqual(new Uint8Array([5, 0, 0, 0, 0x01, 0xFF, 0xFE, 0xFD, 0xFC]));
+
+    ws.disconnect();
   });
 });

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -150,20 +150,65 @@ export class ManagedWebSocket {
     this.ws = null;
   }
 
-  /** Pong-filter, then resolve the next pending request (FIFO). */
+    /**
+   * Pong-filter, then resolve the next pending request (FIFO).
+   *
+   * A single WebSocket message may carry one record (the historical
+   * shape) or several length-prefixed records concatenated back-to-back
+   * — the HarmonyPIR hint coalescing introduced 2026-05-20 (see
+   * `HINT_BATCH_BYTES` in `runtime/src/bin/unified_server.rs`) flushes
+   * ~750 KB of records per WS message. This method peels each
+   * `[4B len LE][payload of len bytes]` record off the head of `data`
+   * and resolves one pending callback per record. For any non-coalesced
+   * message (one record per WS message) the loop runs exactly once,
+   * preserving the historical behaviour.
+   */
   private deliver(data: Uint8Array): void {
-    // Filter pong responses: [4B len LE][1B variant]. Pong: len=1, variant=0x00.
-    if (data.length >= 5) {
-      const len = data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
-      if (len === 1 && data[4] === 0x00) {
-        return; // Silently discard pong
+    let off = 0;
+    while (off + 4 <= data.length) {
+      const len =
+        data[off] |
+        (data[off + 1] << 8) |
+        (data[off + 2] << 16) |
+        (data[off + 3] << 24);
+      const recordEnd = off + 4 + len;
+      if (recordEnd > data.length) {
+        // Malformed: length prefix points past the WS message. Drop
+        // the rest — coalescing is strictly within one WS message, so
+        // a record can never span a boundary.
+        this.log(
+          `Truncated record in WS message: len=${len} but only ${data.length - off - 4} bytes available`,
+          'error',
+        );
+        return;
+      }
+      const record = data.subarray(off, recordEnd);
+      off = recordEnd;
+
+      // Filter pong responses: [4B len=1 LE][1B variant=0x00].
+      if (len === 1 && record[4] === 0x00) {
+        continue; // Silently discard pong
+      }
+
+      const cb = this.pending.shift();
+      if (cb) {
+        clearTimeout(cb.timeout);
+        // Copy out of the subarray so callers can hold the buffer past
+        // the next onmessage event without aliasing the WS message's
+        // backing ArrayBuffer.
+        cb.resolve(new Uint8Array(record));
+      } else {
+        this.log(
+          `Received record with no pending caller (len=${len}); dropping`,
+          'error',
+        );
       }
     }
-
-    const cb = this.pending.shift();
-    if (cb) {
-      clearTimeout(cb.timeout);
-      cb.resolve(data);
+    if (off !== data.length) {
+      this.log(
+        `WS message had ${data.length - off} trailing bytes (not a complete record)`,
+        'error',
+      );
     }
   }
 


### PR DESCRIPTION
## Problem

A single HarmonyPIR query through the public dev site (https://bitcoin-pir.github.io/playground/) produced **622 RX HARMONY_HINTS frames** totalling 46 MB across two server connections — one onmessage event per frame on the browser side, for data the client can't act on until the entire hint set has arrived.

Captured 2026-05-20 against `wss://weikeng1.bitcoinpir.org` + `wss://weikeng2.bitcoinpir.org`:

```
HarmonyPIR query, 2026-05-20:
  ← HARMONY_HINTS    622 frames    avg 74 KB    total 46.1 MB
  ← UNKNOWN_0x44       2 frames    avg 24 B     total   48 B   (V2_HALF KEY preamble)
  →   0x46             2 frames    avg 22 B     total   44 B   (V2_HALF requests)
```

The 622 frames split ~301 to sock#1 + 321 to sock#2 (primary + secondary servers).

## Fix

Server side, the three HarmonyPIR hint streaming paths (V1, V2, V2-half) accumulate per-record `[4B len][body]` frames into a ~**768 KB** buffer (`HINT_BATCH_BYTES`) before flushing as one `Message::Binary`. The threshold is kept below 1 MiB so the message survives the Cloudflare WebSocket proxy (see [docs/PIR1_REGISTER_KEYS_TRUNCATION.md](docs/PIR1_REGISTER_KEYS_TRUNCATION.md)).

Expected wire-frame count for the same query drops from **~622 → ~32** (~20× fewer onmessage events).

## Scope note vs original brief

The original brief said *"Clients (Rust SDK + TS) read length-prefixed records from a byte stream; they don't care whether records arrived in one onmessage or many"* — but the current clients ([pir-sdk-client/src/connection.rs](pir-sdk-client/src/connection.rs)'s `WsConnection::recv`, [web/src/ws.ts](web/src/ws.ts)'s `ManagedWebSocket.deliver`, [pir-sdk-client/src/wasm_transport.rs](pir-sdk-client/src/wasm_transport.rs)'s `WasmWebSocketTransport::recv`) all assume **1 WS Binary message = 1 length-prefixed record**.

To preserve the existing one-record-per-`recv()` contract (which the higher-level HarmonyPIR hint loops in `harmony.rs` rely on at e.g. lines 1610, 1650, 1870), this PR adds a small **client-side demux**: each transport gains a `recv_buf: Vec<u8>` field, `recv()` peels one `[4B len][body]` record off the buffer head, and only reaches for the next WS message when the buffer drains to empty. The change is a no-op for any server that still emits one record per WS message.

If you'd rather merge only the server-side change and ship the client demux separately (e.g., to roll out the client first, then enable coalescing), the boundary is the four files in `pir-sdk-client/src/` + `web/src/`. The server-side three files (`harmonypir_hint_server.rs`, `unified_server.rs`) are independently mergeable, but **deploying coalescing without the client change would break the deployed clients**.

## Files touched

  Server-side coalescing
  - [runtime/src/bin/harmonypir_hint_server.rs](runtime/src/bin/harmonypir_hint_server.rs) — V1 + V2 streaming loops accumulate into a `Vec<u8>` buffer, then flush as one `Message::Binary` per batch.
  - [runtime/src/bin/unified_server.rs](runtime/src/bin/unified_server.rs) — V1 + V2 + V2-half handlers switch to a new `send_resp_batch` helper that takes a `Vec<Vec<u8>>` of `[4B len][body]` records, seals each individually (preserving per-record framing the client demuxes), and emits the concatenated buffer as one `Sink::send`-flushed Binary message. Removes the now-unused `feed_resp` helper.

  Client-side demux
  - [pir-sdk-client/src/connection.rs](pir-sdk-client/src/connection.rs) — `WsConnection` gains `recv_buf`; `recv()` drains records via a new `take_record_from_buf` helper. **6 new unit tests** cover empty / single / multi-record drain, truncated-prefix + partial-prefix errors, and a 7-record server-side-concat → client-side-demux round-trip.
  - [pir-sdk-client/src/wasm_transport.rs](pir-sdk-client/src/wasm_transport.rs) — `WasmWebSocketTransport` gets the same treatment via a free-function `take_record_from_buf`.
  - [web/src/ws.ts](web/src/ws.ts) — `ManagedWebSocket.deliver` loops over the WS message, peeling one record per pending caller. Pong filtering moves inside the loop (a pong embedded in a coalesced batch is still dropped silently).
  - [web/src/__tests__/ws.test.ts](web/src/__tests__/ws.test.ts) — **3 new vitest tests** for the demux + pong-inside-batch case. Two existing fixtures had a length prefix of `5` but only 2 trailing bytes — fine when `deliver` shoved the whole message at the next caller, but the strict demux now actually parses the prefix, so they were updated to `[2, 0, 0, 0, 0x01, 0xAA]` (len=2, matching body).

## Privacy invariants — NOT affected

The four privacy invariants documented in [CLAUDE.md](CLAUDE.md) (Query Padding, Merkle INDEX Item-Count Symmetry, CHUNK Round-Presence Symmetry, INDEX Merkle Group-Symmetry) are unaffected by this change — they are all enforced at layers strictly above WS framing:

  - Query Padding (K=75 / K_CHUNK=80) lives in the client's `query_index_phase_batched` / `query_chunk_level` planning code.
  - Per-Merkle-level item-count symmetry is enforced by `pir-sdk-client/src/harmony.rs`'s response-assembly code.
  - CHUNK Round-Presence Symmetry is enforced by the per-query dispatch loop, which calls `query_chunk_level(...)` even for not-found / whale queries.

Coalescing only moves WS message boundaries; the inner length-prefixed record stream is **byte-identical** to the unbuffered version. The `batch_round_trip_demuxes_to_original_records` unit test in `connection.rs` is the strongest argument for this — a 7-record server-side concat demuxes to the exact same 7 records on the client.

## Test plan

  - [x] `cargo build --release --bin unified_server --bin harmonypir_hint_server` — clean.
  - [x] `cargo check --target wasm32-unknown-unknown -p pir-sdk-wasm` — clean.
  - [x] `cargo test -p pir-sdk-client --lib` — **176 passed** (incl. 6 new demux tests).
  - [x] `cargo test -p pir-sdk --lib` — **78 passed**.
  - [x] `cd web && npm test` — **138 passed** (incl. 3 new demux tests), 2 skipped (unrelated).
  - [x] Per-host clippy on the modified bins — zero new warnings introduced; pre-existing warnings unchanged.
  - [ ] Leakage integration tests — **not run locally** per project policy (strictly server-side with `--test-threads=1`, enforced by a PreToolUse hook). The change is byte-equivalent at the record layer, so they should pass once the server is redeployed.
  - [ ] Live verification against pir1 + pir2 once deployed — wire-frame count should drop from ~622 → ~32 (verify with the playground's wire explorer at `/explorer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)