### PR TITLE
E2E channel hardening: handshake binding, operator identity, VCEK verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "hex",
  "pir-attest-verify",
  "pir-core",
+ "pir-identity",
  "pir-runtime-core",
  "pir-sdk",
  "pir-sdk-client",
@@ -1691,6 +1692,17 @@ dependencies = [
 [[package]]
 name = "pir-core"
 version = "0.1.0"
+dependencies = [
+ "sha2",
+]
+
+[[package]]
+name = "pir-identity"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "sha2",
+]
 
 [[package]]
 name = "pir-runtime-core"
@@ -1706,6 +1718,7 @@ dependencies = [
  "memmap2",
  "pir-channel",
  "pir-core",
+ "pir-identity",
  "rand_core 0.6.4",
  "rayon",
  "serde",
@@ -1750,6 +1763,7 @@ dependencies = [
  "onionpir",
  "pir-channel",
  "pir-core",
+ "pir-identity",
  "pir-sdk",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -1793,6 +1807,7 @@ dependencies = [
  "getrandom 0.2.17",
  "js-sys",
  "pir-attest-verify",
+ "pir-channel",
  "pir-core",
  "pir-runtime-core",
  "pir-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "pir-core",
     "pir-channel",
+    "pir-identity",
     "pir-attest-verify",
     "pir-sdk",
     "pir-runtime-core",

--- a/bpir-admin/Cargo.toml
+++ b/bpir-admin/Cargo.toml
@@ -16,6 +16,9 @@ path = "src/main.rs"
 pir-core = { path = "../pir-core" }
 pir-sdk = { path = "../pir-sdk" }
 pir-sdk-client = { path = "../pir-sdk-client" }
+# Used by `generate-identity` + `sign-identity` subcommands to build
+# IdentityCert blobs the server consumes.
+pir-identity = { path = "../pir-identity" }
 # Slice D: parse the SNP report locally so `bpir-admin show-vcek-url`
 # can extract chip_id + TCB and print the AMD KDS curl commands.
 pir-attest-verify = { path = "../pir-attest-verify" }

--- a/bpir-admin/src/generate_identity.rs
+++ b/bpir-admin/src/generate_identity.rs
@@ -1,0 +1,187 @@
+//! `bpir-admin generate-identity` — generate an Ed25519 keypair for
+//! the BitcoinPIR operator-signed identity flow.
+//!
+//! Generates the same shape of Ed25519 key as `keygen` (the admin-auth
+//! keypair) but with messaging tuned for two distinct purposes:
+//!
+//! 1. **Server identity key** (Tier 2) — lives on the server's
+//!    filesystem and signs the per-boot ChannelManifest. Generated
+//!    on the server host with `--purpose server`.
+//! 2. **Operator key** (Tier 1) — lives ONLY on the operator's
+//!    workstation (never the server) and signs IdentityCerts.
+//!    Generated with `--purpose operator`.
+//!
+//! Output is interchangeable — the file format is identical (raw
+//! 32-byte seed). The `--purpose` flag only changes the help text
+//! and the "where does this go" hint printed to stderr, so it's harder
+//! for an operator to accidentally deploy an operator key onto a
+//! server.
+
+use clap::{Args, ValueEnum};
+use ed25519_dalek::SigningKey;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum IdentityPurpose {
+    /// Server-side identity key. Signs per-boot ChannelManifests.
+    /// Lives on disk inside the SEV guest (pir2) or on the server's
+    /// filesystem (pir1). Pass to unified_server via
+    /// `--identity-key-path`.
+    Server,
+    /// Operator's long-term Ed25519 key. Signs IdentityCerts via
+    /// `bpir-admin sign-identity`. MUST NEVER touch a server host —
+    /// generate on the workstation; pubkey gets published out-of-band
+    /// (e.g. Nostr) so clients can pin it.
+    Operator,
+}
+
+#[derive(Args, Debug)]
+pub struct GenerateIdentityArgs {
+    /// Write the secret key to this path. Defaults vary by purpose
+    /// (see `--purpose`).
+    #[arg(long)]
+    pub out: Option<PathBuf>,
+    /// Overwrite an existing key file. Without this, refuses to
+    /// clobber an existing key.
+    #[arg(long)]
+    pub force: bool,
+    /// What this key is for. Affects help messaging only; the file
+    /// format is purpose-independent.
+    #[arg(long, value_enum, default_value_t = IdentityPurpose::Server)]
+    pub purpose: IdentityPurpose,
+}
+
+pub fn run(args: GenerateIdentityArgs) -> Result<(), String> {
+    let out = args
+        .out
+        .unwrap_or_else(|| default_path_for(args.purpose));
+
+    if out.exists() && !args.force {
+        return Err(format!(
+            "{} already exists; rerun with --force to overwrite (you'll lose the existing privkey)",
+            out.display()
+        ));
+    }
+
+    if let Some(parent) = out.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("create dir {}: {}", parent.display(), e))?;
+    }
+
+    let mut seed = [0u8; 32];
+    getrandom::getrandom(&mut seed).map_err(|e| format!("getrandom: {}", e))?;
+    let sk = SigningKey::from_bytes(&seed);
+    let pk = sk.verifying_key();
+    let pk_hex = hex::encode(pk.to_bytes());
+
+    crate::keygen::write_secret_key_unix(&out, &seed)?;
+
+    eprintln!("wrote secret key (32 bytes, mode 0600) to {}", out.display());
+    eprintln!();
+    match args.purpose {
+        IdentityPurpose::Server => {
+            eprintln!("Server identity pubkey (give this hex to the operator so they");
+            eprintln!("can sign an IdentityCert with `bpir-admin sign-identity`):");
+            println!("{}", pk_hex);
+            eprintln!();
+            eprintln!(
+                "Then deploy: place the key file at the path you'll pass to unified_server's"
+            );
+            eprintln!(
+                "  --identity-key-path, and the operator-signed cert at --identity-cert-path."
+            );
+        }
+        IdentityPurpose::Operator => {
+            eprintln!("Operator pubkey — KEEP THE SECRET KEY OFFLINE. Publish this hex");
+            eprintln!("via the agreed out-of-band channel (e.g. Nostr) so clients can pin it:");
+            println!("{}", pk_hex);
+            eprintln!();
+            eprintln!("To sign a server's identity_pubkey:");
+            eprintln!(
+                "  bpir-admin sign-identity --operator-key-path {} \\",
+                out.display()
+            );
+            eprintln!("    --server-id <e.g. pir1> --identity-pubkey-hex <hex from server>  \\");
+            eprintln!("    --valid-until <unix-seconds> --out <cert path>");
+        }
+    }
+    Ok(())
+}
+
+fn default_path_for(purpose: IdentityPurpose) -> PathBuf {
+    let base = if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        PathBuf::from(xdg).join("bpir-admin")
+    } else if let Ok(home) = std::env::var("HOME") {
+        PathBuf::from(home).join(".config/bpir-admin")
+    } else {
+        PathBuf::from(".")
+    };
+    match purpose {
+        IdentityPurpose::Server => base.join("server-identity.key"),
+        IdentityPurpose::Operator => base.join("operator.key"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn generate_identity_writes_32_byte_seed() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("id.key");
+        run(GenerateIdentityArgs {
+            out: Some(path.clone()),
+            force: false,
+            purpose: IdentityPurpose::Server,
+        })
+        .unwrap();
+        let bytes = fs::read(&path).unwrap();
+        assert_eq!(bytes.len(), 32);
+        // And the pubkey loads cleanly.
+        let sk = SigningKey::from_bytes(&bytes.try_into().unwrap());
+        assert_eq!(sk.verifying_key().to_bytes().len(), 32);
+    }
+
+    #[test]
+    fn generate_identity_refuses_overwrite_without_force() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("id.key");
+        run(GenerateIdentityArgs {
+            out: Some(path.clone()),
+            force: false,
+            purpose: IdentityPurpose::Server,
+        })
+        .unwrap();
+        let err = run(GenerateIdentityArgs {
+            out: Some(path.clone()),
+            force: false,
+            purpose: IdentityPurpose::Server,
+        })
+        .unwrap_err();
+        assert!(err.contains("already exists"));
+    }
+
+    #[test]
+    fn generate_identity_with_force_replaces() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("id.key");
+        run(GenerateIdentityArgs {
+            out: Some(path.clone()),
+            force: false,
+            purpose: IdentityPurpose::Operator,
+        })
+        .unwrap();
+        let bytes1 = fs::read(&path).unwrap();
+        run(GenerateIdentityArgs {
+            out: Some(path.clone()),
+            force: true,
+            purpose: IdentityPurpose::Operator,
+        })
+        .unwrap();
+        let bytes2 = fs::read(&path).unwrap();
+        assert_ne!(bytes1, bytes2);
+    }
+}

--- a/bpir-admin/src/keygen.rs
+++ b/bpir-admin/src/keygen.rs
@@ -54,6 +54,22 @@ pub fn run(args: KeygenArgs) -> Result<(), String> {
 }
 
 #[cfg(unix)]
+pub(crate) fn write_secret_key_unix(
+    path: &std::path::Path,
+    seed: &[u8; 32],
+) -> Result<(), String> {
+    write_secret_key(path, seed)
+}
+
+#[cfg(not(unix))]
+pub(crate) fn write_secret_key_unix(
+    path: &std::path::Path,
+    seed: &[u8; 32],
+) -> Result<(), String> {
+    write_secret_key(path, seed)
+}
+
+#[cfg(unix)]
 fn write_secret_key(path: &std::path::Path, seed: &[u8; 32]) -> Result<(), String> {
     use std::os::unix::fs::OpenOptionsExt;
     let mut f = fs::OpenOptions::new()

--- a/bpir-admin/src/main.rs
+++ b/bpir-admin/src/main.rs
@@ -22,8 +22,10 @@ use clap::{Parser, Subcommand};
 
 mod attest;
 mod channel_test;
+mod generate_identity;
 mod keygen;
 mod show_vcek_url;
+mod sign_identity;
 mod upload;
 
 #[derive(Parser, Debug)]
@@ -37,6 +39,16 @@ struct Cli {
 enum Command {
     /// Generate an ed25519 admin keypair.
     Keygen(keygen::KeygenArgs),
+    /// Generate an Ed25519 identity keypair (server identity OR
+    /// operator long-term key — see `--purpose`). For the
+    /// operator-signed announcement bundle flow.
+    #[command(name = "generate-identity")]
+    GenerateIdentity(generate_identity::GenerateIdentityArgs),
+    /// Operator signs an IdentityCert for a server, OFFLINE on the
+    /// operator's workstation. Output is deployed to the server at
+    /// the path passed to unified_server via `--identity-cert-path`.
+    #[command(name = "sign-identity")]
+    SignIdentity(sign_identity::SignIdentityArgs),
     /// Send REQ_ATTEST to a server and verify the response.
     Attest(attest::AttestArgs),
     /// End-to-end smoke test of the encrypted channel: attest → handshake
@@ -60,6 +72,20 @@ async fn main() {
             Ok(()) => 0,
             Err(e) => {
                 eprintln!("keygen: {}", e);
+                1
+            }
+        },
+        Command::GenerateIdentity(args) => match generate_identity::run(args) {
+            Ok(()) => 0,
+            Err(e) => {
+                eprintln!("generate-identity: {}", e);
+                1
+            }
+        },
+        Command::SignIdentity(args) => match sign_identity::run(args) {
+            Ok(()) => 0,
+            Err(e) => {
+                eprintln!("sign-identity: {}", e);
                 1
             }
         },

--- a/bpir-admin/src/sign_identity.rs
+++ b/bpir-admin/src/sign_identity.rs
@@ -1,0 +1,273 @@
+//! `bpir-admin sign-identity` — operator signs an IdentityCert.
+//!
+//! Runs OFFLINE on the operator's workstation. Reads the operator's
+//! long-term Ed25519 secret key from disk, takes the server's
+//! identity_pubkey (hex) + server_id + validity window as inputs, and
+//! produces a canonically-encoded [`pir_identity::IdentityCert`] blob.
+//!
+//! The blob is then deployed to the server (path passed to
+//! unified_server via `--identity-cert-path`) alongside the matching
+//! server-identity key file (`--identity-key-path`).
+//!
+//! Verifying the signature after generation is mandatory — catches
+//! the case where the operator typo'd the hex pubkey, since the cert
+//! signing wouldn't catch that (it just bakes whatever bytes you gave
+//! it into the preimage).
+//!
+//! [HUMAN-decided 2026-05-21] No default validity window: the operator
+//! MUST pass `--valid-until` explicitly. Pass `0` for an indefinite
+//! upper bound if you actually want that.
+
+use clap::Args;
+use ed25519_dalek::SigningKey;
+use pir_identity::{sign_identity_cert, IdentityCert, ED25519_PUBKEY_LEN};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Args, Debug)]
+pub struct SignIdentityArgs {
+    /// Path to the operator's Ed25519 secret key (raw 32-byte seed,
+    /// from `bpir-admin generate-identity --purpose operator`).
+    #[arg(long)]
+    pub operator_key_path: PathBuf,
+
+    /// Server identifier this cert is endorsed for, e.g. "pir1" or
+    /// "pir2". MUST match the value the server will start with via
+    /// `--identity-server-id`.
+    #[arg(long)]
+    pub server_id: String,
+
+    /// Hex-encoded (64 chars / 32 bytes) Ed25519 public key of the
+    /// server's identity keypair (from `bpir-admin generate-identity
+    /// --purpose server`'s stdout).
+    #[arg(long)]
+    pub identity_pubkey_hex: String,
+
+    /// Earliest unix-seconds timestamp at which the cert is valid.
+    /// Default 0 (no lower bound).
+    #[arg(long, default_value_t = 0)]
+    pub valid_from: i64,
+
+    /// Latest unix-seconds timestamp at which the cert is valid.
+    /// REQUIRED — the operator MUST think about cert expiry. Pass
+    /// 0 for "no upper bound" (indefinite), but that's a deliberate
+    /// choice, not a default.
+    #[arg(long)]
+    pub valid_until: i64,
+
+    /// Write the encoded cert to this path. Default:
+    /// `./<server_id>.cert`.
+    #[arg(long)]
+    pub out: Option<PathBuf>,
+
+    /// Overwrite an existing cert file.
+    #[arg(long)]
+    pub force: bool,
+}
+
+pub fn run(args: SignIdentityArgs) -> Result<(), String> {
+    if args.valid_from < 0 {
+        return Err("--valid-from must be non-negative".into());
+    }
+    if args.valid_until < 0 {
+        return Err("--valid-until must be non-negative".into());
+    }
+    if args.valid_until != 0 && args.valid_until <= args.valid_from {
+        return Err(format!(
+            "--valid-until ({}) must be 0 (indefinite) or strictly greater than --valid-from ({})",
+            args.valid_until, args.valid_from
+        ));
+    }
+
+    let operator_sk = crate::keygen::read_secret_key(&args.operator_key_path)?;
+
+    let identity_pubkey = parse_pubkey_hex(&args.identity_pubkey_hex)?;
+    // Reject the all-zero key — that's the sentinel for "no channel
+    // key yet" elsewhere in the protocol, never a legitimate pubkey.
+    if identity_pubkey.iter().all(|b| *b == 0) {
+        return Err("identity_pubkey is all-zero — refusing to sign".into());
+    }
+
+    let cert = sign_identity_cert(
+        &operator_sk,
+        &args.server_id,
+        identity_pubkey,
+        args.valid_from,
+        args.valid_until,
+    );
+
+    // Sanity-verify what we just signed. Catches a typo'd
+    // `--identity-pubkey-hex` if it accidentally bakes the wrong
+    // operator pubkey into the preimage — Ed25519 signing wouldn't
+    // catch it (any bytes can be a "preimage"), but this round-trip
+    // through `verify()` exercises the same path the server / clients
+    // will run.
+    cert.verify()
+        .map_err(|e| format!("internal: signed cert fails to verify: {}", e))?;
+
+    let encoded = cert.encode();
+    // And decode roundtrips — catches future encode/decode drift.
+    let decoded = IdentityCert::decode(&encoded)
+        .map_err(|e| format!("internal: signed cert fails to decode: {}", e))?;
+    if decoded != cert {
+        return Err("internal: cert decode roundtrip diverged".into());
+    }
+
+    let out = args
+        .out
+        .unwrap_or_else(|| PathBuf::from(format!("{}.cert", args.server_id)));
+    if out.exists() && !args.force {
+        return Err(format!(
+            "{} already exists; rerun with --force to overwrite",
+            out.display()
+        ));
+    }
+    if let Some(parent) = out.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("create dir {}: {}", parent.display(), e))?;
+        }
+    }
+    fs::write(&out, &encoded).map_err(|e| format!("write {}: {}", out.display(), e))?;
+
+    let op_pk = operator_sk.verifying_key().to_bytes();
+    eprintln!("wrote IdentityCert ({} bytes) to {}", encoded.len(), out.display());
+    eprintln!("  server_id:        {}", args.server_id);
+    eprintln!("  identity_pubkey:  {}", hex::encode(identity_pubkey));
+    eprintln!("  operator_pubkey:  {}", hex::encode(op_pk));
+    eprintln!("  valid_from:       {}", args.valid_from);
+    eprintln!(
+        "  valid_until:      {}{}",
+        args.valid_until,
+        if args.valid_until == 0 {
+            " (indefinite)"
+        } else {
+            ""
+        }
+    );
+    Ok(())
+}
+
+fn parse_pubkey_hex(hex: &str) -> Result<[u8; ED25519_PUBKEY_LEN], String> {
+    let trimmed = hex.trim();
+    if trimmed.len() != ED25519_PUBKEY_LEN * 2 {
+        return Err(format!(
+            "identity-pubkey-hex must be {} hex chars ({} bytes), got {}",
+            ED25519_PUBKEY_LEN * 2,
+            ED25519_PUBKEY_LEN,
+            trimmed.len()
+        ));
+    }
+    let mut out = [0u8; ED25519_PUBKEY_LEN];
+    ::hex::decode_to_slice(trimmed, &mut out)
+        .map_err(|e| format!("identity-pubkey-hex not valid hex: {}", e))?;
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keygen;
+    use ed25519_dalek::SigningKey;
+    use tempfile::tempdir;
+
+    fn write_op_key(dir: &std::path::Path) -> (PathBuf, SigningKey) {
+        let path = dir.join("op.key");
+        keygen::run(keygen::KeygenArgs {
+            out: Some(path.clone()),
+            force: false,
+        })
+        .unwrap();
+        let sk = keygen::read_secret_key(&path).unwrap();
+        (path, sk)
+    }
+
+    fn id_pubkey_hex(seed: u8) -> ([u8; 32], String) {
+        let sk = SigningKey::from_bytes(&[seed; 32]);
+        let pk = sk.verifying_key().to_bytes();
+        (pk, hex::encode(pk))
+    }
+
+    #[test]
+    fn sign_identity_produces_verifiable_cert() {
+        let dir = tempdir().unwrap();
+        let (op_key_path, op_sk) = write_op_key(dir.path());
+        let (_id_pk, id_pk_hex) = id_pubkey_hex(0x42);
+        let cert_path = dir.path().join("pir1.cert");
+
+        run(SignIdentityArgs {
+            operator_key_path: op_key_path,
+            server_id: "pir1".into(),
+            identity_pubkey_hex: id_pk_hex,
+            valid_from: 0,
+            valid_until: 1_900_000_000,
+            out: Some(cert_path.clone()),
+            force: false,
+        })
+        .unwrap();
+
+        let bytes = fs::read(&cert_path).unwrap();
+        let cert = IdentityCert::decode(&bytes).unwrap();
+        cert.verify().unwrap();
+        assert_eq!(
+            cert.operator_pubkey,
+            op_sk.verifying_key().to_bytes()
+        );
+        assert_eq!(cert.server_id, "pir1");
+        assert_eq!(cert.valid_until, 1_900_000_000);
+    }
+
+    #[test]
+    fn sign_identity_rejects_short_hex() {
+        let dir = tempdir().unwrap();
+        let (op_key_path, _) = write_op_key(dir.path());
+        let err = run(SignIdentityArgs {
+            operator_key_path: op_key_path,
+            server_id: "pir1".into(),
+            identity_pubkey_hex: "abc123".into(),
+            valid_from: 0,
+            valid_until: 100,
+            out: Some(dir.path().join("c")),
+            force: false,
+        })
+        .unwrap_err();
+        assert!(err.contains("must be 64 hex chars"));
+    }
+
+    #[test]
+    fn sign_identity_rejects_all_zero_pubkey() {
+        let dir = tempdir().unwrap();
+        let (op_key_path, _) = write_op_key(dir.path());
+        let zero_hex = "0".repeat(64);
+        let err = run(SignIdentityArgs {
+            operator_key_path: op_key_path,
+            server_id: "pir1".into(),
+            identity_pubkey_hex: zero_hex,
+            valid_from: 0,
+            valid_until: 100,
+            out: Some(dir.path().join("c")),
+            force: false,
+        })
+        .unwrap_err();
+        assert!(err.contains("all-zero"));
+    }
+
+    #[test]
+    fn sign_identity_rejects_invalid_validity_window() {
+        let dir = tempdir().unwrap();
+        let (op_key_path, _) = write_op_key(dir.path());
+        let (_, id_hex) = id_pubkey_hex(0x42);
+        // valid_until < valid_from (and != 0)
+        let err = run(SignIdentityArgs {
+            operator_key_path: op_key_path,
+            server_id: "pir1".into(),
+            identity_pubkey_hex: id_hex,
+            valid_from: 200,
+            valid_until: 100,
+            out: Some(dir.path().join("c")),
+            force: false,
+        })
+        .unwrap_err();
+        assert!(err.contains("must be 0 (indefinite)"));
+    }
+}

--- a/pir-attest-verify/src/lib.rs
+++ b/pir-attest-verify/src/lib.rs
@@ -51,6 +51,35 @@ use sev::firmware::guest::AttestationReport;
 use sev::parser::ByteParser;
 
 pub use sev::firmware::guest::AttestationReport as SnpReport;
+pub use sev::firmware::host::TcbVersion;
+
+/// Operator-pinned SHA-256 fingerprint of the AMD **Turin**-family ARK
+/// (Root Key) certificate, DER-encoded.
+///
+/// Source: AMD's published cert chain at
+/// `https://kdsintf.amd.com/vcek/v1/Turin/cert_chain` (the ARK is the
+/// second PEM block). Same fingerprint applies to every Turin-family
+/// chip — there's one ARK per CPU generation, not per chip.
+///
+/// This is the *trust anchor* for the SEV-SNP chain. Verifiers pass
+/// `Some(TURIN_ARK_FINGERPRINT_SHA256)` to [`verify_chain`] so the
+/// supplied ARK PEM is checked against this value before any RSA
+/// signature work — defends against a malicious server bundling a
+/// self-signed forgery and claiming it's AMD's root.
+///
+/// Mirrored in `web/src/attest-pin.ts` as
+/// `AMD_TURIN_ARK_FINGERPRINT_HEX` — keep both in sync. To rotate
+/// (~25-year cadence; ARK rolls are very rare):
+/// 1. Re-fetch `cert_chain.pem` from AMD KDS.
+/// 2. `csplit -z -f cert_ -b "%d.pem" cert_chain.pem '/-----BEGIN CERT/' '{*}'`
+/// 3. `openssl x509 -in cert_1.pem -outform DER | sha256sum`
+/// 4. Replace both constants + rebuild.
+pub const TURIN_ARK_FINGERPRINT_SHA256: [u8; 32] = [
+    0x1f, 0x08, 0x41, 0x61, 0xa4, 0x4b, 0xb6, 0xd9, 0x37, 0x78, 0xa9, 0x04, 0x87, 0x7d, 0x48, 0x19,
+    0xca, 0xfa, 0x5d, 0x05, 0xef, 0x41, 0x93, 0xb2, 0xde, 0xd9, 0xdd, 0x9c, 0x73, 0xdd, 0x3f, 0x6a,
+];
+
+pub mod policy;
 
 /// Bytes-level offset of the report's MEASUREMENT field.
 ///
@@ -209,6 +238,72 @@ pub fn verify_chain(
         .map_err(|e| VerifyError::ChainBroken(format!("{e}")))?;
     Ok(())
 }
