### PR TITLE
feat(attest): operator-signed identity (REQ_ANNOUNCE) end-to-end

### DIFF
--- a/docs/OPERATOR_IDENTITY.md
+++ b/docs/OPERATOR_IDENTITY.md
@@ -261,9 +261,11 @@ await adapter.connect();
   returns "not configured").
 - ✅ `BatchPirClientAdapter` exposes a gated `operatorIdentity` snapshot
   (opt-in via `verifyOperatorIdentity`); `gateOperatorIdentity` unit-tested.
+- ✅ Standalone TS `OnionPirWebClient.announce()` — reuses the Rust
+  parser/chain check via the WASM `verifyAnnounceResponse` binding
+  (operator-pin + chain; channel-binding N/A — no attest/channel there).
 - ⏳ Playground still needs to render the badge from the snapshot;
-  `issued_at` freshness policy not enforced; standalone TS
-  `OnionPirWebClient` has no `announce()`.
+  `issued_at` freshness policy not enforced.
 
 ### Remaining work
 
@@ -274,5 +276,4 @@ await adapter.connect();
   `adapter.operatorIdentity.serverN.state` / `onOperatorIdentity`. The
   gating already lives in the adapter; the badge is the only remaining
   piece, in the playground repo.
-- **E** — add `announce()` to the standalone TS `OnionPirWebClient`.
 - **F** — enforce `valid_until` / `issued_at` freshness policy in clients.

--- a/docs/OPERATOR_IDENTITY.md
+++ b/docs/OPERATOR_IDENTITY.md
@@ -260,10 +260,11 @@ await adapter.connect();
   client `announce` / `announce_with_pinned_operator` / `announce_bound`
   / `check_pinned_operator` / `check_channel_binding`, WASM bindings.
 - ✅ Live-verified e2e (`test_announce_operator_identity_end_to_end`).
-- ✅ Build-time operator-pubkey pin scaffold (`attest-pin.ts`).
-- ⏳ **Pin value is a DEV stand-in** — replace with a real published key.
-- ⏳ **Not deployed** on pir1/pir2 (`--identity-*` flags unset → announce
-  returns "not configured").
+- ✅ Real operator key minted (2026-05-25) + pinned in `attest-pin.ts`
+  (`PIR_OPERATOR_PUBKEY_HEX = 256fb106…`; secret offline at
+  `~/.config/bpir-admin/operator.key`).
+- 🟡 pir1 **staged** with `--identity-*` (server_id=pir1, cert valid to
+  2029) — see Deployment status below. pir2 not yet staged.
 - ✅ `BatchPirClientAdapter` exposes a gated `operatorIdentity` snapshot
   (opt-in via `verifyOperatorIdentity`); `gateOperatorIdentity` unit-tested.
 - ✅ Standalone TS `OnionPirWebClient.announce()` — reuses the Rust
@@ -273,11 +274,41 @@ await adapter.connect();
   `check_freshness(now, maxAge)` available (Rust + WASM + adapter
   `maxAnnounceAgeSeconds`); validity enforced via real `now`.
 
+## Deployment status (2026-05-25)
+
+Operator-identity provisioning is **done**, but announce is **not yet
+functional in production** — the deployed reproducible binary
+(`binarySha256Hex 71a041ae…`, main @ ea4ee8c8) predates the REQ_ANNOUNCE
+**dispatch arm**. It builds + logs the bundle ("Identity announce:
+enabled") yet still answers `unsupported request 0x07`. Verified live:
+`announce()` against `wss://weikeng1.bitcoinpir.org` returns that error.
+
+Done:
+- Operator key + pir1/pir2 `IdentityCert`s signed (valid to 2029).
+- pir1: identity key/cert at `/home/pir/data/pir1-{identity.key,.cert}`;
+  `pir-primary` + `pir-secondary` carry `--identity-*` via systemd drop-in
+  overrides (`/etc/systemd/system/pir-{primary,secondary}.service.d/override.conf`).
+  Both restarted + verified `Identity announce: enabled (server_id=pir1)`.
+- Operator pubkey pinned in `attest-pin.ts`.
+
+To make it live (a coordinated **binary release**, not a flag flip):
+1. Merge the announce dispatch work (the `fb11a0ef` arm) to main.
+2. `nix build .#unified-server` (reproducible) from that commit → new
+   `binary_sha256`.
+3. Deploy the new binary to pir1; rebuild the pir2 Tier-3 UKI with it +
+   the pir2 identity key/cert + `--identity-server-id pir2` baked in.
+4. Re-pin `PIR1_PIN.binarySha256Hex` + `PIR2_TIER3_PIN.binarySha256Hex`
+   (new hash) and `PIR2_TIER3_PIN.measurementHex` (new UKI), capture via
+   `bpir-admin attest`.
+5. pir2 deploy needs the **VPSBG portal** (upload UKI → Save & Reboot;
+   pir2 is unreachable over SSH in Tier 3).
+6. Then flip the web `verifyOperatorIdentity` on / wire the playground badge.
+
 ### Remaining work
 
-- **C** — generate the real operator key + deploy `--identity-*` to
-  pir1/pir2 (replaces the DEV stand-in pin; flips `verifyOperatorIdentity`
-  default to on once live).
+- **C (binary release)** — the 6 steps above; needs a merge + reproducible
+  build + the VPSBG portal for pir2. pir1 identity is staged and will
+  activate the instant the dispatch-arm binary lands.
 - **D (playground)** — render the badge from
   `adapter.operatorIdentity.serverN.state` / `onOperatorIdentity`. The
   gating already lives in the adapter; the badge is the only remaining

--- a/docs/OPERATOR_IDENTITY.md
+++ b/docs/OPERATOR_IDENTITY.md
@@ -88,10 +88,15 @@ to the live session.
 
 - **Trust bottoms out at the pin.** Operator-pin assurance is only as
   good as the out-of-band pin in `attest-pin.ts` (today a DEV stand-in).
-- **Freshness/replay** (`manifest.issued_at`) and **validity**
-  (`now` arg) are caller policy. `announce_bound` enforces validity when
-  you pass a real `now`; replay-bounding via `issued_at` is not yet
-  enforced (backlog item F).
+- **Validity** (`valid_from` / `valid_until`) is enforced by
+  `check_pinned_operator` / `announce_bound` whenever you pass a real
+  `now` (≠ 0). **Replay/staleness** is `check_freshness(now, max_age)` —
+  but `issued_at` is the server's *boot time* (the bundle is built once
+  at startup), so set `max_age` ≥ expected uptime, and lean on
+  `check_channel_binding` (per-boot `channel_pub`) as the real
+  anti-replay for DPF/Harmony. `check_freshness` always rejects
+  future-dated bundles (300 s skew) and is the main staleness guard for
+  the channel-binding-less OnionPIR path.
 - **pir1 has no SEV.** Step 1 (hardware attestation) is absent;
   `binary_sha256` there is self-reported and pinned only for drift
   detection. Channel binding + operator endorsement still hold.
@@ -265,7 +270,8 @@ await adapter.connect();
   parser/chain check via the WASM `verifyAnnounceResponse` binding
   (operator-pin + chain; channel-binding N/A — no attest/channel there).
 - ⏳ Playground still needs to render the badge from the snapshot;
-  `issued_at` freshness policy not enforced.
+  `check_freshness(now, maxAge)` available (Rust + WASM + adapter
+  `maxAnnounceAgeSeconds`); validity enforced via real `now`.
 
 ### Remaining work
 
@@ -276,4 +282,3 @@ await adapter.connect();
   `adapter.operatorIdentity.serverN.state` / `onOperatorIdentity`. The
   gating already lives in the adapter; the badge is the only remaining
   piece, in the playground repo.
-- **F** — enforce `valid_until` / `issued_at` freshness policy in clients.

