### PR TITLE
fix(pir): anchor-aware cuckoo table offset for DPF/HarmonyPIR (+ v23 pins)

### DIFF
--- a/build/src/merkle_bucket_builder.rs
+++ b/build/src/merkle_bucket_builder.rs
@@ -47,18 +47,25 @@ pub fn build_bucket_merkle(data_dir: &str) {
     // in the cuckoo header but aren't used here.
     let index_path = Path::new(data_dir).join("batch_pir_cuckoo.bin");
     let index_mmap = mmap_file(&index_path);
-    let index_bins = pir_core::cuckoo::read_cuckoo_header_with_anchor(&index_mmap, &INDEX_PARAMS)
-        .expect("INDEX cuckoo header parse")
-        .bins_per_table;
+    let index_header = pir_core::cuckoo::read_cuckoo_header_with_anchor(&index_mmap, &INDEX_PARAMS)
+        .expect("INDEX cuckoo header parse");
+    let index_bins = index_header.bins_per_table;
+    // Anchor-aware offset to the per-group tables (legacy header + anchor
+    // length). Building leaves at the legacy params.header_size on a v2
+    // (chain-anchored) cuckoo file hashes misaligned bins, so the roots
+    // disagree with the anchor-correct served bins and client Merkle
+    // verification fails. Mirrors MappedSubTable::data_offset.
+    let index_data_offset = index_header.header_size;
     let index_bin_size = INDEX_PARAMS.bin_size();
     println!("[INDEX] bins_per_table={}, bin_size={}B, K={}", index_bins, index_bin_size, INDEX_PARAMS.k);
 
     // Load CHUNK cuckoo table
     let chunk_path = Path::new(data_dir).join("chunk_pir_cuckoo.bin");
     let chunk_mmap = mmap_file(&chunk_path);
-    let chunk_bins = pir_core::cuckoo::read_cuckoo_header_with_anchor(&chunk_mmap, &CHUNK_PARAMS)
-        .expect("CHUNK cuckoo header parse")
-        .bins_per_table;
+    let chunk_header = pir_core::cuckoo::read_cuckoo_header_with_anchor(&chunk_mmap, &CHUNK_PARAMS)
+        .expect("CHUNK cuckoo header parse");
+    let chunk_bins = chunk_header.bins_per_table;
+    let chunk_data_offset = chunk_header.header_size;
     let chunk_bin_size = CHUNK_PARAMS.bin_size();
     println!("[CHUNK] bins_per_table={}, bin_size={}B, K={}", chunk_bins, chunk_bin_size, CHUNK_PARAMS.k);
     println!();
@@ -71,7 +78,7 @@ pub fn build_bucket_merkle(data_dir: &str) {
         .map(|g| {
             build_group_tree(
                 &index_mmap,
-                INDEX_PARAMS.header_size,
+                index_data_offset,
                 g,
                 index_bins,
                 index_bin_size,
@@ -88,7 +95,7 @@ pub fn build_bucket_merkle(data_dir: &str) {
         .map(|g| {
             build_group_tree(
                 &chunk_mmap,
-                CHUNK_PARAMS.header_size,
+                chunk_data_offset,
                 g,
                 chunk_bins,
                 chunk_bin_size,
@@ -193,13 +200,13 @@ struct PerGroupTree {
 /// tree-top caches (e.g. 565K bins padded to 2.1M would waste 30× space).
 fn build_group_tree(
     mmap: &[u8],
-    header_size: usize,
+    data_offset: usize,
     group_id: usize,
     bins_per_table: usize,
     bin_size: usize,
 ) -> PerGroupTree {
     let table_byte_size = bins_per_table * bin_size;
-    let group_offset = header_size + group_id * table_byte_size;
+    let group_offset = data_offset + group_id * table_byte_size;
     let group_data = &mmap[group_offset..group_offset + table_byte_size];
 
     // Compute leaf hashes: leaf[i] = SHA256(i_u32_LE || bin_content)

--- a/pir-runtime-core/src/table.rs
+++ b/pir-runtime-core/src/table.rs
@@ -46,6 +46,14 @@ pub struct MappedSubTable {
     pub bins_per_table: usize,
     /// Byte size of one group's sub-table (bins × slots_per_bin × slot_size).
     pub table_byte_size: usize,
+    /// Byte offset where the per-group tables begin = legacy header size +
+    /// chain-anchor length (0 legacy / 36 snapshot / 72 delta). On a v2
+    /// database the anchor is written BETWEEN the header and the tables, so
+    /// `group_bytes` MUST use this — not the hardcoded `params.header_size`,
+    /// which would read every group's bins `anchor_len` bytes too early and
+    /// silently serve misaligned data. Mirrors the OnionPIR
+    /// `OnionChunkHeader.data_offset` fix (commit ea4ee8c8).
+    pub data_offset: usize,
     /// Tag seed from header (0 if the table has no tag seed).
     pub tag_seed: u64,
     /// Master cuckoo seed as read from the file header (the real on-disk
@@ -74,6 +82,32 @@ impl MappedSubTable {
         let master_seed = parsed.master_seed;
         let anchor = parsed.anchor;
         let table_byte_size = params.table_byte_size(bins_per_table);
+        // Anchor-aware: legacy header size + anchor payload length. The v2
+        // anchor sits between the header and the tables, so the per-group
+        // table data starts here, not at `params.header_size`.
+        let data_offset = parsed.header_size;
+
+        // Fail loudly if a v2 (chain-anchored) table's on-disk size is
+        // inconsistent with the anchor-aware layout, instead of silently
+        // serving misaligned bins. Anchored tables are only ever the
+        // INDEX/CHUNK cuckoo files, written as [header][anchor][k ×
+        // table_byte_size]; non-anchored tables (legacy cuckoo + Merkle
+        // siblings) have other layouts, so the check is scoped to anchored.
+        if anchor.is_some() {
+            let expected = data_offset + params.k * table_byte_size;
+            assert_eq!(
+                mmap.len(),
+                expected,
+                "cuckoo table {} size {} != expected {} (data_offset {} + k {} × table_byte_size {}) \
+                 — anchor-aware offset mismatch, refusing to serve",
+                path.display(),
+                mmap.len(),
+                expected,
+                data_offset,
+                params.k,
+                table_byte_size,
+            );
+        }
 
         println!(
             "    bins_per_table={}, slot={}B, table={:.1}MB, file={:.2}GB",
@@ -94,12 +128,12 @@ impl MappedSubTable {
             }
         }
 
-        MappedSubTable { mmap, params, bins_per_table, table_byte_size, tag_seed, master_seed, anchor }
+        MappedSubTable { mmap, params, bins_per_table, table_byte_size, data_offset, tag_seed, master_seed, anchor }
     }
 
     /// Get the byte slice for a specific group's sub-table.
     pub fn group_bytes(&self, group_id: usize) -> &[u8] {
-        let offset = self.params.header_size + group_id * self.table_byte_size;
+        let offset = self.data_offset + group_id * self.table_byte_size;
         &self.mmap[offset..offset + self.table_byte_size]
     }
 
@@ -498,5 +532,94 @@ impl CuckooTablePair {
             chunk_bins_per_table,
             chunk_table_byte_size,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pir_core::cuckoo::{write_header_with_anchor, HeaderAnchor};
+    use pir_core::seeds::{ChainAnchor, CHAIN_ANCHOR_BYTES};
+    use std::io::Write as _;
+
+    fn temp_path(tag: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "mst_{}_{}_{}.bin",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        p
+    }
+
+    /// Regression: on a v2 (chain-anchored) INDEX cuckoo file the per-group
+    /// tables begin AFTER the 36-byte snapshot anchor. `group_bytes` must use
+    /// the anchor-aware `data_offset` (40 + 36 = 76) — not `params.header_size`
+    /// (40), which read every group 36 bytes too early and silently served
+    /// misaligned bins (the DPF/HarmonyPIR 0-UTXO regression).
+    #[test]
+    fn group_bytes_skips_v2_snapshot_anchor() {
+        let params = INDEX_PARAMS;
+        let bins_per_table = 1usize;
+        let table_byte_size = params.table_byte_size(bins_per_table);
+
+        let anchor = ChainAnchor { block_hash: [0xAB; 32], block_height: 948_454 };
+        let header = write_header_with_anchor(
+            &params,
+            bins_per_table,
+            0xdead_beef_cafe_babe, // tag_seed (load does not verify it)
+            Some(&HeaderAnchor::Snapshot(anchor)),
+        );
+        let expected_offset = params.header_size + CHAIN_ANCHOR_BYTES;
+        assert_eq!(header.len(), expected_offset, "anchored header = legacy + 36");
+
+        // Marker at the first byte of group 0's real table. The anchor bytes
+        // are never 0x5A, so reading it back proves we skipped the anchor.
+        let mut tables = vec![0u8; params.k * table_byte_size];
+        tables[0] = 0x5A;
+        let mut bytes = header;
+        bytes.extend_from_slice(&tables);
+
+        let path = temp_path("snap");
+        std::fs::File::create(&path).unwrap().write_all(&bytes).unwrap();
+        let st = MappedSubTable::load(&path, params);
+
+        assert_eq!(st.data_offset, expected_offset, "data_offset must skip the v2 anchor");
+        let g0 = st.group_bytes(0);
+        assert_eq!(g0.len(), table_byte_size);
+        assert_eq!(g0[0], 0x5A, "group_bytes(0) must start at real table data, past the anchor");
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// A legacy (anchor-less) file is unchanged: data_offset == header_size,
+    /// so the fix is a no-op for pre-Phase-C databases.
+    #[test]
+    fn group_bytes_legacy_no_anchor_unchanged() {
+        let params = INDEX_PARAMS;
+        let bins_per_table = 1usize;
+        let table_byte_size = params.table_byte_size(bins_per_table);
+
+        let header_size = params.header_size; // capture before `params` is moved into load()
+        let header = write_header_with_anchor(&params, bins_per_table, 0, None);
+        assert_eq!(header.len(), header_size, "legacy header carries no anchor");
+
+        let mut tables = vec![0u8; table_byte_size];
+        tables[0] = 0x5A;
+        let mut bytes = header;
+        bytes.extend_from_slice(&tables);
+
+        let path = temp_path("legacy");
+        std::fs::File::create(&path).unwrap().write_all(&bytes).unwrap();
+        let st = MappedSubTable::load(&path, params);
+
+        assert_eq!(st.data_offset, header_size);
+        assert_eq!(st.group_bytes(0)[0], 0x5A);
+
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/runtime/src/hint_pool.rs
+++ b/runtime/src/hint_pool.rs
@@ -142,6 +142,8 @@ impl HintPool {
             chunk_bins: db.chunk.bins_per_table,
             index_entry_size: db.index.params.bin_size(),
             chunk_entry_size: db.chunk.params.bin_size(),
+            index_data_offset: db.index.data_offset,
+            chunk_data_offset: db.chunk.data_offset,
         };
         let index_mmap_ptr = db.index.mmap.as_ptr() as usize;
         let index_mmap_len = db.index.mmap.len();
@@ -218,6 +220,14 @@ struct DbParams {
     chunk_bins: usize,
     index_entry_size: usize,
     chunk_entry_size: usize,
+    /// Anchor-aware byte offset to the per-group tables (legacy header +
+    /// chain-anchor length). MUST be used instead of `*_params.header_size`,
+    /// which is legacy-only and reads v2 (anchored) DBs `anchor_len` bytes
+    /// too early — see `MappedSubTable::data_offset`. Hints computed at the
+    /// wrong offset disagree with the anchor-correct eval path and corrupt
+    /// HarmonyPIR reconstruction.
+    index_data_offset: usize,
+    chunk_data_offset: usize,
 }
 
 fn generation_loop(
@@ -327,7 +337,7 @@ fn generate_pool_entry(
                 g,
                 0, // k_offset for INDEX groups
                 index_mmap,
-                db_params.index_params.header_size,
+                db_params.index_data_offset,
                 db_params.index_bins,
                 db_params.index_entry_size,
             )
@@ -345,7 +355,7 @@ fn generate_pool_entry(
                 g,
                 index_k, // k_offset for CHUNK groups
                 chunk_mmap,
-                db_params.chunk_params.header_size,
+                db_params.chunk_data_offset,
                 db_params.chunk_bins,
                 db_params.chunk_entry_size,
             )

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -132,20 +132,20 @@ export interface ServerAttestPin {
  * binary, embedded via the full Nix closure.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // Tier 3 UKI v22 — 2026-05-25. Rebuilt from main @ fda3eb47 (PR #9 —
-  // operator-signed identity / REQ_ANNOUNCE dispatch arm). New reproducible
-  // Nix `unified_server` (`f7df82d0…`); pir1 runs the SAME binary so
-  // PIR1_PIN and PIR2_TIER3_PIN share `binarySha256Hex`. pir2 runs
+  // Tier 3 UKI v23 — 2026-05-26. Rebuilt from fix/dpf-harmony-anchor-offset
+  // @ c72020ba (DPF/HarmonyPIR v2 chain-anchor table-offset fix). New
+  // reproducible Nix `unified_server` (`57ac525b…`); pir1 runs the SAME
+  // binary so PIR1_PIN and PIR2_TIER3_PIN share `binarySha256Hex`. pir2 runs
   // `--serve-queries` (no hint pool, no OnionPIR) plus `--identity-*`
   // (operator-signed identity, server_id=pir2). MEASUREMENT captured from
-  // the v22 deploy via `bpir-admin attest wss://weikeng2.bitcoinpir.org`
-  // (SEV-SNP Status: ReportDataMatch — verified on real hardware).
-  // NOTE: v21 was a mis-deploy (a stale `result-tier3-uki` symlink holding
-  // an old pre-v2 binary `3925cc4d…`) that crash-looped; v22 is correct.
+  // the v23 deploy via `bpir-admin attest wss://weikeng2.bitcoinpir.org`
+  // (SEV-SNP REPORT_DATA binding verified on real hardware).
+  // (v22 = `f7df82d0…` announce-enabled binary; v23 = v22 + the anchor-offset
+  // fix, so both servers' Merkle was also regenerated to match the fix.)
   measurementHex:
-    '41461a8856cc2ca9e2157c7e71fb75c618c03e4d28f5dac4346cefe528229f906568ed8effc934e31ada9c6afaee786e',
+    '4fb0ad57b28b7c33e6b2977f911fd6bf407ccf28bbab3ef9d24dceec579464a5961e10f5297a294c7dde24839eca4c6e',
   binarySha256Hex:
-    'f7df82d04fb4a02fa51f6d595f04ea302fefece7da15b33bd30c7102f9729101',
+    '57ac525b1d92656a0ae39d6def562d6fc2889a8c6337b8b34f71a59d6ac44d59',
   description: 'weikeng2.bitcoinpir.org (VPSBG, SEV-SNP, Tier 3 UKI v22)',
 };
 
@@ -158,13 +158,13 @@ export const PIR2_TIER3_PIN: ServerAttestPin = {
  */
 export const PIR1_PIN: ServerAttestPin = {
   // No measurementHex — Hetzner has no SEV.
-  // Bumped 2026-05-25 (v22): pir1 redeployed from main @ fda3eb47 (PR #9 —
-  // operator-signed identity / REQ_ANNOUNCE). Binary is the reproducible
-  // `nix build .#unified-server` output (`f7df82d0…`) — the same Nix binary
-  // embedded in the v22 Tier-3 UKI for pir2, so PIR1_PIN and PIR2_TIER3_PIN
-  // share `binarySha256Hex` (shared-binary invariant preserved).
+  // Bumped 2026-05-26 (v23): pir1 redeployed from fix/dpf-harmony-anchor-offset
+  // @ c72020ba (DPF/HarmonyPIR v2 chain-anchor table-offset fix). Binary is the
+  // reproducible `nix build .#unified-server` output (`57ac525b…`) — the same
+  // Nix binary embedded in the v23 Tier-3 UKI for pir2, so PIR1_PIN and
+  // PIR2_TIER3_PIN share `binarySha256Hex` (shared-binary invariant preserved).
   binarySha256Hex:
-    'f7df82d04fb4a02fa51f6d595f04ea302fefece7da15b33bd30c7102f9729101',
+    '57ac525b1d92656a0ae39d6def562d6fc2889a8c6337b8b34f71a59d6ac44d59',
   description: 'weikeng1.bitcoinpir.org (Hetzner i7-8700, no SEV)',
 };
 


### PR DESCRIPTION
## Summary
DPF-PIR and HarmonyPIR returned **0 UTXOs** for funded addresses on bitcoinpir.org (OnionPIR was unaffected). Root cause: readers of the v2 chain-anchored cuckoo files used the legacy `params.header_size`, ignoring the anchor (snapshot +36 / delta +72) written between the header and the per-group tables — reading every group's bins `anchor_len` bytes too early.

Fixes the **three** readers that hardcoded the legacy offset (OnionPIR has its own readers, fixed earlier in `ea4ee8c8`):
- `pir-runtime-core/src/table.rs` — `MappedSubTable::group_bytes` now uses an anchor-aware `data_offset`; adds a load-time guard (`mmap.len() == data_offset + k*table_byte_size` for anchored tables) + regression tests.
- `runtime/src/hint_pool.rs` — HarmonyPIR pooled-hint generator threads `data_offset` through `DbParams`.
- `build/src/merkle_bucket_builder.rs` — per-bucket Merkle leaves built at the anchor-aware offset (param renamed `data_offset`).

All three were *consistently* mis-offset before, which is why Merkle verified green on wrong data; fixing only one would have broken verification.

## Deploy (already live on the servers)
- pir1 + pir2 redeployed with the reproducible nix `unified_server` **`57ac525b`**; Merkle + `MANIFEST.toml` **regenerated** on both (a binary swap alone is insufficient — the deployed Merkle was built over misaligned bins; the manifest root is dynamically attested so no client pin for it).
- pir2 Tier-3 UKI v23 (`deploy/uki/bpir-tier3-c72020ba.efi`), measurement `4fb0ad57…`, SEV REPORT_DATA verified on hardware.
- `web/src/attest-pin.ts` bumped to v23 (both pins → `57ac525b`, pir2 measurement → `4fb0ad57…`).

## Verification (local web build w/ new pins vs. live fleet)
| Backend | addr1 | addr2 | Merkle |
|---|---|---|---|
| DPF-PIR | 0.00001600 BTC | 0.00012900 BTC | ✅ All 2 Verified (`68f29751…`) |
| HarmonyPIR | 0.00001600 BTC | 0.00012900 BTC | ✅ All 2 Verified (`68f29751…`) |

Both attest clean on the new binary; matches the OnionPIR ground truth.

**Merging deploys `www.bitcoinpir.org`** (deploy-web.yml) with the v23 pins — restoring the public site (currently degraded by the old pin vs. new binary).

Follow-up (not in this PR): dev-only tools `harmonypir_gen_hints` / `_hint_bench` / `_real_test` share the same legacy-offset pattern but aren't in the deploy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)