+
+/// One-shot full SEV-SNP attestation verification: chain + report
+/// signature + policy.
+///
+/// This is the recommended entry point for production callers. It runs
+/// the three independent checks in order, short-circuiting on first
+/// failure, and returns the parsed [`SnpReport`] only if everything
+/// passed:
+///
+/// 1. **Chain** ([`verify_chain`]): server-supplied `ark_pem` matches
+///    the operator-pinned fingerprint, ARK self-signed, ARK→ASK,
+///    ASK→VCEK (RSA-PSS-SHA384). Pass
+///    `Some(TURIN_ARK_FINGERPRINT_SHA256)` for the Turin pin.
+/// 2. **Report signature** ([`verify_report_against_vcek`]): the SNP
+///    report's ECDSA-P384-SHA384 signature verifies against the VCEK
+///    pubkey — i.e. the report was minted by the chip whose VCEK was
+///    supplied.
+/// 3. **Policy** ([`policy::verify_policy`]): VMPL, debug, migrate,
+///    TCB monotonicity + minimum, and the optional measurement /
+///    family / image / chip_id pins all hold.
+///
+/// On success, the returned [`SnpReport`] carries every field the
+/// caller might want to inspect (REPORT_DATA, MEASUREMENT, chip_id,
+/// etc.) — and they're all anchored in silicon at this point.
+pub fn verify_full(
+    report_bytes: &[u8],
+    ark_pem: &[u8],
+    ask_pem: &[u8],
+    vcek_pem: &[u8],
+    expected_ark_fingerprint: Option<[u8; 32]>,
+    requirements: &policy::PolicyRequirements,
+) -> Result<SnpReport, FullVerifyError> {
+    verify_chain(ark_pem, ask_pem, vcek_pem, expected_ark_fingerprint)
+        .map_err(FullVerifyError::Chain)?;
+    let report = verify_report_against_vcek(report_bytes, vcek_pem)
+        .map_err(FullVerifyError::ReportSignature)?;
+    policy::verify_policy(&report, requirements).map_err(FullVerifyError::Policy)?;
+    Ok(report)
+}
+
+/// Composite error from [`verify_full`]. Each variant wraps the
+/// step-specific error type so callers can drill in if they need to.
+#[derive(Debug)]
+pub enum FullVerifyError {
+    /// ARK / ASK / VCEK chain validation failed (pre-signature check
+    /// on the report itself).
+    Chain(VerifyError),
+    /// VCEK chain was sound but the report's signature didn't verify
+    /// against the VCEK pubkey.
+    ReportSignature(VerifyError),
+    /// Chain and signature were sound but a policy assertion (VMPL,
+    /// debug bit, TCB, measurement, etc.) failed.
+    Policy(policy::PolicyError),
+}
+
+impl core::fmt::Display for FullVerifyError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Chain(e) => write!(f, "chain: {}", e),
+            Self::ReportSignature(e) => write!(f, "report-sig: {}", e),
+            Self::Policy(e) => write!(f, "policy: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for FullVerifyError {}
 
 /// Compute SHA-256 of the ARK's PEM bytes (after stripping the
 /// PEM armor — i.e. the SHA-256 of the DER-encoded certificate).
@@ -398,5 +493,70 @@ mod tests {
         assert!(s.contains("ARK fingerprint mismatch"));
         assert!(s.contains(&"aa".repeat(32)));
         assert!(s.contains(&"bb".repeat(32)));
+    }
+
+    #[test]
+    fn turin_ark_fingerprint_is_32_bytes_and_nonzero() {
+        // Sanity: caught a copy-paste mistake earlier where I had 31
+        // bytes. Belt-and-suspenders.
+        assert_eq!(TURIN_ARK_FINGERPRINT_SHA256.len(), 32);
+        assert!(TURIN_ARK_FINGERPRINT_SHA256.iter().any(|&b| b != 0));
+        // First byte matches the published value 0x1f (sanity-check
+        // against a single-character typo).
+        assert_eq!(TURIN_ARK_FINGERPRINT_SHA256[0], 0x1f);
+        // Last byte 0x6a.
+        assert_eq!(TURIN_ARK_FINGERPRINT_SHA256[31], 0x6a);
+    }
+
+    #[test]
+    fn verify_full_short_circuits_on_chain_failure() {
+        // Garbage PEM bytes → chain check fails before report-sig or
+        // policy is even attempted.
+        let req = policy::PolicyRequirements::default();
+        let err = verify_full(
+            &[0u8; SNP_REPORT_LEN],
+            b"garbage",
+            b"garbage",
+            b"garbage",
+            None,
+            &req,
+        )
+        .unwrap_err();
+        assert!(matches!(err, FullVerifyError::Chain(_)), "{:?}", err);
+    }
+
+    #[test]
+    fn verify_full_short_circuits_on_pinned_ark_mismatch() {
+        // Even with garbage PEM, the fingerprint check fires first
+        // (per `verify_chain`'s contract). FullVerifyError wraps that
+        // as Chain.
+        let req = policy::PolicyRequirements::default();
+        let err = verify_full(
+            &[0u8; SNP_REPORT_LEN],
+            b"garbage",
+            b"garbage",
+            b"garbage",
+            Some([0xFFu8; 32]),
+            &req,
+        )
+        .unwrap_err();
+        match err {
+            FullVerifyError::Chain(VerifyError::ArkFingerprintMismatch { .. }) => {}
+            other => panic!("expected Chain(ArkFingerprintMismatch), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn full_verify_error_display_includes_step() {
+        // Display should say which step failed — operators reading
+        // logs want to know whether to fix their pin, their VCEK
+        // bundle, or their policy config.
+        let e = FullVerifyError::Chain(VerifyError::ChainBroken("oops".into()));
+        let s = e.to_string();
+        assert!(s.starts_with("chain:"), "got: {}", s);
+
+        let e = FullVerifyError::Policy(policy::PolicyError::DebugNotAllowed);
+        let s = e.to_string();
+        assert!(s.starts_with("policy:"), "got: {}", s);
     }
 }

--- a/pir-attest-verify/src/policy.rs
+++ b/pir-attest-verify/src/policy.rs
@@ -1,0 +1,501 @@
+// Variants in `PolicyError` and pinned-field structs in
+// `PolicyRequirements` are self-documenting from context (their
+// Display impls + the surrounding docstrings), and adding /// to
+// every `actual`/`expected` field pair clutters the source without
+// adding information. Allow missing-docs on this module's struct
+// fields and enum payloads — the module-level docstring covers it.
+#![allow(missing_docs)]
+
+//! Policy checks on a parsed [`SnpReport`].
+//!
+//! Cryptographic verification ([`crate::verify_chain`] +
+//! [`crate::verify_report_against_vcek`]) only proves the report was
+//! signed by an AMD SEV-SNP chip whose VCEK chains back to AMD's ARK.
+//! It does NOT prove the report's *contents* are acceptable — a fully
+//! valid signature is no use if the guest was launched with debug
+//! mode enabled, or VMPL ≠ 0, or running an old TCB the operator
+//! considers vulnerable.
+//!
+//! This module bundles the runtime-configurable policy that production
+//! verifiers should apply ON TOP of the signature check. The default
+//! [`PolicyRequirements`] is what BitcoinPIR's `unified_server`
+//! expects: VMPL 0, no debug, no MA migration, TCB-monotonic (no
+//! claimed-newer-than-committed downgrade attack).
+//!
+//! ## What this module does NOT check
+//!
+//! - **`chip_id` vs the VCEK's HWID extension.** Modern VCEKs have a
+//!   1.3.6.1.4.1.3704.1.4 OID extension binding the cert to a
+//!   specific chip's hardware ID; the report's `chip_id` field
+//!   should match. The `sev` crate doesn't currently expose the
+//!   parsed VCEK extension fields, and writing an X.509-extension
+//!   walker for the wasm32 target is out of scope here. If the
+//!   server-supplied VCEK is the wrong one for this chip, the
+//!   report-signature check still catches it (the VCEK pubkey
+//!   wouldn't verify the chip-emitted signature). The HWID check is
+//!   strictly defense-in-depth.
+//! - **Replay across boots.** A report's `report_data` covers a
+//!   one-shot client nonce in BitcoinPIR's V2 layout, so a captured
+//!   report can't be re-used against a different client. This
+//!   module doesn't enforce that — it's a `pir-sdk-client::attest`
+//!   concern.
+
+use crate::SnpReport;
+use sev::firmware::host::TcbVersion;
+
+/// Caller-supplied policy: which contents are acceptable when the
+/// chain + signature already passed.
+///
+/// Default = strictest production stance: VMPL 0, debug forbidden, MA
+/// migration forbidden, TCB-monotonic. Override individual fields if
+/// you need a looser stance (e.g. tests that mint debug guests).
+#[derive(Clone, Debug)]
+pub struct PolicyRequirements {
+    /// Maximum allowed VMPL. Production wants `0` (highest
+    /// privilege; only the guest itself can sign reports at that
+    /// level). Tests may relax.
+    pub max_vmpl: u32,
+    /// Whether the guest's `policy.debug_allowed` bit may be set.
+    /// Production: `false` (a debug-mode guest can dump memory to
+    /// the host).
+    pub allow_debug: bool,
+    /// Whether the guest's `policy.migrate_ma_allowed` bit may be set.
+    /// Production: `false` (a migration agent can exfiltrate guest
+    /// state at migration time).
+    pub allow_migrate_ma: bool,
+    /// If `true`, require the guest's `policy.single_socket_required`
+    /// bit to be set. Defaults to `false` — VPSBG's deployments are
+    /// single-host without needing the assertion. Tighten if you
+    /// want explicit anti-cross-socket-side-channel coverage.
+    pub require_single_socket: bool,
+    /// Minimum TCB version the operator considers safe. `None`
+    /// disables the lower-bound check (only TCB monotonicity is
+    /// enforced — `reported_tcb` ≤ `committed_tcb`). Set to the
+    /// last-known-good TCB after a microcode/firmware update.
+    pub min_tcb: Option<TcbVersion>,
+    /// Pinned MEASUREMENT bytes. `None` skips. Set to the operator-
+    /// published value (e.g. from the production attest-pin file)
+    /// to lock the verifier to a specific UKI build.
+    pub expected_measurement: Option<[u8; 48]>,
+    /// Pinned family/image ID pair. `None` skips. Useful for
+    /// catching the case where the chain + sig validate but the
+    /// guest was launched with a different launch-data set than the
+    /// operator runs in production.
+    pub expected_family_id: Option<[u8; 16]>,
+    pub expected_image_id: Option<[u8; 16]>,
+}
+
+impl Default for PolicyRequirements {
+    fn default() -> Self {
+        Self {
+            max_vmpl: 0,
+            allow_debug: false,
+            allow_migrate_ma: false,
+            require_single_socket: false,
+            min_tcb: None,
+            expected_measurement: None,
+            expected_family_id: None,
+            expected_image_id: None,
+        }
+    }
+}
+
+/// Things the policy can reject. Distinct from
+/// [`crate::VerifyError`] because policy failures are *configurable*
+/// — a different verifier could legitimately accept what this one
+/// rejects (e.g. a CI rig that allows debug guests).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyError {
+    /// Report's VMPL exceeds the policy maximum.
+    VmplTooHigh { actual: u32, max: u32 },
+    /// `policy.debug_allowed` was set but the verifier disallows it.
+    DebugNotAllowed,
+    /// `policy.migrate_ma_allowed` was set but the verifier
+    /// disallows it.
+    MigrateMaNotAllowed,
+    /// Verifier required `policy.single_socket_required` but it was
+    /// clear in the report.
+    NotSingleSocket,
+    /// Reported TCB exceeds the chip's committed TCB — i.e. the
+    /// firmware is claiming a higher security version than the chip
+    /// has actually shipped. Should be impossible on real hardware;
+    /// fail loud.
+    ReportedTcbExceedsCommitted {
+        reported: TcbVersion,
+        committed: TcbVersion,
+    },
+    /// Reported TCB is below the operator-configured minimum.
+    /// Indicates the guest is running on chip firmware older than
+    /// the operator's "last-known-safe" threshold.
+    TcbBelowMinimum {
+        reported: TcbVersion,
+        min: TcbVersion,
+    },
+    /// MEASUREMENT field doesn't match the operator pin.
+    MeasurementMismatch {
+        actual: [u8; 48],
+        expected: [u8; 48],
+    },
+    /// `family_id` doesn't match the operator pin.
+    FamilyIdMismatch {
+        actual: [u8; 16],
+        expected: [u8; 16],
+    },
+    /// `image_id` doesn't match the operator pin.
+    ImageIdMismatch {
+        actual: [u8; 16],
+        expected: [u8; 16],
+    },
+}
+
+impl core::fmt::Display for PolicyError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::VmplTooHigh { actual, max } => {
+                write!(f, "VMPL {} exceeds max {}", actual, max)
+            }
+            Self::DebugNotAllowed => write!(f, "guest policy allows debug"),
+            Self::MigrateMaNotAllowed => {
+                write!(f, "guest policy allows MA migration")
+            }
+            Self::NotSingleSocket => {
+                write!(f, "guest policy lacks single_socket_required")
+            }
+            Self::ReportedTcbExceedsCommitted {
+                reported,
+                committed,
+            } => write!(
+                f,
+                "reported TCB {:?} > committed TCB {:?}",
+                reported, committed
+            ),
+            Self::TcbBelowMinimum { reported, min } => {
+                write!(f, "reported TCB {:?} < required min {:?}", reported, min)
+            }
+            Self::MeasurementMismatch { actual, expected } => write!(
+                f,
+                "MEASUREMENT mismatch: expected {}, got {}",
+                hex::encode(expected),
+                hex::encode(actual),
+            ),
+            Self::FamilyIdMismatch { actual, expected } => write!(
+                f,
+                "family_id mismatch: expected {}, got {}",
+                hex::encode(expected),
+                hex::encode(actual),
+            ),
+            Self::ImageIdMismatch { actual, expected } => write!(
+                f,
+                "image_id mismatch: expected {}, got {}",
+                hex::encode(expected),
+                hex::encode(actual),
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PolicyError {}
+
+/// Apply the policy to a parsed [`SnpReport`]. Returns `Ok(())` if
+/// every check passes; otherwise the first failure (checks are
+/// short-circuiting in a stable order — see the source).
+///
+/// **Order matters for readability of failure messages**: VMPL → policy
+/// bits → TCB monotonicity → TCB minimum → measurement → family/image.
+/// Callers should NOT depend on a specific order of multiple
+/// concurrent violations, but the order is stable for a given build.
+pub fn verify_policy(report: &SnpReport, req: &PolicyRequirements) -> Result<(), PolicyError> {
+    if report.vmpl > req.max_vmpl {
+        return Err(PolicyError::VmplTooHigh {
+            actual: report.vmpl,
+            max: req.max_vmpl,
+        });
+    }
+    if !req.allow_debug && report.policy.debug_allowed() {
+        return Err(PolicyError::DebugNotAllowed);
+    }
+    if !req.allow_migrate_ma && report.policy.migrate_ma_allowed() {
+        return Err(PolicyError::MigrateMaNotAllowed);
+    }
+    if req.require_single_socket && !report.policy.single_socket_required() {
+        return Err(PolicyError::NotSingleSocket);
+    }
+    // TCB monotonicity: the firmware claiming a higher reported_tcb
+    // than what's been actually committed by the chip would be a
+    // bug-or-tamper signal.
+    if report.reported_tcb > report.committed_tcb {
+        return Err(PolicyError::ReportedTcbExceedsCommitted {
+            reported: report.reported_tcb,
+            committed: report.committed_tcb,
+        });
+    }
+    if let Some(min) = req.min_tcb {
+        if report.reported_tcb < min {
+            return Err(PolicyError::TcbBelowMinimum {
+                reported: report.reported_tcb,
+                min,
+            });
+        }
+    }
+    if let Some(exp) = req.expected_measurement {
+        if report.measurement != exp {
+            return Err(PolicyError::MeasurementMismatch {
+                actual: report.measurement,
+                expected: exp,
+            });
+        }
+    }
+    if let Some(exp) = req.expected_family_id {
+        if report.family_id != exp {
+            return Err(PolicyError::FamilyIdMismatch {
+                actual: report.family_id,
+                expected: exp,
+            });
+        }
+    }
+    if let Some(exp) = req.expected_image_id {
+        if report.image_id != exp {
+            return Err(PolicyError::ImageIdMismatch {
+                actual: report.image_id,
+                expected: exp,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_report() -> SnpReport {
+        // The sev crate's Default impl gives us a report with all
+        // fields zeroed. That happens to satisfy the strict default
+        // policy (vmpl 0, all flag bits cleared) — so we use it as a
+        // baseline and tamper specific fields per test.
+        SnpReport::default()
+    }
+
+    #[test]
+    fn default_policy_accepts_default_report() {
+        // A zero-filled report has VMPL 0, no debug, no migrate, etc.
+        // The strict default policy accepts it.
+        verify_policy(&base_report(), &PolicyRequirements::default()).unwrap();
+    }
+
+    #[test]
+    fn vmpl_too_high_rejected() {
+        let mut r = base_report();
+        r.vmpl = 1;
+        let err = verify_policy(&r, &PolicyRequirements::default()).unwrap_err();
+        assert!(
+            matches!(err, PolicyError::VmplTooHigh { actual: 1, max: 0 }),
+            "{:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn vmpl_within_allowance_accepted() {
+        let mut r = base_report();
+        r.vmpl = 2;
+        let req = PolicyRequirements {
+            max_vmpl: 3,
+            ..PolicyRequirements::default()
+        };
+        verify_policy(&r, &req).unwrap();
+    }
+
+    #[test]
+    fn debug_bit_rejected_by_default() {
+        let mut r = base_report();
+        r.policy.set_debug_allowed(true);
+        let err = verify_policy(&r, &PolicyRequirements::default()).unwrap_err();
+        assert!(matches!(err, PolicyError::DebugNotAllowed), "{:?}", err);
+    }
+
+    #[test]
+    fn debug_bit_accepted_when_policy_relaxed() {
+        let mut r = base_report();
+        r.policy.set_debug_allowed(true);
+        let req = PolicyRequirements {
+            allow_debug: true,
+            ..PolicyRequirements::default()
+        };
+        verify_policy(&r, &req).unwrap();
+    }
+
+    #[test]
+    fn migrate_ma_bit_rejected_by_default() {
+        let mut r = base_report();
+        r.policy.set_migrate_ma_allowed(true);
+        let err = verify_policy(&r, &PolicyRequirements::default()).unwrap_err();
+        assert!(matches!(err, PolicyError::MigrateMaNotAllowed), "{:?}", err);
+    }
+
+    #[test]
+    fn single_socket_required_when_policy_demands() {
+        // Default report has single_socket clear → require=true rejects.
+        let req = PolicyRequirements {
+            require_single_socket: true,
+            ..PolicyRequirements::default()
+        };
+        let err = verify_policy(&base_report(), &req).unwrap_err();
+        assert!(matches!(err, PolicyError::NotSingleSocket), "{:?}", err);
+    }
+
+    #[test]
+    fn reported_tcb_above_committed_is_rejected() {
+        let mut r = base_report();
+        r.reported_tcb = TcbVersion {
+            fmc: None,
+            bootloader: 5,
+            tee: 0,
+            snp: 0,
+            microcode: 0,
+        };
+        r.committed_tcb = TcbVersion {
+            fmc: None,
+            bootloader: 3,
+            tee: 0,
+            snp: 0,
+            microcode: 0,
+        };
+        let err = verify_policy(&r, &PolicyRequirements::default()).unwrap_err();
+        assert!(
+            matches!(err, PolicyError::ReportedTcbExceedsCommitted { .. }),
+            "{:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn tcb_below_minimum_is_rejected() {
+        let mut r = base_report();
+        r.reported_tcb = TcbVersion {
+            fmc: None,
+            bootloader: 1,
+            tee: 0,
+            snp: 0,
+            microcode: 0,
+        };
+        r.committed_tcb = r.reported_tcb;
+        let req = PolicyRequirements {
+            min_tcb: Some(TcbVersion {
+                fmc: None,
+                bootloader: 5,
+                tee: 0,
+                snp: 0,
+                microcode: 0,
+            }),
+            ..PolicyRequirements::default()
+        };
+        let err = verify_policy(&r, &req).unwrap_err();
+        assert!(matches!(err, PolicyError::TcbBelowMinimum { .. }), "{:?}", err);
+    }
+
+    #[test]
+    fn tcb_at_minimum_is_accepted() {
+        let mut r = base_report();
+        r.reported_tcb = TcbVersion {
+            fmc: None,
+            bootloader: 5,
+            tee: 0,
+            snp: 0,
+            microcode: 0,
+        };
+        r.committed_tcb = r.reported_tcb;
+        let req = PolicyRequirements {
+            min_tcb: Some(r.reported_tcb),
+            ..PolicyRequirements::default()
+        };
+        verify_policy(&r, &req).unwrap();
+    }
+
+    #[test]
+    fn measurement_mismatch_rejected() {
+        let mut r = base_report();
+        r.measurement = [0xAAu8; 48];
+        let req = PolicyRequirements {
+            expected_measurement: Some([0xBBu8; 48]),
+            ..PolicyRequirements::default()
+        };
+        let err = verify_policy(&r, &req).unwrap_err();
+        assert!(
+            matches!(err, PolicyError::MeasurementMismatch { .. }),
+            "{:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn measurement_match_accepted() {
+        let mut r = base_report();
+        r.measurement = [0xCCu8; 48];
+        let req = PolicyRequirements {
+            expected_measurement: Some([0xCCu8; 48]),
+            ..PolicyRequirements::default()
+        };
+        verify_policy(&r, &req).unwrap();
+    }
+
+    #[test]
+    fn family_id_mismatch_rejected() {
+        let mut r = base_report();
+        r.family_id = [0x11u8; 16];
+        let req = PolicyRequirements {
+            expected_family_id: Some([0x22u8; 16]),
+            ..PolicyRequirements::default()
+        };
+        let err = verify_policy(&r, &req).unwrap_err();
+        assert!(matches!(err, PolicyError::FamilyIdMismatch { .. }), "{:?}", err);
+    }
+
+    #[test]
+    fn image_id_mismatch_rejected() {
+        let mut r = base_report();
+        r.image_id = [0x33u8; 16];
+        let req = PolicyRequirements {
+            expected_image_id: Some([0x44u8; 16]),
+            ..PolicyRequirements::default()
+        };
+        let err = verify_policy(&r, &req).unwrap_err();
+        assert!(matches!(err, PolicyError::ImageIdMismatch { .. }), "{:?}", err);
+    }
+
+    #[test]
+    fn policy_short_circuits_on_first_failure() {
+        // VMPL fails first → we don't get a TCB error even though
+        // TCB would also fail.
+        let mut r = base_report();
+        r.vmpl = 99;
+        r.reported_tcb = TcbVersion {
+            fmc: None,
+            bootloader: 200,
+            tee: 0,
+            snp: 0,
+            microcode: 0,
+        };
+        r.committed_tcb = TcbVersion {
+            fmc: None,
+            bootloader: 1,
+            tee: 0,
+            snp: 0,
+            microcode: 0,
+        };
+        let err = verify_policy(&r, &PolicyRequirements::default()).unwrap_err();
+        assert!(matches!(err, PolicyError::VmplTooHigh { .. }), "{:?}", err);
+    }
+
+    #[test]
+    fn display_includes_hex_for_pinned_fields() {
+        let e = PolicyError::MeasurementMismatch {
+            actual: [0xAA; 48],
+            expected: [0xBB; 48],
+        };
+        let s = e.to_string();
+        assert!(s.contains("MEASUREMENT mismatch"));
+        assert!(s.contains(&"aa".repeat(48)));
+        assert!(s.contains(&"bb".repeat(48)));
+    }
+}

--- a/pir-channel/src/lib.rs
+++ b/pir-channel/src/lib.rs
@@ -133,6 +133,23 @@ impl std::error::Error for ChannelError {}
 
 // ─── Handshake derivation ────────────────────────────────────────────
 
+/// Compute the X25519 public key corresponding to a 32-byte seed,
+/// without minting a [`ClientHandshake`]. Useful when the caller needs
+/// the pubkey ahead of time — e.g. to bind it into an attestation
+/// nonce via [`pir_core::attest::derive_attest_nonce`] BEFORE running
+/// REQ_ATTEST / REQ_HANDSHAKE.
+///
+/// The seed must remain stable between this call and the subsequent
+/// [`ClientHandshake::new`] call so the eph pubkey committed-to in
+/// REPORT_DATA matches the eph pubkey sent in REQ_HANDSHAKE. In
+/// practice: generate `eph_seed` once, derive `client_eph_pub` here,
+/// derive the attest nonce, run REQ_ATTEST, then pass the same
+/// `eph_seed` into [`ClientHandshake::new`].
+pub fn eph_pub_from_seed(seed: [u8; 32]) -> [u8; X25519_PUBKEY_LEN] {
+    let secret = StaticSecret::from(seed);
+    *PublicKey::from(&secret).as_bytes()
+}
+
 fn derive_from_dh(
     ecdh_static: &[u8; 32],
     ecdh_eph: &[u8; 32],
@@ -371,6 +388,24 @@ mod tests {
         let secret = StaticSecret::from(seed);
         let pub_bytes = *PublicKey::from(&secret).as_bytes();
         (secret, pub_bytes)
+    }
+
+    #[test]
+    fn eph_pub_from_seed_matches_client_handshake_pub() {
+        // The standalone helper and the ClientHandshake constructor
+        // must agree on the eph_pub for the same seed, so a caller
+        // can pre-compute the pubkey for nonce binding and trust that
+        // the subsequent handshake will send the same bytes.
+        let seed = random_seed();
+        let helper_pub = eph_pub_from_seed(seed);
+        let hs = ClientHandshake::new(seed, [0u8; 32]);
+        assert_eq!(helper_pub, hs.client_eph_pub());
+    }
+
+    #[test]
+    fn eph_pub_from_seed_is_deterministic() {
+        let seed = [0x42u8; 32];
+        assert_eq!(eph_pub_from_seed(seed), eph_pub_from_seed(seed));
     }
 
     #[test]

--- a/pir-core/src/attest.rs
+++ b/pir-core/src/attest.rs
@@ -61,6 +61,43 @@ pub const X25519_PUBKEY_LEN: usize = 32;
 /// preimage — see module docs for the migration story.
 pub const REPORT_DATA_DOMAIN_TAG: &[u8] = b"BPIR-ATTEST-V2";
 
+/// Domain-separation tag for the *attest nonce* derivation that binds
+/// the client's handshake ephemeral pubkey into the chip-signed
+/// REPORT_DATA. Distinct from [`REPORT_DATA_DOMAIN_TAG`] so a verifier
+/// cannot confuse a nonce preimage with a REPORT_DATA preimage.
+pub const ATTEST_NONCE_DOMAIN_TAG: &[u8] = b"BPIR-ATTEST-NONCE-V1";
+
+/// Derive the 32-byte attest nonce so the SEV-SNP report's REPORT_DATA
+/// commits to *this specific* client handshake ephemeral pubkey:
+///
+/// ```text
+/// attest_nonce = sha256(BPIR-ATTEST-NONCE-V1 || client_eph_pub || random_32)
+/// ```
+///
+/// The bound nonce is what gets passed to [`build_report_data`] as the
+/// `nonce` argument (and ultimately to the server's REQ_ATTEST). On the
+/// verifier side, the client recomputes this value from the same
+/// `client_eph_pub` (which it controls — it's the public half of the
+/// X25519 ephemeral the client will use in REQ_HANDSHAKE) plus the
+/// `random_32` it generated; if the chip-signed REPORT_DATA matches the
+/// reconstructed preimage, the attestation provably covers this
+/// handshake — not a stale or replayed one.
+///
+/// `random_32` MUST come from a CSPRNG. Production callers feed it
+/// from `OsRng` / `getrandom`. Tests can pass a fixed value for
+/// reproducibility.
+pub fn derive_attest_nonce(
+    client_eph_pub: [u8; X25519_PUBKEY_LEN],
+    random_32: [u8; 32],
+) -> [u8; 32] {
+    let mut preimage =
+        Vec::with_capacity(ATTEST_NONCE_DOMAIN_TAG.len() + X25519_PUBKEY_LEN + 32);
+    preimage.extend_from_slice(ATTEST_NONCE_DOMAIN_TAG);
+    preimage.extend_from_slice(&client_eph_pub);
+    preimage.extend_from_slice(&random_32);
+    sha256(&preimage)
+}
+
 /// Concatenate per-DB manifest roots and hash, producing the single
 /// "combined manifest root" that goes into REPORT_DATA. Empty input
 /// returns the all-zero hash so a server with no manifests still has
@@ -224,6 +261,51 @@ mod tests {
 
         let out = build_report_data(nonce, &[root], binary, server_pub, git);
         assert_eq!(&out[..32], &manual);
+    }
+
+    #[test]
+    fn derive_attest_nonce_changes_with_client_eph_pub() {
+        let n1 = derive_attest_nonce([0xAAu8; 32], [0x11u8; 32]);
+        let n2 = derive_attest_nonce([0xBBu8; 32], [0x11u8; 32]);
+        assert_ne!(n1, n2);
+    }
+
+    #[test]
+    fn derive_attest_nonce_changes_with_random_32() {
+        let n1 = derive_attest_nonce([0xAAu8; 32], [0x11u8; 32]);
+        let n2 = derive_attest_nonce([0xAAu8; 32], [0x22u8; 32]);
+        assert_ne!(n1, n2);
+    }
+
+    #[test]
+    fn derive_attest_nonce_is_deterministic() {
+        let eph = [0xCCu8; 32];
+        let rnd = [0xDDu8; 32];
+        assert_eq!(
+            derive_attest_nonce(eph, rnd),
+            derive_attest_nonce(eph, rnd)
+        );
+    }
+
+    #[test]
+    fn derive_attest_nonce_domain_tag_distinct_from_report_data_tag() {
+        // A nonce preimage and a REPORT_DATA preimage with the same
+        // trailing bytes must not collide — distinct domain tags
+        // prevent cross-protocol confusion.
+        assert_ne!(ATTEST_NONCE_DOMAIN_TAG, REPORT_DATA_DOMAIN_TAG);
+    }
+
+    #[test]
+    fn derive_attest_nonce_matches_manual_sha256() {
+        // Catch accidental field-order or domain-tag regressions.
+        let eph = [0x12u8; 32];
+        let rnd = [0x34u8; 32];
+        let mut p = Vec::new();
+        p.extend_from_slice(b"BPIR-ATTEST-NONCE-V1");
+        p.extend_from_slice(&eph);
+        p.extend_from_slice(&rnd);
+        let manual = sha256(&p);
+        assert_eq!(derive_attest_nonce(eph, rnd), manual);
     }
 
     #[test]

--- a/pir-identity/Cargo.toml
+++ b/pir-identity/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "pir-identity"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.78"
+authors = ["Bitcoin PIR contributors"]
+description = "Operator-signed server identity primitives for Bitcoin PIR: two-tier Ed25519 cert chain (operator IdentityCert → server-side ChannelManifest) used by the REQ_ANNOUNCE opcode to authenticate `server_static_pub` on hosts that lack hardware attestation (pir1) and to layer defense-in-depth on hosts that do (pir2)."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/Bitcoin-PIR/Bitcoin-PIR"
+homepage = "https://github.com/Bitcoin-PIR/Bitcoin-PIR"
+documentation = "https://docs.rs/pir-identity"
+readme = "README.md"
+keywords = ["pir", "privacy", "ed25519", "attestation", "identity"]
+categories = ["cryptography", "cryptography::cryptocurrencies"]
+
+[dependencies]
+# Ed25519 sign + verify. Same crate already pulled in by
+# pir-runtime-core / pir-sdk-client / bpir-admin so no new git dep.
+ed25519-dalek = { version = "2", default-features = false, features = ["std"] }
+# SHA-256 isn't strictly needed (Ed25519 handles its own hashing) but
+# we use it for canonical-encoding sanity tests + future test-only
+# fingerprinting. Default-features off so the dep stays light.
+sha2 = { version = "0.10", default-features = false }

--- a/pir-identity/src/lib.rs
+++ b/pir-identity/src/lib.rs
@@ -1,0 +1,1122 @@
+//! Two-tier operator-signed identity for BitcoinPIR servers.
+//!
+//! ## Why this exists
+//!
+//! The PIR encrypted channel ([`pir_channel`]) terminates inside the
+//! unified_server process, *behind* cloudflared. For hosts with SEV-SNP
+//! (pir2), the channel's long-lived X25519 pubkey is bound into the
+//! chip-signed REPORT_DATA via [`pir_core::attest::build_report_data`]
+//! — so a client verifying the SEV report can trust that the pubkey it
+//! handshakes against came from the attested guest.
+//!
+//! Hosts without hardware attestation (pir1, on Hetzner) have no such
+//! anchor. The wire-returned `server_static_pub` is just self-asserted,
+//! and a TLS-terminating middlebox (cloudflared) could substitute it
+//! at will. This crate closes that gap with operator-signed identity:
+//!
+//! ```text
+//!   Operator's long-term Ed25519 key   (offline; eventually broadcast
+//!     │                                 via Nostr or similar)
+//!     │ signs once per server identity rotation
+//!     ▼
+//!   IdentityCert  { server_id, identity_pubkey, valid_from, valid_until }
+//!     │
+//!     │ identity_pubkey signs once per server boot
+//!     ▼
+//!   ChannelManifest  { server_id, channel_pub, binary_sha256, git_rev,
+//!                       manifest_roots, issued_at }
+//! ```
+//!
+//! A client that has the operator pubkey pinned can therefore prove
+//! that `channel_pub` was endorsed by the operator (transitively, via
+//! the identity key on the server). Cloudflare-position adversaries
+//! cannot forge either layer without the offline operator key.
+//!
+//! ## What this crate exposes
+//!
+//! - [`IdentityCert`] + [`sign_identity_cert`] / [`IdentityCert::verify`]
+//! - [`ChannelManifest`] + [`sign_channel_manifest`] / [`ChannelManifest::verify`]
+//! - Canonical wire encoding (`encode` / `decode`) for both. Stable;
+//!   any layout change requires a version bump.
+//!
+//! Pure-crypto only — no filesystem, no networking. Server-side I/O
+//! (loading the identity key from disk, broadcasting the bundle over
+//! REQ_ANNOUNCE) lives in `pir-runtime-core`. Operator tooling for
+//! offline signing lives in `bpir-admin`.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+
+/// Length of an Ed25519 public key (RFC 8032).
+pub const ED25519_PUBKEY_LEN: usize = 32;
+/// Length of an Ed25519 signature (RFC 8032).
+pub const ED25519_SIG_LEN: usize = 64;
+/// Length of an X25519 public key (RFC 7748 §6.1).
+pub const X25519_PUBKEY_LEN: usize = 32;
+/// Length of a SHA-256 digest.
+pub const HASH_LEN: usize = 32;
+
+/// Domain separation prefix for IdentityCert signing preimage. Bump
+/// to V2 if the [`IdentityCert`] field set or canonical encoding
+/// changes.
+pub const IDENTITY_CERT_DOMAIN_TAG: &[u8] = b"BPIR-IDENTITY-CERT-V1";
+
+/// Domain separation prefix for ChannelManifest signing preimage.
+pub const CHANNEL_MANIFEST_DOMAIN_TAG: &[u8] = b"BPIR-CHANNEL-MANIFEST-V1";
+
+/// Wire-format / verification errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentityError {
+    /// Wire decode found a length-prefixed field whose body would
+    /// extend past the end of the input.
+    Truncated(&'static str),
+    /// Wire decode found a `version` byte the crate doesn't know how
+    /// to parse. New layouts MUST bump the version; verifiers reject
+    /// unknown ones rather than fall through.
+    UnknownVersion { kind: &'static str, version: u8 },
+    /// A `server_id` / `git_rev` length prefix exceeded a sanity cap.
+    /// Caps are large enough for realistic operator strings but
+    /// prevent a malicious blob from forcing huge allocations.
+    FieldTooLong { field: &'static str, len: usize },
+    /// `manifest_roots` count exceeded the per-server cap. PIR
+    /// servers serve a handful of DBs (today: 4); we cap at 32 to
+    /// allow growth without admitting absurd blobs.
+    TooManyManifestRoots(usize),
+    /// Provided bytes are not the right length for the field they
+    /// were assigned to.
+    BadLength { field: &'static str, expected: usize, got: usize },
+    /// Ed25519 signature failed verification.
+    BadSignature,
+    /// The Ed25519 pubkey bytes are not a valid point.
+    BadPubkey,
+    /// Trailing bytes after the structure's declared end. Strict
+    /// decode rejects this — easier to catch protocol drift early.
+    TrailingBytes(usize),
+}
+
+impl core::fmt::Display for IdentityError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Truncated(s) => write!(f, "truncated: {}", s),
+            Self::UnknownVersion { kind, version } => {
+                write!(f, "{}: unknown version {}", kind, version)
+            }
+            Self::FieldTooLong { field, len } => {
+                write!(f, "field {} too long: {}", field, len)
+            }
+            Self::TooManyManifestRoots(n) => write!(f, "manifest_roots count {} > 32", n),
+            Self::BadLength { field, expected, got } => write!(
+                f,
+                "bad length for {}: expected {}, got {}",
+                field, expected, got
+            ),
+            Self::BadSignature => write!(f, "Ed25519 signature verification failed"),
+            Self::BadPubkey => write!(f, "Ed25519 pubkey is not a valid point"),
+            Self::TrailingBytes(n) => write!(f, "{} trailing bytes after structure", n),
+        }
+    }
+}
+
+impl std::error::Error for IdentityError {}
+
+/// Caps on variable-length fields. Plenty of headroom for realistic
+/// operator strings while preventing OOM blowup from a malicious blob.
+const MAX_SERVER_ID_LEN: usize = 256;
+const MAX_GIT_REV_LEN: usize = 256;
+const MAX_MANIFEST_ROOTS: usize = 32;
+
+/// Operator-signed Tier-1 cert. Bound: a single `server_id` is endorsed
+/// to use `identity_pubkey` between `valid_from` and `valid_until`.
+///
+/// The operator signs this OFFLINE — `identity_pubkey` is generated
+/// server-side; the operator receives it out-of-band (e.g., via
+/// `bpir-admin generate-identity` output) and produces this blob with
+/// `bpir-admin sign-identity`. Rotating the operator key requires
+/// publishing the new pubkey through the agreed channel (Nostr,
+/// eventually). Rotating just the `identity_pubkey` requires re-signing
+/// the cert with the unchanged operator key.
+///
+/// `valid_from` and `valid_until` are unix-seconds (i64 for negative
+/// values; in practice always positive). Use `0` for `valid_from` if
+/// no lower bound is desired.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IdentityCert {
+    pub version: u8,
+    pub operator_pubkey: [u8; ED25519_PUBKEY_LEN],
+    pub server_id: String,
+    pub identity_pubkey: [u8; ED25519_PUBKEY_LEN],
+    pub valid_from: i64,
+    pub valid_until: i64,
+    pub signature: [u8; ED25519_SIG_LEN],
+}
+
+impl IdentityCert {
+    pub const CURRENT_VERSION: u8 = 1;
+
+    /// Build the canonical preimage that gets signed by the operator
+    /// key. Exposed for tests; production callers should use
+    /// [`sign_identity_cert`].
+    pub fn signing_preimage(
+        version: u8,
+        operator_pubkey: &[u8; ED25519_PUBKEY_LEN],
+        server_id: &str,
+        identity_pubkey: &[u8; ED25519_PUBKEY_LEN],
+        valid_from: i64,
+        valid_until: i64,
+    ) -> Vec<u8> {
+        let server_id_bytes = server_id.as_bytes();
+        let mut p = Vec::with_capacity(
+            IDENTITY_CERT_DOMAIN_TAG.len()
+                + 1
+                + ED25519_PUBKEY_LEN
+                + 2
+                + server_id_bytes.len()
+                + ED25519_PUBKEY_LEN
+                + 8
+                + 8,
+        );
+        p.extend_from_slice(IDENTITY_CERT_DOMAIN_TAG);
+        p.push(version);
+        p.extend_from_slice(operator_pubkey);
+        p.extend_from_slice(&(server_id_bytes.len() as u16).to_le_bytes());
+        p.extend_from_slice(server_id_bytes);
+        p.extend_from_slice(identity_pubkey);
+        p.extend_from_slice(&valid_from.to_le_bytes());
+        p.extend_from_slice(&valid_until.to_le_bytes());
+        p
+    }
+
+    /// Verify the signature on this cert. Does NOT check that
+    /// `operator_pubkey` matches an expected operator (that's a caller
+    /// policy decision: pin one or more operator pubkeys client-side).
+    /// Does NOT check `valid_from` / `valid_until` against the current
+    /// time — call [`Self::check_validity`] for that.
+    pub fn verify(&self) -> Result<(), IdentityError> {
+        if self.version != Self::CURRENT_VERSION {
+            return Err(IdentityError::UnknownVersion {
+                kind: "IdentityCert",
+                version: self.version,
+            });
+        }
+        let pk = VerifyingKey::from_bytes(&self.operator_pubkey)
+            .map_err(|_| IdentityError::BadPubkey)?;
+        let sig = Signature::from_bytes(&self.signature);
+        let preimage = Self::signing_preimage(
+            self.version,
+            &self.operator_pubkey,
+            &self.server_id,
+            &self.identity_pubkey,
+            self.valid_from,
+            self.valid_until,
+        );
+        pk.verify(&preimage, &sig)
+            .map_err(|_| IdentityError::BadSignature)
+    }
+
+    /// Return `Ok(())` iff `now_unix_seconds` falls in
+    /// `[valid_from, valid_until]` (inclusive). `valid_until == 0`
+    /// is treated as "no upper bound" — useful for indefinite certs.
+    pub fn check_validity(&self, now_unix_seconds: i64) -> Result<(), IdentityError> {
+        if now_unix_seconds < self.valid_from {
+            return Err(IdentityError::BadSignature); // re-use; cert is not yet valid
+        }
+        if self.valid_until != 0 && now_unix_seconds > self.valid_until {
+            return Err(IdentityError::BadSignature); // cert is expired
+        }
+        Ok(())
+    }
+
+    /// Encode as wire bytes (stable layout — see module docs).
+    pub fn encode(&self) -> Vec<u8> {
+        let server_id_bytes = self.server_id.as_bytes();
+        let mut out = Vec::with_capacity(
+            2 + ED25519_PUBKEY_LEN
+                + 2
+                + server_id_bytes.len()
+                + ED25519_PUBKEY_LEN
+                + 8
+                + 8
+                + ED25519_SIG_LEN,
+        );
+        out.push(self.version);
+        out.push(1); // type discriminator: 1 = IdentityCert
+        out.extend_from_slice(&self.operator_pubkey);
+        out.extend_from_slice(&(server_id_bytes.len() as u16).to_le_bytes());
+        out.extend_from_slice(server_id_bytes);
+        out.extend_from_slice(&self.identity_pubkey);
+        out.extend_from_slice(&self.valid_from.to_le_bytes());
+        out.extend_from_slice(&self.valid_until.to_le_bytes());
+        out.extend_from_slice(&self.signature);
+        out
+    }
+
+    /// Strict decode — fails on trailing bytes or unknown version.
+    pub fn decode(bytes: &[u8]) -> Result<Self, IdentityError> {
+        let mut p = 0;
+        let version = read_u8(bytes, &mut p, "IdentityCert.version")?;
+        if version != Self::CURRENT_VERSION {
+            return Err(IdentityError::UnknownVersion {
+                kind: "IdentityCert",
+                version,
+            });
+        }
+        let cert_type = read_u8(bytes, &mut p, "IdentityCert.type")?;
+        if cert_type != 1 {
+            return Err(IdentityError::UnknownVersion {
+                kind: "IdentityCert.type",
+                version: cert_type,
+            });
+        }
+        let operator_pubkey = read_fixed::<ED25519_PUBKEY_LEN>(
+            bytes,
+            &mut p,
+            "IdentityCert.operator_pubkey",
+        )?;
+        let server_id_len =
+            read_u16_le(bytes, &mut p, "IdentityCert.server_id_len")? as usize;
+        if server_id_len > MAX_SERVER_ID_LEN {
+            return Err(IdentityError::FieldTooLong {
+                field: "server_id",
+                len: server_id_len,
+            });
+        }
+        let server_id_bytes = read_slice(bytes, &mut p, server_id_len, "IdentityCert.server_id")?;
+        let server_id = String::from_utf8(server_id_bytes.to_vec())
+            .map_err(|_| IdentityError::FieldTooLong {
+                field: "server_id (utf8)",
+                len: server_id_len,
+            })?;
+        let identity_pubkey = read_fixed::<ED25519_PUBKEY_LEN>(
+            bytes,
+            &mut p,
+            "IdentityCert.identity_pubkey",
+        )?;
+        let valid_from = read_i64_le(bytes, &mut p, "IdentityCert.valid_from")?;
+        let valid_until = read_i64_le(bytes, &mut p, "IdentityCert.valid_until")?;
+        let signature =
+            read_fixed::<ED25519_SIG_LEN>(bytes, &mut p, "IdentityCert.signature")?;
+        if p != bytes.len() {
+            return Err(IdentityError::TrailingBytes(bytes.len() - p));
+        }
+        Ok(Self {
+            version,
+            operator_pubkey,
+            server_id,
+            identity_pubkey,
+            valid_from,
+            valid_until,
+            signature,
+        })
+    }
+}
+
+/// Sign an [`IdentityCert`] with the operator's secret key. Used by
+/// `bpir-admin sign-identity` on the operator's workstation; production
+/// servers never have the operator secret.
+pub fn sign_identity_cert(
+    operator_sk: &SigningKey,
+    server_id: &str,
+    identity_pubkey: [u8; ED25519_PUBKEY_LEN],
+    valid_from: i64,
+    valid_until: i64,
+) -> IdentityCert {
+    let operator_pubkey = operator_sk.verifying_key().to_bytes();
+    let preimage = IdentityCert::signing_preimage(
+        IdentityCert::CURRENT_VERSION,
+        &operator_pubkey,
+        server_id,
+        &identity_pubkey,
+        valid_from,
+        valid_until,
+    );
+    let sig = operator_sk.sign(&preimage);
+    IdentityCert {
+        version: IdentityCert::CURRENT_VERSION,
+        operator_pubkey,
+        server_id: server_id.to_string(),
+        identity_pubkey,
+        valid_from,
+        valid_until,
+        signature: sig.to_bytes(),
+    }
+}
+
+/// Per-boot Tier-2 manifest. Signed by the server's identity key (held
+/// on disk inside the SEV guest / on pir1's filesystem). Commits the
+/// long-lived X25519 channel pubkey along with build identifiers so a
+/// client can cross-check what binary + git rev + DB manifest the
+/// channel pubkey came from.
+///
+/// `issued_at` is unix-seconds. There is no `valid_until` — the manifest
+/// is implicitly fresh because a server reboot mints a new one
+/// (per the project's per-boot channel-key rotation invariant).
+/// Clients that want to bound replay should check `issued_at` against
+/// their own clock and apply a local freshness policy.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelManifest {
+    pub version: u8,
+    pub identity_pubkey: [u8; ED25519_PUBKEY_LEN],
+    pub server_id: String,
+    pub channel_pub: [u8; X25519_PUBKEY_LEN],
+    pub binary_sha256: [u8; HASH_LEN],
+    pub git_rev: String,
+    pub manifest_roots: Vec<[u8; HASH_LEN]>,
+    pub issued_at: i64,
+    pub signature: [u8; ED25519_SIG_LEN],
+}
+
+impl ChannelManifest {
+    pub const CURRENT_VERSION: u8 = 1;
+
+    pub fn signing_preimage(
+        version: u8,
+        identity_pubkey: &[u8; ED25519_PUBKEY_LEN],
+        server_id: &str,
+        channel_pub: &[u8; X25519_PUBKEY_LEN],
+        binary_sha256: &[u8; HASH_LEN],
+        git_rev: &str,
+        manifest_roots: &[[u8; HASH_LEN]],
+        issued_at: i64,
+    ) -> Vec<u8> {
+        let server_id_bytes = server_id.as_bytes();
+        let git_rev_bytes = git_rev.as_bytes();
+        let mut p = Vec::with_capacity(
+            CHANNEL_MANIFEST_DOMAIN_TAG.len()
+                + 1
+                + ED25519_PUBKEY_LEN
+                + 2
+                + server_id_bytes.len()
+                + X25519_PUBKEY_LEN
+                + HASH_LEN
+                + 2
+                + git_rev_bytes.len()
+                + 1
+                + manifest_roots.len() * HASH_LEN
+                + 8,
+        );
+        p.extend_from_slice(CHANNEL_MANIFEST_DOMAIN_TAG);
+        p.push(version);
+        p.extend_from_slice(identity_pubkey);
+        p.extend_from_slice(&(server_id_bytes.len() as u16).to_le_bytes());
+        p.extend_from_slice(server_id_bytes);
+        p.extend_from_slice(channel_pub);
+        p.extend_from_slice(binary_sha256);
+        p.extend_from_slice(&(git_rev_bytes.len() as u16).to_le_bytes());
+        p.extend_from_slice(git_rev_bytes);
+        p.push(manifest_roots.len() as u8);
+        for r in manifest_roots {
+            p.extend_from_slice(r);
+        }
+        p.extend_from_slice(&issued_at.to_le_bytes());
+        p
+    }
+
+    pub fn verify(&self) -> Result<(), IdentityError> {
+        if self.version != Self::CURRENT_VERSION {
+            return Err(IdentityError::UnknownVersion {
+                kind: "ChannelManifest",
+                version: self.version,
+            });
+        }
+        let pk = VerifyingKey::from_bytes(&self.identity_pubkey)
+            .map_err(|_| IdentityError::BadPubkey)?;
+        let sig = Signature::from_bytes(&self.signature);
+        let preimage = Self::signing_preimage(
+            self.version,
+            &self.identity_pubkey,
+            &self.server_id,
+            &self.channel_pub,
+            &self.binary_sha256,
+            &self.git_rev,
+            &self.manifest_roots,
+            self.issued_at,
+        );
+        pk.verify(&preimage, &sig)
+            .map_err(|_| IdentityError::BadSignature)
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let server_id_bytes = self.server_id.as_bytes();
+        let git_rev_bytes = self.git_rev.as_bytes();
+        let mut out = Vec::with_capacity(
+            2 + ED25519_PUBKEY_LEN
+                + 2
+                + server_id_bytes.len()
+                + X25519_PUBKEY_LEN
+                + HASH_LEN
+                + 2
+                + git_rev_bytes.len()
+                + 1
+                + self.manifest_roots.len() * HASH_LEN
+                + 8
+                + ED25519_SIG_LEN,
+        );
+        out.push(self.version);
+        out.push(2); // type discriminator: 2 = ChannelManifest
+        out.extend_from_slice(&self.identity_pubkey);
+        out.extend_from_slice(&(server_id_bytes.len() as u16).to_le_bytes());
+        out.extend_from_slice(server_id_bytes);
+        out.extend_from_slice(&self.channel_pub);
+        out.extend_from_slice(&self.binary_sha256);
+        out.extend_from_slice(&(git_rev_bytes.len() as u16).to_le_bytes());
+        out.extend_from_slice(git_rev_bytes);
+        out.push(self.manifest_roots.len() as u8);
+        for r in &self.manifest_roots {
+            out.extend_from_slice(r);
+        }
+        out.extend_from_slice(&self.issued_at.to_le_bytes());
+        out.extend_from_slice(&self.signature);
+        out
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, IdentityError> {
+        let mut p = 0;
+        let version = read_u8(bytes, &mut p, "ChannelManifest.version")?;
+        if version != Self::CURRENT_VERSION {
+            return Err(IdentityError::UnknownVersion {
+                kind: "ChannelManifest",
+                version,
+            });
+        }
+        let manifest_type = read_u8(bytes, &mut p, "ChannelManifest.type")?;
+        if manifest_type != 2 {
+            return Err(IdentityError::UnknownVersion {
+                kind: "ChannelManifest.type",
+                version: manifest_type,
+            });
+        }
+        let identity_pubkey = read_fixed::<ED25519_PUBKEY_LEN>(
+            bytes,
+            &mut p,
+            "ChannelManifest.identity_pubkey",
+        )?;
+        let server_id_len =
+            read_u16_le(bytes, &mut p, "ChannelManifest.server_id_len")? as usize;
+        if server_id_len > MAX_SERVER_ID_LEN {
+            return Err(IdentityError::FieldTooLong {
+                field: "server_id",
+                len: server_id_len,
+            });
+        }
+        let server_id_bytes =
+            read_slice(bytes, &mut p, server_id_len, "ChannelManifest.server_id")?;
+        let server_id = String::from_utf8(server_id_bytes.to_vec())
+            .map_err(|_| IdentityError::FieldTooLong {
+                field: "server_id (utf8)",
+                len: server_id_len,
+            })?;
+        let channel_pub = read_fixed::<X25519_PUBKEY_LEN>(
+            bytes,
+            &mut p,
+            "ChannelManifest.channel_pub",
+        )?;
+        let binary_sha256 =
+            read_fixed::<HASH_LEN>(bytes, &mut p, "ChannelManifest.binary_sha256")?;
+        let git_rev_len =
+            read_u16_le(bytes, &mut p, "ChannelManifest.git_rev_len")? as usize;
+        if git_rev_len > MAX_GIT_REV_LEN {
+            return Err(IdentityError::FieldTooLong {
+                field: "git_rev",
+                len: git_rev_len,
+            });
+        }
+        let git_rev_bytes = read_slice(bytes, &mut p, git_rev_len, "ChannelManifest.git_rev")?;
+        let git_rev = String::from_utf8(git_rev_bytes.to_vec())
+            .map_err(|_| IdentityError::FieldTooLong {
+                field: "git_rev (utf8)",
+                len: git_rev_len,
+            })?;
+        let n_roots = read_u8(bytes, &mut p, "ChannelManifest.n_roots")? as usize;
+        if n_roots > MAX_MANIFEST_ROOTS {
+            return Err(IdentityError::TooManyManifestRoots(n_roots));
+        }
+        let mut manifest_roots = Vec::with_capacity(n_roots);
+        for i in 0..n_roots {
+            let root = read_fixed::<HASH_LEN>(
+                bytes,
+                &mut p,
+                if i == 0 {
+                    "ChannelManifest.manifest_roots[0]"
+                } else {
+                    "ChannelManifest.manifest_roots[i]"
+                },
+            )?;
+            manifest_roots.push(root);
+        }
+        let issued_at = read_i64_le(bytes, &mut p, "ChannelManifest.issued_at")?;
+        let signature =
+            read_fixed::<ED25519_SIG_LEN>(bytes, &mut p, "ChannelManifest.signature")?;
+        if p != bytes.len() {
+            return Err(IdentityError::TrailingBytes(bytes.len() - p));
+        }
+        Ok(Self {
+            version,
+            identity_pubkey,
+            server_id,
+            channel_pub,
+            binary_sha256,
+            git_rev,
+            manifest_roots,
+            issued_at,
+            signature,
+        })
+    }
+}
+
+/// Sign a [`ChannelManifest`] with the server's identity key. Used by
+/// the unified_server at boot.
+pub fn sign_channel_manifest(
+    identity_sk: &SigningKey,
+    server_id: &str,
+    channel_pub: [u8; X25519_PUBKEY_LEN],
+    binary_sha256: [u8; HASH_LEN],
+    git_rev: &str,
+    manifest_roots: Vec<[u8; HASH_LEN]>,
+    issued_at: i64,
+) -> ChannelManifest {
+    let identity_pubkey = identity_sk.verifying_key().to_bytes();
+    let preimage = ChannelManifest::signing_preimage(
+        ChannelManifest::CURRENT_VERSION,
+        &identity_pubkey,
+        server_id,
+        &channel_pub,
+        &binary_sha256,
+        git_rev,
+        &manifest_roots,
+        issued_at,
+    );
+    let sig = identity_sk.sign(&preimage);
+    ChannelManifest {
+        version: ChannelManifest::CURRENT_VERSION,
+        identity_pubkey,
+        server_id: server_id.to_string(),
+        channel_pub,
+        binary_sha256,
+        git_rev: git_rev.to_string(),
+        manifest_roots,
+        issued_at,
+        signature: sig.to_bytes(),
+    }
+}
+
+/// Full server announcement bundle returned by REQ_ANNOUNCE. The
+/// client verifies it in this order:
+///
+/// 1. `cert.verify()` using a pinned `operator_pubkey` (caller policy).
+/// 2. `cert.check_validity(now)` for the current wall-clock time.
+/// 3. `manifest.verify()` using `manifest.identity_pubkey`.
+/// 4. Cross-checks:
+///    * `manifest.identity_pubkey == cert.identity_pubkey`
+///    * `manifest.server_id == cert.server_id`
+/// 5. Apply the caller's freshness policy on `manifest.issued_at`.
+///
+/// Step 1 is currently optional in the client (the operator pubkey
+/// publishing mechanism is being designed — see the project notes on
+/// Nostr distribution). When the operator pubkey becomes pinned, the
+/// caller MUST run step 1, otherwise the chain is unauthenticated.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AnnouncementBundle {
+    pub cert: IdentityCert,
+    pub manifest: ChannelManifest,
+}
+
+impl AnnouncementBundle {
+    /// Run the chain check (steps 3 + 4 of the verify flow above).
+    /// Caller still owns steps 1 / 2 / 5 (pinning policy + freshness).
+    pub fn verify_chain(&self) -> Result<(), IdentityError> {
+        self.manifest.verify()?;
+        if self.manifest.identity_pubkey != self.cert.identity_pubkey {
+            return Err(IdentityError::BadSignature);
+        }
+        if self.manifest.server_id != self.cert.server_id {
+            return Err(IdentityError::BadSignature);
+        }
+        Ok(())
+    }
+
+    /// Encode bundle as `[cert_len:u32 LE][cert bytes][manifest_len:u32 LE][manifest bytes]`.
+    pub fn encode(&self) -> Vec<u8> {
+        let cert_bytes = self.cert.encode();
+        let manifest_bytes = self.manifest.encode();
+        let mut out =
+            Vec::with_capacity(4 + cert_bytes.len() + 4 + manifest_bytes.len());
+        out.extend_from_slice(&(cert_bytes.len() as u32).to_le_bytes());
+        out.extend_from_slice(&cert_bytes);
+        out.extend_from_slice(&(manifest_bytes.len() as u32).to_le_bytes());
+        out.extend_from_slice(&manifest_bytes);
+        out
+    }
+
+    /// Strict decode, mirroring [`Self::encode`].
+    pub fn decode(bytes: &[u8]) -> Result<Self, IdentityError> {
+        let mut p = 0;
+        let cert_len = read_u32_le(bytes, &mut p, "AnnouncementBundle.cert_len")? as usize;
+        let cert_bytes = read_slice(bytes, &mut p, cert_len, "AnnouncementBundle.cert")?;
+        let cert = IdentityCert::decode(cert_bytes)?;
+        let manifest_len =
+            read_u32_le(bytes, &mut p, "AnnouncementBundle.manifest_len")? as usize;
+        let manifest_bytes =
+            read_slice(bytes, &mut p, manifest_len, "AnnouncementBundle.manifest")?;
+        let manifest = ChannelManifest::decode(manifest_bytes)?;
+        if p != bytes.len() {
+            return Err(IdentityError::TrailingBytes(bytes.len() - p));
+        }
+        Ok(Self { cert, manifest })
+    }
+}
+
+// ───── decode helpers ─────────────────────────────────────────────────
+
+fn read_u8(buf: &[u8], pos: &mut usize, field: &'static str) -> Result<u8, IdentityError> {
+    if *pos + 1 > buf.len() {
+        return Err(IdentityError::Truncated(field));
+    }
+    let v = buf[*pos];
+    *pos += 1;
+    Ok(v)
+}
+
+fn read_u16_le(
+    buf: &[u8],
+    pos: &mut usize,
+    field: &'static str,
+) -> Result<u16, IdentityError> {
+    if *pos + 2 > buf.len() {
+        return Err(IdentityError::Truncated(field));
+    }
+    let v = u16::from_le_bytes(buf[*pos..*pos + 2].try_into().unwrap());
+    *pos += 2;
+    Ok(v)
+}
+
+fn read_u32_le(
+    buf: &[u8],
+    pos: &mut usize,
+    field: &'static str,
+) -> Result<u32, IdentityError> {
+    if *pos + 4 > buf.len() {
+        return Err(IdentityError::Truncated(field));
+    }
+    let v = u32::from_le_bytes(buf[*pos..*pos + 4].try_into().unwrap());
+    *pos += 4;
+    Ok(v)
+}
+
+fn read_i64_le(
+    buf: &[u8],
+    pos: &mut usize,
+    field: &'static str,
+) -> Result<i64, IdentityError> {
+    if *pos + 8 > buf.len() {
+        return Err(IdentityError::Truncated(field));
+    }
+    let v = i64::from_le_bytes(buf[*pos..*pos + 8].try_into().unwrap());
+    *pos += 8;
+    Ok(v)
+}
+
+fn read_fixed<const N: usize>(
+    buf: &[u8],
+    pos: &mut usize,
+    field: &'static str,
+) -> Result<[u8; N], IdentityError> {
+    if *pos + N > buf.len() {
+        return Err(IdentityError::Truncated(field));
+    }
+    let mut out = [0u8; N];
+    out.copy_from_slice(&buf[*pos..*pos + N]);
+    *pos += N;
+    Ok(out)
+}
+
+fn read_slice<'a>(
+    buf: &'a [u8],
+    pos: &mut usize,
+    n: usize,
+    field: &'static str,
+) -> Result<&'a [u8], IdentityError> {
+    if *pos + n > buf.len() {
+        return Err(IdentityError::Truncated(field));
+    }
+    let out = &buf[*pos..*pos + n];
+    *pos += n;
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn fake_sk(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    #[test]
+    fn identity_cert_sign_then_verify_ok() {
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            1_700_000_000,
+            1_800_000_000,
+        );
+        cert.verify().expect("honest cert must verify");
+    }
+
+    #[test]
+    fn identity_cert_tampered_server_id_fails() {
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let mut cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        cert.server_id = "pir2".into(); // attacker re-targets
+        assert!(matches!(cert.verify(), Err(IdentityError::BadSignature)));
+    }
+
+    #[test]
+    fn identity_cert_tampered_identity_pub_fails() {
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let mut cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        cert.identity_pubkey = fake_sk(0x33).verifying_key().to_bytes();
+        assert!(matches!(cert.verify(), Err(IdentityError::BadSignature)));
+    }
+
+    #[test]
+    fn identity_cert_wrong_operator_pubkey_fails() {
+        let op_sk = fake_sk(0x11);
+        let attacker_sk = fake_sk(0x99);
+        let id_sk = fake_sk(0x22);
+        let mut cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        // Attacker swaps the bound operator_pubkey — preimage diverges
+        // and the signature (still made by op_sk) no longer matches.
+        cert.operator_pubkey = attacker_sk.verifying_key().to_bytes();
+        assert!(matches!(cert.verify(), Err(IdentityError::BadSignature)));
+    }
+
+    #[test]
+    fn identity_cert_roundtrip_encode_decode() {
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1.example.org",
+            id_sk.verifying_key().to_bytes(),
+            42,
+            1_800_000_000,
+        );
+        let bytes = cert.encode();
+        let parsed = IdentityCert::decode(&bytes).expect("roundtrip decode");
+        assert_eq!(cert, parsed);
+        parsed.verify().expect("parsed cert verifies");
+    }
+
+    #[test]
+    fn identity_cert_trailing_bytes_rejected() {
+        let op_sk = fake_sk(0x11);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            fake_sk(0x22).verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        let mut bytes = cert.encode();
+        bytes.push(0xff);
+        assert!(matches!(
+            IdentityCert::decode(&bytes),
+            Err(IdentityError::TrailingBytes(_))
+        ));
+    }
+
+    #[test]
+    fn identity_cert_unknown_version_rejected() {
+        let op_sk = fake_sk(0x11);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            fake_sk(0x22).verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        let mut bytes = cert.encode();
+        bytes[0] = 99; // mangle version
+        assert!(matches!(
+            IdentityCert::decode(&bytes),
+            Err(IdentityError::UnknownVersion { .. })
+        ));
+    }
+
+    #[test]
+    fn identity_cert_validity_window_checks() {
+        let op_sk = fake_sk(0x11);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            fake_sk(0x22).verifying_key().to_bytes(),
+            100,
+            200,
+        );
+        assert!(cert.check_validity(50).is_err()); // before
+        assert!(cert.check_validity(150).is_ok()); // inside
+        assert!(cert.check_validity(250).is_err()); // after
+
+        // valid_until == 0 → indefinite upper bound
+        let cert2 = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            fake_sk(0x22).verifying_key().to_bytes(),
+            100,
+            0,
+        );
+        assert!(cert2.check_validity(50).is_err()); // still has lower bound
+        assert!(cert2.check_validity(1_000_000_000).is_ok()); // indefinite up
+    }
+
+    #[test]
+    fn channel_manifest_sign_then_verify_ok() {
+        let id_sk = fake_sk(0x22);
+        let manifest = sign_channel_manifest(
+            &id_sk,
+            "pir1",
+            [0xCCu8; 32],
+            [0xAAu8; 32],
+            "abc1234",
+            vec![[0x11u8; 32], [0x22u8; 32]],
+            1_700_000_000,
+        );
+        manifest.verify().expect("honest manifest must verify");
+    }
+
+    #[test]
+    fn channel_manifest_tampered_channel_pub_fails() {
+        let id_sk = fake_sk(0x22);
+        let mut m = sign_channel_manifest(
+            &id_sk,
+            "pir1",
+            [0xCCu8; 32],
+            [0xAAu8; 32],
+            "abc",
+            vec![],
+            0,
+        );
+        m.channel_pub = [0xDDu8; 32];
+        assert!(matches!(m.verify(), Err(IdentityError::BadSignature)));
+    }
+
+    #[test]
+    fn channel_manifest_tampered_binary_sha_fails() {
+        let id_sk = fake_sk(0x22);
+        let mut m = sign_channel_manifest(
+            &id_sk,
+            "pir1",
+            [0xCCu8; 32],
+            [0xAAu8; 32],
+            "abc",
+            vec![],
+            0,
+        );
+        m.binary_sha256 = [0xBBu8; 32];
+        assert!(matches!(m.verify(), Err(IdentityError::BadSignature)));
+    }
+
+    #[test]
+    fn channel_manifest_roundtrip_with_empty_roots() {
+        let id_sk = fake_sk(0x22);
+        let m = sign_channel_manifest(
+            &id_sk,
+            "pir1",
+            [0x55u8; 32],
+            [0x66u8; 32],
+            "deadbeef",
+            vec![],
+            1_700_000_001,
+        );
+        let bytes = m.encode();
+        let parsed = ChannelManifest::decode(&bytes).unwrap();
+        assert_eq!(m, parsed);
+        parsed.verify().unwrap();
+    }
+
+    #[test]
+    fn channel_manifest_roundtrip_with_max_roots() {
+        let id_sk = fake_sk(0x22);
+        let roots = (0..MAX_MANIFEST_ROOTS).map(|i| [i as u8; 32]).collect();
+        let m = sign_channel_manifest(
+            &id_sk,
+            "pir1",
+            [0u8; 32],
+            [0u8; 32],
+            "v1",
+            roots,
+            0,
+        );
+        let bytes = m.encode();
+        let parsed = ChannelManifest::decode(&bytes).unwrap();
+        assert_eq!(m, parsed);
+        parsed.verify().unwrap();
+    }
+
+    #[test]
+    fn channel_manifest_too_many_roots_rejected_on_decode() {
+        // Craft a malicious blob claiming 200 roots — must reject.
+        let id_sk = fake_sk(0x22);
+        let m = sign_channel_manifest(
+            &id_sk,
+            "pir1",
+            [0u8; 32],
+            [0u8; 32],
+            "v1",
+            vec![],
+            0,
+        );
+        let mut bytes = m.encode();
+        // Find the n_roots byte position: header is 2 + 32 + 2 + |server_id|
+        // + 32 + 32 + 2 + |git_rev| = 2 + 32 + 2 + 4 + 32 + 32 + 2 + 2 = 108
+        let nroots_offset =
+            2 + ED25519_PUBKEY_LEN + 2 + "pir1".len() + X25519_PUBKEY_LEN + HASH_LEN + 2 + "v1".len();
+        bytes[nroots_offset] = 200;
+        assert!(matches!(
+            ChannelManifest::decode(&bytes),
+            Err(IdentityError::TooManyManifestRoots(200)) | Err(IdentityError::Truncated(_))
+        ));
+    }
+
+    #[test]
+    fn announcement_bundle_chain_check_ok() {
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        let manifest = sign_channel_manifest(
+            &id_sk,
+            "pir1",
+            [0xCCu8; 32],
+            [0xAAu8; 32],
+            "abc",
+            vec![],
+            1_700_000_000,
+        );
+        let bundle = AnnouncementBundle { cert, manifest };
+        bundle.verify_chain().expect("matching chain must verify");
+    }
+
+    #[test]
+    fn announcement_bundle_server_id_mismatch_fails() {
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        // Attacker takes a valid cert for pir1 but pairs it with a
+        // manifest claiming server_id = "pir2". Even though both
+        // signatures verify in isolation, the chain cross-check
+        // catches the mismatch.
+        let manifest = sign_channel_manifest(
+            &id_sk,
+            "pir2", // ≠ cert.server_id
+            [0xCCu8; 32],
+            [0xAAu8; 32],
+            "abc",
+            vec![],
+            0,
+        );
+        let bundle = AnnouncementBundle { cert, manifest };
+        assert!(matches!(
+            bundle.verify_chain(),
+            Err(IdentityError::BadSignature)
+        ));
+    }
+
+    #[test]
+    fn announcement_bundle_identity_pub_mismatch_fails() {
+        let op_sk = fake_sk(0x11);
+        let id_sk_a = fake_sk(0x22);
+        let id_sk_b = fake_sk(0x33);
+        // cert endorses id_sk_a, but manifest is signed by id_sk_b.
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk_a.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        let manifest = sign_channel_manifest(
+            &id_sk_b,
+            "pir1",
+            [0u8; 32],
+            [0u8; 32],
+            "v",
+            vec![],
+            0,
+        );
+        let bundle = AnnouncementBundle { cert, manifest };
+        assert!(matches!(
+            bundle.verify_chain(),
+            Err(IdentityError::BadSignature)
+        ));
+    }
+
+    #[test]
+    fn announcement_bundle_encode_decode_roundtrip() {
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            42,
+            1_800_000_000,
+        );
+        let manifest = sign_channel_manifest(
+            &id_sk,
+            "pir1",
+            [0xCCu8; 32],
+            [0xAAu8; 32],
+            "abc",
+            vec![[0x11u8; 32]],
+            1_700_000_000,
+        );
+        let bundle = AnnouncementBundle { cert, manifest };
+        let bytes = bundle.encode();
+        let parsed = AnnouncementBundle::decode(&bytes).unwrap();
+        assert_eq!(bundle, parsed);
+        parsed.verify_chain().unwrap();
+    }
+
+    #[test]
+    fn domain_tags_are_distinct() {
+        // No risk of cross-protocol confusion: a signature over an
+        // IdentityCert preimage cannot be re-used as a ChannelManifest
+        // signature (or vice versa) because the domain tags differ.
+        assert_ne!(IDENTITY_CERT_DOMAIN_TAG, CHANNEL_MANIFEST_DOMAIN_TAG);
+    }
+}

--- a/pir-runtime-core/Cargo.toml
+++ b/pir-runtime-core/Cargo.toml
@@ -17,6 +17,11 @@ categories = ["cryptography", "cryptography::cryptocurrencies", "network-program
 [dependencies]
 pir-core = { version = "0.1.0", path = "../pir-core" }
 pir-channel = { version = "0.1.0", path = "../pir-channel" }
+# Two-tier operator-signed identity bundle returned by REQ_ANNOUNCE.
+# Pure crypto (Ed25519 sign/verify + canonical wire encoding) — the
+# server-side I/O wrapper (loading the identity key + cert from disk,
+# building the per-boot ChannelManifest) lives in `crate::identity`.
+pir-identity = { version = "0.1.0", path = "../pir-identity" }
 libdpf = { git = "https://github.com/weikengchen/libdpf.git" }
 memmap2 = "0.9"
 rayon = "1.10"

--- a/pir-runtime-core/src/cashu_verifier.rs
+++ b/pir-runtime-core/src/cashu_verifier.rs
@@ -228,6 +228,10 @@ fn base64url_decode(input: &str) -> Option<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Brings the `is_identity` trait method into scope for ProjectivePoint
+    // in tests. Production code in this module uses it through a different
+    // path; only the test path needed the explicit import.
+    use k256::elliptic_curve::Group;
 
     #[test]
     fn test_hash_to_curve_round_trip() {

--- a/pir-runtime-core/src/handler.rs
+++ b/pir-runtime-core/src/handler.rs
@@ -32,8 +32,19 @@ impl RequestHandler {
                 ark_pem: Vec::new(),
                 ask_pem: Vec::new(),
                 vcek_pem: Vec::new(),
+                announcement_bundle: None,
             },
         }
+    }
+
+    /// Install the pre-encoded operator-signed announcement bundle —
+    /// the bytes REQ_ANNOUNCE will return verbatim. See
+    /// [`crate::identity::build_announcement_bundle`] for how to
+    /// produce these bytes. Pass `None` to leave the server in
+    /// "unannounced" mode (REQ_ANNOUNCE → RESP_ERROR).
+    pub fn with_announcement_bundle(mut self, bundle: Option<Vec<u8>>) -> Self {
+        self.state.announcement_bundle = bundle;
+        self
     }
 
     /// Bind the long-lived X25519 channel pubkey the server generated
@@ -142,6 +153,13 @@ impl RequestHandler {
             Request::HarmonyQuery(query) => self.handle_harmony_query(query),
             Request::HarmonyBatchQuery(query) => self.handle_harmony_batch_query(query),
             Request::Attest { nonce } => Response::Attest(self.handle_attest(*nonce)),
+            Request::Announce => match &self.state.announcement_bundle {
+                Some(bytes) => Response::Announce(bytes.clone()),
+                None => Response::Error(
+                    "announce not configured: server lacks identity key or operator cert"
+                        .into(),
+                ),
+            },
             // Handshake needs per-connection state to mint a fresh
             // ephemeral keypair, derive the session key, and stash it
             // for subsequent encrypted-frame open/seal. The stateless

--- a/pir-runtime-core/src/identity.rs
+++ b/pir-runtime-core/src/identity.rs
@@ -1,0 +1,418 @@
+//! Server-side identity-key + operator-cert loader, plus the per-boot
+//! [`ChannelManifest`] builder that REQ_ANNOUNCE serves.
+//!
+//! ## Two-tier signing recap
+//!
+//! - **Operator key** (Tier 1) lives OFFLINE on the operator's
+//!   workstation. It signs an [`IdentityCert`] for each server once per
+//!   identity rotation. The operator publishes the operator pubkey
+//!   out-of-band (eventually via Nostr).
+//! - **Identity key** (Tier 2) is held on the server's filesystem
+//!   (`--identity-key-path`). At boot, the server signs a per-boot
+//!   [`ChannelManifest`] that commits the current `channel_pub` plus
+//!   build metadata.
+//!
+//! Either file missing at startup is non-fatal: the server simply runs
+//! in "unannounced" mode — REQ_ANNOUNCE returns a RESP_ERROR. The
+//! existing attest / handshake / query paths are unaffected. This
+//! matches the project's [HUMAN-decided] boot policy: "Serve without
+//! announce, log warning."
+//!
+//! ## Filesystem layout (operator policy, not protocol)
+//!
+//! The server takes paths for the key + cert via CLI flags or env vars;
+//! contents are byte-blobs only (no JSON / TOML wrapping). The
+//! identity-key file holds the raw 32-byte Ed25519 seed; the cert file
+//! holds the bytes of [`IdentityCert::encode`]. Both files SHOULD be
+//! mode `0600` and owned by the unified_server user.
+//!
+//! ## Threat model
+//!
+//! - **Cloudflared / passive middlebox**: can't forge the bundle
+//!   (operator key is offline). Can drop/delay/replay — for replay,
+//!   the per-boot ChannelManifest's `issued_at` lets clients apply a
+//!   freshness policy.
+//! - **Compromise of the on-disk identity key**: attacker can sign
+//!   forged ChannelManifests with that server's identity_pubkey, but
+//!   they can't move to a different `server_id` or substitute the
+//!   `identity_pubkey` (those are bound in the IdentityCert signed by
+//!   the offline operator key). Mitigation: operator re-signs an
+//!   IdentityCert with a new identity_pubkey (rotation).
+//! - **Compromise of the offline operator key**: attacker can mint
+//!   IdentityCerts for any server_id, including ones the operator
+//!   never set up. Mitigation: operator publishes a new operator
+//!   pubkey via the out-of-band channel; clients pin the new one.
+
+use ed25519_dalek::SigningKey;
+use pir_core::merkle::Hash256;
+use pir_identity::{
+    sign_channel_manifest, AnnouncementBundle, ChannelManifest, IdentityCert, IdentityError,
+};
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// Errors loading identity material at server startup.
+#[derive(Debug)]
+pub enum IdentityLoadError {
+    /// File read failed (missing, no permission, etc.).
+    Io { path: String, source: io::Error },
+    /// Identity-key file's byte length is wrong (must be 32 bytes).
+    KeyLength { path: String, got: usize },
+    /// Cert file failed to parse as an [`IdentityCert`].
+    CertParse { path: String, source: IdentityError },
+    /// Cert's `identity_pubkey` doesn't match the loaded identity key's
+    /// public half. Almost certainly a deploy-time mismatch (operator
+    /// signed against a different identity key than the one on disk).
+    PubkeyMismatch {
+        expected_from_key_file: [u8; 32],
+        cert_says: [u8; 32],
+    },
+    /// Cert's signature failed verification (operator's own key
+    /// disagrees with the signature). Indicates a corrupt cert file
+    /// or a deploy mishap.
+    CertSignatureInvalid(IdentityError),
+}
+
+impl std::fmt::Display for IdentityLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io { path, source } => {
+                write!(f, "failed to read {}: {}", path, source)
+            }
+            Self::KeyLength { path, got } => write!(
+                f,
+                "identity-key file {} is {} bytes (must be 32)",
+                path, got
+            ),
+            Self::CertParse { path, source } => {
+                write!(f, "failed to parse {}: {}", path, source)
+            }
+            Self::PubkeyMismatch {
+                expected_from_key_file,
+                cert_says,
+            } => write!(
+                f,
+                "cert.identity_pubkey ({}) ≠ pubkey derived from key file ({})",
+                hex_8(cert_says),
+                hex_8(expected_from_key_file)
+            ),
+            Self::CertSignatureInvalid(e) => {
+                write!(f, "cert signature does not verify: {}", e)
+            }
+        }
+    }
+}
+
+impl std::error::Error for IdentityLoadError {}
+
+fn hex_8(bytes: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(18);
+    for b in &bytes[..8] {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s.push('…');
+    s
+}
+
+/// In-memory bundle the unified_server holds for the duration of its
+/// boot. Built once at startup from the on-disk key + cert plus the
+/// boot-fresh `channel_pub`, and served verbatim on REQ_ANNOUNCE.
+#[derive(Debug)]
+pub struct ServerIdentity {
+    /// Pre-encoded `AnnouncementBundle::encode()` bytes. Cached so
+    /// REQ_ANNOUNCE is a zero-cost copy.
+    pub encoded_bundle: Vec<u8>,
+    /// Decoded cert — used internally for diagnostics / logging.
+    pub cert: IdentityCert,
+    /// Decoded manifest — same. Includes the issued_at timestamp.
+    pub manifest: ChannelManifest,
+}
+
+/// Load the identity Ed25519 keypair from disk. Returns the parsed
+/// [`SigningKey`]. The file must hold exactly 32 raw seed bytes (this
+/// matches `bpir-admin generate-identity --raw` output).
+pub fn load_identity_key(path: &Path) -> Result<SigningKey, IdentityLoadError> {
+    let bytes = fs::read(path).map_err(|e| IdentityLoadError::Io {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+    if bytes.len() != 32 {
+        return Err(IdentityLoadError::KeyLength {
+            path: path.display().to_string(),
+            got: bytes.len(),
+        });
+    }
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&bytes);
+    Ok(SigningKey::from_bytes(&seed))
+}
+
+/// Load the operator-signed [`IdentityCert`] from disk. Verifies the
+/// signature against `cert.operator_pubkey`. Does NOT compare
+/// `cert.operator_pubkey` against any pinned operator pubkey — that's
+/// a client-side check (the server has no policy on which operator
+/// signed it; it just serves what the operator deployed).
+pub fn load_identity_cert(path: &Path) -> Result<IdentityCert, IdentityLoadError> {
+    let bytes = fs::read(path).map_err(|e| IdentityLoadError::Io {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+    let cert = IdentityCert::decode(&bytes).map_err(|e| IdentityLoadError::CertParse {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+    cert.verify()
+        .map_err(IdentityLoadError::CertSignatureInvalid)?;
+    Ok(cert)
+}
+
+/// Build the per-boot announcement bundle.
+///
+/// Cross-checks that `identity_key`'s public half matches
+/// `cert.identity_pubkey` — a mismatch means the deploy is broken
+/// (operator signed against a key the server doesn't hold) and we
+/// MUST refuse to ship the bundle rather than silently produce one
+/// the client will reject. Per the project's boot policy, the caller
+/// (unified_server startup) downgrades this error to "log warning,
+/// serve without announce".
+///
+/// `binary_sha256` and `git_rev` are the same values that go into
+/// REPORT_DATA; passing them in (rather than recomputing) keeps the
+/// announcement bundle in sync with the chip-signed attestation on
+/// SEV hosts.
+///
+/// `issued_at` is unix-seconds. Production callers pass
+/// `SystemTime::now()`'s unix epoch; tests can pin it for
+/// reproducibility.
+#[allow(clippy::too_many_arguments)]
+pub fn build_announcement_bundle(
+    identity_key: &SigningKey,
+    cert: IdentityCert,
+    server_id: &str,
+    channel_pub: [u8; 32],
+    binary_sha256: Hash256,
+    git_rev: &str,
+    manifest_roots: Vec<Hash256>,
+    issued_at: i64,
+) -> Result<ServerIdentity, IdentityLoadError> {
+    let identity_pubkey = identity_key.verifying_key().to_bytes();
+    if identity_pubkey != cert.identity_pubkey {
+        return Err(IdentityLoadError::PubkeyMismatch {
+            expected_from_key_file: identity_pubkey,
+            cert_says: cert.identity_pubkey,
+        });
+    }
+    // server_id consistency: the manifest commits to the same server_id
+    // that the cert was issued for. If the operator changes the cert's
+    // server_id but the unified_server is started with a different
+    // identity, the bundle would be incoherent — fail loudly.
+    if cert.server_id != server_id {
+        return Err(IdentityLoadError::PubkeyMismatch {
+            // Re-use the variant — we don't have a dedicated one and the
+            // payload still tells the operator what went wrong. Encode
+            // the server_id mismatch as two distinct "pubkeys" so the
+            // Display impl is still useful.
+            expected_from_key_file: blake_from_str(server_id),
+            cert_says: blake_from_str(&cert.server_id),
+        });
+    }
+    let manifest = sign_channel_manifest(
+        identity_key,
+        server_id,
+        channel_pub,
+        binary_sha256,
+        git_rev,
+        manifest_roots,
+        issued_at,
+    );
+    let bundle = AnnouncementBundle {
+        cert: cert.clone(),
+        manifest: manifest.clone(),
+    };
+    let encoded_bundle = bundle.encode();
+    Ok(ServerIdentity {
+        encoded_bundle,
+        cert,
+        manifest,
+    })
+}
+
+/// Cheap derive-a-hash-from-a-string for the server_id mismatch
+/// Display message. Not cryptographic — diagnostic only.
+fn blake_from_str(s: &str) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    h.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use pir_identity::sign_identity_cert;
+    use tempfile::tempdir;
+
+    fn fake_sk(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    #[test]
+    fn load_identity_key_round_trips_raw_32_byte_seed() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("identity.key");
+        let original = fake_sk(0x77);
+        fs::write(&path, original.to_bytes()).unwrap();
+        let loaded = load_identity_key(&path).unwrap();
+        assert_eq!(loaded.to_bytes(), original.to_bytes());
+        // And the pubkey matches — sanity for the deploy invariant.
+        assert_eq!(
+            loaded.verifying_key().to_bytes(),
+            original.verifying_key().to_bytes()
+        );
+    }
+
+    #[test]
+    fn load_identity_key_wrong_length_rejected() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("identity.key");
+        fs::write(&path, b"too short").unwrap();
+        let err = load_identity_key(&path).unwrap_err();
+        assert!(matches!(err, IdentityLoadError::KeyLength { got: 9, .. }));
+    }
+
+    #[test]
+    fn load_identity_key_missing_file_returns_io_error() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("absent.key");
+        let err = load_identity_key(&path).unwrap_err();
+        assert!(matches!(err, IdentityLoadError::Io { .. }));
+    }
+
+    #[test]
+    fn load_identity_cert_verifies_signature() {
+        let dir = tempdir().unwrap();
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        let path = dir.path().join("identity.cert");
+        fs::write(&path, cert.encode()).unwrap();
+        let loaded = load_identity_cert(&path).unwrap();
+        assert_eq!(loaded.operator_pubkey, op_sk.verifying_key().to_bytes());
+        assert_eq!(loaded.server_id, "pir1");
+    }
+
+    #[test]
+    fn load_identity_cert_rejects_tampered_blob() {
+        let dir = tempdir().unwrap();
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        let path = dir.path().join("identity.cert");
+        let mut bytes = cert.encode();
+        // Flip a byte in the server_id field — preimage diverges.
+        let server_id_start = 2 + 32 + 2; // version + type + operator_pub + len
+        bytes[server_id_start] ^= 0x01;
+        fs::write(&path, &bytes).unwrap();
+        let err = load_identity_cert(&path).unwrap_err();
+        assert!(matches!(err, IdentityLoadError::CertSignatureInvalid(_)));
+    }
+
+    #[test]
+    fn build_bundle_with_matching_key_and_cert_succeeds() {
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        let identity = build_announcement_bundle(
+            &id_sk,
+            cert,
+            "pir1",
+            [0xCCu8; 32],
+            [0xAAu8; 32],
+            "abc",
+            vec![],
+            1_700_000_000,
+        )
+        .unwrap();
+        // Encoded bundle round-trips and verifies end-to-end.
+        let parsed =
+            pir_identity::AnnouncementBundle::decode(&identity.encoded_bundle).unwrap();
+        parsed.cert.verify().unwrap();
+        parsed.verify_chain().unwrap();
+        assert_eq!(parsed.cert.server_id, "pir1");
+        assert_eq!(parsed.manifest.channel_pub, [0xCCu8; 32]);
+        assert_eq!(parsed.manifest.binary_sha256, [0xAAu8; 32]);
+        assert_eq!(parsed.manifest.issued_at, 1_700_000_000);
+    }
+
+    #[test]
+    fn build_bundle_rejects_mismatched_identity_key() {
+        let op_sk = fake_sk(0x11);
+        let id_sk_on_disk = fake_sk(0x22);
+        let id_sk_in_cert = fake_sk(0x33); // different!
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk_in_cert.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        let err = build_announcement_bundle(
+            &id_sk_on_disk,
+            cert,
+            "pir1",
+            [0u8; 32],
+            [0u8; 32],
+            "v",
+            vec![],
+            0,
+        )
+        .unwrap_err();
+        assert!(matches!(err, IdentityLoadError::PubkeyMismatch { .. }));
+    }
+
+    #[test]
+    fn build_bundle_rejects_server_id_mismatch() {
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        // Server is started with server_id = "pir2" but cert says "pir1".
+        let err = build_announcement_bundle(
+            &id_sk,
+            cert,
+            "pir2",
+            [0u8; 32],
+            [0u8; 32],
+            "v",
+            vec![],
+            0,
+        )
+        .unwrap_err();
+        assert!(matches!(err, IdentityLoadError::PubkeyMismatch { .. }));
+    }
+}

--- a/pir-runtime-core/src/lib.rs
+++ b/pir-runtime-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cashu_verifier;
 pub mod channel;
 pub mod eval;
 pub mod handler;
+pub mod identity;
 pub mod manifest;
 pub mod protocol;
 pub mod table;

--- a/pir-runtime-core/src/protocol.rs
+++ b/pir-runtime-core/src/protocol.rs
@@ -98,6 +98,33 @@ pub const RESP_CASHU_BAT_OK: u8 = 0x09;
 // cleartext frame after that is a protocol error.
 pub const REQ_HANDSHAKE: u8 = 0x06;
 
+// ─── Operator-signed identity announce ─────────────────────────────────────
+//
+// One-shot query: client asks "who are you?" and gets a two-tier
+// signed bundle:
+//
+//   client → server:  REQ_ANNOUNCE   (no payload)
+//   server → client:  RESP_ANNOUNCE  { AnnouncementBundle bytes }
+//
+// where the bundle is `pir_identity::AnnouncementBundle::encode()` —
+// `[cert_len:u32 LE][cert][manifest_len:u32 LE][manifest]`.
+//
+// The two layers it carries:
+// * IdentityCert  — operator's offline Ed25519 key signs (server_id,
+//                    identity_pubkey, valid_from, valid_until). Operator
+//                    key is published out-of-band (eventually Nostr).
+// * ChannelManifest — server's on-disk identity key signs the current
+//                    boot's channel_pub (X25519, from
+//                    `ChannelKeypair::generate`) + binary_sha256 +
+//                    git_rev + manifest_roots + issued_at.
+//
+// Servers that lack the identity-key file or operator-cert file at
+// startup serve attest/handshake but reject REQ_ANNOUNCE with
+// RESP_ERROR; existing flows are unaffected. Clients use the bundle to
+// authenticate `server_static_pub` on hosts that lack SEV-SNP (pir1),
+// and as defense-in-depth on hosts that do (pir2).
+pub const REQ_ANNOUNCE: u8 = 0x07;
+
 // ─── Admin auth (Slice 3a) ─────────────────────────────────────────────────
 //
 // Challenge/response with ed25519. The server holds the admin's public
@@ -156,6 +183,7 @@ pub const RESP_INFO: u8 = 0x01;
 pub const RESP_DB_CATALOG: u8 = 0x02;
 pub const RESP_ATTEST: u8 = 0x05;
 pub const RESP_HANDSHAKE: u8 = 0x06;
+pub const RESP_ANNOUNCE: u8 = 0x07;
 pub const RESP_ADMIN_AUTH_CHALLENGE: u8 = 0x80;
 pub const RESP_ADMIN_AUTH_RESPONSE: u8 = 0x81;
 pub const RESP_ADMIN_DB_UPLOAD_BEGIN: u8 = 0x82;
@@ -390,6 +418,11 @@ pub enum Request {
     HarmonyHintsV2Half(HarmonyHintRequestV2Half),
     HarmonyQuery(HarmonyQuery),
     HarmonyBatchQuery(HarmonyBatchQuery),
+    /// Operator-signed identity announce. Body is empty — the server
+    /// returns its cached, pre-encoded `pir_identity::AnnouncementBundle`
+    /// in `Response::Announce`. Servers that lack the on-disk identity
+    /// material reply with `Response::Error`.
+    Announce,
 }
 
 // ─── Response types ─────────────────────────────────────────────────────────
@@ -557,6 +590,11 @@ pub enum Response {
     /// X25519 ephemeral pubkey. After this exchange both sides have the
     /// same session key derived via `pir_channel`'s ECDH+HKDF.
     Handshake(HandshakeResult),
+    /// Server's reply to `Request::Announce`. Body is the raw bytes of
+    /// `pir_identity::AnnouncementBundle::encode()` — the wire format
+    /// is opaque to this enum so a future bundle version bump doesn't
+    /// require touching the protocol layer.
+    Announce(Vec<u8>),
     AdminAuthChallenge(AdminAuthChallenge),
     AdminAuthResponse(AdminAuthResult),
     AdminDbUploadBegin(AdminAck),
@@ -696,6 +734,9 @@ impl Request {
                 payload.push(REQ_HARMONY_BATCH_QUERY);
                 encode_harmony_batch_query(&mut payload, q);
             }
+            Request::Announce => {
+                payload.push(REQ_ANNOUNCE);
+            }
         }
         let mut msg = Vec::with_capacity(4 + payload.len());
         msg.extend_from_slice(&(payload.len() as u32).to_le_bytes());
@@ -830,6 +871,7 @@ impl Request {
                 let q = decode_harmony_batch_query(&data[1..])?;
                 Ok(Request::HarmonyBatchQuery(q))
             }
+            REQ_ANNOUNCE => Ok(Request::Announce),
             v => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("unknown request variant: 0x{:02x}", v),
@@ -864,6 +906,11 @@ impl Response {
             Response::Handshake(r) => {
                 payload.push(RESP_HANDSHAKE);
                 payload.extend_from_slice(&r.server_eph_pub);
+            }
+            Response::Announce(bundle_bytes) => {
+                payload.push(RESP_ANNOUNCE);
+                payload.extend_from_slice(&(bundle_bytes.len() as u32).to_le_bytes());
+                payload.extend_from_slice(bundle_bytes);
             }
             Response::AdminAuthChallenge(c) => {
                 payload.push(RESP_ADMIN_AUTH_CHALLENGE);
@@ -984,6 +1031,22 @@ impl Response {
                 let mut server_eph_pub = [0u8; 32];
                 server_eph_pub.copy_from_slice(&data[1..33]);
                 Ok(Response::Handshake(HandshakeResult { server_eph_pub }))
+            }
+            RESP_ANNOUNCE => {
+                if data.len() < 1 + 4 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "announce response missing 4-byte bundle length",
+                    ));
+                }
+                let blen = u32::from_le_bytes(data[1..5].try_into().unwrap()) as usize;
+                if 5 + blen > data.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "announce response: bundle length exceeds buffer",
+                    ));
+                }
+                Ok(Response::Announce(data[5..5 + blen].to_vec()))
             }
             RESP_ADMIN_AUTH_CHALLENGE => {
                 if data.len() < 1 + 32 {
@@ -1894,5 +1957,111 @@ mod attest_wire_tests {
         let err = Response::decode(&payload).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(format!("{}", err).contains("ark_pem"), "got: {}", err);
+    }
+
+    // ─── Announce wire round-trips ──────────────────────────────────────
+
+    #[test]
+    fn announce_request_roundtrip() {
+        let encoded = Request::Announce.encode();
+        // [4B len LE][1B variant] = 5 bytes total.
+        assert_eq!(encoded.len(), 5);
+        assert_eq!(u32::from_le_bytes(encoded[..4].try_into().unwrap()), 1);
+        let decoded = Request::decode(&encoded[4..]).unwrap();
+        assert!(matches!(decoded, Request::Announce));
+    }
+
+    #[test]
+    fn announce_response_roundtrip_arbitrary_bundle() {
+        // The Response::Announce wraps the bundle bytes verbatim — it
+        // doesn't decode them. So this test uses an arbitrary blob to
+        // confirm the length-prefix framing is symmetric.
+        let bundle_bytes = (0u8..200u8).collect::<Vec<u8>>();
+        let encoded = Response::Announce(bundle_bytes.clone()).encode();
+        let decoded = Response::decode(&encoded[4..]).unwrap();
+        match decoded {
+            Response::Announce(bytes) => assert_eq!(bytes, bundle_bytes),
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn announce_response_truncated_bundle_length_fails() {
+        // [RESP_ANNOUNCE][len = 100][only 50 bytes of payload]
+        let mut payload = vec![RESP_ANNOUNCE];
+        payload.extend_from_slice(&100u32.to_le_bytes());
+        payload.extend_from_slice(&[0u8; 50]);
+        let err = Response::decode(&payload).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn announce_handler_returns_bundle_when_configured() {
+        use crate::handler::RequestHandler;
+        let bundle_bytes = vec![1u8, 2, 3, 4, 5];
+        let handler = RequestHandler::new(vec![])
+            .with_announcement_bundle(Some(bundle_bytes.clone()));
+        let resp = handler.handle_request(&Request::Announce);
+        match resp {
+            Response::Announce(bytes) => assert_eq!(bytes, bundle_bytes),
+            other => panic!("expected Announce, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn announce_handler_returns_error_when_unconfigured() {
+        use crate::handler::RequestHandler;
+        let handler = RequestHandler::new(vec![]); // announcement_bundle = None
+        let resp = handler.handle_request(&Request::Announce);
+        match resp {
+            Response::Error(msg) => assert!(msg.contains("announce not configured")),
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn announce_end_to_end_with_pir_identity() {
+        use crate::handler::RequestHandler;
+        use ed25519_dalek::SigningKey;
+        // Build a real bundle the SDK client will parse.
+        let op_sk = SigningKey::from_bytes(&[0x11u8; 32]);
+        let id_sk = SigningKey::from_bytes(&[0x22u8; 32]);
+        let cert = pir_identity::sign_identity_cert(
+            &op_sk,
+            "pir-test",
+            id_sk.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        let manifest = pir_identity::sign_channel_manifest(
+            &id_sk,
+            "pir-test",
+            [0xCCu8; 32],
+            [0xAAu8; 32],
+            "test-rev",
+            vec![],
+            1_700_000_000,
+        );
+        let bundle = pir_identity::AnnouncementBundle { cert, manifest };
+        let encoded_bundle = bundle.encode();
+        let handler = RequestHandler::new(vec![])
+            .with_announcement_bundle(Some(encoded_bundle.clone()));
+
+        // Server-side: produce the RESP_ANNOUNCE wire bytes.
+        let resp = handler.handle_request(&Request::Announce);
+        let wire = resp.encode();
+
+        // Client-side: decode the same wire. Bundle bytes round-trip.
+        let parsed = Response::decode(&wire[4..]).unwrap();
+        match parsed {
+            Response::Announce(b) => {
+                assert_eq!(b, encoded_bundle);
+                // And the bundle itself decodes + verify_chain passes.
+                let bundle2 = pir_identity::AnnouncementBundle::decode(&b).unwrap();
+                bundle2.verify_chain().unwrap();
+                assert_eq!(bundle2.cert.server_id, "pir-test");
+            }
+            other => panic!("expected Announce, got {:?}", other),
+        }
     }
 }

--- a/pir-runtime-core/src/table.rs
+++ b/pir-runtime-core/src/table.rs
@@ -358,6 +358,15 @@ pub struct ServerState {
     pub ark_pem: Vec<u8>,
     pub ask_pem: Vec<u8>,
     pub vcek_pem: Vec<u8>,
+    /// Pre-encoded `pir_identity::AnnouncementBundle` bytes that
+    /// REQ_ANNOUNCE returns verbatim. Populated at startup by
+    /// `crate::identity::build_announcement_bundle` if both the
+    /// `--identity-key-path` and `--identity-cert-path` files are
+    /// present and consistent; left `None` (and a warning is logged)
+    /// when either file is missing or the cert / key disagree. With
+    /// `None`, REQ_ANNOUNCE returns a `Response::Error` and the rest
+    /// of the protocol is unaffected.
+    pub announcement_bundle: Option<Vec<u8>>,
 }
 
 impl ServerState {

--- a/pir-sdk-client/Cargo.toml
+++ b/pir-sdk-client/Cargo.toml
@@ -48,6 +48,9 @@ pir-core = { version = "0.1.0", path = "../pir-core" }
 # (pir-runtime-core::channel). Compiles to wasm32 (verified — uses
 # RustCrypto's pure-Rust x25519-dalek + chacha20poly1305 + hkdf).
 pir-channel = { version = "0.1.0", path = "../pir-channel" }
+# Operator-signed identity bundle (REQ_ANNOUNCE response parser).
+# Pure-crypto Ed25519 — compiles to wasm32 without modification.
+pir-identity = { version = "0.1.0", path = "../pir-identity" }
 # Per-handshake ephemeral seed + nonce generation in
 # `DpfClient::upgrade_to_secure_channel`. The "js" feature lets it
 # use WebCrypto on wasm32; on native it reads /dev/urandom.

--- a/pir-sdk-client/src/announce.rs
+++ b/pir-sdk-client/src/announce.rs
@@ -1,0 +1,420 @@
+//! Client-side REQ_ANNOUNCE caller — fetches the operator-signed
+//! identity bundle from a connected server.
+//!
+//! ## What this does
+//!
+//! - Sends REQ_ANNOUNCE (opcode 0x07, empty body) over any
+//!   [`PirTransport`].
+//! - Decodes RESP_ANNOUNCE → a `pir_identity::AnnouncementBundle`.
+//! - Runs the [chain check](pir_identity::AnnouncementBundle::verify_chain):
+//!   the `ChannelManifest`'s signature must verify against the
+//!   `IdentityCert`'s `identity_pubkey`, and the `server_id` /
+//!   `identity_pubkey` cross-references must match.
+//!
+//! ## What this does NOT do
+//!
+//! - **Verify the IdentityCert against a pinned operator pubkey.**
+//!   The publishing mechanism for the operator pubkey is being
+//!   designed (eventually Nostr). Until pinning lands, the
+//!   `cert.operator_pubkey` is just what the server claims; clients
+//!   must NOT rely on it for trust. Callers that want full
+//!   authentication should pass an `operator_pubkey` to
+//!   [`announce_with_pinned_operator`] once the publishing path is in
+//!   place — that variant runs the missing check.
+//! - **Cross-check `channel_pub` against the value the encrypted
+//!   channel handshake used.** The caller is responsible for taking
+//!   `bundle.manifest.channel_pub` and comparing it against
+//!   `AttestVerification::response.server_static_pub` (or whatever
+//!   key path it actually handshook against). This crate doesn't
+//!   know about the handshake state.
+//! - **Validate `cert.valid_from` / `cert.valid_until`.** That's a
+//!   caller wall-clock policy. See
+//!   [`IdentityCert::check_validity`](pir_identity::IdentityCert::check_validity).
+//! - **Bound replay via `manifest.issued_at`.** Caller policy.
+
+use crate::protocol::encode_request;
+use crate::transport::PirTransport;
+use pir_identity::{AnnouncementBundle, IdentityError};
+use pir_sdk::{PirError, PirResult};
+
+/// REQ_ANNOUNCE opcode (mirrors `pir_runtime_core::protocol::REQ_ANNOUNCE`).
+pub(crate) const REQ_ANNOUNCE: u8 = 0x07;
+/// RESP_ANNOUNCE opcode.
+pub(crate) const RESP_ANNOUNCE: u8 = 0x07;
+/// Generic server-side error envelope.
+const RESP_ERROR: u8 = 0xff;
+
+/// What [`announce`] returns: the parsed bundle plus its chain-check
+/// verdict. The bundle is always returned (decode succeeded), but
+/// callers should consult `chain_verified` before trusting any of its
+/// fields. A `false` value here means the server returned a
+/// well-formed but inconsistent bundle — almost certainly a deploy
+/// bug, but also the shape a MITM with a misconfigured rig would
+/// produce.
+#[derive(Clone, Debug)]
+pub struct AnnounceVerification {
+    pub bundle: AnnouncementBundle,
+    /// Result of the in-bundle cross-check: manifest signature valid,
+    /// `cert.identity_pubkey == manifest.identity_pubkey`, and
+    /// `cert.server_id == manifest.server_id`. Operator-pubkey pinning
+    /// is a separate, caller-driven step.
+    pub chain_verified: bool,
+    /// `Some(e)` if `chain_verified` is `false`, for diagnostics.
+    pub chain_error: Option<IdentityError>,
+}
+
+/// Send REQ_ANNOUNCE and parse the response.
+///
+/// Returns:
+/// - `Ok(v)` — the server returned a well-formed bundle. `v.chain_verified`
+///   indicates whether the manifest-vs-cert chain check passed. Either
+///   way, the caller still owes (a) operator-pubkey pinning and
+///   (b) cross-check of `bundle.manifest.channel_pub` against the
+///   handshake pubkey.
+/// - `Err(PirError::ServerError(_))` — the server explicitly returned
+///   `RESP_ERROR`, typically meaning "announce is not configured on
+///   this server" (no `--identity-key-path` / `--identity-cert-path`).
+///   Production clients should treat this as a soft state — the
+///   server's other endpoints (attest, handshake, query) are still
+///   usable; just no operator-signed identity is available.
+/// - `Err(PirError::Protocol(_))` — wire-format violation.
+pub async fn announce<T: PirTransport + ?Sized>(
+    transport: &mut T,
+) -> PirResult<AnnounceVerification> {
+    let request = encode_request(REQ_ANNOUNCE, &[]);
+    let response = transport.roundtrip(&request).await?;
+
+    if response.is_empty() {
+        return Err(PirError::Protocol("empty announce response".into()));
+    }
+    match response[0] {
+        RESP_ANNOUNCE => { /* fall through */ }
+        RESP_ERROR => {
+            // Server-side error envelope. Decoder is shared with the
+            // existing attest path — wire layout is
+            // [RESP_ERROR][u32 len LE][utf-8 msg]. Older servers (pre-
+            // REQ_ANNOUNCE) reject the opcode at the request decoder,
+            // surfacing the same envelope, so this branch covers both.
+            let msg = if response.len() >= 5 {
+                let len = u32::from_le_bytes(response[1..5].try_into().unwrap()) as usize;
+                if 5 + len <= response.len() {
+                    String::from_utf8_lossy(&response[5..5 + len]).to_string()
+                } else {
+                    "<truncated error message>".into()
+                }
+            } else {
+                String::from_utf8_lossy(&response[1..]).to_string()
+            };
+            return Err(PirError::ServerError(msg));
+        }
+        v => {
+            return Err(PirError::Protocol(format!(
+                "unexpected response variant 0x{:02x} for announce",
+                v
+            )));
+        }
+    }
+
+    // Layout (after the variant byte): [u32 LE bundle_len][bundle_bytes]
+    if response.len() < 1 + 4 {
+        return Err(PirError::Protocol(
+            "announce response missing 4-byte bundle length".into(),
+        ));
+    }
+    let blen = u32::from_le_bytes(response[1..5].try_into().unwrap()) as usize;
+    if 5 + blen > response.len() {
+        return Err(PirError::Protocol(
+            "announce response: declared bundle length exceeds payload".into(),
+        ));
+    }
+    let bundle_bytes = &response[5..5 + blen];
+    let bundle = AnnouncementBundle::decode(bundle_bytes)
+        .map_err(|e| PirError::Protocol(format!("decode AnnouncementBundle: {}", e)))?;
+
+    // Run the chain check. Verifying the operator's signature on the
+    // cert is a SEPARATE step (caller policy) — see
+    // `announce_with_pinned_operator`.
+    let chain_result = bundle.verify_chain();
+    let (chain_verified, chain_error) = match chain_result {
+        Ok(()) => (true, None),
+        Err(e) => (false, Some(e)),
+    };
+
+    Ok(AnnounceVerification {
+        bundle,
+        chain_verified,
+        chain_error,
+    })
+}
+
+/// Same as [`announce`] but ALSO verifies the IdentityCert against a
+/// pinned operator pubkey. Use this once you have a trustworthy way
+/// to know the operator's pubkey (build-time pin, DNSSEC TXT, Nostr,
+/// etc.). Fails if the cert's signature doesn't validate under
+/// `pinned_operator_pubkey`, OR if the cert was signed by a different
+/// operator key than expected.
+///
+/// `now_unix_seconds` is the wall clock the caller wants to apply for
+/// the `valid_from` / `valid_until` window check. Pass `0` to skip
+/// the time check.
+pub async fn announce_with_pinned_operator<T: PirTransport + ?Sized>(
+    transport: &mut T,
+    pinned_operator_pubkey: &[u8; 32],
+    now_unix_seconds: i64,
+) -> PirResult<AnnounceVerification> {
+    let v = announce(transport).await?;
+    if &v.bundle.cert.operator_pubkey != pinned_operator_pubkey {
+        return Err(PirError::Protocol(format!(
+            "announce: cert.operator_pubkey ({}) does not match pinned operator ({})",
+            short_hex(&v.bundle.cert.operator_pubkey),
+            short_hex(pinned_operator_pubkey),
+        )));
+    }
+    v.bundle
+        .cert
+        .verify()
+        .map_err(|e| PirError::Protocol(format!("announce: cert.verify failed: {}", e)))?;
+    if now_unix_seconds != 0 {
+        v.bundle
+            .cert
+            .check_validity(now_unix_seconds)
+            .map_err(|e| PirError::Protocol(format!("announce: cert outside validity: {}", e)))?;
+    }
+    if !v.chain_verified {
+        return Err(PirError::Protocol(format!(
+            "announce: chain check failed: {}",
+            v.chain_error
+                .as_ref()
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "unknown".into())
+        )));
+    }
+    Ok(v)
+}
+
+fn short_hex(bytes: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(18);
+    for b in &bytes[..8] {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s.push('…');
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use ed25519_dalek::SigningKey;
+    use pir_identity::{sign_channel_manifest, sign_identity_cert, AnnouncementBundle};
+    use std::sync::Mutex;
+
+    struct MockTransport {
+        reply: Vec<u8>,
+        last_request: Mutex<Vec<u8>>,
+    }
+
+    #[async_trait]
+    impl PirTransport for MockTransport {
+        async fn send(&mut self, _data: Vec<u8>) -> PirResult<()> {
+            Ok(())
+        }
+        async fn recv(&mut self) -> PirResult<Vec<u8>> {
+            Ok(self.reply.clone())
+        }
+        async fn roundtrip(&mut self, request: &[u8]) -> PirResult<Vec<u8>> {
+            *self.last_request.lock().unwrap() = request.to_vec();
+            Ok(self.reply.clone())
+        }
+        async fn close(&mut self) -> PirResult<()> {
+            Ok(())
+        }
+        fn url(&self) -> &str {
+            "mock://test"
+        }
+    }
+
+    fn fake_sk(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn build_resp_announce(bundle: &AnnouncementBundle) -> Vec<u8> {
+        let mut payload = Vec::new();
+        payload.push(RESP_ANNOUNCE);
+        let b = bundle.encode();
+        payload.extend_from_slice(&(b.len() as u32).to_le_bytes());
+        payload.extend_from_slice(&b);
+        payload
+    }
+
+    fn build_bundle() -> AnnouncementBundle {
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        let manifest = sign_channel_manifest(
+            &id_sk,
+            "pir1",
+            [0xCCu8; 32],
+            [0xAAu8; 32],
+            "abc",
+            vec![],
+            1_700_000_000,
+        );
+        AnnouncementBundle { cert, manifest }
+    }
+
+    #[tokio::test]
+    async fn announce_returns_parsed_bundle_with_chain_verified() {
+        let bundle = build_bundle();
+        let mut mock = MockTransport {
+            reply: build_resp_announce(&bundle),
+            last_request: Mutex::new(Vec::new()),
+        };
+        let v = announce(&mut mock).await.unwrap();
+        assert!(v.chain_verified);
+        assert!(v.chain_error.is_none());
+        assert_eq!(v.bundle.cert.server_id, "pir1");
+        assert_eq!(v.bundle.manifest.channel_pub, [0xCCu8; 32]);
+
+        // Wire-sanity: REQ_ANNOUNCE has empty body.
+        let req = mock.last_request.lock().unwrap().clone();
+        assert_eq!(req.len(), 4 + 1);
+        assert_eq!(req[4], REQ_ANNOUNCE);
+    }
+
+    #[tokio::test]
+    async fn announce_chain_mismatch_surfaces_as_chain_verified_false() {
+        // Bundle that decodes fine but whose chain check fails.
+        let op_sk = fake_sk(0x11);
+        let id_sk_a = fake_sk(0x22);
+        let id_sk_b = fake_sk(0x33);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk_a.verifying_key().to_bytes(),
+            0,
+            0,
+        );
+        // Manifest signed by a different identity key than the cert
+        // endorses → chain check fails. (Each signature in isolation
+        // still verifies, but the cross-check catches it.)
+        let manifest = sign_channel_manifest(
+            &id_sk_b,
+            "pir1",
+            [0u8; 32],
+            [0u8; 32],
+            "v",
+            vec![],
+            0,
+        );
+        let bundle = AnnouncementBundle { cert, manifest };
+
+        let mut mock = MockTransport {
+            reply: build_resp_announce(&bundle),
+            last_request: Mutex::new(Vec::new()),
+        };
+        let v = announce(&mut mock).await.unwrap();
+        assert!(!v.chain_verified);
+        assert!(v.chain_error.is_some());
+    }
+
+    #[tokio::test]
+    async fn announce_server_error_envelope_propagates() {
+        // Server returns RESP_ERROR (e.g. "announce not configured").
+        let mut reply = vec![RESP_ERROR];
+        let msg = b"announce not configured";
+        reply.extend_from_slice(&(msg.len() as u32).to_le_bytes());
+        reply.extend_from_slice(msg);
+        let mut mock = MockTransport {
+            reply,
+            last_request: Mutex::new(Vec::new()),
+        };
+        let err = announce(&mut mock).await.unwrap_err();
+        match err {
+            PirError::ServerError(m) => assert!(m.contains("not configured")),
+            other => panic!("expected ServerError, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn announce_unknown_response_variant_is_decode_error() {
+        let mut mock = MockTransport {
+            reply: vec![0x42, 0x00, 0x00, 0x00, 0x00],
+            last_request: Mutex::new(Vec::new()),
+        };
+        let err = announce(&mut mock).await.unwrap_err();
+        assert!(matches!(err, PirError::Protocol(_)));
+    }
+
+    #[tokio::test]
+    async fn announce_with_pinned_operator_happy_path() {
+        let bundle = build_bundle();
+        let pinned = bundle.cert.operator_pubkey;
+        let mut mock = MockTransport {
+            reply: build_resp_announce(&bundle),
+            last_request: Mutex::new(Vec::new()),
+        };
+        let v = announce_with_pinned_operator(&mut mock, &pinned, 0)
+            .await
+            .unwrap();
+        assert!(v.chain_verified);
+    }
+
+    #[tokio::test]
+    async fn announce_with_pinned_operator_rejects_wrong_pin() {
+        let bundle = build_bundle();
+        let wrong_pin = [0u8; 32];
+        let mut mock = MockTransport {
+            reply: build_resp_announce(&bundle),
+            last_request: Mutex::new(Vec::new()),
+        };
+        let err = announce_with_pinned_operator(&mut mock, &wrong_pin, 0)
+            .await
+            .unwrap_err();
+        match err {
+            PirError::Protocol(m) => assert!(m.contains("does not match pinned operator")),
+            other => panic!("expected Protocol, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn announce_with_pinned_operator_rejects_expired_cert() {
+        // Cert with a tight validity window — query at a time outside
+        // the window must fail.
+        let op_sk = fake_sk(0x11);
+        let id_sk = fake_sk(0x22);
+        let cert = sign_identity_cert(
+            &op_sk,
+            "pir1",
+            id_sk.verifying_key().to_bytes(),
+            100,
+            200,
+        );
+        let manifest = sign_channel_manifest(
+            &id_sk,
+            "pir1",
+            [0u8; 32],
+            [0u8; 32],
+            "v",
+            vec![],
+            150,
+        );
+        let bundle = AnnouncementBundle { cert, manifest };
+        let pinned = bundle.cert.operator_pubkey;
+        let mut mock = MockTransport {
+            reply: build_resp_announce(&bundle),
+            last_request: Mutex::new(Vec::new()),
+        };
+        let err = announce_with_pinned_operator(&mut mock, &pinned, 999).await;
+        match err {
+            Err(PirError::Protocol(m)) => assert!(m.contains("outside validity")),
+            other => panic!("expected Protocol(outside validity), got {:?}", other),
+        }
+    }
+}

--- a/pir-sdk-client/src/attest.rs
+++ b/pir-sdk-client/src/attest.rs
@@ -33,7 +33,7 @@
 
 use crate::protocol::encode_request;
 use crate::transport::PirTransport;
-use pir_core::attest::{build_report_data, extract_report_data};
+use pir_core::attest::{build_report_data, derive_attest_nonce, extract_report_data};
 use pir_core::merkle::Hash256;
 use pir_sdk::{PirError, PirResult};
 
@@ -176,6 +176,42 @@ pub async fn attest<T: PirTransport + ?Sized>(
         expected_report_data_hash: expected_low,
         sev_status,
     })
+}
+
+/// Send REQ_ATTEST with the nonce *bound* to the client's handshake
+/// ephemeral pubkey, so the chip-signed REPORT_DATA commits to *this*
+/// handshake — not a stale or replayed attestation.
+///
+/// Concretely: `nonce = derive_attest_nonce(eph_pub_from_seed(eph_seed),
+/// random_32)`. The same `eph_seed` MUST be threaded into the
+/// subsequent [`crate::channel::establish`] call so the eph pubkey
+/// committed-to in REPORT_DATA equals the eph pubkey sent in
+/// REQ_HANDSHAKE.
+///
+/// `random_32` MUST be a fresh CSPRNG draw per call (Os entropy in
+/// production; deterministic in tests for reproducibility).
+///
+/// The returned [`AttestVerification`] is the same shape as
+/// [`attest`]'s — its `expected_report_data_hash` was computed using
+/// the derived nonce, so the existing `sev_status` semantics apply
+/// (e.g. `ReportDataMatch` proves the SEV report covers both the
+/// server's static pubkey AND this handshake's client ephemeral).
+pub async fn attest_with_eph_binding<T: PirTransport + ?Sized>(
+    transport: &mut T,
+    eph_seed: [u8; 32],
+    random_32: [u8; 32],
+) -> PirResult<AttestVerification> {
+    let client_eph_pub = pir_channel::eph_pub_from_seed(eph_seed);
+    let nonce = derive_attest_nonce(client_eph_pub, random_32);
+    attest(transport, nonce).await
+}
+
+/// Recompute the bound attest nonce from an `eph_seed` + `random_32`.
+/// Useful for tests / inspectors that want to compare a captured
+/// `AttestVerification::nonce` against the binding it should encode.
+pub fn bound_nonce_for(eph_seed: [u8; 32], random_32: [u8; 32]) -> [u8; 32] {
+    let client_eph_pub = pir_channel::eph_pub_from_seed(eph_seed);
+    derive_attest_nonce(client_eph_pub, random_32)
 }
 
 /// Mirror of `pir_runtime_core::protocol::decode_attest_result`. Kept
@@ -553,5 +589,139 @@ mod tests {
         };
         let err = attest(&mut mock, [0u8; 32]).await.unwrap_err();
         assert!(matches!(err, PirError::Protocol(_)), "got {:?}", err);
+    }
+
+    #[tokio::test]
+    async fn attest_with_eph_binding_sends_bound_nonce_on_the_wire() {
+        // The function must derive the nonce from (eph_seed, random_32)
+        // and put exactly those bytes into REQ_ATTEST. Recompute the
+        // expected nonce independently and compare to the wire bytes.
+        let eph_seed = [0x77u8; 32];
+        let random_32 = [0x88u8; 32];
+        let expected_nonce = bound_nonce_for(eph_seed, random_32);
+
+        let resp = AttestResponse {
+            sev_snp_report: Vec::new(),
+            manifest_roots: vec![],
+            binary_sha256: [0u8; 32],
+            server_static_pub: [0u8; 32],
+            git_rev: "x".into(),
+            ark_pem: Vec::new(),
+            ask_pem: Vec::new(),
+            vcek_pem: Vec::new(),
+        };
+        let mut mock = MockTransport {
+            reply: build_response_payload(&resp),
+            last_request: Mutex::new(Vec::new()),
+        };
+        let v = attest_with_eph_binding(&mut mock, eph_seed, random_32)
+            .await
+            .unwrap();
+        assert_eq!(v.nonce, expected_nonce);
+
+        let req = mock.last_request.lock().unwrap().clone();
+        assert_eq!(req.len(), 4 + 1 + 32);
+        assert_eq!(req[4], REQ_ATTEST);
+        assert_eq!(&req[5..37], &expected_nonce);
+    }
+
+    #[tokio::test]
+    async fn stale_report_against_different_eph_pub_is_rejected() {
+        // Threat model: an attacker captured a real SEV report from a
+        // prior session bound to eph_seed_A's nonce. They replay it
+        // against a client running eph_seed_B. The client's recomputed
+        // REPORT_DATA preimage uses nonce_B (committing to client_eph_pub_B);
+        // the captured report's REPORT_DATA was computed from nonce_A
+        // (committing to client_eph_pub_A) → mismatch.
+        let eph_seed_a = [0xAAu8; 32];
+        let eph_seed_b = [0xBBu8; 32];
+        let random_32 = [0x99u8; 32]; // same random, different eph_seeds
+        let nonce_a = bound_nonce_for(eph_seed_a, random_32);
+        let nonce_b = bound_nonce_for(eph_seed_b, random_32);
+        assert_ne!(nonce_a, nonce_b);
+
+        let manifest_roots = vec![[0u8; 32]];
+        let binary_sha256 = [0u8; 32];
+        let server_static_pub = [0xEEu8; 32];
+        let git_rev = "v1".to_string();
+
+        // The captured report's REPORT_DATA was computed against nonce_A.
+        let captured_preimage = build_report_data(
+            nonce_a,
+            &manifest_roots,
+            binary_sha256,
+            server_static_pub,
+            &git_rev,
+        );
+        let mut sev_blob = vec![0u8; 1184];
+        sev_blob[SEV_SNP_REPORT_DATA_OFFSET..SEV_SNP_REPORT_DATA_OFFSET + 64]
+            .copy_from_slice(&captured_preimage);
+
+        // Attacker re-serves the captured report verbatim (same SEV
+        // bytes + same self-reported fields) — what changes is which
+        // eph_seed the *current* client is using.
+        let resp = AttestResponse {
+            sev_snp_report: sev_blob,
+            manifest_roots,
+            binary_sha256,
+            server_static_pub,
+            git_rev,
+            ark_pem: Vec::new(),
+            ask_pem: Vec::new(),
+            vcek_pem: Vec::new(),
+        };
+        let mut mock = MockTransport {
+            reply: build_response_payload(&resp),
+            last_request: Mutex::new(Vec::new()),
+        };
+        // Current client runs with eph_seed_B → expects REPORT_DATA
+        // bound to nonce_B; gets one bound to nonce_A → mismatch.
+        let v = attest_with_eph_binding(&mut mock, eph_seed_b, random_32)
+            .await
+            .unwrap();
+        assert_eq!(v.sev_status, SevStatus::ReportDataMismatch);
+    }
+
+    #[tokio::test]
+    async fn bound_nonce_matches_against_honest_server() {
+        // Sanity: honest server signs against the SAME nonce the client
+        // derived → ReportDataMatch.
+        let eph_seed = [0x55u8; 32];
+        let random_32 = [0x66u8; 32];
+        let nonce = bound_nonce_for(eph_seed, random_32);
+
+        let manifest_roots = vec![[0x33u8; 32]];
+        let binary_sha256 = [0x44u8; 32];
+        let server_static_pub = [0xEEu8; 32];
+        let git_rev = "main".to_string();
+        let preimage = build_report_data(
+            nonce,
+            &manifest_roots,
+            binary_sha256,
+            server_static_pub,
+            &git_rev,
+        );
+        let mut sev_blob = vec![0u8; 1184];
+        sev_blob[SEV_SNP_REPORT_DATA_OFFSET..SEV_SNP_REPORT_DATA_OFFSET + 64]
+            .copy_from_slice(&preimage);
+
+        let resp = AttestResponse {
+            sev_snp_report: sev_blob,
+            manifest_roots,
+            binary_sha256,
+            server_static_pub,
+            git_rev,
+            ark_pem: Vec::new(),
+            ask_pem: Vec::new(),
+            vcek_pem: Vec::new(),
+        };
+        let mut mock = MockTransport {
+            reply: build_response_payload(&resp),
+            last_request: Mutex::new(Vec::new()),
+        };
+        let v = attest_with_eph_binding(&mut mock, eph_seed, random_32)
+            .await
+            .unwrap();
+        assert_eq!(v.sev_status, SevStatus::ReportDataMatch);
     }
 }

--- a/pir-sdk-client/src/dpf.rs
+++ b/pir-sdk-client/src/dpf.rs
@@ -1742,6 +1742,33 @@ impl DpfClient {
         crate::attest::attest(conn.as_mut(), nonce).await
     }
 
+    /// Send REQ_ANNOUNCE to the chosen server and parse the
+    /// operator-signed identity bundle. See
+    /// [`crate::announce::announce`] for the verification semantics.
+    /// The returned [`AnnounceVerification`](crate::announce::AnnounceVerification)
+    /// carries the parsed bundle plus the in-bundle chain check
+    /// result; operator-pubkey pinning is a caller-driven step on top.
+    pub async fn announce(
+        &mut self,
+        server_index: u8,
+    ) -> PirResult<crate::announce::AnnounceVerification> {
+        let conn = match server_index {
+            0 => self.conn0.as_mut().ok_or_else(|| {
+                PirError::Protocol("announce: server0 not connected".into())
+            })?,
+            1 => self.conn1.as_mut().ok_or_else(|| {
+                PirError::Protocol("announce: server1 not connected".into())
+            })?,
+            _ => {
+                return Err(PirError::Protocol(format!(
+                    "announce: server_index must be 0 or 1, got {}",
+                    server_index
+                )))
+            }
+        };
+        crate::announce::announce(conn.as_mut()).await
+    }
+
     /// Replace both server connections with secure-channel-wrapped
     /// versions. Sends REQ_HANDSHAKE on each, derives the per-session
     /// AEAD key, and stores `SecureChannelTransport` wrappers in place
@@ -1759,10 +1786,63 @@ impl DpfClient {
     /// Errors if either connection is unestablished or if either
     /// handshake fails. On error the connections are restored to their
     /// pre-call state (cleartext) so the caller can retry.
+    ///
+    /// **Note:** this overload mints fresh ephemeral seeds internally, so
+    /// the handshake's `client_eph_pub` is *unbound* from any prior
+    /// REQ_ATTEST. For the binding flow (attest nonce committed to the
+    /// same eph_pub used in the handshake), call
+    /// [`Self::upgrade_to_secure_channel_with_seeds`] instead, threading
+    /// the same `eph_seed` you passed to
+    /// [`crate::attest::attest_with_eph_binding`].
     pub async fn upgrade_to_secure_channel(
         &mut self,
         server_static_pub_0: [u8; 32],
         server_static_pub_1: [u8; 32],
+    ) -> PirResult<()> {
+        // Mint fresh ephemeral seed + nonce per server.
+        let mut eph0 = [0u8; 32];
+        let mut nonce0 = [0u8; 32];
+        let mut eph1 = [0u8; 32];
+        let mut nonce1 = [0u8; 32];
+        getrandom::getrandom(&mut eph0)
+            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
+        getrandom::getrandom(&mut nonce0)
+            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
+        getrandom::getrandom(&mut eph1)
+            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
+        getrandom::getrandom(&mut nonce1)
+            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
+
+        self.upgrade_to_secure_channel_with_seeds(
+            server_static_pub_0,
+            eph0,
+            nonce0,
+            server_static_pub_1,
+            eph1,
+            nonce1,
+        )
+        .await
+    }
+
+    /// Same as [`Self::upgrade_to_secure_channel`] but lets the caller
+    /// supply the handshake ephemeral seeds + HKDF nonces. **Production
+    /// callers SHOULD use this overload** and pass the same `eph_seed`
+    /// they fed to [`crate::attest::attest_with_eph_binding`] for the
+    /// matching server — otherwise the attestation does not bind to the
+    /// handshake (a stale captured report could be replayed against a
+    /// fresh handshake undetected).
+    ///
+    /// `hs_nonce_0` / `hs_nonce_1` are HKDF salts for session-key
+    /// derivation (not the attest nonce). They MUST be CSPRNG-fresh per
+    /// call.
+    pub async fn upgrade_to_secure_channel_with_seeds(
+        &mut self,
+        server_static_pub_0: [u8; 32],
+        eph_seed_0: [u8; 32],
+        hs_nonce_0: [u8; 32],
+        server_static_pub_1: [u8; 32],
+        eph_seed_1: [u8; 32],
+        hs_nonce_1: [u8; 32],
     ) -> PirResult<()> {
         // Take out both transports up front. If either is missing we
         // re-store what we took before bailing.
@@ -1778,26 +1858,14 @@ impl DpfClient {
             }
         };
 
-        // Mint fresh ephemeral seed + nonce per server.
-        let mut eph0 = [0u8; 32];
-        let mut nonce0 = [0u8; 32];
-        let mut eph1 = [0u8; 32];
-        let mut nonce1 = [0u8; 32];
-        getrandom::getrandom(&mut eph0)
-            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
-        getrandom::getrandom(&mut nonce0)
-            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
-        getrandom::getrandom(&mut eph1)
-            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
-        getrandom::getrandom(&mut nonce1)
-            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
-
         // Run the two handshakes. If either fails, leave both connections
         // in self.conn0/conn1 as None — the caller knows from the error
         // that the connection state is now invalid (and should reconnect
         // before retrying).
-        let wrapped0 = crate::channel::establish(raw0, server_static_pub_0, eph0, nonce0).await?;
-        let wrapped1 = crate::channel::establish(raw1, server_static_pub_1, eph1, nonce1).await?;
+        let wrapped0 =
+            crate::channel::establish(raw0, server_static_pub_0, eph_seed_0, hs_nonce_0).await?;
+        let wrapped1 =
+            crate::channel::establish(raw1, server_static_pub_1, eph_seed_1, hs_nonce_1).await?;
 
         self.conn0 = Some(Box::new(wrapped0));
         self.conn1 = Some(Box::new(wrapped1));

--- a/pir-sdk-client/src/harmony.rs
+++ b/pir-sdk-client/src/harmony.rs
@@ -791,6 +791,29 @@ impl HarmonyClient {
         crate::attest::attest(conn.as_mut(), nonce).await
     }
 
+    /// Send REQ_ANNOUNCE to the chosen server (0 = hint, 1 = query).
+    /// See [`super::DpfClient::announce`] for full semantics.
+    pub async fn announce(
+        &mut self,
+        server_index: u8,
+    ) -> PirResult<crate::announce::AnnounceVerification> {
+        let conn = match server_index {
+            0 => self.hint_conn.as_mut().ok_or_else(|| {
+                PirError::Protocol("announce: hint server not connected".into())
+            })?,
+            1 => self.query_conn.as_mut().ok_or_else(|| {
+                PirError::Protocol("announce: query server not connected".into())
+            })?,
+            _ => {
+                return Err(PirError::Protocol(format!(
+                    "announce: server_index must be 0 (hint) or 1 (query), got {}",
+                    server_index
+                )))
+            }
+        };
+        crate::announce::announce(conn.as_mut()).await
+    }
+
     /// Replace both server connections with secure-channel-wrapped
     /// versions. See [`super::DpfClient::upgrade_to_secure_channel`]
     /// for the full semantics. Argument order matches the
@@ -799,6 +822,45 @@ impl HarmonyClient {
         &mut self,
         hint_server_static_pub: [u8; 32],
         query_server_static_pub: [u8; 32],
+    ) -> PirResult<()> {
+        let mut eph_h = [0u8; 32];
+        let mut nonce_h = [0u8; 32];
+        let mut eph_q = [0u8; 32];
+        let mut nonce_q = [0u8; 32];
+        getrandom::getrandom(&mut eph_h)
+            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
+        getrandom::getrandom(&mut nonce_h)
+            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
+        getrandom::getrandom(&mut eph_q)
+            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
+        getrandom::getrandom(&mut nonce_q)
+            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
+
+        self.upgrade_to_secure_channel_with_seeds(
+            hint_server_static_pub,
+            eph_h,
+            nonce_h,
+            query_server_static_pub,
+            eph_q,
+            nonce_q,
+        )
+        .await
+    }
+
+    /// Binding-friendly overload: thread the same `eph_seed_*` you
+    /// passed to [`crate::attest::attest_with_eph_binding`] for the
+    /// corresponding server so the attestation covers this exact
+    /// handshake. See
+    /// [`super::DpfClient::upgrade_to_secure_channel_with_seeds`] for
+    /// rationale. `hs_nonce_*` are HKDF salts (CSPRNG-fresh per call).
+    pub async fn upgrade_to_secure_channel_with_seeds(
+        &mut self,
+        hint_server_static_pub: [u8; 32],
+        eph_seed_hint: [u8; 32],
+        hs_nonce_hint: [u8; 32],
+        query_server_static_pub: [u8; 32],
+        eph_seed_query: [u8; 32],
+        hs_nonce_query: [u8; 32],
     ) -> PirResult<()> {
         let raw_hint = self
             .hint_conn
@@ -814,23 +876,20 @@ impl HarmonyClient {
             }
         };
 
-        let mut eph_h = [0u8; 32];
-        let mut nonce_h = [0u8; 32];
-        let mut eph_q = [0u8; 32];
-        let mut nonce_q = [0u8; 32];
-        getrandom::getrandom(&mut eph_h)
-            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
-        getrandom::getrandom(&mut nonce_h)
-            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
-        getrandom::getrandom(&mut eph_q)
-            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
-        getrandom::getrandom(&mut nonce_q)
-            .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
-
-        let wrapped_hint =
-            crate::channel::establish(raw_hint, hint_server_static_pub, eph_h, nonce_h).await?;
-        let wrapped_query =
-            crate::channel::establish(raw_query, query_server_static_pub, eph_q, nonce_q).await?;
+        let wrapped_hint = crate::channel::establish(
+            raw_hint,
+            hint_server_static_pub,
+            eph_seed_hint,
+            hs_nonce_hint,
+        )
+        .await?;
+        let wrapped_query = crate::channel::establish(
+            raw_query,
+            query_server_static_pub,
+            eph_seed_query,
+            hs_nonce_query,
+        )
+        .await?;
 
         self.hint_conn = Some(Box::new(wrapped_hint));
         self.query_conn = Some(Box::new(wrapped_query));

--- a/pir-sdk-client/src/lib.rs
+++ b/pir-sdk-client/src/lib.rs
@@ -58,6 +58,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod connection;
 pub mod admin;
+pub mod announce;
 pub mod attest;
 pub mod channel;
 mod dpf;

--- a/pir-sdk-client/src/onion.rs
+++ b/pir-sdk-client/src/onion.rs
@@ -584,6 +584,18 @@ impl OnionClient {
         crate::attest::attest(conn.as_mut(), nonce).await
     }
 
+    /// Send REQ_ANNOUNCE and parse the operator-signed identity bundle.
+    /// See [`super::DpfClient::announce`] for full semantics.
+    pub async fn announce(
+        &mut self,
+    ) -> PirResult<crate::announce::AnnounceVerification> {
+        let conn = self
+            .conn
+            .as_mut()
+            .ok_or_else(|| PirError::Protocol("announce: server not connected".into()))?;
+        crate::announce::announce(conn.as_mut()).await
+    }
+
     /// Replace the server connection with a secure-channel-wrapped
     /// version. See [`super::DpfClient::upgrade_to_secure_channel`]
     /// for the full semantics.
@@ -591,17 +603,32 @@ impl OnionClient {
         &mut self,
         server_static_pub: [u8; 32],
     ) -> PirResult<()> {
-        let raw = self
-            .conn
-            .take()
-            .ok_or_else(|| PirError::Protocol("upgrade: server not connected".into()))?;
         let mut eph = [0u8; 32];
         let mut nonce = [0u8; 32];
         getrandom::getrandom(&mut eph)
             .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
         getrandom::getrandom(&mut nonce)
             .map_err(|e| PirError::Protocol(format!("getrandom: {}", e)))?;
-        let wrapped = crate::channel::establish(raw, server_static_pub, eph, nonce).await?;
+        self.upgrade_to_secure_channel_with_seeds(server_static_pub, eph, nonce)
+            .await
+    }
+
+    /// Binding-friendly overload: thread the same `eph_seed` you
+    /// passed to [`crate::attest::attest_with_eph_binding`] so the
+    /// attestation covers this exact handshake. `hs_nonce` is the HKDF
+    /// salt (CSPRNG-fresh per call).
+    pub async fn upgrade_to_secure_channel_with_seeds(
+        &mut self,
+        server_static_pub: [u8; 32],
+        eph_seed: [u8; 32],
+        hs_nonce: [u8; 32],
+    ) -> PirResult<()> {
+        let raw = self
+            .conn
+            .take()
+            .ok_or_else(|| PirError::Protocol("upgrade: server not connected".into()))?;
+        let wrapped =
+            crate::channel::establish(raw, server_static_pub, eph_seed, hs_nonce).await?;
         self.conn = Some(Box::new(wrapped));
         Ok(())
     }

--- a/pir-sdk-wasm/Cargo.toml
+++ b/pir-sdk-wasm/Cargo.toml
@@ -39,6 +39,11 @@ pir-core = { version = "0.1.0", path = "../pir-core" }
 # the native path in `cargo test -p pir-sdk-wasm`, so the tokio pull-in is
 # acceptable.
 pir-sdk-client = { version = "0.1.0", path = "../pir-sdk-client" }
+# Provides `eph_pub_from_seed` for the bound-nonce derivation in
+# `WasmDpfClient::attest` / `WasmHarmonyClient::attest` (so the SEV-SNP
+# REPORT_DATA commits to the *exact* X25519 eph pubkey used in the
+# subsequent `upgradeToSecureChannel` handshake).
+pir-channel = { version = "0.1.0", path = "../pir-channel" }
 arc = { git = "https://github.com/Bitcoin-PIR/arc.git", rev = "de6c1709eee0faa32985d5a452be11904ee95de4" }
 rand_core = { version = "0.6", features = ["getrandom"] }
 # Browser-side AMD VCEK chain verifier (Slice D). Pure-Rust crypto

--- a/pir-sdk-wasm/src/client.rs
+++ b/pir-sdk-wasm/src/client.rs
@@ -591,6 +591,285 @@ impl WasmAttestVerification {
         .map_err(|e| JsError::new(&format!("{}", e)))?;
         Ok(())
     }
+
+    /// Highest-level SEV-SNP check: runs `verifyVcekChain`'s four
+    /// steps AND the policy assertions described below — in a single
+    /// call. On success, the report is fully trustworthy
+    /// (signature-anchored AND content-acceptable).
+    ///
+    /// `expectedArkFingerprint`: same as `verifyVcekChain`. Pass the
+    /// `AMD_TURIN_ARK_FINGERPRINT` constant from `attest-pin.ts` for
+    /// production.
+    ///
+    /// `policy` is a `WasmPolicyRequirements` (constructed via its
+    /// JS-visible constructor + setters). Defaults to the strictest
+    /// production policy: VMPL 0, no debug, no migration, TCB
+    /// monotonic. Override individual fields for tests / non-strict
+    /// deployments.
+    ///
+    /// Throws a single-line JsError on the FIRST failing step (chain
+    /// → report sig → policy). Use `verifyVcekChain` directly if you
+    /// want to surface the chain / sig failure separately from a
+    /// policy failure.
+    #[wasm_bindgen(js_name = verifyFull)]
+    pub fn verify_full(
+        &self,
+        expected_ark_fingerprint: Option<Box<[u8]>>,
+        policy: &WasmPolicyRequirements,
+    ) -> Result<(), JsError> {
+        if !self.has_vcek_chain() {
+            return Err(JsError::new(
+                "verifyFull: server didn't bundle a VCEK chain (arkPem/askPem/vcekPem empty)",
+            ));
+        }
+        let pin = match expected_ark_fingerprint {
+            None => None,
+            Some(bytes) => {
+                if bytes.len() != 32 {
+                    return Err(JsError::new(&format!(
+                        "expectedArkFingerprint must be exactly 32 bytes, got {}",
+                        bytes.len()
+                    )));
+                }
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&bytes);
+                Some(arr)
+            }
+        };
+        pir_attest_verify::verify_full(
+            &self.inner.response.sev_snp_report,
+            &self.inner.response.ark_pem,
+            &self.inner.response.ask_pem,
+            &self.inner.response.vcek_pem,
+            pin,
+            &policy.inner,
+        )
+        .map_err(|e| JsError::new(&format!("{}", e)))?;
+        Ok(())
+    }
+}
+
+/// JS-visible policy requirements for [`WasmAttestVerification::verify_full`].
+/// Constructed with sensible production defaults (strict). Mutate
+/// individual fields via the setters to relax.
+#[wasm_bindgen]
+pub struct WasmPolicyRequirements {
+    inner: pir_attest_verify::policy::PolicyRequirements,
+}
+
+#[wasm_bindgen]
+impl WasmPolicyRequirements {
+    /// Construct the strictest production policy: VMPL 0, no debug,
+    /// no MA migration, TCB-monotonic. No measurement / family /
+    /// image pin (set via the corresponding setters if you want them).
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            inner: pir_attest_verify::policy::PolicyRequirements::default(),
+        }
+    }
+
+    /// Raise the VMPL ceiling. Production: leave at 0.
+    #[wasm_bindgen(js_name = setMaxVmpl)]
+    pub fn set_max_vmpl(&mut self, v: u32) {
+        self.inner.max_vmpl = v;
+    }
+
+    /// Permit guests with `policy.debug_allowed` set. Production: leave false.
+    #[wasm_bindgen(js_name = setAllowDebug)]
+    pub fn set_allow_debug(&mut self, v: bool) {
+        self.inner.allow_debug = v;
+    }
+
+    /// Permit guests with `policy.migrate_ma_allowed` set. Production: leave false.
+    #[wasm_bindgen(js_name = setAllowMigrateMa)]
+    pub fn set_allow_migrate_ma(&mut self, v: bool) {
+        self.inner.allow_migrate_ma = v;
+    }
+
+    /// Require guests to have `policy.single_socket_required`. Off by default.
+    #[wasm_bindgen(js_name = setRequireSingleSocket)]
+    pub fn set_require_single_socket(&mut self, v: bool) {
+        self.inner.require_single_socket = v;
+    }
+
+    /// Pin the expected MEASUREMENT (48 bytes). Must be exactly 48
+    /// bytes or a JsError is thrown. Set to the operator-published
+    /// value for your Tier 3 UKI.
+    #[wasm_bindgen(js_name = setExpectedMeasurement)]
+    pub fn set_expected_measurement(&mut self, bytes: &[u8]) -> Result<(), JsError> {
+        if bytes.len() != 48 {
+            return Err(JsError::new(&format!(
+                "expectedMeasurement must be exactly 48 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut arr = [0u8; 48];
+        arr.copy_from_slice(bytes);
+        self.inner.expected_measurement = Some(arr);
+        Ok(())
+    }
+
+    /// Pin the expected family_id (16 bytes).
+    #[wasm_bindgen(js_name = setExpectedFamilyId)]
+    pub fn set_expected_family_id(&mut self, bytes: &[u8]) -> Result<(), JsError> {
+        if bytes.len() != 16 {
+            return Err(JsError::new(&format!(
+                "expectedFamilyId must be exactly 16 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut arr = [0u8; 16];
+        arr.copy_from_slice(bytes);
+        self.inner.expected_family_id = Some(arr);
+        Ok(())
+    }
+
+    /// Pin the expected image_id (16 bytes).
+    #[wasm_bindgen(js_name = setExpectedImageId)]
+    pub fn set_expected_image_id(&mut self, bytes: &[u8]) -> Result<(), JsError> {
+        if bytes.len() != 16 {
+            return Err(JsError::new(&format!(
+                "expectedImageId must be exactly 16 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut arr = [0u8; 16];
+        arr.copy_from_slice(bytes);
+        self.inner.expected_image_id = Some(arr);
+        Ok(())
+    }
+}
+
+impl Default for WasmPolicyRequirements {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// JS-visible accessor for the Turin ARK fingerprint pinned in
+/// pir-attest-verify (matches `web/src/attest-pin.ts`). Returns the
+/// 32-byte SHA-256 as a Uint8Array. Pass directly to
+/// [`WasmAttestVerification::verify_full`] /
+/// [`WasmAttestVerification::verify_vcek_chain`] for Turin servers.
+#[wasm_bindgen(js_name = turinArkFingerprint)]
+pub fn turin_ark_fingerprint() -> Uint8Array {
+    Uint8Array::from(&pir_attest_verify::TURIN_ARK_FINGERPRINT_SHA256[..])
+}
+
+// ─── WasmAnnounceVerification ──────────────────────────────────────────────
+
+/// JS-visible result of a `WasmDpfClient.announce()` (or
+/// `WasmHarmonyClient.announce()`) call.
+///
+/// Carries the parsed operator-signed bundle:
+/// - `IdentityCert` (Tier 1): operator's offline Ed25519 key endorses
+///   the server's identity_pubkey for a given server_id + validity
+///   window.
+/// - `ChannelManifest` (Tier 2): server's per-boot Ed25519 key signs
+///   the current channel_pub + build metadata.
+///
+/// `chainVerified` tells you whether the two layers cross-check
+/// (manifest signature + identity_pubkey + server_id agreement).
+/// Pinning the operator pubkey is a separate, caller-driven step:
+/// compare `operatorPubkeyHex` against your pinned value, then call
+/// the IdentityCert's verify yourself if you want defense-in-depth on
+/// top of `chainVerified` — but `chainVerified` already runs the
+/// manifest signature check internally.
+#[wasm_bindgen]
+pub struct WasmAnnounceVerification {
+    inner: pir_sdk_client::announce::AnnounceVerification,
+}
+
+#[wasm_bindgen]
+impl WasmAnnounceVerification {
+    /// Server identifier the cert was endorsed for (e.g. "pir1").
+    #[wasm_bindgen(getter, js_name = serverId)]
+    pub fn server_id(&self) -> String {
+        self.inner.bundle.cert.server_id.clone()
+    }
+
+    /// Hex-encoded operator pubkey (the Tier-1 signer). Compare this
+    /// against the value the operator published out-of-band (e.g. via
+    /// Nostr) before trusting any of the bundle's fields.
+    #[wasm_bindgen(getter, js_name = operatorPubkeyHex)]
+    pub fn operator_pubkey_hex(&self) -> String {
+        hex_encode(&self.inner.bundle.cert.operator_pubkey)
+    }
+
+    /// Hex-encoded identity pubkey the operator endorsed for this
+    /// server. The Tier-2 manifest signature chains back to this key.
+    #[wasm_bindgen(getter, js_name = identityPubkeyHex)]
+    pub fn identity_pubkey_hex(&self) -> String {
+        hex_encode(&self.inner.bundle.cert.identity_pubkey)
+    }
+
+    /// X25519 channel pubkey the manifest endorses. Cross-check
+    /// against the value you'll handshake with (e.g.
+    /// `attestVerification.serverStaticPub`). Returns the raw 32 bytes.
+    #[wasm_bindgen(getter, js_name = channelPub)]
+    pub fn channel_pub(&self) -> Uint8Array {
+        Uint8Array::from(&self.inner.bundle.manifest.channel_pub[..])
+    }
+
+    /// Same data as [`Self::channel_pub`] but hex-encoded for display.
+    #[wasm_bindgen(getter, js_name = channelPubHex)]
+    pub fn channel_pub_hex(&self) -> String {
+        hex_encode(&self.inner.bundle.manifest.channel_pub)
+    }
+
+    /// Hex-encoded binary SHA-256 the manifest claims (self-reported,
+    /// trustworthy iff the chain check passed).
+    #[wasm_bindgen(getter, js_name = binarySha256Hex)]
+    pub fn binary_sha256_hex(&self) -> String {
+        hex_encode(&self.inner.bundle.manifest.binary_sha256)
+    }
+
+    /// Server-self-reported git rev (string).
+    #[wasm_bindgen(getter, js_name = gitRev)]
+    pub fn git_rev(&self) -> String {
+        self.inner.bundle.manifest.git_rev.clone()
+    }
+
+    /// Cert validity lower bound (unix-seconds). 0 = no lower bound.
+    #[wasm_bindgen(getter, js_name = validFrom)]
+    pub fn valid_from(&self) -> i64 {
+        self.inner.bundle.cert.valid_from
+    }
+
+    /// Cert validity upper bound (unix-seconds). 0 = indefinite.
+    #[wasm_bindgen(getter, js_name = validUntil)]
+    pub fn valid_until(&self) -> i64 {
+        self.inner.bundle.cert.valid_until
+    }
+
+    /// Manifest's `issued_at` timestamp (unix-seconds). Use this to
+    /// apply a freshness policy if you want one.
+    #[wasm_bindgen(getter, js_name = issuedAt)]
+    pub fn issued_at(&self) -> i64 {
+        self.inner.bundle.manifest.issued_at
+    }
+
+    /// Whether the in-bundle chain check passed: manifest signature
+    /// valid against `identityPubkey`, and `cert.server_id` ==
+    /// `manifest.server_id`, and `cert.identity_pubkey` ==
+    /// `manifest.identity_pubkey`. Does NOT include cert-vs-pinned-
+    /// operator verification (caller-driven).
+    #[wasm_bindgen(getter, js_name = chainVerified)]
+    pub fn chain_verified(&self) -> bool {
+        self.inner.chain_verified
+    }
+
+    /// Diagnostic string describing why `chainVerified` is false.
+    /// Empty when verified.
+    #[wasm_bindgen(getter, js_name = chainError)]
+    pub fn chain_error(&self) -> String {
+        self.inner
+            .chain_error
+            .as_ref()
+            .map(|e| e.to_string())
+            .unwrap_or_default()
+    }
 }
 
 // ─── WasmDpfClient ──────────────────────────────────────────────────────────
@@ -612,6 +891,12 @@ impl WasmAttestVerification {
 #[wasm_bindgen]
 pub struct WasmDpfClient {
     inner: DpfClient,
+    /// Per-server cache of the handshake-eph seed committed-to in the
+    /// most recent `attest()` call's REPORT_DATA. Threaded into
+    /// `upgradeToSecureChannel` so the chip-signed report binds the
+    /// exact eph_pub used in the handshake. Cleared after a successful
+    /// upgrade. JS callers never see these bytes.
+    attest_eph_seeds: [Option<[u8; 32]>; 2],
 }
 
 #[wasm_bindgen]
@@ -622,6 +907,7 @@ impl WasmDpfClient {
     pub fn new(server0_url: &str, server1_url: &str) -> Self {
         Self {
             inner: DpfClient::new(server0_url, server1_url),
+            attest_eph_seeds: [None, None],
         }
     }
 
@@ -751,31 +1037,81 @@ impl WasmDpfClient {
     /// Send REQ_ATTEST to one of the connected servers and return a
     /// [`WasmAttestVerification`] handle covering the response.
     ///
-    /// `serverIndex` selects 0 (first URL) or 1 (second URL). The 32-byte
-    /// nonce is generated browser-side from `crypto.getRandomValues` (via
-    /// `getrandom`'s "js" feature) — different on every call, so callers
-    /// can correlate parallel attests by re-reading
-    /// [`WasmAttestVerification::nonce_hex`].
+    /// `serverIndex` selects 0 (first URL) or 1 (second URL). Internally
+    /// the 32-byte nonce is *bound* to the X25519 handshake ephemeral
+    /// the client will use in the subsequent `upgradeToSecureChannel`:
     ///
-    /// Use the returned `serverStaticPub` (32 bytes) as input to
-    /// [`Self::upgradeToSecureChannel`]. Verifying the SEV-SNP report's
-    /// AMD VCEK chain is a separate concern (Slice D) — until that
-    /// lands, the V2 binding only proves internal consistency of the
-    /// claimed server-side state, not the chip's signature.
+    /// ```text
+    /// eph_seed       = OsRng()                                  (cached per-server)
+    /// client_eph_pub = X25519(eph_seed)
+    /// random_32      = OsRng()
+    /// nonce          = sha256("BPIR-ATTEST-NONCE-V1" || client_eph_pub || random_32)
+    /// ```
+    ///
+    /// Caching the `eph_seed` here lets `upgradeToSecureChannel` reuse
+    /// the same pubkey the report committed to, so the chip-signed
+    /// REPORT_DATA covers *this* handshake — not a stale or replayed
+    /// one. The `eph_seed` is never exposed to JS.
+    ///
+    /// Calling `attest(serverIndex)` twice for the same server rotates
+    /// the cached seed (the prior eph is dropped). Callers should call
+    /// `attest` for *both* servers before `upgradeToSecureChannel`.
     #[wasm_bindgen(js_name = attest)]
     pub async fn attest(
         &mut self,
         server_index: u8,
     ) -> Result<WasmAttestVerification, JsError> {
-        let mut nonce = [0u8; 32];
-        getrandom::getrandom(&mut nonce)
+        if server_index >= 2 {
+            return Err(JsError::new(&format!(
+                "attest: serverIndex must be 0 or 1, got {}",
+                server_index
+            )));
+        }
+        let mut eph_seed = [0u8; 32];
+        let mut random_32 = [0u8; 32];
+        getrandom::getrandom(&mut eph_seed)
             .map_err(|e| JsError::new(&format!("getrandom: {}", e)))?;
+        getrandom::getrandom(&mut random_32)
+            .map_err(|e| JsError::new(&format!("getrandom: {}", e)))?;
+        let client_eph_pub = pir_channel::eph_pub_from_seed(eph_seed);
+        let nonce = pir_core::attest::derive_attest_nonce(client_eph_pub, random_32);
         let v = self
             .inner
             .attest(server_index, nonce)
             .await
             .map_err(err_to_js)?;
+        // Only cache on a successful attest call so a network failure
+        // doesn't leave a stale seed behind that a subsequent upgrade
+        // would silently use.
+        self.attest_eph_seeds[server_index as usize] = Some(eph_seed);
         Ok(WasmAttestVerification { inner: v })
+    }
+
+    /// Send REQ_ANNOUNCE to one of the connected servers and return a
+    /// [`WasmAnnounceVerification`] with the parsed operator-signed
+    /// identity bundle.
+    ///
+    /// Errors with the server's RESP_ERROR text ("announce not
+    /// configured") if the server doesn't have an identity key + cert
+    /// installed. That's a soft state — attest / handshake / queries
+    /// still work as normal.
+    #[wasm_bindgen(js_name = announce)]
+    pub async fn announce(
+        &mut self,
+        server_index: u8,
+    ) -> Result<WasmAnnounceVerification, JsError> {
+        if server_index >= 2 {
+            return Err(JsError::new(&format!(
+                "announce: serverIndex must be 0 or 1, got {}",
+                server_index
+            )));
+        }
+        let v = self
+            .inner
+            .announce(server_index)
+            .await
+            .map_err(err_to_js)?;
+        Ok(WasmAnnounceVerification { inner: v })
     }
 
     /// Wrap both server connections with the encrypted-channel
@@ -789,9 +1125,15 @@ impl WasmDpfClient {
     /// frame format — cloudflared (or any other transport-layer
     /// intermediary) sees only ciphertext.
     ///
-    /// Errors if either connection isn't established, or if either
-    /// handshake fails. On error, the connections are dropped — call
-    /// [`Self::connect`] to re-establish.
+    /// Uses the eph_seeds cached by [`Self::attest`] so the handshake's
+    /// `client_eph_pub` matches the one the SEV-SNP REPORT_DATA
+    /// committed to. **You MUST call `attest(0)` and `attest(1)` before
+    /// this method**, otherwise it rejects with a JsError. On success
+    /// the cached seeds are cleared (one-shot per attest call).
+    ///
+    /// Errors if either connection isn't established, either cached
+    /// eph_seed is missing, or either handshake fails. On error, the
+    /// connections are dropped — call [`Self::connect`] to re-establish.
     #[wasm_bindgen(js_name = upgradeToSecureChannel)]
     pub async fn upgrade_to_secure_channel(
         &mut self,
@@ -804,10 +1146,32 @@ impl WasmDpfClient {
         let pub1: [u8; 32] = server_static_pub_1
             .try_into()
             .map_err(|_| JsError::new("serverStaticPub1 must be exactly 32 bytes"))?;
+        let eph_seed_0 = self.attest_eph_seeds[0].ok_or_else(|| {
+            JsError::new(
+                "upgradeToSecureChannel: must call attest(0) first (eph_seed binding required)",
+            )
+        })?;
+        let eph_seed_1 = self.attest_eph_seeds[1].ok_or_else(|| {
+            JsError::new(
+                "upgradeToSecureChannel: must call attest(1) first (eph_seed binding required)",
+            )
+        })?;
+        let mut hs_nonce_0 = [0u8; 32];
+        let mut hs_nonce_1 = [0u8; 32];
+        getrandom::getrandom(&mut hs_nonce_0)
+            .map_err(|e| JsError::new(&format!("getrandom: {}", e)))?;
+        getrandom::getrandom(&mut hs_nonce_1)
+            .map_err(|e| JsError::new(&format!("getrandom: {}", e)))?;
         self.inner
-            .upgrade_to_secure_channel(pub0, pub1)
+            .upgrade_to_secure_channel_with_seeds(
+                pub0, eph_seed_0, hs_nonce_0, pub1, eph_seed_1, hs_nonce_1,
+            )
             .await
-            .map_err(err_to_js)
+            .map_err(err_to_js)?;
+        // One-shot: consume the cached seeds so a follow-up reconnect
+        // is forced to re-attest before another upgrade.
+        self.attest_eph_seeds = [None, None];
+        Ok(())
     }
 
     /// Inspector-path batch query — like [`queryBatch`](Self::query_batch)
@@ -1032,6 +1396,11 @@ impl WasmDpfClient {
 #[wasm_bindgen]
 pub struct WasmHarmonyClient {
     inner: HarmonyClient,
+    /// Per-server cache of the handshake-eph seed committed-to in the
+    /// most recent `attest()` call's REPORT_DATA. Index 0 = hint
+    /// server, index 1 = query server. See
+    /// [`WasmDpfClient::attest_eph_seeds`].
+    attest_eph_seeds: [Option<[u8; 32]>; 2],
 }
 
 #[wasm_bindgen]
@@ -1044,6 +1413,7 @@ impl WasmHarmonyClient {
     pub fn new(hint_server_url: &str, query_server_url: &str) -> Self {
         Self {
             inner: HarmonyClient::new(hint_server_url, query_server_url),
+            attest_eph_seeds: [None, None],
         }
     }
 
@@ -1179,26 +1549,63 @@ impl WasmHarmonyClient {
 
     /// Send REQ_ATTEST to the hint (`serverIndex=0`) or query
     /// (`serverIndex=1`) server and return the verification result.
-    /// See [`WasmDpfClient::attest`] for the full semantics.
+    /// See [`WasmDpfClient::attest`] for the full semantics (including
+    /// the bound-nonce derivation that ties this attestation to the
+    /// subsequent handshake).
     #[wasm_bindgen(js_name = attest)]
     pub async fn attest(
         &mut self,
         server_index: u8,
     ) -> Result<WasmAttestVerification, JsError> {
-        let mut nonce = [0u8; 32];
-        getrandom::getrandom(&mut nonce)
+        if server_index >= 2 {
+            return Err(JsError::new(&format!(
+                "attest: serverIndex must be 0 or 1, got {}",
+                server_index
+            )));
+        }
+        let mut eph_seed = [0u8; 32];
+        let mut random_32 = [0u8; 32];
+        getrandom::getrandom(&mut eph_seed)
             .map_err(|e| JsError::new(&format!("getrandom: {}", e)))?;
+        getrandom::getrandom(&mut random_32)
+            .map_err(|e| JsError::new(&format!("getrandom: {}", e)))?;
+        let client_eph_pub = pir_channel::eph_pub_from_seed(eph_seed);
+        let nonce = pir_core::attest::derive_attest_nonce(client_eph_pub, random_32);
         let v = self
             .inner
             .attest(server_index, nonce)
             .await
             .map_err(err_to_js)?;
+        self.attest_eph_seeds[server_index as usize] = Some(eph_seed);
         Ok(WasmAttestVerification { inner: v })
     }
 
+    /// Send REQ_ANNOUNCE to the hint (`serverIndex=0`) or query
+    /// (`serverIndex=1`) server. See [`WasmDpfClient::announce`] for
+    /// full semantics.
+    #[wasm_bindgen(js_name = announce)]
+    pub async fn announce(
+        &mut self,
+        server_index: u8,
+    ) -> Result<WasmAnnounceVerification, JsError> {
+        if server_index >= 2 {
+            return Err(JsError::new(&format!(
+                "announce: serverIndex must be 0 or 1, got {}",
+                server_index
+            )));
+        }
+        let v = self
+            .inner
+            .announce(server_index)
+            .await
+            .map_err(err_to_js)?;
+        Ok(WasmAnnounceVerification { inner: v })
+    }
+
     /// Wrap both server connections (hint + query) with the encrypted
-    /// channel transport. See [`WasmDpfClient::upgrade_to_secure_channel`].
-    /// Argument order matches `serverUrls()` — `(hint, query)`.
+    /// channel transport. See [`WasmDpfClient::upgrade_to_secure_channel`]
+    /// — same eph_seed caching + binding flow. Argument order matches
+    /// `serverUrls()` — `(hint, query)`.
     #[wasm_bindgen(js_name = upgradeToSecureChannel)]
     pub async fn upgrade_to_secure_channel(
         &mut self,
@@ -1211,10 +1618,37 @@ impl WasmHarmonyClient {
         let query_pub: [u8; 32] = query_server_static_pub
             .try_into()
             .map_err(|_| JsError::new("queryServerStaticPub must be exactly 32 bytes"))?;
+        let eph_seed_hint = self.attest_eph_seeds[0].ok_or_else(|| {
+            JsError::new(
+                "upgradeToSecureChannel: must call attest(0) on the hint server first \
+                 (eph_seed binding required)",
+            )
+        })?;
+        let eph_seed_query = self.attest_eph_seeds[1].ok_or_else(|| {
+            JsError::new(
+                "upgradeToSecureChannel: must call attest(1) on the query server first \
+                 (eph_seed binding required)",
+            )
+        })?;
+        let mut hs_nonce_hint = [0u8; 32];
+        let mut hs_nonce_query = [0u8; 32];
+        getrandom::getrandom(&mut hs_nonce_hint)
+            .map_err(|e| JsError::new(&format!("getrandom: {}", e)))?;
+        getrandom::getrandom(&mut hs_nonce_query)
+            .map_err(|e| JsError::new(&format!("getrandom: {}", e)))?;
         self.inner
-            .upgrade_to_secure_channel(hint_pub, query_pub)
+            .upgrade_to_secure_channel_with_seeds(
+                hint_pub,
+                eph_seed_hint,
+                hs_nonce_hint,
+                query_pub,
+                eph_seed_query,
+                hs_nonce_query,
+            )
             .await
-            .map_err(err_to_js)
+            .map_err(err_to_js)?;
+        self.attest_eph_seeds = [None, None];
+        Ok(())
     }
 
     /// Inspector-path batch query — like [`queryBatch`](Self::query_batch)

--- a/runtime/src/bin/unified_server.rs
+++ b/runtime/src/bin/unified_server.rs
@@ -135,6 +135,21 @@ struct CliArgs {
     /// `--serve-queries`. See `serve_hints` for the deployment
     /// topology rationale.
     serve_queries: bool,
+    /// Path to the server's long-lived Ed25519 identity key (raw 32-byte
+    /// seed). Combined with `--identity-cert-path` to build the
+    /// REQ_ANNOUNCE bundle. If either is missing or fails to load,
+    /// REQ_ANNOUNCE is disabled but the rest of the protocol runs
+    /// normally. Generate one with `bpir-admin generate-identity`.
+    identity_key_path: Option<PathBuf>,
+    /// Path to the operator-signed IdentityCert (raw bytes produced by
+    /// `bpir-admin sign-identity`, encoded per
+    /// `pir_identity::IdentityCert::encode`).
+    identity_cert_path: Option<PathBuf>,
+    /// Human-readable server identifier (e.g. "pir1", "pir2"). Bound
+    /// into the announcement bundle; cross-checked against the cert
+    /// loaded from `--identity-cert-path`. Required if either of the
+    /// identity flags is set.
+    identity_server_id: Option<String>,
 }
 
 fn parse_args() -> CliArgs {
@@ -156,6 +171,9 @@ fn parse_args() -> CliArgs {
     let mut cashu_keysets: Vec<(String, String)> = Vec::new();
     let mut serve_hints = false;
     let mut serve_queries = false;
+    let mut identity_key_path: Option<PathBuf> = None;
+    let mut identity_cert_path: Option<PathBuf> = None;
+    let mut identity_server_id: Option<String> = None;
 
     let mut i = 1;
     while i < args.len() {
@@ -256,12 +274,30 @@ fn parse_args() -> CliArgs {
             "--serve-queries" => {
                 serve_queries = true;
             }
+            "--identity-key-path" => {
+                if let Some(p) = args.get(i + 1) {
+                    identity_key_path = Some(PathBuf::from(p));
+                }
+                i += 1;
+            }
+            "--identity-cert-path" => {
+                if let Some(p) = args.get(i + 1) {
+                    identity_cert_path = Some(PathBuf::from(p));
+                }
+                i += 1;
+            }
+            "--identity-server-id" => {
+                if let Some(s) = args.get(i + 1) {
+                    identity_server_id = Some(s.clone());
+                }
+                i += 1;
+            }
             _ => {}
         }
         i += 1;
     }
 
-    CliArgs { port, data_dir, role, warmup, config_path, checkpoints, deltas, admin_pubkey_hex, disable_onion, vcek_dir, pool_size, pool_dir, require_arc, require_cashu, cashu_keysets, serve_hints, serve_queries }
+    CliArgs { port, data_dir, role, warmup, config_path, checkpoints, deltas, admin_pubkey_hex, disable_onion, vcek_dir, pool_size, pool_dir, require_arc, require_cashu, cashu_keysets, serve_hints, serve_queries, identity_key_path, identity_cert_path, identity_server_id }
 }
 
 // ─── OnionPIR worker thread ─────────────────────────────────────────────────
@@ -2219,6 +2255,92 @@ async fn main() {
         }
     };
 
+    // ── Build the operator-signed announcement bundle, if configured ─
+    // [HUMAN-decided 2026-05-21] When either file is missing or the
+    // cert / key disagree, log a warning and serve without announce
+    // (REQ_ANNOUNCE returns RESP_ERROR). Existing attest / handshake
+    // / query paths are unaffected.
+    let announcement_bundle: Option<Vec<u8>> = match (
+        args.identity_key_path.as_ref(),
+        args.identity_cert_path.as_ref(),
+        args.identity_server_id.as_deref(),
+    ) {
+        (Some(key_path), Some(cert_path), Some(server_id)) => {
+            match pir_runtime_core::identity::load_identity_key(key_path)
+                .and_then(|sk| {
+                    pir_runtime_core::identity::load_identity_cert(cert_path)
+                        .map(|cert| (sk, cert))
+                })
+            {
+                Ok((sk, cert)) => {
+                    // Manifest roots in db_id order — same as the V2
+                    // attest layout, so the bundle and the SEV report
+                    // commit to the same set.
+                    let manifest_roots: Vec<[u8; 32]> = all_databases
+                        .iter()
+                        .map(|db| db.manifest_root.unwrap_or([0u8; 32]))
+                        .collect();
+                    let binary_sha256 = pir_runtime_core::attest::self_exe_sha256();
+                    let git_rev = pir_runtime_core::attest::GIT_REV;
+                    let issued_at = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs() as i64)
+                        .unwrap_or(0);
+                    match pir_runtime_core::identity::build_announcement_bundle(
+                        &sk,
+                        cert,
+                        server_id,
+                        channel_pubkey,
+                        binary_sha256,
+                        git_rev,
+                        manifest_roots,
+                        issued_at,
+                    ) {
+                        Ok(id) => {
+                            let id_short: String = id
+                                .cert
+                                .identity_pubkey[..8]
+                                .iter()
+                                .map(|b| format!("{:02x}", b))
+                                .collect();
+                            println!(
+                                "  Identity announce: enabled (server_id={}, identity_pub={}…, issued_at={})",
+                                server_id, id_short, issued_at
+                            );
+                            Some(id.encoded_bundle)
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "  Identity announce: DISABLED — failed to build bundle: {}. REQ_ANNOUNCE will return RESP_ERROR; attest/handshake/queries still serve normally.",
+                                e
+                            );
+                            None
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "  Identity announce: DISABLED — {}. REQ_ANNOUNCE will return RESP_ERROR; attest/handshake/queries still serve normally.",
+                        e
+                    );
+                    None
+                }
+            }
+        }
+        (None, None, None) => {
+            println!(
+                "  Identity announce: not configured (--identity-key-path / --identity-cert-path / --identity-server-id unset)"
+            );
+            None
+        }
+        _ => {
+            eprintln!(
+                "  Identity announce: DISABLED — all three of --identity-key-path, --identity-cert-path, --identity-server-id must be set together (or none of them)."
+            );
+            None
+        }
+    };
+
     // ── Assemble ServerState ────────────────────────────────────────────
     let num_databases = all_databases.len();
     let state = ServerState {
@@ -2227,6 +2349,7 @@ async fn main() {
         ark_pem,
         ask_pem,
         vcek_pem,
+        announcement_bundle,
     };
 
     let admin_config = match args.admin_pubkey_hex.as_deref() {

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -1,11 +1,16 @@
+import { requireSdkWasm } from './sdk-bridge.js';
+
 /**
  * Operator-pinned 32-byte SHA-256 fingerprint of the AMD ARK (Root
- * Key) certificate.
+ * Key) certificate, as a human-readable hex string.
  *
- * This is the trust anchor for browser-side AMD VCEK chain validation
- * (Slice D). When the adapter calls `verifyVcekChain`, it computes
- * SHA-256(ARK_DER) and compares to this constant; mismatch = the
- * server's bundled cert chain doesn't actually root at AMD's ARK.
+ * This constant is **documentation** — the live runtime value used by
+ * the verifier comes from the WASM module (`turinArkFingerprint()`,
+ * exported from `pir-attest-verify::TURIN_ARK_FINGERPRINT_SHA256`).
+ * Keeping the hex here gives operators a searchable, auditable copy
+ * of the pinned value AND a build-time cross-check (see
+ * [`getAmdTurinArkFingerprint`] below) that catches drift if anyone
+ * ever rotates one without the other.
  *
  * Pinned 2026-05-03 by the operator from the Turin family ARK at
  * https://kdsintf.amd.com/vcek/v1/Turin/cert_chain (second PEM block).
@@ -16,7 +21,9 @@
  *        # Split, then SHA-256 the ARK DER:
  *        csplit -z -f cert_ -b "%d.pem" cert_chain.pem '/-----BEGIN CERT/' '{*}'
  *        openssl x509 -in cert_1.pem -outform DER | sha256sum
- *   3. Replace the hex below + rebuild + redeploy the web bundle.
+ *   3. Replace the hex below AND the Rust constant
+ *      `pir-attest-verify::TURIN_ARK_FINGERPRINT_SHA256`, then rebuild
+ *      the WASM bundle.
  *
  * Same fingerprint applies to all Turin-family chips. (Genoa, Milan,
  * etc. would have different ARKs and need their own pins; we only
@@ -25,9 +32,11 @@
 export const AMD_TURIN_ARK_FINGERPRINT_HEX =
   '1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a';
 
-/** Same as `AMD_TURIN_ARK_FINGERPRINT_HEX` but as Uint8Array — the
- *  shape `WasmAttestVerification.verifyVcekChain` expects. */
-export const AMD_TURIN_ARK_FINGERPRINT: Uint8Array = (() => {
+/** Decode the hex constant once at module load. Used as the
+ *  authoritative *human-readable* source — the runtime value comes
+ *  from WASM and is checked against this at [`getAmdTurinArkFingerprint`]
+ *  call time. */
+const HEX_AS_BYTES: Uint8Array = (() => {
   const hex = AMD_TURIN_ARK_FINGERPRINT_HEX;
   const out = new Uint8Array(32);
   for (let i = 0; i < 32; i++) {
@@ -35,6 +44,57 @@ export const AMD_TURIN_ARK_FINGERPRINT: Uint8Array = (() => {
   }
   return out;
 })();
+
+/**
+ * Return the 32-byte ARK fingerprint sourced from the WASM module
+ * (which mirrors the Rust constant
+ * `pir-attest-verify::TURIN_ARK_FINGERPRINT_SHA256`).
+ *
+ * Throws if [`initSdkWasm`] hasn't resolved yet — the WASM module is
+ * the single source of truth, so this function intentionally has no
+ * pure-TS fallback. Callers that need the value before WASM init can
+ * use [`AMD_TURIN_ARK_FINGERPRINT_HEX`] for display purposes only
+ * (never as the value passed to `verifyVcekChain` / `verifyFull` —
+ * that would defeat the cross-check).
+ *
+ * On first call after WASM init, cross-checks the WASM-exported bytes
+ * against the hex constant and throws on mismatch (build-time drift
+ * between Rust + TS). Subsequent calls return the cached Uint8Array.
+ */
+let cachedArkFingerprint: Uint8Array | null = null;
+export function getAmdTurinArkFingerprint(): Uint8Array {
+  if (cachedArkFingerprint) return cachedArkFingerprint;
+  const sdk = requireSdkWasm();
+  const fromWasm = sdk.turinArkFingerprint();
+  if (fromWasm.length !== 32) {
+    throw new Error(
+      `attest-pin: WASM turinArkFingerprint returned ${fromWasm.length} bytes (expected 32)`,
+    );
+  }
+  for (let i = 0; i < 32; i++) {
+    if (fromWasm[i] !== HEX_AS_BYTES[i]) {
+      throw new Error(
+        `attest-pin: ARK fingerprint mismatch between WASM (${bytesToHex(fromWasm)}) ` +
+          `and AMD_TURIN_ARK_FINGERPRINT_HEX (${AMD_TURIN_ARK_FINGERPRINT_HEX}). ` +
+          `One was rotated without the other — fix and rebuild.`,
+      );
+    }
+  }
+  cachedArkFingerprint = fromWasm;
+  return fromWasm;
+}
+
+/**
+ * @deprecated Use [`getAmdTurinArkFingerprint`] instead. This eager
+ * Uint8Array is kept for back-compat with pre-Slice-D.4 callers; new
+ * code should source from WASM so the cross-check fires. Will be
+ * removed once `dpf-adapter.ts` / `harmonypir-adapter.ts` migrate.
+ */
+export const AMD_TURIN_ARK_FINGERPRINT: Uint8Array = HEX_AS_BYTES;
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
 
 /**
  * Per-server build-time pins for values the SEV-SNP report surfaces.

--- a/web/src/dpf-adapter.ts
+++ b/web/src/dpf-adapter.ts
@@ -51,6 +51,7 @@ import {
   type WasmDpfClient,
   type WasmQueryResult,
 } from './sdk-bridge.js';
+import { getAmdTurinArkFingerprint } from './attest-pin.js';
 import type { ConnectionState, QueryResult, UtxoEntry } from './types.js';
 import { ManagedWebSocket } from './ws.js';
 
@@ -524,7 +525,41 @@ export class BatchPirClientAdapter {
     const att0 = await attestOne(0);
     const att1 = await attestOne(1);
 
-    const expectedArkFp = this.config.expectedArkFingerprint ?? null;
+    // Default behaviour: source the ARK fingerprint from WASM
+    // (`getAmdTurinArkFingerprint`), which mirrors the Rust constant
+    // `pir-attest-verify::TURIN_ARK_FINGERPRINT_SHA256` and runs a
+    // cross-check against `AMD_TURIN_ARK_FINGERPRINT_HEX` on first
+    // call. Callers can still pass `null` explicitly to skip the
+    // chain check (tests, pre-deploy debugging) or pass a different
+    // fingerprint to override (e.g. for a future Milan migration —
+    // they'd ship a custom Uint8Array).
+    let expectedArkFp: Uint8Array | null;
+    if (this.config.expectedArkFingerprint === null) {
+      expectedArkFp = null;
+    } else if (this.config.expectedArkFingerprint !== undefined) {
+      expectedArkFp = this.config.expectedArkFingerprint;
+    } else {
+      try {
+        expectedArkFp = getAmdTurinArkFingerprint();
+      } catch (e) {
+        // 'info' rather than 'error' because this is a fallback path
+        // (skip chain validation) rather than an outright failure —
+        // the connection still works, just without ARK pinning.
+        this.log(
+          `default ARK fingerprint unavailable (WASM not initialised?): ${(e as Error)?.message ?? e}`,
+          'info',
+        );
+        expectedArkFp = null;
+      }
+    }
+
+    // Strict production policy: VMPL 0, no debug, no migrate-MA, TCB-
+    // monotonic. We deliberately do NOT pin MEASUREMENT here even when
+    // a per-server pin is configured — the manual measurement check
+    // below produces a more granular error message (which pin failed,
+    // for which server) than the single-line WASM diagnostic.
+    const sdk = requireSdkWasm();
+    const policyReqs = new sdk.WasmPolicyRequirements();
 
     const summarise = (
       idx: 0 | 1,
@@ -555,26 +590,35 @@ export class BatchPirClientAdapter {
         launchMeasurementHex: att.launchMeasurementHex,
       };
 
-      // Slice D.3: AMD VCEK chain validation. Only attempt when the
-      // V2 binding already passed (otherwise the report is suspect
-      // anyway), the server bundled a chain, AND we have an
+      // Slice D.3+: AMD VCEK chain + policy validation. Only attempt
+      // when the V2 binding already passed (otherwise the report is
+      // suspect anyway), the server bundled a chain, AND we have an
       // operator-pinned ARK fingerprint to anchor trust.
+      //
+      // `verifyFull` runs:
+      //   1. ARK fingerprint match + ARK→ASK→VCEK chain (RSA-PSS)
+      //   2. SEV-SNP report ECDSA-P384 signature against VCEK
+      //   3. Policy: VMPL ≤ max, no debug, no migrate-MA, TCB
+      //      monotonicity + optional minimum / measurement / id pins
+      // — and throws on the FIRST failure. Error message starts with
+      // "chain:", "report-sig:" or "policy:" so the operator can
+      // tell which step rejected.
       if (state === 'verified' && matched && att.hasVcekChain) {
         if (expectedArkFp) {
           try {
-            att.verifyVcekChain(expectedArkFp);
+            att.verifyFull(expectedArkFp, policyReqs);
             result.state = 'verified-vcek';
             result.vcekChain = 'pass';
           } catch (e) {
             result.vcekChain = 'fail';
             result.vcekChainError = (e as Error)?.message ?? String(e);
             this.log(
-              `verifyVcekChain(server${idx}) failed: ${result.vcekChainError}`,
+              `verifyFull(server${idx}) failed: ${result.vcekChainError}`,
               'error',
             );
-            // Demote to 'mismatch' on chain failure — the operator's
-            // pinning explicitly demanded chain validation, and it
-            // didn't pass. Treat as a strong negative signal.
+            // Demote to 'mismatch' on any failure — the operator's
+            // pinning explicitly demanded chain + policy validation
+            // and it didn't pass. Treat as a strong negative signal.
             result.state = 'mismatch';
           }
         } else {

--- a/web/src/harmonypir-adapter.ts
+++ b/web/src/harmonypir-adapter.ts
@@ -71,6 +71,7 @@ import {
   type WasmHarmonyClient,
   type WasmQueryResult,
 } from './sdk-bridge.js';
+import { getAmdTurinArkFingerprint } from './attest-pin.js';
 import type { ServerAttestation } from './dpf-adapter.js';
 import type {
   HarmonyQueryResult,
@@ -212,7 +213,26 @@ export class HarmonyPirClientAdapter {
     const hintAtt = await attestOne(0);
     const queryAtt = await attestOne(1);
 
-    const expectedArkFp = this.config.expectedArkFingerprint ?? null;
+    // Same default-to-WASM-export logic as the DPF adapter — see
+    // dpf-adapter.ts::attestAndUpgrade for rationale.
+    let expectedArkFp: Uint8Array | null;
+    if (this.config.expectedArkFingerprint === null) {
+      expectedArkFp = null;
+    } else if (this.config.expectedArkFingerprint !== undefined) {
+      expectedArkFp = this.config.expectedArkFingerprint;
+    } else {
+      try {
+        expectedArkFp = getAmdTurinArkFingerprint();
+      } catch (e) {
+        this.log(
+          `HarmonyPIR default ARK fingerprint unavailable: ${(e as Error)?.message ?? e}`,
+        );
+        expectedArkFp = null;
+      }
+    }
+
+    const sdk = requireSdkWasm();
+    const policyReqs = new sdk.WasmPolicyRequirements();
 
     const summarise = (
       idx: 0 | 1,
@@ -235,19 +255,19 @@ export class HarmonyPirClientAdapter {
         gitRev: att.gitRev,
         launchMeasurementHex: att.launchMeasurementHex,
       };
-      // Slice D.3 chain validation. Same gating logic as the DPF
-      // adapter — see dpf-adapter.ts::attestAndUpgrade for rationale.
+      // Slice D.3+ chain + policy validation. Same gating logic as
+      // the DPF adapter — see dpf-adapter.ts::attestAndUpgrade.
       if (state === 'verified' && matched && att.hasVcekChain) {
         if (expectedArkFp) {
           try {
-            att.verifyVcekChain(expectedArkFp);
+            att.verifyFull(expectedArkFp, policyReqs);
             result.state = 'verified-vcek';
             result.vcekChain = 'pass';
           } catch (e) {
             result.vcekChain = 'fail';
             result.vcekChainError = (e as Error)?.message ?? String(e);
             this.log(
-              `HarmonyPIR verifyVcekChain failed: ${result.vcekChainError}`,
+              `HarmonyPIR verifyFull failed: ${result.vcekChainError}`,
             );
             result.state = 'mismatch';
           }

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -49,6 +49,27 @@ interface PirSdkWasm {
   WasmAtomicMetrics: {
     new(): WasmAtomicMetrics;
   };
+  /**
+   * Constructor for [`WasmPolicyRequirements`] used by
+   * `WasmAttestVerification.verifyFull`. `new sdk.WasmPolicyRequirements()`
+   * returns the strict production defaults; mutate via setters.
+   */
+  WasmPolicyRequirements: {
+    new(): WasmPolicyRequirements;
+  };
+  /**
+   * Returns the 32-byte SHA-256 fingerprint of the AMD Turin-family
+   * ARK certificate (DER-encoded). Pinned inside `pir-attest-verify`
+   * so the WASM module is the single source of truth — pass directly
+   * to `WasmAttestVerification.verifyFull` /
+   * `WasmAttestVerification.verifyVcekChain` on Turin hardware.
+   *
+   * Mirrors `web/src/attest-pin.ts::AMD_TURIN_ARK_FINGERPRINT_HEX` —
+   * `attest-pin.ts` uses this function as its runtime source and
+   * cross-checks the human-readable hex string against the WASM bytes
+   * at module load (catches drift if the two ever diverge).
+   */
+  turinArkFingerprint(): Uint8Array;
   // ARC (Anonymous Rate-limited Credentials) presentation state. Opaque
   // wrapper over the Rust `arc::PresentationState`; mirrored in TS by
   // `web/src/credential-manager.ts::ArcCredentialManager`. The constructor
@@ -228,6 +249,50 @@ export interface WasmAttestVerification {
    * diagnostic string.
    */
   verifyVcekChain(expectedArkFingerprint: Uint8Array | null): void;
+
+  /**
+   * Highest-level verify: runs `verifyVcekChain`'s four steps PLUS
+   * the policy assertions captured in `policy` — VMPL ceiling,
+   * `debug_allowed` / `migrate_ma_allowed` / `single_socket_required`
+   * bits, TCB monotonicity (`reported_tcb ≤ committed_tcb`) + optional
+   * minimum TCB, optional MEASUREMENT / family_id / image_id pins.
+   *
+   * Throws on the FIRST failing step. Caller can detect which step
+   * failed by inspecting the error message ("chain: …", "report-sig: …",
+   * "policy: …"). Use `verifyVcekChain` directly if you'd rather get a
+   * raw chain-only verdict.
+   */
+  verifyFull(
+    expectedArkFingerprint: Uint8Array | null,
+    policy: WasmPolicyRequirements,
+  ): void;
+}
+
+/**
+ * Policy requirements for [`WasmAttestVerification.verifyFull`].
+ *
+ * Constructed via `new sdk.WasmPolicyRequirements()` for strict
+ * production defaults: VMPL 0, no debug, no MA migration, TCB-
+ * monotonic, no pinned MEASUREMENT/family_id/image_id. Mutate via the
+ * setters to relax (e.g. enabling debug for a local test rig) or to
+ * pin MEASUREMENT.
+ */
+export interface WasmPolicyRequirements {
+  free(): void;
+  /** Raise the VMPL ceiling. Production wants 0. */
+  setMaxVmpl(v: number): void;
+  /** Permit guests with `policy.debug_allowed` set. Production: false. */
+  setAllowDebug(v: boolean): void;
+  /** Permit guests with `policy.migrate_ma_allowed` set. Production: false. */
+  setAllowMigrateMa(v: boolean): void;
+  /** Require `policy.single_socket_required`. Off by default. */
+  setRequireSingleSocket(v: boolean): void;
+  /** Pin the expected MEASUREMENT (must be exactly 48 bytes). */
+  setExpectedMeasurement(bytes: Uint8Array): void;
+  /** Pin the expected family_id (16 bytes). */
+  setExpectedFamilyId(bytes: Uint8Array): void;
+  /** Pin the expected image_id (16 bytes). */
+  setExpectedImageId(bytes: Uint8Array): void;
 }
 
 interface WasmDpfClient {


### PR DESCRIPTION
## Summary

Closes the Cloudflare-MITM gap on the inner encrypted channel. cloudflared terminates TLS at the tunnel edge, so today it sees plaintext PIR frames and could in principle substitute the server's channel pubkey. This PR adds three independent hardening layers:

- **Handshake binding** — the attest nonce is now derived from the client's X25519 handshake ephemeral (`pir-core::attest::derive_attest_nonce`), so the chip-signed REPORT_DATA commits to *this* handshake. A stale/replayed report against a fresh `eph_pub` fails. WASM clients cache the `eph_seed` across `attest → upgrade` so the binding is enforced internally (JS API unchanged).

- **Operator-signed identity** (new `REQ_ANNOUNCE` opcode `0x07`) — new `pir-identity` crate with a two-tier Ed25519 cert chain: an offline operator `IdentityCert` endorses a per-server identity key, which signs a per-boot `ChannelManifest` over the channel pubkey + build metadata. Authenticates `server_static_pub` on non-SEV hosts (pir1) and adds defense-in-depth on SEV hosts (pir2). The server loads its identity key + cert from `--identity-{key,cert}-path`; **missing/invalid files → serve without announce (warn, non-fatal)**, so existing deployments are unaffected. New `bpir-admin generate-identity` + `sign-identity` tooling. Client-side parser with optional operator-pubkey pinning (Nostr publishing path TBD).

- **VCEK chain + policy verification** (`pir-attest-verify`) — `verifyFull` runs the ARK→ASK→VCEK chain + the report's ECDSA-P384 signature + policy assertions (VMPL 0, no debug, no migrate-MA, TCB monotonic). The Turin ARK fingerprint is pinned as the WASM single-source-of-truth; the web adapters source it from WASM and cross-check against the documented hex.

**Web:** `attest-pin.ts` derives the ARK fingerprint from WASM; the DPF + HarmonyPIR adapters call `verifyFull` instead of `verifyVcekChain`.

### Policy decisions baked in (operator-confirmed)
- IdentityCert validity window: **no default** — `sign-identity` requires explicit `--valid-until`.
- Missing identity files at boot: **serve without announce + warn** (non-fatal).
- Per-boot ChannelManifest: **no expiry** (implicitly fresh per reboot; client applies its own freshness policy on `issued_at`).

### Not included / follow-ups
- This branch deliberately does **not** carry the in-progress OnionPIR sharding work. `pir-sdk-client/src/onion.rs` here uses the single-connection `self.conn` API; when sharding lands on main it'll need a small reconciliation (sharded API replaces `self.conn`).
- Operator pubkey distribution (Nostr) is out of scope — `REQ_ANNOUNCE` is wired and the client can pin an operator key, but the publishing mechanism is still being designed.
- Also includes a 1-line test-only fix in `cashu_verifier.rs` (missing `use k256::elliptic_curve::Group` in the test module) that was blocking the pir-runtime-core test build.

## Test plan

- [x] `cargo build --workspace` clean (only pre-existing warnings)
- [x] Unit/integration tests green: pir-identity 19, pir-channel 17, pir-core 50, pir-runtime-core 65, pir-sdk-client 186, bpir-admin 15 (~50 new across the feature)
- [x] `bpir-admin generate-identity → sign-identity` round-trip produces a verifiable IdentityCert
- [x] Live verification against pir1/pir2 (DPF + HarmonyPIR adapters): pir2 passes full `verifyFull` (chain + report-sig + strict policy), pir1 correctly reports "V2 binding only (no chain)", encrypted-channel upgrade succeeds with the eph-bound nonce, HarmonyPIR hint download completes post-upgrade. Zero console errors; `tsc --noEmit` clean; 138 vitest tests pass.
- [ ] Reviewer: sanity-check the `REQ_ANNOUNCE` wire format + the two-tier signing model in `pir-identity/src/lib.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)