--- a/docs/OPERATOR_IDENTITY.md
+++ b/docs/OPERATOR_IDENTITY.md
@@ -1,0 +1,256 @@
+# Operator-Signed Identity (REQ_ANNOUNCE)
+
+How a BitcoinPIR operator publishes a signed identity for each server, and
+exactly what a client learns when it verifies one. This covers the
+end-to-end **operator runbook** (generate → sign → deploy) and the
+**client trust model** (what each check proves, and what it does not).
+
+> **Status (2026-05-24).** The full path is wired and live-verified
+> end-to-end (`bpir-admin` → `unified_server --identity-*` → client
+> `announce()`), but **not yet deployed on pir1/pir2** and the pinned
+> operator pubkey in `web/src/attest-pin.ts` is currently a **DEV
+> stand-in** (the e2e test key), not a real published key. See
+> [Current status](#current-status).
+
+---
+
+## 1. Keys and tiers
+
+Three keypairs are involved. Keep them straight — the whole trust
+argument depends on which key signs what.
+
+| Tier | Key | Algo | Lives | Signs | Rotation |
+|------|-----|------|-------|-------|----------|
+| **1** | Operator key | Ed25519 | **Offline**, operator workstation only | `IdentityCert` | Rare (root of trust) |
+| **2** | Server identity key | Ed25519 | Server filesystem (inside the SEV guest on pir2) | `ChannelManifest` | Per server, occasional |
+| — | Channel key | X25519 | Generated **per boot** inside the (SEV) guest; secret never on disk | the encrypted-channel handshake (ECDH) | Every reboot |
+
+- **`IdentityCert`** (Tier-1 signed): `{ operator_pubkey, server_id,
+  identity_pubkey, valid_from, valid_until, signature }`. The operator
+  asserts: "for `server_id`, the legitimate Tier-2 identity key is
+  `identity_pubkey`, valid in this window."
+- **`ChannelManifest`** (Tier-2 signed): `{ identity_pubkey, server_id,
+  channel_pub, binary_sha256, git_rev, manifest_roots, issued_at,
+  signature }`. The server asserts: "this boot's channel key is
+  `channel_pub`, running binary `binary_sha256` / `git_rev` over these
+  DB `manifest_roots`."
+- **`AnnouncementBundle`** = `{ cert, manifest }`, returned verbatim by
+  `REQ_ANNOUNCE` (opcode `0x07`).
+
+The channel key (`channel_pub`) is the hinge: attestation
+(SEV-SNP `REPORT_DATA`, V2 layout) commits to it from the **hardware**
+side, and the `ChannelManifest` commits to it from the **operator**
+side. The client checks they're the same key, and that it's the key the
+session actually handshook against.
+
+Source: `pir-identity/src/lib.rs`.
+
+---
+
+## 2. What each client check proves
+
+A client fetches the bundle with `announce()` and then layers checks. In
+ascending order of assurance:
+
+| Check | API | Proves | Does NOT prove |
+|-------|-----|--------|----------------|
+| In-bundle chain | `AnnounceVerification::chain_verified` | Manifest is signed by the `identity_pubkey` the cert names; `server_id` / `identity_pubkey` cross-refs agree. **Internal consistency.** | Authenticity. A MITM with its *own* operator+identity keys produces a self-consistent bundle. |
+| Operator pin | `check_pinned_operator(pinned, now)` | Cert is signed by the **pinned operator key** (`cert.verify()`), within validity, and the chain check passed. **The operator you trust vouches for this identity key.** | That you're on the right *session* (see channel binding). |
+| Channel binding | `check_channel_binding(expected)` | `manifest.channel_pub == expected` (the **attested** `server_static_pub` you handshook against). **Binds the bundle to the live encrypted session.** | Operator endorsement (orthogonal). |
+| All three | `announce_bound(transport, pinned, expected_channel_pub, now)` | The full-trust path: operator-endorsed identity, bound to the attested channel key of the live session. | — |
+
+> ⚠️ **Do not** hand-roll the operator check as a string compare of
+> `operatorPubkeyHex == pin`. That checks only the *pubkey*, not the
+> cert's operator **signature** — which neither `chain_verified` nor
+> `check_channel_binding` covers. Use `check_pinned_operator` /
+> `checkPinnedOperator`, which calls `cert.verify()`.
+
+### The combined chain (when all checks pass, SEV server e.g. pir2)
+
+1. **Hardware → channel key.** The SEV-SNP report, verified through the
+   AMD VCEK chain (`verifyFull` / `bpir-admin attest`), attests that a
+   genuine SEV-SNP guest running `binary_sha256` generated the X25519
+   key `server_static_pub` (bound into `REPORT_DATA`, V2 layout).
+2. **Channel binding.** `manifest.channel_pub == server_static_pub` →
+   the announce bundle describes *this* session's channel key, not some
+   other server's.
+3. **Chain.** The manifest is signed by the identity key the cert names,
+   for the same `server_id`.
+4. **Operator pin.** The cert is signed by the operator key the client
+   pinned out-of-band → the operator vouches that this identity key is
+   the legitimate one for `server_id`, within the validity window.
+
+Net: the client is talking to a server whose channel key is both
+**chip-attested to a known binary** *and* **operator-endorsed**, bound
+to the live session.
+
+### Caveats / not proven
+
+- **Trust bottoms out at the pin.** Operator-pin assurance is only as
+  good as the out-of-band pin in `attest-pin.ts` (today a DEV stand-in).
+- **Freshness/replay** (`manifest.issued_at`) and **validity**
+  (`now` arg) are caller policy. `announce_bound` enforces validity when
+  you pass a real `now`; replay-bounding via `issued_at` is not yet
+  enforced (backlog item F).
+- **pir1 has no SEV.** Step 1 (hardware attestation) is absent;
+  `binary_sha256` there is self-reported and pinned only for drift
+  detection. Channel binding + operator endorsement still hold.
+- The client must supply `expected_channel_pub` itself — this crate
+  doesn't track handshake state. Use the attested
+  `AttestVerification.response.server_static_pub`.
+
+Source: `pir-sdk-client/src/announce.rs`, `pir-sdk-wasm/src/client.rs`.
+
+---
+
+## 3. Operator runbook
+
+All commands use `bpir-admin` (build: `cargo build --release -p bpir-admin`).
+
+### Step 1 — Generate the operator key (offline, once for the fleet)
+
+On your workstation, **never on a server**:
+
+```bash
+bpir-admin generate-identity --purpose operator --out ~/.config/bpir-admin/operator.key
+# stdout: the 64-char operator PUBKEY hex (keep the .key secret offline)
+```
+
+One operator key signs the whole fleet; per-server certs differ only by
+`server_id`.
+
+### Step 2 — Publish + pin the operator pubkey
+
+Publish the operator **pubkey** out-of-band so clients can pin it, and
+record it in the client pin:
+
+- `web/src/attest-pin.ts` → `PIR_OPERATOR_PUBKEY_HEX` (build-time pin —
+  the current MVP mechanism; DNSSEC/Nostr can layer on later). Replace
+  the DEV stand-in value and follow the provenance-comment convention
+  used by `PIR1_PIN` / `AMD_TURIN_ARK_FINGERPRINT_HEX`.
+- Native SDK clients pass the pubkey bytes to `announce_bound` /
+  `check_pinned_operator` directly (there is no Rust-side pin module).
+
+### Step 3 — Generate the server identity key (per server)
+
+On (or for) each server host:
+
+```bash
+bpir-admin generate-identity --purpose server --out /path/to/server-identity.key
+# stdout: the server's identity PUBKEY hex → hand to Step 4
+```
+
+For **pir2 (SEV-SNP / UKI Tier 3)** the key lives inside the guest;
+provisioning it is part of the image/deploy flow (see the UKI build/deploy
+section of `CLAUDE.md` → Operations and `scripts/build_uki_tier3.sh`). The
+key file is *not* measured into `MEASUREMENT` (it's passed via
+`--identity-key-path`, not the cmdline-pubkey path).
+
+### Step 4 — Sign the cert (offline, operator)
+
+```bash
+bpir-admin sign-identity \
+  --operator-key-path ~/.config/bpir-admin/operator.key \
+  --server-id pir1 \
+  --identity-pubkey-hex <server identity pubkey from Step 3> \
+  --valid-until <unix-seconds>           # REQUIRED; 0 = indefinite (deliberate)
+  # --valid-from <unix-seconds>          # optional, default 0
+  # --out <path>                          # default ./<server_id>.cert
+```
+
+`sign-identity` verifies the signature after generating (catches a
+typo'd `--identity-pubkey-hex`). Repeat per `server_id` (pir1, pir2, …).
+
+### Step 5 — Deploy
+
+Place the identity key + cert on the server and start `unified_server`
+with all three flags (all-or-none):
+
+```bash
+unified_server --serve-queries \
+  --data-dir <checkpoint> \
+  --identity-key-path  /path/to/server-identity.key \
+  --identity-cert-path /path/to/pir1.cert \
+  --identity-server-id pir1
+```
+
+On success the startup log shows:
+
+```
+  Identity announce: enabled (server_id=pir1, identity_pub=<8 hex>…, issued_at=<ts>)
+```
+
+If a flag is missing, the key/cert disagree, or bundle-build fails, the
+server logs `Identity announce: DISABLED — …` (or `not configured`) and
+`REQ_ANNOUNCE` returns `RESP_ERROR` "announce not configured" — the rest
+of the protocol (attest / handshake / queries) is unaffected.
+
+`--identity-server-id` **must** equal the cert's `--server-id`.
+
+### Step 6 — Verify the deploy
+
+```bash
+# Channel pubkey (== the value clients cross-check manifest.channel_pub against):
+bpir-admin attest wss://weikeng1.bitcoinpir.org      # prints "channel pubkey: <hex>"
+
+# Full client-side announce check (the durable integration test):
+PIR_ANNOUNCE_URL=wss://weikeng1.bitcoinpir.org \
+PIR_ANNOUNCE_OPERATOR_PUB=<operator pubkey hex> \
+  cargo test -p pir-sdk-client --test integration_test \
+    test_announce_operator_identity_end_to_end -- --ignored --nocapture
+```
+
+The binary is unchanged by the identity flags, so attestation pins
+(`binarySha256Hex` / `measurementHex`) do **not** change on enabling
+announce.
+
+---
+
+## 4. Client usage
+
+### Native SDK (`pir-sdk-client`)
+
+```rust
+// after attest + handshake, with `server_static_pub` = the attested key:
+let v = client.announce(/* server_index */ 0).await?;       // DpfClient::announce
+v.check_pinned_operator(&PINNED_OPERATOR_PUBKEY, now_unix)?; // operator endorsement
+v.check_channel_binding(&server_static_pub)?;                // bind to this session
+// …or the all-in-one over a raw transport:
+let v = announce_bound(&mut conn, &PINNED_OPERATOR_PUBKEY, &server_static_pub, now_unix).await?;
+```
+
+### Web / WASM (`pir-sdk-wasm`)
+
+```ts
+import { PIR_OPERATOR_PUBKEY } from './attest-pin';
+const v = await wasmDpfClient.announce(0);         // WasmAnnounceVerification (serverIndex 0|1)
+v.checkPinnedOperator(PIR_OPERATOR_PUBKEY, nowUnixSeconds);   // throws on failure
+v.checkChannelBinding(attestVerification.serverStaticPub);    // throws on mismatch
+// getters for display: v.serverId, v.operatorPubkeyHex, v.gitRev, v.validUntil, v.chainVerified
+```
+
+---
+
+## Current status
+
+- ✅ Crypto, protocol (`0x07`), server build helpers, `unified_server`
+  dispatch arm, `PirServerBuilder::with_announcement_bundle`, admin CLI,
+  client `announce` / `announce_with_pinned_operator` / `announce_bound`
+  / `check_pinned_operator` / `check_channel_binding`, WASM bindings.
+- ✅ Live-verified e2e (`test_announce_operator_identity_end_to_end`).
+- ✅ Build-time operator-pubkey pin scaffold (`attest-pin.ts`).
+- ⏳ **Pin value is a DEV stand-in** — replace with a real published key.
+- ⏳ **Not deployed** on pir1/pir2 (`--identity-*` flags unset → announce
+  returns "not configured").
+- ⏳ Web UI indicator not wired; `issued_at` freshness policy not enforced;
+  standalone TS `OnionPirWebClient` has no `announce()`.
+
+### Remaining work
+
+- **C** — generate the real operator key + deploy `--identity-*` to
+  pir1/pir2 (replaces the DEV stand-in pin).
+- **D** — surface a web "operator identity" indicator (gate it on
+  `checkPinnedOperator` + `checkChannelBinding` + `chainVerified`, never on
+  `chainVerified` alone).
+- **E** — add `announce()` to the standalone TS `OnionPirWebClient`.
+- **F** — enforce `valid_until` / `issued_at` freshness policy in clients.

--- a/docs/OPERATOR_IDENTITY.md
+++ b/docs/OPERATOR_IDENTITY.md
@@ -229,6 +229,23 @@ v.checkChannelBinding(attestVerification.serverStaticPub);    // throws on misma
 // getters for display: v.serverId, v.operatorPubkeyHex, v.gitRev, v.validUntil, v.chainVerified
 ```
 
+Or let `BatchPirClientAdapter` do it during `connect()` and read the
+gated snapshot (this is what a badge should consume):
+
+```ts
+const adapter = new BatchPirClientAdapter({
+  server0Url, server1Url,
+  useSecureChannel: true,        // required — binds against the attested key
+  verifyOperatorIdentity: true,  // default false (prod not configured + DEV pin)
+  // pinnedOperatorPubkey defaults to PIR_OPERATOR_PUBKEY
+  onOperatorIdentity: (i, info) => renderBadge(i, info),
+});
+await adapter.connect();
+// adapter.operatorIdentity.server0.state ∈
+//   'verified' | 'unconfigured' | 'unverified' | 'error' | 'not-checked'
+// Gate the "verified operator" badge on === 'verified' ONLY.
+```
+
 ---
 
 ## Current status
@@ -242,15 +259,20 @@ v.checkChannelBinding(attestVerification.serverStaticPub);    // throws on misma
 - ⏳ **Pin value is a DEV stand-in** — replace with a real published key.
 - ⏳ **Not deployed** on pir1/pir2 (`--identity-*` flags unset → announce
   returns "not configured").
-- ⏳ Web UI indicator not wired; `issued_at` freshness policy not enforced;
-  standalone TS `OnionPirWebClient` has no `announce()`.
+- ✅ `BatchPirClientAdapter` exposes a gated `operatorIdentity` snapshot
+  (opt-in via `verifyOperatorIdentity`); `gateOperatorIdentity` unit-tested.
+- ⏳ Playground still needs to render the badge from the snapshot;
+  `issued_at` freshness policy not enforced; standalone TS
+  `OnionPirWebClient` has no `announce()`.
 
 ### Remaining work
 
 - **C** — generate the real operator key + deploy `--identity-*` to
-  pir1/pir2 (replaces the DEV stand-in pin).
-- **D** — surface a web "operator identity" indicator (gate it on
-  `checkPinnedOperator` + `checkChannelBinding` + `chainVerified`, never on
-  `chainVerified` alone).
+  pir1/pir2 (replaces the DEV stand-in pin; flips `verifyOperatorIdentity`
+  default to on once live).
+- **D (playground)** — render the badge from
+  `adapter.operatorIdentity.serverN.state` / `onOperatorIdentity`. The
+  gating already lives in the adapter; the badge is the only remaining
+  piece, in the playground repo.
 - **E** — add `announce()` to the standalone TS `OnionPirWebClient`.
 - **F** — enforce `valid_until` / `issued_at` freshness policy in clients.

--- a/pir-sdk-client/src/announce.rs
+++ b/pir-sdk-client/src/announce.rs
@@ -165,7 +165,25 @@ pub async fn announce<T: PirTransport + ?Sized>(
 ) -> PirResult<AnnounceVerification> {
     let request = encode_request(REQ_ANNOUNCE, &[]);
     let response = transport.roundtrip(&request).await?;
+    parse_announce_response(&response)
+}
 
+/// Parse a raw RESP_ANNOUNCE wire payload (the response frame starting
+/// at the variant byte) into an [`AnnounceVerification`], running the
+/// in-bundle chain check. Operator-pubkey pinning
+/// ([`AnnounceVerification::check_pinned_operator`]) and channel binding
+/// ([`AnnounceVerification::check_channel_binding`]) are SEPARATE steps.
+///
+/// This is the synchronous core of [`announce`] (which is just a
+/// `roundtrip` + this). It's exposed so transports that aren't a
+/// [`PirTransport`] — e.g. the standalone TS `OnionPirWebClient`, via
+/// the WASM `verifyAnnounceResponse` binding — can reuse the exact same
+/// parsing + chain verification instead of reimplementing it.
+///
+/// A `RESP_ERROR` envelope surfaces as [`PirError::ServerError`] (e.g.
+/// "announce not configured"); a wire-format violation as
+/// [`PirError::Protocol`].
+pub fn parse_announce_response(response: &[u8]) -> PirResult<AnnounceVerification> {
     if response.is_empty() {
         return Err(PirError::Protocol("empty announce response".into()));
     }
@@ -613,5 +631,35 @@ mod tests {
             PirError::Protocol(m) => assert!(m.contains("does not match pinned operator")),
             other => panic!("expected Protocol(operator mismatch), got {:?}", other),
         }
+    }
+
+    #[test]
+    fn parse_announce_response_ok_runs_chain_check() {
+        // The synchronous core used by the WASM `verifyAnnounceResponse`
+        // binding (and thus the standalone TS OnionPirWebClient).
+        let wire = build_resp_announce(&build_bundle());
+        let v = parse_announce_response(&wire).expect("parse ok");
+        assert!(v.chain_verified);
+        assert_eq!(v.bundle.cert.server_id, "pir1");
+    }
+
+    #[test]
+    fn parse_announce_response_error_envelope_is_server_error() {
+        let mut reply = vec![RESP_ERROR];
+        let msg = b"announce not configured";
+        reply.extend_from_slice(&(msg.len() as u32).to_le_bytes());
+        reply.extend_from_slice(msg);
+        match parse_announce_response(&reply).unwrap_err() {
+            PirError::ServerError(m) => assert!(m.contains("not configured")),
+            other => panic!("expected ServerError, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_announce_response_empty_is_protocol_error() {
+        assert!(matches!(
+            parse_announce_response(&[]).unwrap_err(),
+            PirError::Protocol(_)
+        ));
     }
 }

--- a/pir-sdk-client/src/announce.rs
+++ b/pir-sdk-client/src/announce.rs
@@ -46,6 +46,11 @@ pub(crate) const RESP_ANNOUNCE: u8 = 0x07;
 /// Generic server-side error envelope.
 const RESP_ERROR: u8 = 0xff;
 
+/// Clock-skew tolerance for the `issued_at` freshness check: a manifest
+/// timestamped up to this far in the future is accepted (covers modest
+/// client/server clock drift); beyond it is rejected as future-dated.
+pub const FRESHNESS_SKEW_SECS: i64 = 300;
+
 /// What [`announce`] returns: the parsed bundle plus its chain-check
 /// verdict. The bundle is always returned (decode succeeded), but
 /// callers should consult `chain_verified` before trusting any of its
@@ -140,6 +145,46 @@ impl AnnounceVerification {
                 short_hex(&self.bundle.manifest.channel_pub),
                 short_hex(expected_channel_pub),
             )));
+        }
+        Ok(())
+    }
+
+    /// Replay / staleness guard on `manifest.issued_at` (caller policy).
+    /// Rejects a bundle issued more than `max_age_seconds` before `now`
+    /// (stale), or more than [`FRESHNESS_SKEW_SECS`] *after* `now`
+    /// (future-dated — clock skew or forgery).
+    ///
+    /// **`issued_at` is the server's boot time**, not a per-request
+    /// nonce: the bundle is built once at startup and served unchanged
+    /// for the server's whole uptime. So pick `max_age_seconds`
+    /// generously (≥ expected max uptime) or you'll reject a
+    /// legitimately long-running server. For DPF / HarmonyPIR the
+    /// per-boot `channel_pub` + [`Self::check_channel_binding`] already
+    /// reject a replayed old bundle; this check mainly hardens the
+    /// standalone OnionPIR path, which has no channel binding.
+    ///
+    /// Pass `max_age_seconds == 0` to skip the staleness arm (the
+    /// future-dated arm still runs whenever `now_unix_seconds != 0`).
+    /// Pass `now_unix_seconds == 0` to skip the check entirely.
+    pub fn check_freshness(&self, now_unix_seconds: i64, max_age_seconds: i64) -> PirResult<()> {
+        if now_unix_seconds == 0 {
+            return Ok(());
+        }
+        let issued = self.bundle.manifest.issued_at;
+        if issued > now_unix_seconds + FRESHNESS_SKEW_SECS {
+            return Err(PirError::Protocol(format!(
+                "announce: manifest issued_at ({}) is in the future vs now ({}, skew {}s)",
+                issued, now_unix_seconds, FRESHNESS_SKEW_SECS
+            )));
+        }
+        if max_age_seconds != 0 {
+            let age = now_unix_seconds - issued;
+            if age > max_age_seconds {
+                return Err(PirError::Protocol(format!(
+                    "announce: manifest issued_at ({}) is {}s old, exceeds max age {}s",
+                    issued, age, max_age_seconds
+                )));
+            }
         }
         Ok(())
     }
@@ -661,5 +706,42 @@ mod tests {
             parse_announce_response(&[]).unwrap_err(),
             PirError::Protocol(_)
         ));
+    }
+
+    fn verification_with_issued_at_1_7b() -> AnnounceVerification {
+        // build_bundle()'s manifest is signed with issued_at = 1_700_000_000.
+        AnnounceVerification {
+            bundle: build_bundle(),
+            chain_verified: true,
+            chain_error: None,
+        }
+    }
+
+    #[test]
+    fn check_freshness_accepts_within_window_and_skip_modes() {
+        let v = verification_with_issued_at_1_7b();
+        v.check_freshness(1_700_000_100, 3600).expect("recent → ok");
+        v.check_freshness(0, 1).expect("now=0 skips entirely");
+        v.check_freshness(1_900_000_000, 0).expect("max_age=0 skips staleness");
+    }
+
+    #[test]
+    fn check_freshness_rejects_stale() {
+        let v = verification_with_issued_at_1_7b();
+        // now is a day after issue, max age 1h → stale.
+        match v.check_freshness(1_700_000_000 + 86_400, 3600).unwrap_err() {
+            PirError::Protocol(m) => assert!(m.contains("exceeds max age")),
+            other => panic!("expected Protocol(stale), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn check_freshness_rejects_future_dated() {
+        let v = verification_with_issued_at_1_7b();
+        // now is 1000s before issue (beyond the 300s skew) → future-dated.
+        match v.check_freshness(1_700_000_000 - 1000, 0).unwrap_err() {
+            PirError::Protocol(m) => assert!(m.contains("in the future")),
+            other => panic!("expected Protocol(future), got {:?}", other),
+        }
     }
 }

--- a/pir-sdk-client/src/announce.rs
+++ b/pir-sdk-client/src/announce.rs
@@ -21,12 +21,14 @@
 //!   authentication should pass an `operator_pubkey` to
 //!   [`announce_with_pinned_operator`] once the publishing path is in
 //!   place — that variant runs the missing check.
-//! - **Cross-check `channel_pub` against the value the encrypted
-//!   channel handshake used.** The caller is responsible for taking
-//!   `bundle.manifest.channel_pub` and comparing it against
-//!   `AttestVerification::response.server_static_pub` (or whatever
-//!   key path it actually handshook against). This crate doesn't
-//!   know about the handshake state.
+//! - **Know the expected channel key on its own.** This crate doesn't
+//!   track handshake state, so the caller must supply the X25519 key
+//!   the channel actually handshook against (the attested
+//!   `AttestVerification::response.server_static_pub`). Given that key,
+//!   [`AnnounceVerification::check_channel_binding`] performs the
+//!   cross-check against `bundle.manifest.channel_pub`, and the
+//!   all-in-one [`announce_bound`] folds it together with operator
+//!   pinning + validity in one call.
 //! - **Validate `cert.valid_from` / `cert.valid_until`.** That's a
 //!   caller wall-clock policy. See
 //!   [`IdentityCert::check_validity`](pir_identity::IdentityCert::check_validity).
@@ -61,6 +63,37 @@ pub struct AnnounceVerification {
     pub chain_verified: bool,
     /// `Some(e)` if `chain_verified` is `false`, for diagnostics.
     pub chain_error: Option<IdentityError>,
+}
+
+impl AnnounceVerification {
+    /// Bind the bundle to the encrypted session: check that the
+    /// operator-signed `manifest.channel_pub` equals the X25519 public
+    /// key the channel actually handshook against.
+    ///
+    /// Pass the *attested* `server_static_pub` — i.e. the value the
+    /// client verified via the SEV-SNP report / VCEK chain (V2 layout
+    /// commits the channel key to `REPORT_DATA`) and then ran
+    /// `REQ_HANDSHAKE` against. Equality closes the loop: the chip
+    /// vouches for the channel key, the operator vouches for the same
+    /// key, and the client confirms they agree. A mismatch means the
+    /// bundle describes a *different* channel than the one in use —
+    /// either a deploy bug or a relay splicing one server's bundle onto
+    /// another server's session — so trust nothing in the bundle.
+    ///
+    /// This is orthogonal to operator-pubkey pinning ([`announce_with_pinned_operator`])
+    /// and the in-bundle chain check ([`AnnounceVerification::chain_verified`]);
+    /// the full-trust path wants all three, which [`announce_bound`] runs
+    /// in one call.
+    pub fn check_channel_binding(&self, expected_channel_pub: &[u8; 32]) -> PirResult<()> {
+        if &self.bundle.manifest.channel_pub != expected_channel_pub {
+            return Err(PirError::Protocol(format!(
+                "announce: bundle channel_pub ({}) does not match the handshake key ({})",
+                short_hex(&self.bundle.manifest.channel_pub),
+                short_hex(expected_channel_pub),
+            )));
+        }
+        Ok(())
+    }
 }
 
 /// Send REQ_ANNOUNCE and parse the response.
@@ -189,6 +222,34 @@ pub async fn announce_with_pinned_operator<T: PirTransport + ?Sized>(
                 .unwrap_or_else(|| "unknown".into())
         )));
     }
+    Ok(v)
+}
+
+/// Full-trust announce: [`announce_with_pinned_operator`] **plus** the
+/// channel-binding cross-check ([`AnnounceVerification::check_channel_binding`]).
+///
+/// This is the call a production client should use once it has both a
+/// pinned operator pubkey and the attested channel key in hand. It
+/// fails unless ALL of the following hold:
+/// - the cert is signed by `pinned_operator_pubkey` and (if
+///   `now_unix_seconds != 0`) is inside its validity window,
+/// - the in-bundle chain check passes (manifest signed by the cert's
+///   identity key, server_id / identity_pubkey cross-refs match),
+/// - `bundle.manifest.channel_pub == expected_channel_pub` (the
+///   attested `server_static_pub` the channel handshook against).
+///
+/// `expected_channel_pub` is the X25519 key the caller verified through
+/// attestation and ran `REQ_HANDSHAKE` against. `now_unix_seconds` is
+/// the wall clock for the validity check; pass `0` to skip it.
+pub async fn announce_bound<T: PirTransport + ?Sized>(
+    transport: &mut T,
+    pinned_operator_pubkey: &[u8; 32],
+    expected_channel_pub: &[u8; 32],
+    now_unix_seconds: i64,
+) -> PirResult<AnnounceVerification> {
+    let v =
+        announce_with_pinned_operator(transport, pinned_operator_pubkey, now_unix_seconds).await?;
+    v.check_channel_binding(expected_channel_pub)?;
     Ok(v)
 }
 
@@ -415,6 +476,83 @@ mod tests {
         match err {
             Err(PirError::Protocol(m)) => assert!(m.contains("outside validity")),
             other => panic!("expected Protocol(outside validity), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn check_channel_binding_accepts_matching_key() {
+        // build_bundle()'s manifest commits channel_pub = [0xCC; 32].
+        let v = AnnounceVerification {
+            bundle: build_bundle(),
+            chain_verified: true,
+            chain_error: None,
+        };
+        v.check_channel_binding(&[0xCCu8; 32])
+            .expect("matching channel_pub must pass");
+    }
+
+    #[test]
+    fn check_channel_binding_rejects_mismatched_key() {
+        let v = AnnounceVerification {
+            bundle: build_bundle(),
+            chain_verified: true,
+            chain_error: None,
+        };
+        let err = v.check_channel_binding(&[0u8; 32]).unwrap_err();
+        match err {
+            PirError::Protocol(m) => assert!(m.contains("does not match the handshake key")),
+            other => panic!("expected Protocol(channel mismatch), got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn announce_bound_happy_path() {
+        let bundle = build_bundle();
+        let pinned = bundle.cert.operator_pubkey;
+        let mut mock = MockTransport {
+            reply: build_resp_announce(&bundle),
+            last_request: Mutex::new(Vec::new()),
+        };
+        let v = announce_bound(&mut mock, &pinned, &[0xCCu8; 32], 0)
+            .await
+            .expect("correct operator + channel key must pass");
+        assert!(v.chain_verified);
+    }
+
+    #[tokio::test]
+    async fn announce_bound_rejects_wrong_channel_pub() {
+        // Operator pin is correct, but the bundle's channel_pub does not
+        // match the key the channel handshook against → reject.
+        let bundle = build_bundle();
+        let pinned = bundle.cert.operator_pubkey;
+        let mut mock = MockTransport {
+            reply: build_resp_announce(&bundle),
+            last_request: Mutex::new(Vec::new()),
+        };
+        let err = announce_bound(&mut mock, &pinned, &[0x99u8; 32], 0)
+            .await
+            .unwrap_err();
+        match err {
+            PirError::Protocol(m) => assert!(m.contains("does not match the handshake key")),
+            other => panic!("expected Protocol(channel mismatch), got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn announce_bound_rejects_wrong_operator_even_with_right_channel() {
+        // A wrong operator pin must fail before the channel key is even
+        // considered (operator pinning is checked first).
+        let bundle = build_bundle();
+        let mut mock = MockTransport {
+            reply: build_resp_announce(&bundle),
+            last_request: Mutex::new(Vec::new()),
+        };
+        let err = announce_bound(&mut mock, &[0u8; 32], &[0xCCu8; 32], 0)
+            .await
+            .unwrap_err();
+        match err {
+            PirError::Protocol(m) => assert!(m.contains("does not match pinned operator")),
+            other => panic!("expected Protocol(operator mismatch), got {:?}", other),
         }
     }
 }

--- a/pir-sdk-client/src/announce.rs
+++ b/pir-sdk-client/src/announce.rs
@@ -66,6 +66,55 @@ pub struct AnnounceVerification {
 }
 
 impl AnnounceVerification {
+    /// Verify the already-fetched bundle is fully trustworthy under a
+    /// pinned operator pubkey. This is the synchronous core of
+    /// [`announce_with_pinned_operator`] (which is just `announce()` +
+    /// this), exposed so callers that already hold an
+    /// `AnnounceVerification` — e.g. the WASM client after
+    /// `WasmDpfClient.announce()` — can run the same check without a
+    /// second round-trip. Fails unless ALL hold:
+    /// - `cert.operator_pubkey == pinned_operator_pubkey`,
+    /// - the cert's operator signature verifies (`cert.verify()`) —
+    ///   note neither [`Self::chain_verified`] nor
+    ///   [`Self::check_channel_binding`] covers this, so a bare
+    ///   pubkey-equality compare would miss a forged cert signature,
+    /// - the cert is inside its validity window (skipped when
+    ///   `now_unix_seconds == 0`),
+    /// - the in-bundle chain check passed.
+    pub fn check_pinned_operator(
+        &self,
+        pinned_operator_pubkey: &[u8; 32],
+        now_unix_seconds: i64,
+    ) -> PirResult<()> {
+        if &self.bundle.cert.operator_pubkey != pinned_operator_pubkey {
+            return Err(PirError::Protocol(format!(
+                "announce: cert.operator_pubkey ({}) does not match pinned operator ({})",
+                short_hex(&self.bundle.cert.operator_pubkey),
+                short_hex(pinned_operator_pubkey),
+            )));
+        }
+        self.bundle
+            .cert
+            .verify()
+            .map_err(|e| PirError::Protocol(format!("announce: cert.verify failed: {}", e)))?;
+        if now_unix_seconds != 0 {
+            self.bundle
+                .cert
+                .check_validity(now_unix_seconds)
+                .map_err(|e| PirError::Protocol(format!("announce: cert outside validity: {}", e)))?;
+        }
+        if !self.chain_verified {
+            return Err(PirError::Protocol(format!(
+                "announce: chain check failed: {}",
+                self.chain_error
+                    .as_ref()
+                    .map(|e| e.to_string())
+                    .unwrap_or_else(|| "unknown".into())
+            )));
+        }
+        Ok(())
+    }
+
     /// Bind the bundle to the encrypted session: check that the
     /// operator-signed `manifest.channel_pub` equals the X25519 public
     /// key the channel actually handshook against.
@@ -196,32 +245,7 @@ pub async fn announce_with_pinned_operator<T: PirTransport + ?Sized>(
     now_unix_seconds: i64,
 ) -> PirResult<AnnounceVerification> {
     let v = announce(transport).await?;
-    if &v.bundle.cert.operator_pubkey != pinned_operator_pubkey {
-        return Err(PirError::Protocol(format!(
-            "announce: cert.operator_pubkey ({}) does not match pinned operator ({})",
-            short_hex(&v.bundle.cert.operator_pubkey),
-            short_hex(pinned_operator_pubkey),
-        )));
-    }
-    v.bundle
-        .cert
-        .verify()
-        .map_err(|e| PirError::Protocol(format!("announce: cert.verify failed: {}", e)))?;
-    if now_unix_seconds != 0 {
-        v.bundle
-            .cert
-            .check_validity(now_unix_seconds)
-            .map_err(|e| PirError::Protocol(format!("announce: cert outside validity: {}", e)))?;
-    }
-    if !v.chain_verified {
-        return Err(PirError::Protocol(format!(
-            "announce: chain check failed: {}",
-            v.chain_error
-                .as_ref()
-                .map(|e| e.to_string())
-                .unwrap_or_else(|| "unknown".into())
-        )));
-    }
+    v.check_pinned_operator(pinned_operator_pubkey, now_unix_seconds)?;
     Ok(v)
 }
 
@@ -535,6 +559,41 @@ mod tests {
         match err {
             PirError::Protocol(m) => assert!(m.contains("does not match the handshake key")),
             other => panic!("expected Protocol(channel mismatch), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn check_pinned_operator_accepts_correct_and_rejects_wrong() {
+        let bundle = build_bundle();
+        let pinned = bundle.cert.operator_pubkey;
+        let v = AnnounceVerification {
+            bundle,
+            chain_verified: true,
+            chain_error: None,
+        };
+        v.check_pinned_operator(&pinned, 0)
+            .expect("correct operator pin must pass");
+        let err = v.check_pinned_operator(&[0u8; 32], 0).unwrap_err();
+        match err {
+            PirError::Protocol(m) => assert!(m.contains("does not match pinned operator")),
+            other => panic!("expected Protocol(operator mismatch), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn check_pinned_operator_requires_chain_verified() {
+        // Right operator pin, but the in-bundle chain check failed → reject.
+        let bundle = build_bundle();
+        let pinned = bundle.cert.operator_pubkey;
+        let v = AnnounceVerification {
+            bundle,
+            chain_verified: false,
+            chain_error: None,
+        };
+        let err = v.check_pinned_operator(&pinned, 0).unwrap_err();
+        match err {
+            PirError::Protocol(m) => assert!(m.contains("chain check failed")),
+            other => panic!("expected Protocol(chain check failed), got {:?}", other),
         }
     }
 

--- a/pir-sdk-client/tests/integration_test.rs
+++ b/pir-sdk-client/tests/integration_test.rs
@@ -579,7 +579,11 @@ async fn test_announce_operator_identity_end_to_end() {
     let mut conn = WsConnection::connect(&url).await.expect("connect");
     let v = announce(&mut conn).await.expect("announce roundtrip");
     assert!(v.chain_verified, "chain check failed: {:?}", v.chain_error);
-    assert_eq!(v.bundle.cert.server_id, "pir-test");
+    // Expected server_id defaults to the local fixture's "pir-test"; override
+    // with PIR_ANNOUNCE_SERVER_ID to verify a real deployment (e.g. "pir1").
+    let expected_server_id =
+        std::env::var("PIR_ANNOUNCE_SERVER_ID").unwrap_or_else(|_| "pir-test".into());
+    assert_eq!(v.bundle.cert.server_id, expected_server_id);
     assert_eq!(
         v.bundle.cert.operator_pubkey, operator_pub,
         "cert's operator_pubkey should match the pinned operator"

--- a/pir-sdk-client/tests/integration_test.rs
+++ b/pir-sdk-client/tests/integration_test.rs
@@ -23,7 +23,7 @@
 //!   cargo run --release -p runtime --bin unified_server -- --port 8091 &
 //!   cargo run --release -p runtime --bin unified_server -- --port 8092 &
 
-use pir_sdk_client::{DpfClient, HarmonyClient, PirClient, ScriptHash};
+use pir_sdk_client::{DpfClient, HarmonyClient, PirClient, PirError, ScriptHash, WsConnection};
 
 /// Default to the public deployment so CI — and contributors who haven't
 /// stood up a fixture server — can exercise the full stack against
@@ -533,4 +533,86 @@ fn test_sync_plan_stale_height() {
 
     assert!(plan.is_fresh_sync);
     assert_eq!(plan.target_height, 920000);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// REQ_ANNOUNCE — operator-signed identity, end-to-end through unified_server.
+//
+// This is the only test that drives the *production* dispatch arm for
+// REQ_ANNOUNCE (the binary re-implements dispatch inline rather than going
+// through pir-runtime-core's stateless RequestHandler). It connects, sends
+// REQ_ANNOUNCE, parses the bundle, runs the in-bundle chain check, then
+// operator-pubkey pinning (accept the right key, reject a wrong one).
+//
+// Unlike the other integration tests it does NOT default to the public
+// deployment — pir1/pir2 run without --identity-* flags and answer
+// "announce not configured". Point it at a locally-booted server:
+//
+//   # operator workflow (once):
+//   bpir-admin generate-identity --purpose server   --out /tmp/s.key   # -> SERVER_PUB (stdout)
+//   bpir-admin generate-identity --purpose operator --out /tmp/op.key  # -> OPERATOR_PUB (stdout)
+//   bpir-admin sign-identity --operator-key-path /tmp/op.key --server-id pir-test \
+//       --identity-pubkey-hex <SERVER_PUB> --valid-until <unix-ts> --out /tmp/s.cert
+//   # boot (any local checkpoint works — announce is independent of the DB):
+//   unified_server --port 8097 --data-dir <ckpt> --serve-queries \
+//       --identity-key-path /tmp/s.key --identity-cert-path /tmp/s.cert \
+//       --identity-server-id pir-test
+//   # run:
+//   PIR_ANNOUNCE_URL=ws://127.0.0.1:8097 \
+//   PIR_ANNOUNCE_OPERATOR_PUB=<OPERATOR_PUB hex> \
+//     cargo test -p pir-sdk-client --test integration_test \
+//       test_announce_operator_identity_end_to_end -- --ignored --nocapture
+#[tokio::test]
+#[ignore = "requires a unified_server booted with --identity-* flags; see PIR_ANNOUNCE_* env vars"]
+async fn test_announce_operator_identity_end_to_end() {
+    use pir_sdk_client::announce::{announce, announce_with_pinned_operator};
+
+    let url = std::env::var("PIR_ANNOUNCE_URL")
+        .expect("set PIR_ANNOUNCE_URL to a unified_server booted with --identity-* flags");
+    let operator_pub = parse_pubkey_hex(
+        &std::env::var("PIR_ANNOUNCE_OPERATOR_PUB")
+            .expect("set PIR_ANNOUNCE_OPERATOR_PUB to the operator pubkey hex (64 chars)"),
+    );
+
+    // 1. Plain announce: the bundle decodes and the in-bundle chain check
+    //    (manifest signature + cert/manifest cross-references) passes.
+    let mut conn = WsConnection::connect(&url).await.expect("connect");
+    let v = announce(&mut conn).await.expect("announce roundtrip");
+    assert!(v.chain_verified, "chain check failed: {:?}", v.chain_error);
+    assert_eq!(v.bundle.cert.server_id, "pir-test");
+    assert_eq!(
+        v.bundle.cert.operator_pubkey, operator_pub,
+        "cert's operator_pubkey should match the pinned operator"
+    );
+
+    // 2. Pinned to the correct operator pubkey → accepted (cert signature
+    //    verifies under the pinned key and the chain check holds).
+    let v2 = announce_with_pinned_operator(&mut conn, &operator_pub, 0)
+        .await
+        .expect("pinned announce with the correct operator must succeed");
+    assert!(v2.chain_verified);
+
+    // 3. Pinned to a wrong operator pubkey → rejected before trusting anything.
+    let wrong = [0u8; 32];
+    let err = announce_with_pinned_operator(&mut conn, &wrong, 0)
+        .await
+        .expect_err("pinned announce with a wrong operator must fail");
+    match err {
+        PirError::Protocol(m) => assert!(
+            m.contains("does not match pinned operator"),
+            "unexpected error: {m}"
+        ),
+        other => panic!("expected Protocol(does not match pinned operator), got {other:?}"),
+    }
+}
+
+/// Parse a 64-char hex Ed25519 pubkey into 32 bytes (test helper).
+fn parse_pubkey_hex(s: &str) -> [u8; 32] {
+    let s = s.trim();
+    assert_eq!(s.len(), 64, "operator pubkey hex must be 64 chars, got {}", s.len());
+    let mut out = [0u8; 32];
+    for (i, b) in out.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).expect("invalid hex in operator pubkey");
+    }
+    out
 }

--- a/pir-sdk-client/tests/integration_test.rs
+++ b/pir-sdk-client/tests/integration_test.rs
@@ -567,12 +567,21 @@ fn test_sync_plan_stale_height() {
 async fn test_announce_operator_identity_end_to_end() {
     use pir_sdk_client::announce::{announce, announce_with_pinned_operator};
 
-    let url = std::env::var("PIR_ANNOUNCE_URL")
-        .expect("set PIR_ANNOUNCE_URL to a unified_server booted with --identity-* flags");
-    let operator_pub = parse_pubkey_hex(
-        &std::env::var("PIR_ANNOUNCE_OPERATOR_PUB")
-            .expect("set PIR_ANNOUNCE_OPERATOR_PUB to the operator pubkey hex (64 chars)"),
-    );
+    // Skip gracefully when unconfigured: unlike the other --ignored tests
+    // there is no sensible public default (the public servers don't serve
+    // announce), so CI runs this as a no-op unless both env vars are set.
+    let (url, operator_pub_hex) =
+        match (std::env::var("PIR_ANNOUNCE_URL"), std::env::var("PIR_ANNOUNCE_OPERATOR_PUB")) {
+            (Ok(u), Ok(p)) => (u, p),
+            _ => {
+                eprintln!(
+                    "skipping test_announce_operator_identity_end_to_end: set PIR_ANNOUNCE_URL \
+                     + PIR_ANNOUNCE_OPERATOR_PUB (and optionally PIR_ANNOUNCE_SERVER_ID) to run"
+                );
+                return;
+            }
+        };
+    let operator_pub = parse_pubkey_hex(&operator_pub_hex);
 
     // 1. Plain announce: the bundle decodes and the in-bundle chain check
     //    (manifest signature + cert/manifest cross-references) passes.

--- a/pir-sdk-server/src/server.rs
+++ b/pir-sdk-server/src/server.rs
@@ -169,6 +169,11 @@ async fn handle_connection(stream: TcpStream, handler: Arc<RequestHandler>) -> P
 /// Builder for creating a PIR server.
 pub struct PirServerBuilder {
     config: ServerConfig,
+    /// Pre-encoded `pir_identity::AnnouncementBundle` bytes that
+    /// REQ_ANNOUNCE returns verbatim. `None` (the default) leaves the
+    /// server in "unannounced" mode (REQ_ANNOUNCE → RESP_ERROR). Build
+    /// the bytes with `pir_runtime_core::identity::build_announcement_bundle`.
+    announcement_bundle: Option<Vec<u8>>,
 }
 
 impl PirServerBuilder {
@@ -176,7 +181,18 @@ impl PirServerBuilder {
     pub fn new() -> Self {
         Self {
             config: ServerConfig::new(),
+            announcement_bundle: None,
         }
+    }
+
+    /// Supply the operator-signed announcement bundle served by
+    /// REQ_ANNOUNCE. Pass the pre-encoded
+    /// `pir_identity::AnnouncementBundle` bytes (build them with
+    /// `pir_runtime_core::identity::build_announcement_bundle`). `None`
+    /// keeps the server in unannounced mode.
+    pub fn with_announcement_bundle(mut self, bundle: Option<Vec<u8>>) -> Self {
+        self.announcement_bundle = bundle;
+        self
     }
 
     /// Load configuration from a TOML file.
@@ -264,7 +280,10 @@ impl PirServerBuilder {
 
         // Create request handler
         let catalog = loader.catalog().clone();
-        let handler = Arc::new(RequestHandler::new(loader.into_databases()));
+        let handler = Arc::new(
+            RequestHandler::new(loader.into_databases())
+                .with_announcement_bundle(self.announcement_bundle),
+        );
 
         // Bind listener
         let addr = format!("0.0.0.0:{}", self.config.port);

--- a/pir-sdk-wasm/src/client.rs
+++ b/pir-sdk-wasm/src/client.rs
@@ -918,6 +918,27 @@ impl WasmAnnounceVerification {
     }
 }
 
+/// Parse + verify a raw RESP_ANNOUNCE wire payload (the response frame
+/// starting at the variant byte) into a [`WasmAnnounceVerification`],
+/// running the in-bundle chain check. Throws on a wire-format violation
+/// or a server `RESP_ERROR` envelope (e.g. "announce not configured").
+///
+/// This is for transports that don't go through `WasmDpfClient` — the
+/// standalone TS `OnionPirWebClient` does its own REQ_ANNOUNCE
+/// round-trip over its WebSocket and hands the response bytes here, so
+/// it reuses the exact same Rust parsing + chain verification (and the
+/// `checkPinnedOperator` / `checkChannelBinding` methods on the result)
+/// instead of reimplementing Ed25519 verification in TS. Mirrors the
+/// Rust `pir_sdk_client::announce::parse_announce_response`.
+#[wasm_bindgen(js_name = verifyAnnounceResponse)]
+pub fn verify_announce_response(
+    resp_payload: &[u8],
+) -> Result<WasmAnnounceVerification, JsError> {
+    let inner = pir_sdk_client::announce::parse_announce_response(resp_payload)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(WasmAnnounceVerification { inner })
+}
+
 // ─── WasmDpfClient ──────────────────────────────────────────────────────────
 
 /// Two-server DPF-PIR client exposed to JavaScript.

--- a/pir-sdk-wasm/src/client.rs
+++ b/pir-sdk-wasm/src/client.rs
@@ -864,6 +864,24 @@ impl WasmAnnounceVerification {
             .map_err(|e| JsError::new(&e.to_string()))
     }
 
+    /// Replay / staleness guard on `manifest.issued_at`. Throws if the
+    /// bundle is older than `maxAgeSeconds` before `nowUnixSeconds`
+    /// (stale) or more than 300s after it (future-dated). NOTE:
+    /// `issued_at` is the server's boot time, so pick `maxAgeSeconds`
+    /// generously (≥ expected uptime); pass `0n` to skip the staleness
+    /// arm, or `nowUnixSeconds === 0n` to skip entirely. Mirrors the Rust
+    /// `AnnounceVerification::check_freshness`.
+    #[wasm_bindgen(js_name = checkFreshness)]
+    pub fn check_freshness(
+        &self,
+        now_unix_seconds: i64,
+        max_age_seconds: i64,
+    ) -> Result<(), JsError> {
+        self.inner
+            .check_freshness(now_unix_seconds, max_age_seconds)
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
     /// Hex-encoded binary SHA-256 the manifest claims (self-reported,
     /// trustworthy iff the chain check passed).
     #[wasm_bindgen(getter, js_name = binarySha256Hex)]

--- a/pir-sdk-wasm/src/client.rs
+++ b/pir-sdk-wasm/src/client.rs
@@ -818,6 +818,30 @@ impl WasmAnnounceVerification {
         hex_encode(&self.inner.bundle.manifest.channel_pub)
     }
 
+    /// Verify the bundle against a pinned operator pubkey: operator
+    /// pubkey match + the cert's operator **signature** (`cert.verify()`)
+    /// + validity window (skipped when `nowUnixSeconds == 0`) + the
+    /// in-bundle chain check. Throws on any failure or a non-32-byte
+    /// argument. A bare `operatorPubkeyHex` string-compare would miss
+    /// the signature check, so use this. Mirrors the Rust
+    /// `AnnounceVerification::check_pinned_operator`.
+    #[wasm_bindgen(js_name = checkPinnedOperator)]
+    pub fn check_pinned_operator(
+        &self,
+        pinned_operator_pubkey: &[u8],
+        now_unix_seconds: i64,
+    ) -> Result<(), JsError> {
+        let arr: [u8; 32] = pinned_operator_pubkey.try_into().map_err(|_| {
+            JsError::new(&format!(
+                "checkPinnedOperator: expected a 32-byte operator pubkey, got {} bytes",
+                pinned_operator_pubkey.len()
+            ))
+        })?;
+        self.inner
+            .check_pinned_operator(&arr, now_unix_seconds)
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
     /// Bind the bundle to the encrypted session: verify that the
     /// manifest's `channelPub` equals the X25519 key the channel
     /// actually handshook against. Pass the *attested* key — i.e.

--- a/pir-sdk-wasm/src/client.rs
+++ b/pir-sdk-wasm/src/client.rs
@@ -818,6 +818,28 @@ impl WasmAnnounceVerification {
         hex_encode(&self.inner.bundle.manifest.channel_pub)
     }
 
+    /// Bind the bundle to the encrypted session: verify that the
+    /// manifest's `channelPub` equals the X25519 key the channel
+    /// actually handshook against. Pass the *attested* key — i.e.
+    /// `attestVerification.serverStaticPub`, which the SEV-SNP report /
+    /// VCEK chain already vouches for. Throws on mismatch (the bundle
+    /// describes a different channel than the live session) or on a
+    /// non-32-byte argument. Mirrors the Rust
+    /// `AnnounceVerification::check_channel_binding` so web and native
+    /// share one implementation and error message.
+    #[wasm_bindgen(js_name = checkChannelBinding)]
+    pub fn check_channel_binding(&self, expected_channel_pub: &[u8]) -> Result<(), JsError> {
+        let arr: [u8; 32] = expected_channel_pub.try_into().map_err(|_| {
+            JsError::new(&format!(
+                "checkChannelBinding: expected a 32-byte channel pubkey, got {} bytes",
+                expected_channel_pub.len()
+            ))
+        })?;
+        self.inner
+            .check_channel_binding(&arr)
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
     /// Hex-encoded binary SHA-256 the manifest claims (self-reported,
     /// trustworthy iff the chain check passed).
     #[wasm_bindgen(getter, js_name = binarySha256Hex)]

--- a/runtime/src/bin/unified_server.rs
+++ b/runtime/src/bin/unified_server.rs
@@ -1312,6 +1312,24 @@ fn split_cert_chain_ask_then_ark(bytes: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
     Some((first_block, second_block))
 }
 
+// ─── REQ_ANNOUNCE response builder ──────────────────────────────────────────
+//
+// Maps the startup-built `ServerState.announcement_bundle` to the wire
+// reply: `Some` → `RESP_ANNOUNCE` carrying the operator-signed bundle
+// verbatim; `None` → `RESP_ERROR` (the server was started without a
+// consistent identity key + operator cert). Extracted so the REQ_ANNOUNCE
+// dispatch arm and its unit test share one implementation — booting the
+// full binary needs a multi-GB checkpoint, so this is the closest seam
+// the production code path can be exercised at in-process.
+fn build_announce_response(announcement_bundle: &Option<Vec<u8>>) -> Response {
+    match announcement_bundle {
+        Some(bytes) => Response::Announce(bytes.clone()),
+        None => Response::Error(
+            "announce not configured: server lacks identity key or operator cert".into(),
+        ),
+    }
+}
+
 // ─── Encrypted-channel send helper ─────────────────────────────────────────
 //
 // Wraps the raw `sink.send(Message::Binary(...))` pattern so that, if a
@@ -3075,6 +3093,14 @@ async fn main() {
                             let _ = send_resp(&mut sink, channel_session.as_mut(), resp.encode()).await;
                         }
                     }
+                    REQ_ANNOUNCE => {
+                        // Operator-signed identity bundle, built at startup
+                        // into `ServerState.announcement_bundle` when the
+                        // --identity-* flags are set. `None` means the server
+                        // lacks an identity key / operator cert.
+                        let resp = build_announce_response(&server.state.announcement_bundle);
+                        let _ = send_resp(&mut sink, channel_session.as_mut(), resp.encode()).await;
+                    }
                     REQ_HANDSHAKE => {
                         // Encrypted-channel handshake. The reply MUST go out
                         // in cleartext — the client doesn't have the session
@@ -3851,5 +3877,57 @@ async fn main() {
 
             println!("[{}] Disconnected (id={})", peer, client_id);
         });
+    }
+}
+
+#[cfg(test)]
+mod announce_dispatch_tests {
+    //! Tests for the REQ_ANNOUNCE response builder used by the
+    //! production dispatch loop. The full per-connection match lives
+    //! inline in `main` and needs a multi-GB checkpoint to boot, so we
+    //! exercise the shared `build_announce_response` seam directly.
+    //! Routing (opcode 0x07 reaching this arm rather than the catch-all
+    //! "unsupported request" arm) is verified live by the operator-
+    //! identity end-to-end check, since it can only be observed against
+    //! a running binary.
+    use super::*;
+
+    #[test]
+    fn announce_response_configured_returns_bundle_verbatim() {
+        let bundle = vec![0xDEu8, 0xAD, 0xBE, 0xEF, 0x07];
+        match build_announce_response(&Some(bundle.clone())) {
+            Response::Announce(b) => assert_eq!(b, bundle),
+            other => panic!("expected Announce, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn announce_response_configured_wire_roundtrips_to_same_bundle() {
+        // The arm sends `resp.encode()` on the wire; a client decodes it
+        // back to identical bundle bytes — proving the dispatch arm emits
+        // a well-formed RESP_ANNOUNCE frame the SDK `announce()` parses.
+        let bundle = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+        let wire = build_announce_response(&Some(bundle.clone())).encode();
+        // Wire layout: [u32 LE outer len][RESP_ANNOUNCE][u32 LE blen][bundle];
+        // `Response::decode` consumes everything after the outer length.
+        match Response::decode(&wire[4..]).expect("decode RESP_ANNOUNCE") {
+            Response::Announce(b) => assert_eq!(b, bundle),
+            other => panic!("expected Announce after round-trip, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn announce_response_unconfigured_returns_error() {
+        // None (server started without --identity-* flags, or with an
+        // inconsistent key/cert pair) must surface as RESP_ERROR carrying
+        // the documented "announce not configured" message — the client's
+        // `announce()` maps this to PirError::ServerError.
+        match build_announce_response(&None) {
+            Response::Error(msg) => assert!(
+                msg.contains("announce not configured"),
+                "unexpected error message: {msg}"
+            ),
+            other => panic!("expected Error, got {:?}", other),
+        }
     }
 }

--- a/web/src/__tests__/operator_identity_gate.test.ts
+++ b/web/src/__tests__/operator_identity_gate.test.ts
@@ -8,7 +8,7 @@ import type { WasmAnnounceVerification } from '../sdk-bridge.js';
  * wasm-bindgen methods do) when `throwOn` selects them. The getters
  * stand in for a parsed bundle so we can assert the surfaced fields.
  */
-function fakeBundle(throwOn?: 'operator' | 'channel'): WasmAnnounceVerification {
+function fakeBundle(throwOn?: 'operator' | 'channel' | 'freshness'): WasmAnnounceVerification {
   return {
     serverId: 'pir1',
     operatorPubkeyHex: '47d98cb6'.padEnd(64, '0'),
@@ -34,6 +34,11 @@ function fakeBundle(throwOn?: 'operator' | 'channel'): WasmAnnounceVerification 
         throw new Error(
           'announce: bundle channel_pub (aa…) does not match the handshake key (bb…)',
         );
+      }
+    },
+    checkFreshness() {
+      if (throwOn === 'freshness') {
+        throw new Error('announce: manifest issued_at (…) is 99999s old, exceeds max age 1s');
       }
     },
     free() {},
@@ -65,5 +70,11 @@ describe('gateOperatorIdentity', () => {
     const r = gateOperatorIdentity(fakeBundle('channel'), PIN, CHANNEL, 0n);
     expect(r.state).toBe('unverified');
     expect(r.error).toMatch(/does not match the handshake key/);
+  });
+
+  it("returns 'unverified' when the freshness check throws (stale bundle)", () => {
+    const r = gateOperatorIdentity(fakeBundle('freshness'), PIN, CHANNEL, 1_700_000_000n, 1n);
+    expect(r.state).toBe('unverified');
+    expect(r.error).toMatch(/exceeds max age/);
   });
 });

--- a/web/src/__tests__/operator_identity_gate.test.ts
+++ b/web/src/__tests__/operator_identity_gate.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { gateOperatorIdentity } from '../dpf-adapter.js';
+import type { WasmAnnounceVerification } from '../sdk-bridge.js';
+
+/**
+ * Minimal fake of the WASM bundle handle. Only `checkPinnedOperator` /
+ * `checkChannelBinding` behaviour matters — they throw (as the real
+ * wasm-bindgen methods do) when `throwOn` selects them. The getters
+ * stand in for a parsed bundle so we can assert the surfaced fields.
+ */
+function fakeBundle(throwOn?: 'operator' | 'channel'): WasmAnnounceVerification {
+  return {
+    serverId: 'pir1',
+    operatorPubkeyHex: '47d98cb6'.padEnd(64, '0'),
+    identityPubkeyHex: 'dbefff8b'.padEnd(64, '0'),
+    channelPub: new Uint8Array(32),
+    channelPubHex: '0'.repeat(64),
+    binarySha256Hex: '0'.repeat(64),
+    gitRev: 'test-rev',
+    validFrom: 0n,
+    validUntil: 1811051894n,
+    issuedAt: 1779515936n,
+    chainVerified: true,
+    chainError: '',
+    checkPinnedOperator() {
+      if (throwOn === 'operator') {
+        throw new Error(
+          'announce: cert.operator_pubkey (aa…) does not match pinned operator (bb…)',
+        );
+      }
+    },
+    checkChannelBinding() {
+      if (throwOn === 'channel') {
+        throw new Error(
+          'announce: bundle channel_pub (aa…) does not match the handshake key (bb…)',
+        );
+      }
+    },
+    free() {},
+  } as unknown as WasmAnnounceVerification;
+}
+
+const PIN = new Uint8Array(32);
+const CHANNEL = new Uint8Array(32);
+
+describe('gateOperatorIdentity', () => {
+  it("returns 'verified' with bundle fields when both checks pass", () => {
+    const r = gateOperatorIdentity(fakeBundle(), PIN, CHANNEL, 0n);
+    expect(r.state).toBe('verified');
+    expect(r.serverId).toBe('pir1');
+    expect(r.gitRev).toBe('test-rev');
+    expect(r.validUntil).toBe(1811051894); // bigint → number
+    expect(r.error).toBeUndefined();
+  });
+
+  it("returns 'unverified' when the operator-pin check throws", () => {
+    const r = gateOperatorIdentity(fakeBundle('operator'), PIN, CHANNEL, 0n);
+    expect(r.state).toBe('unverified');
+    expect(r.error).toMatch(/does not match pinned operator/);
+    // best-effort identifying fields still surfaced for diagnostics
+    expect(r.serverId).toBe('pir1');
+  });
+
+  it("returns 'unverified' when the channel-binding check throws", () => {
+    const r = gateOperatorIdentity(fakeBundle('channel'), PIN, CHANNEL, 0n);
+    expect(r.state).toBe('unverified');
+    expect(r.error).toMatch(/does not match the handshake key/);
+  });
+});

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -187,25 +187,28 @@ export const PIR1_PIN: ServerAttestPin = {
  * NOT a bare `operatorPubkeyHex` string-compare, which would miss the
  * cert's operator signature.
  *
- * ⚠️ DEV STAND-IN — NOT FOR PRODUCTION. The value below is the
- * throwaway keypair used by the announce end-to-end test
- * (`test_announce_operator_identity_end_to_end`), pinned so the path is
- * exercisable in dev. Before any deployment relies on operator identity:
- *   1. generate the real operator key offline,
- *   2. publish its pubkey out-of-band (build-time pin here is the MVP;
- *      DNSSEC/Nostr can layer on later), and
- *   3. replace the hex below + record provenance like the pins above.
- * Until then, callers should treat a passing operator-pin check as
- * dev-only and gate any "verified operator" UI on a real pin landing.
+ * Pinned 2026-05-25. Operator key generated offline via
+ * `bpir-admin generate-identity --purpose operator`; the SECRET lives
+ * only on the operator's workstation (`~/.config/bpir-admin/operator.key`,
+ * backed up out-of-band) and signs the pir1 / pir2 `IdentityCert`s
+ * (`bpir-admin sign-identity`, valid_until 2029-05).
  *
- * Full operator runbook + client trust model: docs/OPERATOR_IDENTITY.md.
+ * ⚠️ NOT YET LIVE END-TO-END. pir1/pir2 are *staged* with `--identity-*`
+ * (the bundle is built + logged "Identity announce: enabled"), but the
+ * deployed reproducible binary predates the REQ_ANNOUNCE *dispatch* arm,
+ * so the servers still answer "unsupported request 0x07". Announce goes
+ * live only once a binary carrying the dispatch arm is reproducibly
+ * rebuilt + deployed to pir1 AND baked into the pir2 Tier-3 UKI, with
+ * `binarySha256Hex` (both pins) + pir2 `measurementHex` re-pinned. Keep
+ * any "verified operator" UI gated until then. See
+ * docs/OPERATOR_IDENTITY.md §"Deployment status".
  */
 export const PIR_OPERATOR_PUBKEY_HEX =
-  '47d98cb6483b2b027e4b08e516e26ce414ebb719421a591f66272f9c97bad562';
+  '256fb106c039f8009d3caa431a9634ff3fe5db3b9e4d9ae7282bbde66772c97a';
 
 /** Decoded 32-byte operator pubkey for
- *  `WasmAnnounceVerification.checkPinnedOperator`. See the loud
- *  DEV-STAND-IN warning on [`PIR_OPERATOR_PUBKEY_HEX`]. */
+ *  `WasmAnnounceVerification.checkPinnedOperator`. See provenance +
+ *  the "not yet live" note on [`PIR_OPERATOR_PUBKEY_HEX`]. */
 export const PIR_OPERATOR_PUBKEY: Uint8Array = (() => {
   const hex = PIR_OPERATOR_PUBKEY_HEX;
   if (hex.length !== 64) {

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -169,3 +169,51 @@ export const PIR1_PIN: ServerAttestPin = {
     '71a041ae1931b81563f460c6e028c96706ea1c2f66545ee700479c0e5c5a93b6',
   description: 'weikeng1.bitcoinpir.org (Hetzner i7-8700, no SEV)',
 };
+
+/**
+ * Operator identity pin (Tier-1) for the REQ_ANNOUNCE operator-signed
+ * identity flow.
+ *
+ * The operator's long-term Ed25519 key (generated OFFLINE via
+ * `bpir-admin generate-identity --purpose operator`, secret never on a
+ * server) signs each server's `IdentityCert`. A client pins the
+ * operator's *public* key here and rejects any announce bundle whose
+ * cert isn't signed by it. One operator key signs the whole fleet; the
+ * per-server `IdentityCert.server_id` (pir1 / pir2) distinguishes them,
+ * so this single pin covers both.
+ *
+ * Pass the decoded bytes to `WasmAnnounceVerification.checkPinnedOperator`
+ * (operator pubkey match + cert signature + validity + chain check) —
+ * NOT a bare `operatorPubkeyHex` string-compare, which would miss the
+ * cert's operator signature.
+ *
+ * ⚠️ DEV STAND-IN — NOT FOR PRODUCTION. The value below is the
+ * throwaway keypair used by the announce end-to-end test
+ * (`test_announce_operator_identity_end_to_end`), pinned so the path is
+ * exercisable in dev. Before any deployment relies on operator identity:
+ *   1. generate the real operator key offline,
+ *   2. publish its pubkey out-of-band (build-time pin here is the MVP;
+ *      DNSSEC/Nostr can layer on later), and
+ *   3. replace the hex below + record provenance like the pins above.
+ * Until then, callers should treat a passing operator-pin check as
+ * dev-only and gate any "verified operator" UI on a real pin landing.
+ */
+export const PIR_OPERATOR_PUBKEY_HEX =
+  '47d98cb6483b2b027e4b08e516e26ce414ebb719421a591f66272f9c97bad562';
+
+/** Decoded 32-byte operator pubkey for
+ *  `WasmAnnounceVerification.checkPinnedOperator`. See the loud
+ *  DEV-STAND-IN warning on [`PIR_OPERATOR_PUBKEY_HEX`]. */
+export const PIR_OPERATOR_PUBKEY: Uint8Array = (() => {
+  const hex = PIR_OPERATOR_PUBKEY_HEX;
+  if (hex.length !== 64) {
+    throw new Error(
+      `attest-pin: PIR_OPERATOR_PUBKEY_HEX must be 64 hex chars, got ${hex.length}`,
+    );
+  }
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+})();

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -197,6 +197,8 @@ export const PIR1_PIN: ServerAttestPin = {
  *   3. replace the hex below + record provenance like the pins above.
  * Until then, callers should treat a passing operator-pin check as
  * dev-only and gate any "verified operator" UI on a real pin landing.
+ *
+ * Full operator runbook + client trust model: docs/OPERATOR_IDENTITY.md.
  */
 export const PIR_OPERATOR_PUBKEY_HEX =
   '47d98cb6483b2b027e4b08e516e26ce414ebb719421a591f66272f9c97bad562';

--- a/web/src/dpf-adapter.ts
+++ b/web/src/dpf-adapter.ts
@@ -174,11 +174,16 @@ export function gateOperatorIdentity(
   pinnedOperatorPubkey: Uint8Array,
   expectedChannelPub: Uint8Array,
   nowUnixSeconds: bigint,
+  maxAgeSeconds: bigint = 0n,
 ): OperatorIdentity {
   try {
     // checkPinnedOperator already requires chainVerified internally.
     v.checkPinnedOperator(pinnedOperatorPubkey, nowUnixSeconds);
     v.checkChannelBinding(expectedChannelPub);
+    // Replay/staleness guard. With maxAgeSeconds=0n only the future-dated
+    // arm runs (issued_at is the server's boot time, so a default
+    // staleness cap would wrongly reject long-uptime servers).
+    v.checkFreshness(nowUnixSeconds, maxAgeSeconds);
     return {
       state: 'verified',
       serverId: v.serverId,
@@ -271,6 +276,14 @@ export interface BatchPirClientConfig {
    * stand-in). Pass a real published key here, or update the constant.
    */
   pinnedOperatorPubkey?: Uint8Array;
+  /**
+   * Replay/staleness cap (seconds) on the announce bundle's `issuedAt`.
+   * `issuedAt` is the server's *boot time*, so set this generously
+   * (≥ expected max uptime). Default `0` = no staleness cap (the
+   * future-dated guard always runs). Only consulted when
+   * `verifyOperatorIdentity`.
+   */
+  maxAnnounceAgeSeconds?: number;
   /** Fires once per server after `connect()` resolves the per-server
    *  operator-identity check (only when `verifyOperatorIdentity`). Use to
    *  surface a "verified operator" badge — gate it on `state === 'verified'`. */
@@ -869,7 +882,8 @@ export class BatchPirClientAdapter {
     }
     try {
       const nowSecs = BigInt(Math.floor(Date.now() / 1000));
-      const result = gateOperatorIdentity(v, pin, att.serverStaticPub, nowSecs);
+      const maxAge = BigInt(this.config.maxAnnounceAgeSeconds ?? 0);
+      const result = gateOperatorIdentity(v, pin, att.serverStaticPub, nowSecs, maxAge);
       if (result.state === 'verified') {
         this.log(`server${idx}: operator identity verified (${result.serverId})`, 'success');
       } else {

--- a/web/src/dpf-adapter.ts
+++ b/web/src/dpf-adapter.ts
@@ -47,11 +47,12 @@ import {
 } from './server-info.js';
 import {
   requireSdkWasm,
+  type WasmAnnounceVerification,
   type WasmAttestVerification,
   type WasmDpfClient,
   type WasmQueryResult,
 } from './sdk-bridge.js';
-import { getAmdTurinArkFingerprint } from './attest-pin.js';
+import { getAmdTurinArkFingerprint, PIR_OPERATOR_PUBKEY } from './attest-pin.js';
 import type { ConnectionState, QueryResult, UtxoEntry } from './types.js';
 import { ManagedWebSocket } from './ws.js';
 
@@ -121,6 +122,81 @@ export interface ServerAttestation {
   pinError?: string;
 }
 
+/**
+ * Per-server operator-signed-identity snapshot, exposed via
+ * `BatchPirClientAdapter.operatorIdentity` when
+ * `config.verifyOperatorIdentity` is enabled. The UI gates a "verified
+ * operator" badge on `state === 'verified'` ONLY — never on the bundle's
+ * `chainVerified` alone (that proves consistency, not authenticity).
+ *
+ * States:
+ *   - `'not-checked'`: verification disabled, or not yet run.
+ *   - `'unconfigured'`: server has no operator identity (started without
+ *     `--identity-*`). Expected for servers that haven't opted in — show
+ *     nothing, not an error.
+ *   - `'verified'`: REQ_ANNOUNCE returned a bundle AND operator-pin
+ *     (`checkPinnedOperator`: pubkey + cert signature + validity + chain)
+ *     AND channel-binding (`checkChannelBinding` vs the attested
+ *     `serverStaticPub`) both passed.
+ *   - `'unverified'`: a bundle came back but a check failed (wrong
+ *     operator, bad signature, expired, chain mismatch, or channel
+ *     mismatch). `error` carries the diagnostic — treat as a strong
+ *     negative signal.
+ *   - `'error'`: couldn't complete the check (no attestation to bind
+ *     against, transport/protocol error). `error` carries the reason.
+ */
+export interface OperatorIdentity {
+  state: 'not-checked' | 'unconfigured' | 'verified' | 'unverified' | 'error';
+  /** `server_id` the cert is endorsed for (e.g. "pir1"). */
+  serverId?: string;
+  /** Hex operator (Tier-1) pubkey the cert claims. Trustworthy only
+   *  when `state === 'verified'`. */
+  operatorPubkeyHex?: string;
+  /** Hex identity (Tier-2) pubkey the operator endorsed. */
+  identityPubkeyHex?: string;
+  /** Git rev the manifest self-reports. */
+  gitRev?: string;
+  /** Cert validity upper bound (unix-seconds; 0 = indefinite). */
+  validUntil?: number;
+  /** Diagnostic for `'unverified'` / `'error'`. */
+  error?: string;
+}
+
+/**
+ * Pure gating step: given a fetched `WasmAnnounceVerification`, the
+ * pinned operator pubkey, the attested channel key, and a wall clock,
+ * run operator-pin + channel-binding and classify. Never throws —
+ * folds a failed check into `state: 'unverified'`. Extracted (and
+ * exported) so it's unit-testable without a live server.
+ */
+export function gateOperatorIdentity(
+  v: WasmAnnounceVerification,
+  pinnedOperatorPubkey: Uint8Array,
+  expectedChannelPub: Uint8Array,
+  nowUnixSeconds: bigint,
+): OperatorIdentity {
+  try {
+    // checkPinnedOperator already requires chainVerified internally.
+    v.checkPinnedOperator(pinnedOperatorPubkey, nowUnixSeconds);
+    v.checkChannelBinding(expectedChannelPub);
+    return {
+      state: 'verified',
+      serverId: v.serverId,
+      operatorPubkeyHex: v.operatorPubkeyHex,
+      identityPubkeyHex: v.identityPubkeyHex,
+      gitRev: v.gitRev,
+      validUntil: Number(v.validUntil),
+    };
+  } catch (e) {
+    return {
+      state: 'unverified',
+      serverId: v.serverId,
+      operatorPubkeyHex: v.operatorPubkeyHex,
+      error: (e as Error)?.message ?? String(e),
+    };
+  }
+}
+
 export interface BatchPirClientConfig {
   server0Url: string;
   server1Url: string;
@@ -179,6 +255,26 @@ export interface BatchPirClientConfig {
    */
   expectedServer0Pin?: import('./attest-pin.js').ServerAttestPin;
   expectedServer1Pin?: import('./attest-pin.js').ServerAttestPin;
+  /**
+   * If `true`, after attesting each server the adapter also fetches its
+   * operator-signed identity (REQ_ANNOUNCE) and verifies it against
+   * `pinnedOperatorPubkey` + the attested channel key, populating
+   * `operatorIdentity.serverN`. Default `false`: production servers
+   * don't yet run with `--identity-*` (they'd report `'unconfigured'`)
+   * and the default pin is a DEV stand-in — see `PIR_OPERATOR_PUBKEY`.
+   * Requires `useSecureChannel` (needs the attested channel key to bind).
+   */
+  verifyOperatorIdentity?: boolean;
+  /**
+   * Operator (Tier-1) pubkey to pin announce bundles against. Defaults
+   * to `PIR_OPERATOR_PUBKEY` from `./attest-pin.ts` (currently a DEV
+   * stand-in). Pass a real published key here, or update the constant.
+   */
+  pinnedOperatorPubkey?: Uint8Array;
+  /** Fires once per server after `connect()` resolves the per-server
+   *  operator-identity check (only when `verifyOperatorIdentity`). Use to
+   *  surface a "verified operator" badge — gate it on `state === 'verified'`. */
+  onOperatorIdentity?: (serverIndex: 0 | 1, info: OperatorIdentity) => void;
 }
 
 // ─── Adapter ─────────────────────────────────────────────────────────────────
@@ -215,6 +311,18 @@ export class BatchPirClientAdapter {
   attestation: { server0: ServerAttestation; server1: ServerAttestation } = {
     server0: { state: 'unattested' },
     server1: { state: 'unattested' },
+  };
+
+  /**
+   * Per-server operator-signed-identity snapshot. Populated by
+   * `connect()` only when `config.verifyOperatorIdentity` is set; stays
+   * `'not-checked'` otherwise. Read after `connect()` or via the
+   * `onOperatorIdentity` callback. Gate any "verified operator" badge on
+   * `state === 'verified'`.
+   */
+  operatorIdentity: { server0: OperatorIdentity; server1: OperatorIdentity } = {
+    server0: { state: 'not-checked' },
+    server1: { state: 'not-checked' },
   };
 
   constructor(config: BatchPirClientConfig) {
@@ -708,10 +816,69 @@ export class BatchPirClientAdapter {
         'info',
       );
     }
+
+    // Operator-signed identity (REQ_ANNOUNCE), opt-in. Runs after the
+    // channel decision so announce() rides the encrypted channel when it
+    // came up; binds against the attested serverStaticPub from `att*`.
+    if (this.config.verifyOperatorIdentity) {
+      const pin = this.config.pinnedOperatorPubkey ?? PIR_OPERATOR_PUBKEY;
+      const oid0 = await this.verifyOperatorIdentityOne(0, att0, pin);
+      const oid1 = await this.verifyOperatorIdentityOne(1, att1, pin);
+      this.operatorIdentity.server0 = oid0;
+      this.operatorIdentity.server1 = oid1;
+      this.config.onOperatorIdentity?.(0, oid0);
+      this.config.onOperatorIdentity?.(1, oid1);
+    }
+
     // Free the WasmAttestVerification handles to release the WASM-side
     // copies. We've already extracted the JS-side fields we need.
     att0?.free();
     att1?.free();
+  }
+
+  /**
+   * Fetch + verify one server's operator-signed identity. Never throws;
+   * returns an `OperatorIdentity` snapshot. `att` supplies the attested
+   * `serverStaticPub` the bundle's `channel_pub` is bound against, so a
+   * `null` att (attest failed) yields `state: 'error'`.
+   */
+  private async verifyOperatorIdentityOne(
+    idx: 0 | 1,
+    att: WasmAttestVerification | null,
+    pin: Uint8Array,
+  ): Promise<OperatorIdentity> {
+    if (!this.wasmClient) {
+      return { state: 'error', error: 'wasm client not initialised' };
+    }
+    if (!att) {
+      return { state: 'error', error: 'attestation unavailable; cannot bind channel key' };
+    }
+    let v: WasmAnnounceVerification;
+    try {
+      v = await this.wasmClient.announce(idx);
+    } catch (e) {
+      const msg = (e as Error)?.message ?? String(e);
+      // A server started without --identity-* answers RESP_ERROR
+      // "announce not configured" — an expected, benign state.
+      if (/not configured/i.test(msg)) {
+        this.log(`server${idx}: operator identity not configured`, 'info');
+        return { state: 'unconfigured' };
+      }
+      this.log(`announce(server${idx}) failed: ${msg}`, 'error');
+      return { state: 'error', error: msg };
+    }
+    try {
+      const nowSecs = BigInt(Math.floor(Date.now() / 1000));
+      const result = gateOperatorIdentity(v, pin, att.serverStaticPub, nowSecs);
+      if (result.state === 'verified') {
+        this.log(`server${idx}: operator identity verified (${result.serverId})`, 'success');
+      } else {
+        this.log(`server${idx}: operator identity UNVERIFIED — ${result.error}`, 'error');
+      }
+      return result;
+    } finally {
+      v.free();
+    }
   }
 }
 

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -28,6 +28,8 @@ if (typeof window !== 'undefined') {
 export {
   BatchPirClientAdapter,
   type BatchPirClientConfig,
+  type OperatorIdentity,
+  gateOperatorIdentity,
 } from './dpf-adapter.js';
 
 export type {

--- a/web/src/onionpir_client.ts
+++ b/web/src/onionpir_client.ts
@@ -28,6 +28,7 @@ import { unpackOnionPlaintext } from './onion-unpack.js';
 import { findEntryInOnionPirIndexResult } from './scan.js';
 import { ManagedWebSocket } from './ws.js';
 import { fetchServerInfoJson } from './server-info.js';
+import { requireSdkWasm, type WasmAnnounceVerification } from './sdk-bridge.js';
 import { computeParentN, ZERO_HASH } from './merkle.js';
 
 import type { UtxoEntry, QueryResult, ConnectionState } from './types.js';
@@ -62,6 +63,9 @@ const MASK64 = 0xFFFFFFFFFFFFFFFFn;
 
 // Protocol constants still used for OnionPIR-specific requests
 // (Ping/pong/info handled by ManagedWebSocket + fetchServerInfoJson)
+
+// Operator-signed identity (shared across all backends; 0x07).
+const REQ_ANNOUNCE              = 0x07;
 
 // NOTE: moved from 0x30-0x32 to 0x50-0x52 to avoid collision with
 // REQ_MERKLE_SIBLING_BATCH (0x31) and REQ_MERKLE_TREE_TOP (0x32).
@@ -950,6 +954,37 @@ export class OnionPirWebClient {
   private sendRaw(msg: Uint8Array): Promise<Uint8Array> {
     if (!this.ws) throw new Error('Not connected');
     return this.ws.sendRaw(msg);
+  }
+
+  // ─── Operator-signed identity (REQ_ANNOUNCE) ──────────────────────────
+
+  /**
+   * Fetch + verify this server's operator-signed identity bundle.
+   * Reuses the audited Rust parsing + in-bundle chain check via the WASM
+   * `verifyAnnounceResponse` binding (SEAL doesn't compile to wasm32, but
+   * Ed25519 verification does). Layer operator-pubkey pinning on the
+   * result with `v.checkPinnedOperator(pinnedOperatorPubkey, nowSecs)`.
+   *
+   * NOTE: this standalone client has no attest / encrypted-channel flow,
+   * so there is no attested `serverStaticPub` to bind against —
+   * `checkChannelBinding` is N/A here. The operator endorsement + chain
+   * check still apply (the connection itself is cleartext, so treat the
+   * result as operator provenance, not session binding).
+   *
+   * Throws on a server `RESP_ERROR` (e.g. "announce not configured" when
+   * the server lacks `--identity-*`) or a wire-format error.
+   */
+  async announce(): Promise<WasmAnnounceVerification> {
+    if (!this.ws) throw new Error('Not connected');
+    // REQ_ANNOUNCE (0x07), empty body. Frame: [u32 LE payloadLen=1][opcode].
+    const msg = new Uint8Array(5);
+    new DataView(msg.buffer).setUint32(0, 1, true);
+    msg[4] = REQ_ANNOUNCE;
+    // sendRaw resolves with the response payload (variant byte first,
+    // outer length already stripped) — exactly the shape
+    // verifyAnnounceResponse expects.
+    const resp = await this.sendRaw(msg);
+    return requireSdkWasm().verifyAnnounceResponse(resp);
   }
 
   // ─── Server info (delegates to shared server-info.ts) ──────────────────

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -338,6 +338,12 @@ export interface WasmAnnounceVerification {
   checkPinnedOperator(pinnedOperatorPubkey: Uint8Array, nowUnixSeconds: bigint): void;
   /** `channelPub === expectedChannelPub` (32 bytes). Throws on mismatch. */
   checkChannelBinding(expectedChannelPub: Uint8Array): void;
+  /** Replay/staleness guard on `issuedAt`: throws if older than
+   *  `maxAgeSeconds` before `now` (stale) or >300s after it (future).
+   *  `issuedAt` is the server's boot time, so keep `maxAgeSeconds`
+   *  generous; `0n` skips the staleness arm, `nowUnixSeconds === 0n`
+   *  skips entirely. */
+  checkFreshness(nowUnixSeconds: bigint, maxAgeSeconds: bigint): void;
   free(): void;
 }
 

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -70,6 +70,19 @@ interface PirSdkWasm {
    * at module load (catches drift if the two ever diverge).
    */
   turinArkFingerprint(): Uint8Array;
+  /**
+   * Parse + verify a raw RESP_ANNOUNCE wire payload (the response frame
+   * starting at the variant byte) into a `WasmAnnounceVerification`,
+   * running the in-bundle chain check. Throws on a wire-format violation
+   * or a server `RESP_ERROR` envelope (e.g. "announce not configured").
+   *
+   * For transports that don't go through `WasmDpfClient` — the
+   * standalone `OnionPirWebClient` does its own REQ_ANNOUNCE round-trip
+   * and hands the response bytes here, reusing the exact Rust parsing +
+   * chain verification. Mirrors
+   * `pir_sdk_client::announce::parse_announce_response`.
+   */
+  verifyAnnounceResponse(respPayload: Uint8Array): WasmAnnounceVerification;
   // ARC (Anonymous Rate-limited Credentials) presentation state. Opaque
   // wrapper over the Rust `arc::PresentationState`; mirrored in TS by
   // `web/src/credential-manager.ts::ArcCredentialManager`. The constructor

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -295,6 +295,39 @@ export interface WasmPolicyRequirements {
   setExpectedImageId(bytes: Uint8Array): void;
 }
 
+/**
+ * JS-visible result of a `WasmDpfClient.announce()` call. Mirrors
+ * `pir_sdk_wasm::WasmAnnounceVerification`. Carries the parsed
+ * operator-signed bundle; the caller layers verification:
+ *   - `checkPinnedOperator(pin, now)` — operator pubkey match + cert
+ *     signature + validity + in-bundle chain check (do NOT settle for a
+ *     bare `operatorPubkeyHex` string-compare — it misses the signature),
+ *   - `checkChannelBinding(expected)` — `channelPub` equals the attested
+ *     `serverStaticPub` the channel handshook against.
+ * Both throw on failure. `i64` fields surface as `bigint` (wasm-bindgen).
+ */
+export interface WasmAnnounceVerification {
+  readonly serverId: string;
+  readonly operatorPubkeyHex: string;
+  readonly identityPubkeyHex: string;
+  readonly channelPub: Uint8Array;
+  readonly channelPubHex: string;
+  readonly binarySha256Hex: string;
+  readonly gitRev: string;
+  readonly validFrom: bigint;
+  readonly validUntil: bigint;
+  readonly issuedAt: bigint;
+  readonly chainVerified: boolean;
+  readonly chainError: string;
+  /** Operator pubkey match + `cert.verify()` signature + validity
+   *  (skipped when `nowUnixSeconds === 0n`) + chain check. Throws on
+   *  failure. */
+  checkPinnedOperator(pinnedOperatorPubkey: Uint8Array, nowUnixSeconds: bigint): void;
+  /** `channelPub === expectedChannelPub` (32 bytes). Throws on mismatch. */
+  checkChannelBinding(expectedChannelPub: Uint8Array): void;
+  free(): void;
+}
+
 interface WasmDpfClient {
   free(): void;
   readonly isConnected: boolean;
@@ -306,6 +339,12 @@ interface WasmDpfClient {
    *  returned `serverStaticPub` (32 bytes) as input to
    *  `upgradeToSecureChannel`. */
   attest(serverIndex: number): Promise<WasmAttestVerification>;
+  /** Send REQ_ANNOUNCE to one of the connected servers (`serverIndex`
+   *  ∈ {0, 1}) and return the parsed operator-signed identity bundle.
+   *  Rejects with "announce not configured" when the server was started
+   *  without `--identity-*` flags. See `WasmAnnounceVerification` for the
+   *  verification methods to run on the result. */
+  announce(serverIndex: number): Promise<WasmAnnounceVerification>;
   /** Wrap both server connections with the encrypted-channel transport.
    *  Caller MUST first verify `pub0`/`pub1` came from a trustworthy
    *  source (call `attest` first; ideally also check the SEV-SNP report's


### PR DESCRIPTION
Closes the operator-signed identity (REQ_ANNOUNCE, opcode 0x07) gap left
open after PR #8 and builds the feature out end-to-end.

## Commits
- **dispatch arm** (`fb11a0ef`) — wire REQ_ANNOUNCE into the production
  `unified_server` per-connection dispatch loop (it has its OWN inline
  match, not `RequestHandler`). **This is the only commit that changes the
  `unified_server` binary** → new reproducible `binary_sha256`. Extracted
  `build_announce_response` + 3 unit tests; also wired
  `PirServerBuilder::with_announcement_bundle`.
- **B** (`2f23d461`) — `check_channel_binding` + `announce_bound` + WASM
  `checkChannelBinding`; binds the bundle to the attested channel key.
- **A** (`ad426684`) — operator-pubkey pin + `check_pinned_operator`
  (pubkey + cert signature + validity + chain) + WASM `checkPinnedOperator`.
- **G** (`c99b4bba`) — `docs/OPERATOR_IDENTITY.md` runbook + trust model.
- **D** (`a0eef018`) — gated `operatorIdentity` snapshot in
  `BatchPirClientAdapter` (opt-in) + pure `gateOperatorIdentity`.
- **E** (`b800f35d`) — `OnionPirWebClient.announce()` reusing the Rust
  verifier via the WASM `verifyAnnounceResponse` binding.
- **F** (`f8effb17`) — `check_freshness` (issued_at) + validity enforcement.
- **C-partial** (`0015db3d`) — pin the real operator pubkey (`256fb106…`);
  pir1 staged with `--identity-*` (see `docs/OPERATOR_IDENTITY.md`
  §Deployment status). Announce goes live once this binary is deployed.

## Tests
pir-sdk-client 199, pir-identity 19, pir-runtime-core 68, bpir-admin 15,
runtime announce 3; web tsc + vitest 142; live e2e against a local
`unified_server`. WASM bindings validated via `wasm-pack build`.

## Deploy note
Merging makes the dispatch arm part of `.#unified-server`; the new binary
must be deployed to pir1 + baked into the pir2 Tier-3 UKI, with
`binarySha256Hex` (both pins) + pir2 `measurementHex` re-pinned. Details
in `docs/OPERATOR_IDENTITY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)