### PR TITLE
feat(ratelimit): ARC + Cashu anonymous rate-limiting demo + dev-issuer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ deploy/
 # rules above (target/, build/, .DS_Store, .claude/, Cargo.lock) don't
 # bite vendored crates.
 !vendor/**
+# dev-issuer demo key files (never commit)
+arc_key.bin
+cashu_key.bin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dev-issuer"
+version = "0.1.0"
+dependencies = [
+ "arc",
+ "hex",
+ "k256",
+ "rand_core 0.6.4",
+ "sha2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,7 +1816,9 @@ dependencies = [
  "arc",
  "console_error_panic_hook",
  "getrandom 0.2.17",
+ "hex",
  "js-sys",
+ "k256",
  "pir-attest-verify",
  "pir-channel",
  "pir-core",
@@ -1817,6 +1830,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "sha2",
  "tracing-wasm",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "runtime",
     "harmonypir-wasm",
     "block_reader",
+    "dev-issuer",
 ]
 exclude = ["electrum_plugin/harmonypir-python"]
 

--- a/deploy/systemd/dev-issuer.service
+++ b/deploy/systemd/dev-issuer.service
@@ -1,0 +1,43 @@
+[Unit]
+Description=BitcoinPIR dev-issuer (ARC + Cashu rate-limiting demo: free issuance + verify gate)
+Documentation=https://github.com/Bitcoin-PIR/Bitcoin-PIR
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=pir
+Group=pir
+WorkingDirectory=/home/pir/dev-issuer
+# DEV-ONLY: free credential issuance (no payment) + a co-located verify gate
+# for the public rate-limiting demo at sdk.bitcoinpir.org/rate-limiting.
+# Binds 127.0.0.1:5601; the Cloudflare tunnel fronts it as
+# issuer.bitcoinpir.org. Does NOT touch the PIR servers (pir-primary/secondary)
+# or their query path. The "rate limit" is a mechanism demo — issuance is free.
+ExecStart=/home/pir/dev-issuer/dev-issuer --arc-key /home/pir/dev-issuer/arc_key.bin --cashu-key /home/pir/dev-issuer/cashu_key.bin --port 5601
+Restart=on-failure
+RestartSec=5
+
+# Security hardening. Key dir /home/pir/dev-issuer must be owned by pir:pir
+# (the binary writes arc_key.bin / cashu_key.bin there on first run).
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/home/pir/dev-issuer
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+SystemCallArchitectures=native
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=dev-issuer
+
+[Install]
+WantedBy=multi-user.target

--- a/dev-issuer/Cargo.toml
+++ b/dev-issuer/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "dev-issuer"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "DEV-ONLY free credential issuer for the ARC/Cashu rate-limiting demo. No payment, no Lightning. Do not deploy to production."
+
+[[bin]]
+name = "dev-issuer"
+path = "src/main.rs"
+
+[dependencies]
+# arc is already vendored at this rev (see .cargo/config.toml); reusing it
+# means the issuer and the server-side ArcVerifier share byte-exact key
+# serialization. No new vendored crates are introduced by this binary — it
+# hand-rolls its HTTP/1.1 handling over std so the offline `vendor/` tree is
+# untouched.
+arc = { git = "https://github.com/Bitcoin-PIR/arc.git", rev = "de6c1709eee0faa32985d5a452be11904ee95de4" }
+rand_core = { version = "0.6", features = ["getrandom"] }
+# Cashu BDHKE blind-signing (mint side). k256/hex are already vendored
+# (pir-runtime-core's CashuVerifier uses the same versions).
+k256 = { version = "0.13", features = ["arithmetic"] }
+hex = "0.4"
+# Cashu hash_to_curve (verify gate) + the round-trip test's client side.
+sha2 = "0.10"

--- a/dev-issuer/README.md
+++ b/dev-issuer/README.md
@@ -1,0 +1,60 @@
+# dev-issuer
+
+**DEV-ONLY** free credential issuer **and** verifier gate for the anonymous
+rate-limiting demo (ARC + Cashu Blind Auth). No payment, no Lightning, no PIR
+database. **Do not deploy to production.**
+
+It stands in for the Lightning-backed payment service *and* the PIR server's
+credential gate so the whole `mint → obtain → present → verify` loop runs as a
+single process. The verify endpoints use the exact same crypto as
+`pir_runtime_core::{arc_verifier, cashu_verifier}`; the present-frame bytes are
+byte-identical to the PIR server's WebSocket `REQ_CREDENTIAL_PRESENT` (0x08) /
+`REQ_CASHU_BAT_PRESENT` (0x09) frames — only the transport differs (HTTP here,
+WebSocket in production).
+
+## Run the demo
+
+```bash
+# 1. Start the issuer + gate (writes arc_key.bin + cashu_key.bin in CWD).
+cargo run -p dev-issuer
+#    → listening on http://127.0.0.1:5601
+
+# 2. Serve the demo page.
+cd web && npm run dev
+#    → open http://localhost:3001/ratelimit-demo.html
+```
+
+Click **Mint** then **Present** in either column. ARC shows one credential
+spending down N presentations; Cashu shows a pool of single-use BATs, with a
+"Replay last" button to demonstrate double-spend rejection.
+
+## Endpoints (CORS-open)
+
+| Method | Path                  | In                          | Out                         |
+|--------|-----------------------|-----------------------------|-----------------------------|
+| GET    | `/dev/arc/pubkey`     | —                           | 99-byte `ServerPublicKey`   |
+| POST   | `/dev/arc/issue`      | 226-byte `CredentialRequest`| 454-byte `CredentialResponse`|
+| POST   | `/dev/arc/verify`     | `[0x08]…` present payload   | 200 ok / 400 reason         |
+| GET    | `/dev/cashu/keyset`   | —                           | JSON `{id, pubkey}`         |
+| POST   | `/dev/cashu/mint`     | `N×33` blinded points       | `N×33` blind signatures     |
+| POST   | `/dev/cashu/verify`   | `[0x09]authA…` payload      | 200 ok / 400 reason         |
+
+## Flags
+
+- `--arc-key <path>` (default `arc_key.bin`) — 128-byte ARC key.
+- `--cashu-key <path>` (default `cashu_key.bin`) — 32-byte secp256k1 scalar.
+- `--port <n>` (default `5601`).
+
+## Presenting against a real PIR server instead
+
+The issuer prints a ready-to-run launch line on startup, e.g.:
+
+```
+unified_server --require-arc --arc-key arc_key.bin \
+    --require-cashu --cashu-keyset <id>:<hex>
+```
+
+A client then presents the same frames over WebSocket
+(`web/src/arc-present.ts::sendArcPresentation`, or `cashu-bat`'s
+`buildPresentFrame` via `ManagedWebSocket.sendRaw`). The dev-issuer's
+`/dev/*/verify` endpoints exist only so the demo needs no PIR database.

--- a/dev-issuer/src/main.rs
+++ b/dev-issuer/src/main.rs
@@ -1,0 +1,516 @@
+//! DEV-ONLY free credential issuer for the ARC / Cashu rate-limiting demo.
+//!
+//! This binary stands in for the real (Lightning-backed) payment service so
+//! the end-to-end demo can run without money, an LDK node, or any network
+//! deploy. It issues credentials **for free** to anyone who asks — there is
+//! deliberately no payment check. DO NOT DEPLOY THIS TO PRODUCTION.
+//!
+//! It is intentionally dependency-light: only `arc` (already vendored) and
+//! `rand_core`. The HTTP/1.1 handling is hand-rolled over `std::net` so the
+//! offline `vendor/` tree is not perturbed by a web framework.
+//!
+//! ## Endpoints (CORS-open for browser `fetch`)
+//!
+//! | Method | Path               | Body (in)                 | Body (out)                 |
+//! |--------|--------------------|---------------------------|----------------------------|
+//! | GET    | `/dev/arc/pubkey`  | —                         | 99-byte `ServerPublicKey`  |
+//! | POST   | `/dev/arc/issue`   | 226-byte `CredentialRequest` | 454-byte `CredentialResponse` |
+//! | OPTIONS| *                  | —                         | 204 (CORS preflight)       |
+//!
+//! The ARC private key is loaded from / generated to `--arc-key <path>` using
+//! the canonical 128-byte `x0 || x1 || x2 || x0_blinding` layout, byte-exact
+//! with `pir_runtime_core::arc_verifier::ArcVerifier`, so the demo PIR server
+//! can be launched with `--require-arc --arc-key <same path>` and will verify
+//! credentials this issuer mints.
+//!
+//! (Cashu `/dev/cashu/*` endpoints are added in Phase 2.)
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::thread;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+
+use arc::group::{deserialize_scalar, serialize_element, serialize_scalar};
+use arc::{
+    create_credential_response, setup_server, verify_presentation, CredentialRequest,
+    Presentation, ServerPrivateKey, ServerPublicKey,
+};
+use k256::elliptic_curve::group::GroupEncoding;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::elliptic_curve::{Group, PrimeField};
+use k256::{ProjectivePoint, Scalar};
+use rand_core::OsRng;
+use sha2::{Digest, Sha256};
+
+/// Canonical ARC private-key file size: 4 × 32-byte scalars.
+const ARC_PRIVKEY_SIZE: usize = 128;
+
+/// A Cashu Blind Auth keyset: a single secp256k1 scalar `k`. Matches the
+/// payment service's `CashuAuthKeyset` (32-byte `k` file, id =
+/// `hex(pubkey)[..16] + "-auth"`) so the demo PIR server can be launched with
+/// `--require-cashu --cashu-keyset <id>:<k_hex>`.
+struct CashuKeyset {
+    k: Scalar,
+    keyset_id: String,
+    pubkey_hex: String,
+    secret_hex: String,
+}
+
+struct IssuerState {
+    sk: ServerPrivateKey,
+    pk: ServerPublicKey,
+    cashu: CashuKeyset,
+    /// ARC seen-tags per presentation_context (reject nonce reuse), mirroring
+    /// `pir_runtime_core::arc_verifier::ArcVerifier`.
+    arc_tags: Mutex<HashMap<Vec<u8>, HashSet<Vec<u8>>>>,
+    /// Cashu spent secrets (SHA-256), mirroring `CashuVerifier` (single-use).
+    cashu_spent: Mutex<HashSet<[u8; 32]>>,
+}
+
+fn main() {
+    let mut arc_key_path = PathBuf::from("arc_key.bin");
+    let mut cashu_key_path = PathBuf::from("cashu_key.bin");
+    let mut port: u16 = 5601;
+
+    let argv: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--arc-key" => {
+                if let Some(p) = argv.get(i + 1) {
+                    arc_key_path = PathBuf::from(p);
+                }
+                i += 1;
+            }
+            "--cashu-key" => {
+                if let Some(p) = argv.get(i + 1) {
+                    cashu_key_path = PathBuf::from(p);
+                }
+                i += 1;
+            }
+            "--port" => {
+                if let Some(p) = argv.get(i + 1) {
+                    port = p.parse().unwrap_or_else(|_| {
+                        eprintln!("invalid --port '{p}', using 5601");
+                        5601
+                    });
+                }
+                i += 1;
+            }
+            "-h" | "--help" => {
+                println!("dev-issuer — DEV-ONLY free ARC/Cashu credential issuer");
+                println!(
+                    "usage: dev-issuer [--arc-key <path>] [--cashu-key <path>] [--port <n>]"
+                );
+                return;
+            }
+            other => eprintln!("ignoring unknown arg: {other}"),
+        }
+        i += 1;
+    }
+
+    let (sk, pk) = load_or_generate_key(&arc_key_path);
+    let cashu = load_or_generate_cashu_key(&cashu_key_path);
+    let cashu_keyset_arg = format!("{}:{}", cashu.keyset_id, cashu.secret_hex);
+    let state = Arc::new(IssuerState {
+        sk,
+        pk,
+        cashu,
+        arc_tags: Mutex::new(HashMap::new()),
+        cashu_spent: Mutex::new(HashSet::new()),
+    });
+
+    let listener = TcpListener::bind(("127.0.0.1", port))
+        .unwrap_or_else(|e| panic!("failed to bind 127.0.0.1:{port}: {e}"));
+
+    println!("┌─────────────────────────────────────────────────────────────");
+    println!("│ dev-issuer  (DEV ONLY — no payment, free issuance)");
+    println!("│ listening   http://127.0.0.1:{port}");
+    println!("│ ARC key     {}", arc_key_path.display());
+    println!("│ ARC pubkey  {} (99 bytes)", hex99(&pk.to_bytes()));
+    println!("│ Cashu key   {}", cashu_key_path.display());
+    println!("│ Cashu id    {}", state.cashu.keyset_id);
+    println!("│ endpoints   GET /dev/arc/pubkey    POST /dev/arc/issue    POST /dev/arc/verify");
+    println!("│             GET /dev/cashu/keyset  POST /dev/cashu/mint   POST /dev/cashu/verify");
+    println!("│ NOTE        verify endpoints co-locate the credential gate (same logic as");
+    println!("│             unified_server) so the demo needs no PIR database.");
+    println!("│ server      unified_server --require-arc --arc-key {} \\", arc_key_path.display());
+    println!("│                 --require-cashu --cashu-keyset {}", cashu_keyset_arg);
+    println!("└─────────────────────────────────────────────────────────────");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(s) => {
+                let st = Arc::clone(&state);
+                thread::spawn(move || handle(s, st));
+            }
+            Err(e) => eprintln!("accept error: {e}"),
+        }
+    }
+}
+
+/// Load the ARC keypair from `path`, or generate + persist a fresh one.
+/// Layout matches `ArcVerifier::secret_key_bytes` exactly.
+fn load_or_generate_key(path: &Path) -> (ServerPrivateKey, ServerPublicKey) {
+    if path.exists() {
+        let bytes = std::fs::read(path)
+            .unwrap_or_else(|e| panic!("failed to read ARC key {}: {e}", path.display()));
+        assert_eq!(
+            bytes.len(),
+            ARC_PRIVKEY_SIZE,
+            "ARC key file {} has wrong size",
+            path.display()
+        );
+        let x0 = deserialize_scalar(&bytes[0..32]).expect("bad x0 scalar in key file");
+        let x1 = deserialize_scalar(&bytes[32..64]).expect("bad x1 scalar in key file");
+        let x2 = deserialize_scalar(&bytes[64..96]).expect("bad x2 scalar in key file");
+        let x0_blinding =
+            deserialize_scalar(&bytes[96..128]).expect("bad x0_blinding scalar in key file");
+        let sk = ServerPrivateKey { x0, x1, x2, x0_blinding };
+        let pk = sk.public_key();
+        (sk, pk)
+    } else {
+        let (sk, pk) = setup_server(&mut OsRng);
+        let mut out = [0u8; ARC_PRIVKEY_SIZE];
+        out[0..32].copy_from_slice(&serialize_scalar(&sk.x0));
+        out[32..64].copy_from_slice(&serialize_scalar(&sk.x1));
+        out[64..96].copy_from_slice(&serialize_scalar(&sk.x2));
+        out[96..128].copy_from_slice(&serialize_scalar(&sk.x0_blinding));
+        std::fs::write(path, out)
+            .unwrap_or_else(|e| panic!("failed to write ARC key {}: {e}", path.display()));
+        println!("generated new ARC key → {}", path.display());
+        (sk, pk)
+    }
+}
+
+/// Handle one HTTP/1.1 connection. Never panics on client input (panic =
+/// 'abort' is workspace-wide, so a panic here would kill the whole process).
+fn handle(mut stream: TcpStream, state: Arc<IssuerState>) {
+    let read_half = match stream.try_clone() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let mut reader = BufReader::new(read_half);
+
+    // Request line: "METHOD PATH HTTP/1.1"
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).is_err() || request_line.is_empty() {
+        return;
+    }
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("").to_string();
+    let path = parts.next().unwrap_or("").to_string();
+
+    // Headers — we only care about Content-Length.
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).is_err() {
+            return;
+        }
+        if line == "\r\n" || line == "\n" || line.is_empty() {
+            break;
+        }
+        let lower = line.to_ascii_lowercase();
+        if let Some(v) = lower.strip_prefix("content-length:") {
+            content_length = v.trim().parse().unwrap_or(0);
+        }
+    }
+
+    // Body (exactly Content-Length bytes; BufReader holds any already-read).
+    let mut body = vec![0u8; content_length];
+    if content_length > 0 && reader.read_exact(&mut body).is_err() {
+        return;
+    }
+
+    match (method.as_str(), path.as_str()) {
+        ("OPTIONS", _) => write_response(&mut stream, 204, "No Content", b"", "text/plain"),
+        ("GET", "/dev/arc/pubkey") => {
+            write_response(&mut stream, 200, "OK", &state.pk.to_bytes(), "application/octet-stream")
+        }
+        ("POST", "/dev/arc/issue") => match issue_arc(&state, &body) {
+            Ok(resp) => {
+                write_response(&mut stream, 200, "OK", &resp, "application/octet-stream")
+            }
+            Err(e) => {
+                eprintln!("/dev/arc/issue rejected: {e}");
+                write_response(&mut stream, 400, "Bad Request", e.as_bytes(), "text/plain")
+            }
+        },
+        ("GET", "/dev/cashu/keyset") => {
+            let json = format!(
+                "{{\"id\":\"{}\",\"pubkey\":\"{}\"}}",
+                state.cashu.keyset_id, state.cashu.pubkey_hex
+            );
+            write_response(&mut stream, 200, "OK", json.as_bytes(), "application/json")
+        }
+        ("POST", "/dev/cashu/mint") => match mint_cashu(&state, &body) {
+            Ok(sigs) => {
+                write_response(&mut stream, 200, "OK", &sigs, "application/octet-stream")
+            }
+            Err(e) => {
+                eprintln!("/dev/cashu/mint rejected: {e}");
+                write_response(&mut stream, 400, "Bad Request", e.as_bytes(), "text/plain")
+            }
+        },
+        ("POST", "/dev/arc/verify") => match verify_arc(&state, &body) {
+            Ok(()) => write_response(&mut stream, 200, "OK", b"ok\n", "text/plain"),
+            Err(e) => write_response(&mut stream, 400, "Bad Request", e.as_bytes(), "text/plain"),
+        },
+        ("POST", "/dev/cashu/verify") => match verify_cashu(&state, &body) {
+            Ok(()) => write_response(&mut stream, 200, "OK", b"ok\n", "text/plain"),
+            Err(e) => write_response(&mut stream, 400, "Bad Request", e.as_bytes(), "text/plain"),
+        },
+        ("GET", "/") | ("GET", "/health") => {
+            write_response(&mut stream, 200, "OK", b"dev-issuer ok\n", "text/plain")
+        }
+        _ => write_response(&mut stream, 404, "Not Found", b"not found\n", "text/plain"),
+    }
+}
+
+/// Sign a blinded credential request → serialized `CredentialResponse`.
+fn issue_arc(state: &IssuerState, request_bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let request = CredentialRequest::from_bytes(request_bytes)
+        .map_err(|e| format!("invalid CredentialRequest ({} bytes): {e}", request_bytes.len()))?;
+    let response = create_credential_response(&state.sk, &state.pk, &request, &mut OsRng)
+        .map_err(|e| format!("issuance failed: {e}"))?;
+    Ok(response.to_bytes().to_vec())
+}
+
+/// Load the Cashu auth keyset from `path`, or generate + persist a fresh
+/// 32-byte secp256k1 scalar. Layout matches the payment service's
+/// `CashuAuthKeyset` (`scalar.to_bytes()`), and the keyset id is derived the
+/// same way (`hex(compressed_pubkey)[..16] + "-auth"`).
+fn load_or_generate_cashu_key(path: &Path) -> CashuKeyset {
+    let scalar_bytes: [u8; 32] = if path.exists() {
+        let bytes = std::fs::read(path)
+            .unwrap_or_else(|e| panic!("failed to read Cashu key {}: {e}", path.display()));
+        assert_eq!(bytes.len(), 32, "Cashu key file {} has wrong size", path.display());
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(&bytes);
+        arr
+    } else {
+        let k = Scalar::generate_vartime(&mut OsRng);
+        let bytes: [u8; 32] = k.to_bytes().into();
+        std::fs::write(path, bytes)
+            .unwrap_or_else(|e| panic!("failed to write Cashu key {}: {e}", path.display()));
+        println!("generated new Cashu key → {}", path.display());
+        bytes
+    };
+
+    let k = Option::<Scalar>::from(Scalar::from_repr(scalar_bytes.into()))
+        .unwrap_or_else(|| panic!("invalid Cashu key scalar in {}", path.display()));
+    let pubkey = (ProjectivePoint::GENERATOR * k).to_affine().to_encoded_point(true);
+    let pubkey_hex = hex::encode(pubkey.as_bytes());
+    let keyset_id = format!("{}-auth", &pubkey_hex[..16]);
+    let secret_hex = hex::encode(scalar_bytes);
+
+    CashuKeyset { k, keyset_id, pubkey_hex, secret_hex }
+}
+
+/// Blind-sign one or more 33-byte blinded points: `C'_i = k · B'_i`.
+/// Body is `N × 33` concatenated compressed points; response is `N × 33`.
+fn mint_cashu(state: &IssuerState, body: &[u8]) -> Result<Vec<u8>, String> {
+    if body.is_empty() || body.len() % 33 != 0 {
+        return Err(format!(
+            "blinded messages must be a non-empty multiple of 33 bytes, got {}",
+            body.len()
+        ));
+    }
+    let mut out = Vec::with_capacity(body.len());
+    for chunk in body.chunks_exact(33) {
+        out.extend_from_slice(&cashu_blind_sign(&state.cashu.k, chunk)?);
+    }
+    Ok(out)
+}
+
+/// `C' = k · B'` for a single 33-byte compressed blinded point.
+fn cashu_blind_sign(k: &Scalar, blinded: &[u8]) -> Result<[u8; 33], String> {
+    let arr: [u8; 33] = blinded
+        .try_into()
+        .map_err(|_| "blinded message must be 33 bytes".to_string())?;
+    let point = Option::<ProjectivePoint>::from(ProjectivePoint::from_bytes(&arr.into()))
+        .ok_or("invalid blinded point encoding")?;
+    if bool::from(point.is_identity()) {
+        return Err("blinded message is the identity point".into());
+    }
+    let signed = (point * k).to_affine().to_encoded_point(true);
+    let mut out = [0u8; 33];
+    out.copy_from_slice(signed.as_bytes());
+    Ok(out)
+}
+
+// ─── Verify gate (co-located so the demo needs no PIR server) ──────────────
+//
+// These mirror `pir_runtime_core::arc_verifier::ArcVerifier` and
+// `cashu_verifier::CashuVerifier` exactly (same `arc::verify_presentation`
+// call; same Cashu `C == k·hash_to_curve(secret)` relation + spent-set). The
+// payload bytes are byte-identical to the WS `REQ_CREDENTIAL_PRESENT` (0x08) /
+// `REQ_CASHU_BAT_PRESENT` (0x09) frames the PIR server receives — only the
+// transport (HTTP here vs WS in production) differs.
+
+/// Verify an ARC presentation payload `[0x08][req_ctx_len][req_ctx]
+/// [pres_ctx_len][pres_ctx][8B limit LE][pres_bytes]` (same layout as
+/// unified_server). Rejects nonce reuse via a per-pres_ctx tag set.
+fn verify_arc(state: &IssuerState, payload: &[u8]) -> Result<(), String> {
+    if payload.first() != Some(&0x08) {
+        return Err("expected REQ_CREDENTIAL_PRESENT (0x08) variant byte".into());
+    }
+    let body = &payload[1..];
+    if body.len() < 11 {
+        return Err("malformed ARC present: too short".into());
+    }
+    let req_ctx_len = body[0] as usize;
+    if body.len() < 1 + req_ctx_len + 1 {
+        return Err("malformed ARC present: truncated request_context".into());
+    }
+    let req_ctx = &body[1..1 + req_ctx_len];
+    let off = 1 + req_ctx_len;
+    let pres_ctx_len = body[off] as usize;
+    if body.len() < off + 1 + pres_ctx_len + 8 {
+        return Err("malformed ARC present: truncated presentation_context".into());
+    }
+    let pres_ctx = &body[off + 1..off + 1 + pres_ctx_len];
+    let limit_off = off + 1 + pres_ctx_len;
+    let limit = u64::from_le_bytes(body[limit_off..limit_off + 8].try_into().unwrap());
+    let pres_bytes = &body[limit_off + 8..];
+
+    let presentation = Presentation::from_bytes(pres_bytes, limit)
+        .map_err(|e| format!("malformed presentation: {e}"))?;
+    let tag = verify_presentation(&state.sk, &state.pk, req_ctx, pres_ctx, &presentation, limit)
+        .map_err(|e| format!("ARC proof invalid: {e}"))?;
+
+    let tag_bytes = serialize_element(&tag).to_vec();
+    let mut tags = state.arc_tags.lock().unwrap();
+    let set = tags.entry(pres_ctx.to_vec()).or_default();
+    if !set.insert(tag_bytes) {
+        return Err("duplicate ARC tag — nonce reused".into());
+    }
+    Ok(())
+}
+
+/// Verify a Cashu BAT payload `[0x09][authA…]`. Rejects double-spends via the
+/// spent-secret set.
+fn verify_cashu(state: &IssuerState, payload: &[u8]) -> Result<(), String> {
+    if payload.first() != Some(&0x09) {
+        return Err("expected REQ_CASHU_BAT_PRESENT (0x09) variant byte".into());
+    }
+    let bat = std::str::from_utf8(&payload[1..]).map_err(|_| "invalid UTF-8 in BAT".to_string())?;
+    let b64 = bat.strip_prefix("authA").ok_or("missing authA prefix")?;
+    let json_bytes = base64url_decode(b64).ok_or("base64url decode failed")?;
+    let json = std::str::from_utf8(&json_bytes).map_err(|_| "BAT JSON not UTF-8".to_string())?;
+
+    let id = extract_json_str(json, "id").ok_or("BAT missing id")?;
+    let secret = extract_json_str(json, "secret").ok_or("BAT missing secret")?;
+    let c_hex = extract_json_str(json, "C").ok_or("BAT missing C")?;
+
+    if id != state.cashu.keyset_id {
+        return Err(format!("unknown keyset: {id}"));
+    }
+    let c_bytes: [u8; 33] = hex::decode(&c_hex)
+        .map_err(|e| format!("C hex: {e}"))?
+        .try_into()
+        .map_err(|_| "C must be 33 bytes".to_string())?;
+    let c = Option::<ProjectivePoint>::from(ProjectivePoint::from_bytes(&c_bytes.into()))
+        .ok_or("invalid C point encoding")?;
+
+    let expected = cashu_hash_to_curve(secret.as_bytes()) * state.cashu.k;
+    if c != expected {
+        return Err("BAT signature verification failed".into());
+    }
+
+    let secret_hash: [u8; 32] = Sha256::digest(secret.as_bytes()).into();
+    let mut spent = state.cashu_spent.lock().unwrap();
+    if !spent.insert(secret_hash) {
+        return Err("BAT already spent".into());
+    }
+    Ok(())
+}
+
+/// Cashu NUT-00 hash-to-curve (matches `cashu_verifier::hash_to_curve_cashu`).
+fn cashu_hash_to_curve(secret: &[u8]) -> ProjectivePoint {
+    let mut hasher = Sha256::new();
+    hasher.update(b"Secp256k1_HashToCurve_Cashu_");
+    hasher.update(secret);
+    let msg_hash = hasher.finalize();
+    for counter in 0u32.. {
+        let mut h = Sha256::new();
+        h.update(msg_hash);
+        h.update(counter.to_le_bytes());
+        let digest: [u8; 32] = h.finalize().into();
+        let mut pt = [0u8; 33];
+        pt[0] = 0x02;
+        pt[1..].copy_from_slice(&digest);
+        if let Some(point) =
+            Option::<ProjectivePoint>::from(ProjectivePoint::from_bytes(&pt.into()))
+        {
+            if !bool::from(point.is_identity()) {
+                return point;
+            }
+        }
+    }
+    unreachable!()
+}
+
+/// Minimal URL-safe base64 decode, no padding (matches the verifier's).
+fn base64url_decode(input: &str) -> Option<Vec<u8>> {
+    if input.is_empty() || input.len() % 4 == 1 {
+        return None;
+    }
+    let alphabet = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut buf = 0u32;
+    let mut bits = 0u8;
+    let mut out = Vec::with_capacity(input.len() * 3 / 4);
+    for &c in input.as_bytes() {
+        let val = alphabet.iter().position(|&a| a == c)? as u32;
+        buf = (buf << 6) | val;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buf >> bits) as u8);
+        }
+    }
+    Some(out)
+}
+
+/// Extract a string field `"key":"value"` from flat JSON (no nesting).
+fn extract_json_str(json: &str, key: &str) -> Option<String> {
+    let needle = format!("\"{key}\":\"");
+    let start = json.find(&needle)? + needle.len();
+    let rest = &json[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Write an HTTP/1.1 response with permissive (dev-only) CORS headers.
+fn write_response(stream: &mut TcpStream, code: u16, status: &str, body: &[u8], content_type: &str) {
+    let header = format!(
+        "HTTP/1.1 {code} {status}\r\n\
+         Content-Type: {content_type}\r\n\
+         Content-Length: {}\r\n\
+         Access-Control-Allow-Origin: *\r\n\
+         Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n\
+         Access-Control-Allow-Headers: *\r\n\
+         Connection: close\r\n\
+         \r\n",
+        body.len()
+    );
+    let _ = stream.write_all(header.as_bytes());
+    if !body.is_empty() {
+        let _ = stream.write_all(body);
+    }
+    let _ = stream.flush();
+}
+
+/// Lowercase hex for the 99-byte pubkey banner.
+fn hex99(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}

--- a/dev-issuer/tests/cashu_roundtrip.rs
+++ b/dev-issuer/tests/cashu_roundtrip.rs
@@ -1,0 +1,173 @@
+//! End-to-end HTTP test for the Cashu BDHKE mint: spawn `dev-issuer`, blind a
+//! secret, get it blind-signed over the wire, unblind, and verify the
+//! resulting BAT against the issuer's actual secret key (read from the key
+//! file). Proves the demo's Cashu "obtain" leg works across real HTTP.
+//!
+//! The client-side crypto here (hash_to_curve / blind / unblind) is the same
+//! math the WASM `WasmCashuBlind` binding implements; this test pins the mint
+//! and the BDHKE relation `C == k · hash_to_curve(secret)` with only k256.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::process::{Child, Command};
+use std::time::Duration;
+
+use k256::elliptic_curve::group::GroupEncoding;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::elliptic_curve::{Group, PrimeField};
+use k256::{ProjectivePoint, Scalar};
+use sha2::{Digest, Sha256};
+
+const PORT: u16 = 5732;
+
+struct ServerGuard(Child);
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn http(method: &str, path: &str, body: Option<&[u8]>) -> (u16, Vec<u8>) {
+    let mut stream = TcpStream::connect(("127.0.0.1", PORT)).expect("connect");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+    let body = body.unwrap_or(&[]);
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(req.as_bytes()).expect("write headers");
+    if !body.is_empty() {
+        stream.write_all(body).expect("write body");
+    }
+    stream.flush().ok();
+
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).expect("read response");
+    let sep = raw.windows(4).position(|w| w == b"\r\n\r\n").expect("no separator");
+    let head = &raw[..sep];
+    let resp_body = raw[sep + 4..].to_vec();
+    let line_end = head.windows(2).position(|w| w == b"\r\n").unwrap_or(head.len());
+    let first = String::from_utf8_lossy(&head[..line_end]);
+    let code: u16 = first.split_whitespace().nth(1).and_then(|c| c.parse().ok()).expect("code");
+    (code, resp_body)
+}
+
+fn wait_until_ready() {
+    for _ in 0..60 {
+        if TcpStream::connect(("127.0.0.1", PORT)).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("dev-issuer did not become ready on port {PORT}");
+}
+
+/// Cashu NUT-00 hash-to-curve (must match `cashu_verifier::hash_to_curve_cashu`
+/// and the dev-issuer's WASM binding byte-for-byte).
+fn hash_to_curve(secret: &[u8]) -> ProjectivePoint {
+    let mut hasher = Sha256::new();
+    hasher.update(b"Secp256k1_HashToCurve_Cashu_");
+    hasher.update(secret);
+    let msg_hash = hasher.finalize();
+    for counter in 0u32.. {
+        let mut h = Sha256::new();
+        h.update(msg_hash);
+        h.update(counter.to_le_bytes());
+        let digest: [u8; 32] = h.finalize().into();
+        let mut pt = [0u8; 33];
+        pt[0] = 0x02;
+        pt[1..].copy_from_slice(&digest);
+        if let Some(point) = Option::<ProjectivePoint>::from(ProjectivePoint::from_bytes(&pt.into())) {
+            if !bool::from(point.is_identity()) {
+                return point;
+            }
+        }
+    }
+    unreachable!()
+}
+
+fn compress(p: &ProjectivePoint) -> [u8; 33] {
+    let enc = p.to_affine().to_encoded_point(true);
+    let mut out = [0u8; 33];
+    out.copy_from_slice(enc.as_bytes());
+    out
+}
+
+/// Pull the `pubkey` hex out of `{"id":"...","pubkey":"..."}` without a JSON dep.
+fn extract_field(json: &str, key: &str) -> String {
+    let needle = format!("\"{key}\":\"");
+    let start = json.find(&needle).expect("key present") + needle.len();
+    let rest = &json[start..];
+    let end = rest.find('"').expect("closing quote");
+    rest[..end].to_string()
+}
+
+#[test]
+fn dev_issuer_cashu_mint_unblind_verify_over_http() {
+    let pid = std::process::id();
+    let arc_key = std::env::temp_dir().join(format!("cashu_test_arc_{pid}.bin"));
+    let cashu_key = std::env::temp_dir().join(format!("cashu_test_k_{pid}.bin"));
+    let _ = std::fs::remove_file(&arc_key);
+    let _ = std::fs::remove_file(&cashu_key);
+
+    let child = Command::new(env!("CARGO_BIN_EXE_dev-issuer"))
+        .args(["--arc-key"])
+        .arg(&arc_key)
+        .args(["--cashu-key"])
+        .arg(&cashu_key)
+        .args(["--port", &PORT.to_string()])
+        .spawn()
+        .expect("spawn dev-issuer");
+    let _guard = ServerGuard(child);
+    wait_until_ready();
+
+    // 1. Fetch the keyset → mint pubkey K (33 bytes).
+    let (code, body) = http("GET", "/dev/cashu/keyset", None);
+    assert_eq!(code, 200, "keyset status");
+    let json = String::from_utf8(body).unwrap();
+    let pubkey_hex = extract_field(&json, "pubkey");
+    let id = extract_field(&json, "id");
+    assert!(id.ends_with("-auth"), "keyset id format: {id}");
+    let k_point = {
+        let bytes: [u8; 33] = hex::decode(&pubkey_hex).unwrap().try_into().unwrap();
+        Option::<ProjectivePoint>::from(ProjectivePoint::from_bytes(&bytes.into())).unwrap()
+    };
+
+    // 2. Client blinds a batch of 3 secrets: B'_i = hash_to_curve(secret_i) + r_i·G.
+    let secrets: Vec<String> = (0..3).map(|i| format!("demo-secret-{pid}-{i}")).collect();
+    let mut rng = rand_core::OsRng;
+    let blindings: Vec<Scalar> = (0..3).map(|_| Scalar::generate_vartime(&mut rng)).collect();
+    let mut blinded = Vec::new();
+    for (secret, r) in secrets.iter().zip(&blindings) {
+        let b_prime = hash_to_curve(secret.as_bytes()) + ProjectivePoint::GENERATOR * r;
+        blinded.extend_from_slice(&compress(&b_prime));
+    }
+
+    // 3. Mint over HTTP → 3 blind signatures (3 × 33 bytes).
+    let (code, sigs) = http("POST", "/dev/cashu/mint", Some(&blinded));
+    assert_eq!(code, 200, "mint status");
+    assert_eq!(sigs.len(), 3 * 33, "expected 3 blind sigs");
+
+    // 4. Read the issuer's actual secret scalar k from the key file (to verify).
+    let k = {
+        let bytes: [u8; 32] = std::fs::read(&cashu_key).unwrap().try_into().unwrap();
+        Option::<Scalar>::from(Scalar::from_repr(bytes.into())).unwrap()
+    };
+    // Sanity: the served pubkey is k·G.
+    assert_eq!(compress(&(ProjectivePoint::GENERATOR * k)), compress(&k_point));
+
+    // 5. Unblind each (C = C' - r·K) and verify the BDHKE relation C == k·Y.
+    for (i, (secret, r)) in secrets.iter().zip(&blindings).enumerate() {
+        let c_prime = {
+            let chunk: [u8; 33] = sigs[i * 33..(i + 1) * 33].try_into().unwrap();
+            Option::<ProjectivePoint>::from(ProjectivePoint::from_bytes(&chunk.into())).unwrap()
+        };
+        let c = c_prime - k_point * r;
+        let expected = hash_to_curve(secret.as_bytes()) * k;
+        assert_eq!(compress(&c), compress(&expected), "BAT {i} failed BDHKE verify");
+    }
+
+    let _ = std::fs::remove_file(&arc_key);
+    let _ = std::fs::remove_file(&cashu_key);
+}

--- a/dev-issuer/tests/http_roundtrip.rs
+++ b/dev-issuer/tests/http_roundtrip.rs
@@ -1,0 +1,155 @@
+//! End-to-end HTTP test: spawn the `dev-issuer` binary, obtain an ARC
+//! credential over the wire, present it, and verify the presentation against
+//! the same key the issuer persisted. Proves the demo's "obtain" leg works
+//! across the real HTTP boundary (not just the in-process crypto of
+//! `pir_runtime_core::arc_verifier`'s native loop test).
+//!
+//! Uses only `arc` + std — no WASM, no Node. The browser-side glue
+//! (`payment-client.ts` + WASM bindings) is exercised by the demo page in its
+//! real environment.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::process::{Child, Command};
+use std::time::Duration;
+
+use arc::group::deserialize_scalar;
+use arc::{
+    create_credential_request, finalize_credential, make_presentation_state, present,
+    verify_presentation, CredentialResponse, ServerPrivateKey, ServerPublicKey,
+};
+
+const REQUEST_CONTEXT: &[u8] = b"bitcoin-pir-v1";
+const PORT: u16 = 5731;
+
+/// Kill the child on drop so a panicking assert never leaks the process.
+struct ServerGuard(Child);
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Minimal HTTP/1.1 client: returns (status_code, body_bytes). Reads to EOF
+/// (the server sends `Connection: close`).
+fn http(method: &str, path: &str, body: Option<&[u8]>) -> (u16, Vec<u8>) {
+    let mut stream = TcpStream::connect(("127.0.0.1", PORT)).expect("connect");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+    let body = body.unwrap_or(&[]);
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(req.as_bytes()).expect("write headers");
+    if !body.is_empty() {
+        stream.write_all(body).expect("write body");
+    }
+    stream.flush().ok();
+
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).expect("read response");
+
+    // Split headers / body on the first CRLFCRLF.
+    let sep = raw
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .expect("no header/body separator");
+    let head = &raw[..sep];
+    let resp_body = raw[sep + 4..].to_vec();
+
+    // Status code from the first line: "HTTP/1.1 <code> <reason>".
+    let first_line_end = head.windows(2).position(|w| w == b"\r\n").unwrap_or(head.len());
+    let first_line = String::from_utf8_lossy(&head[..first_line_end]);
+    let code: u16 = first_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|c| c.parse().ok())
+        .expect("status code");
+
+    (code, resp_body)
+}
+
+fn wait_until_ready() {
+    for _ in 0..60 {
+        if TcpStream::connect(("127.0.0.1", PORT)).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("dev-issuer did not become ready on port {PORT}");
+}
+
+/// Reconstruct the issuer keypair from the persisted `arc_key.bin` so we can
+/// verify the presentation with the *same* key the server issued under.
+fn load_key(path: &std::path::Path) -> (ServerPrivateKey, ServerPublicKey) {
+    let bytes = std::fs::read(path).expect("read key file");
+    assert_eq!(bytes.len(), 128, "key file size");
+    let x0 = deserialize_scalar(&bytes[0..32]).unwrap();
+    let x1 = deserialize_scalar(&bytes[32..64]).unwrap();
+    let x2 = deserialize_scalar(&bytes[64..96]).unwrap();
+    let x0_blinding = deserialize_scalar(&bytes[96..128]).unwrap();
+    let sk = ServerPrivateKey { x0, x1, x2, x0_blinding };
+    let pk = sk.public_key();
+    (sk, pk)
+}
+
+#[test]
+fn dev_issuer_full_obtain_present_verify_over_http() {
+    // Fresh key file per run.
+    let key_path = std::env::temp_dir().join(format!("dev_issuer_test_key_{}.bin", std::process::id()));
+    let _ = std::fs::remove_file(&key_path);
+
+    let child = Command::new(env!("CARGO_BIN_EXE_dev-issuer"))
+        .arg("--arc-key")
+        .arg(&key_path)
+        .arg("--port")
+        .arg(PORT.to_string())
+        .spawn()
+        .expect("spawn dev-issuer");
+    let _guard = ServerGuard(child);
+    wait_until_ready();
+
+    // 1. Fetch the issuer pubkey (99 bytes) and parse it.
+    let (code, pk_bytes) = http("GET", "/dev/arc/pubkey", None);
+    assert_eq!(code, 200, "pubkey status");
+    assert_eq!(pk_bytes.len(), 99, "pubkey length");
+    let pk = ServerPublicKey::from_bytes(&pk_bytes).expect("parse served pubkey");
+
+    // 2. Client builds a blinded credential request.
+    let mut rng = rand_core::OsRng;
+    let (secrets, request) = create_credential_request(REQUEST_CONTEXT, &mut rng).unwrap();
+    let request_bytes = request.to_bytes();
+    assert_eq!(request_bytes.len(), 226, "request length");
+
+    // 3. POST it to the issuer → 454-byte CredentialResponse.
+    let (code, resp_bytes) = http("POST", "/dev/arc/issue", Some(&request_bytes));
+    assert_eq!(code, 200, "issue status");
+    assert_eq!(resp_bytes.len(), 454, "response length");
+    let response = CredentialResponse::from_bytes(&resp_bytes).expect("parse response");
+
+    // 4. Finalize into a credential, using the served pubkey.
+    let credential = finalize_credential(&secrets, &pk, &request, &response).expect("finalize");
+
+    // 5. Produce a presentation.
+    let limit = 16u64;
+    let pres_ctx = b"http-test-session";
+    let state = make_presentation_state(credential, pres_ctx, limit);
+    let (_next, _nonce, presentation) = present(&state, &mut rng).expect("present");
+
+    // 6. Verify it against the key the issuer persisted to disk.
+    let (sk_file, pk_file) = load_key(&key_path);
+    // The served pubkey must equal the one derived from the persisted key.
+    assert_eq!(pk.to_bytes(), pk_file.to_bytes(), "served pubkey vs file-derived");
+    let tag = verify_presentation(
+        &sk_file,
+        &pk_file,
+        REQUEST_CONTEXT,
+        pres_ctx,
+        &presentation,
+        limit,
+    );
+    assert!(tag.is_ok(), "verify failed: {:?}", tag.err());
+
+    let _ = std::fs::remove_file(&key_path);
+}

--- a/dev-issuer/tests/verify_gate.rs
+++ b/dev-issuer/tests/verify_gate.rs
@@ -1,0 +1,214 @@
+//! End-to-end test of the dev-issuer's co-located verify gate (the demo's "D"
+//! leg). Builds the *real* `REQ_CREDENTIAL_PRESENT` (0x08) and
+//! `REQ_CASHU_BAT_PRESENT` (0x09) payloads — byte-identical to what the PIR
+//! server's WS gate receives — and POSTs them to `/dev/arc/verify` and
+//! `/dev/cashu/verify`. Asserts accept, then rejection on replay
+//! (ARC duplicate tag / Cashu double-spend).
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::process::{Child, Command};
+use std::time::Duration;
+
+use arc::{
+    create_credential_request, finalize_credential, make_presentation_state, present,
+    CredentialResponse, ServerPublicKey,
+};
+use k256::elliptic_curve::group::GroupEncoding;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::elliptic_curve::Group;
+use k256::{ProjectivePoint, Scalar};
+use sha2::{Digest, Sha256};
+
+const PORT: u16 = 5733;
+const REQUEST_CONTEXT: &[u8] = b"bitcoin-pir-v1";
+
+struct ServerGuard(Child);
+impl Drop for ServerGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn http(method: &str, path: &str, body: Option<&[u8]>) -> (u16, Vec<u8>) {
+    let mut stream = TcpStream::connect(("127.0.0.1", PORT)).expect("connect");
+    stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+    let body = body.unwrap_or(&[]);
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(req.as_bytes()).expect("write");
+    if !body.is_empty() {
+        stream.write_all(body).expect("write body");
+    }
+    stream.flush().ok();
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).expect("read");
+    let sep = raw.windows(4).position(|w| w == b"\r\n\r\n").expect("sep");
+    let head = &raw[..sep];
+    let resp_body = raw[sep + 4..].to_vec();
+    let line_end = head.windows(2).position(|w| w == b"\r\n").unwrap_or(head.len());
+    let first = String::from_utf8_lossy(&head[..line_end]);
+    let code = first.split_whitespace().nth(1).and_then(|c| c.parse().ok()).expect("code");
+    (code, resp_body)
+}
+
+fn wait_ready() {
+    for _ in 0..60 {
+        if TcpStream::connect(("127.0.0.1", PORT)).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("dev-issuer not ready on {PORT}");
+}
+
+fn h2c(secret: &[u8]) -> ProjectivePoint {
+    let mut hasher = Sha256::new();
+    hasher.update(b"Secp256k1_HashToCurve_Cashu_");
+    hasher.update(secret);
+    let msg = hasher.finalize();
+    for counter in 0u32.. {
+        let mut h = Sha256::new();
+        h.update(msg);
+        h.update(counter.to_le_bytes());
+        let d: [u8; 32] = h.finalize().into();
+        let mut pt = [0u8; 33];
+        pt[0] = 0x02;
+        pt[1..].copy_from_slice(&d);
+        if let Some(p) = Option::<ProjectivePoint>::from(ProjectivePoint::from_bytes(&pt.into())) {
+            if !bool::from(p.is_identity()) {
+                return p;
+            }
+        }
+    }
+    unreachable!()
+}
+
+fn compress(p: &ProjectivePoint) -> [u8; 33] {
+    let e = p.to_affine().to_encoded_point(true);
+    let mut o = [0u8; 33];
+    o.copy_from_slice(e.as_bytes());
+    o
+}
+
+fn base64url_nopad(data: &[u8]) -> String {
+    const A: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::new();
+    for chunk in data.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = *chunk.get(1).unwrap_or(&0);
+        let b2 = *chunk.get(2).unwrap_or(&0);
+        out.push(A[(b0 >> 2) as usize] as char);
+        out.push(A[(((b0 & 0x03) << 4) | (b1 >> 4)) as usize] as char);
+        if chunk.len() > 1 {
+            out.push(A[(((b1 & 0x0f) << 2) | (b2 >> 6)) as usize] as char);
+        }
+        if chunk.len() > 2 {
+            out.push(A[(b2 & 0x3f) as usize] as char);
+        }
+    }
+    out
+}
+
+fn extract(json: &str, key: &str) -> String {
+    let needle = format!("\"{key}\":\"");
+    let start = json.find(&needle).unwrap() + needle.len();
+    let rest = &json[start..];
+    rest[..rest.find('"').unwrap()].to_string()
+}
+
+#[test]
+fn verify_gate_accepts_then_rejects_replays_for_both_schemes() {
+    let pid = std::process::id();
+    let arc_key = std::env::temp_dir().join(format!("vg_arc_{pid}.bin"));
+    let cashu_key = std::env::temp_dir().join(format!("vg_cashu_{pid}.bin"));
+    let _ = std::fs::remove_file(&arc_key);
+    let _ = std::fs::remove_file(&cashu_key);
+
+    let child = Command::new(env!("CARGO_BIN_EXE_dev-issuer"))
+        .args(["--arc-key"])
+        .arg(&arc_key)
+        .args(["--cashu-key"])
+        .arg(&cashu_key)
+        .args(["--port", &PORT.to_string()])
+        .spawn()
+        .expect("spawn");
+    let _guard = ServerGuard(child);
+    wait_ready();
+
+    let mut rng = rand_core::OsRng;
+
+    // ─── ARC: obtain → present payload → verify → replay ───
+    let (_, pk_bytes) = http("GET", "/dev/arc/pubkey", None);
+    let pk = ServerPublicKey::from_bytes(&pk_bytes).unwrap();
+    let (secrets, request) = create_credential_request(REQUEST_CONTEXT, &mut rng).unwrap();
+    let (_, resp) = http("POST", "/dev/arc/issue", Some(&request.to_bytes()));
+    let response = CredentialResponse::from_bytes(&resp).unwrap();
+    let credential = finalize_credential(&secrets, &pk, &request, &response).unwrap();
+
+    let limit = 8u64;
+    let pres_ctx: &[u8] = b"verify-gate-session";
+    let state = make_presentation_state(credential, pres_ctx, limit);
+    let (_s, _n, presentation) = present(&state, &mut rng).unwrap();
+
+    // Build the real REQ_CREDENTIAL_PRESENT payload (no 4B WS length prefix).
+    let mut arc_payload = vec![0x08u8];
+    arc_payload.push(REQUEST_CONTEXT.len() as u8);
+    arc_payload.extend_from_slice(REQUEST_CONTEXT);
+    arc_payload.push(pres_ctx.len() as u8);
+    arc_payload.extend_from_slice(pres_ctx);
+    arc_payload.extend_from_slice(&limit.to_le_bytes());
+    arc_payload.extend_from_slice(&presentation.to_bytes());
+
+    let (code, _) = http("POST", "/dev/arc/verify", Some(&arc_payload));
+    assert_eq!(code, 200, "ARC present should verify");
+    let (code, body) = http("POST", "/dev/arc/verify", Some(&arc_payload));
+    assert_eq!(code, 400, "ARC replay should be rejected");
+    assert!(
+        String::from_utf8_lossy(&body).contains("duplicate"),
+        "expected duplicate-tag rejection, got {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    // ─── Cashu: mint → unblind → authA → verify → replay ───
+    let (_, keyset_json) = http("GET", "/dev/cashu/keyset", None);
+    let keyset_json = String::from_utf8(keyset_json).unwrap();
+    let id = extract(&keyset_json, "id");
+    let pubkey_hex = extract(&keyset_json, "pubkey");
+    let k_point = {
+        let b: [u8; 33] = hex::decode(&pubkey_hex).unwrap().try_into().unwrap();
+        Option::<ProjectivePoint>::from(ProjectivePoint::from_bytes(&b.into())).unwrap()
+    };
+
+    let secret = format!("vg-secret-{pid}");
+    let r = Scalar::generate_vartime(&mut rng);
+    let b_prime = compress(&(h2c(secret.as_bytes()) + ProjectivePoint::GENERATOR * r));
+    let (_, sig) = http("POST", "/dev/cashu/mint", Some(&b_prime));
+    let c_prime = Option::<ProjectivePoint>::from(
+        ProjectivePoint::from_bytes(&<[u8; 33]>::try_from(sig.as_slice()).unwrap().into()),
+    )
+    .unwrap();
+    let c = c_prime - k_point * r;
+    let c_hex = hex::encode(compress(&c));
+
+    let json = format!("{{\"id\":\"{}\",\"secret\":\"{}\",\"C\":\"{}\"}}", id, secret, c_hex);
+    let token = format!("authA{}", base64url_nopad(json.as_bytes()));
+    let mut cashu_payload = vec![0x09u8];
+    cashu_payload.extend_from_slice(token.as_bytes());
+
+    let (code, _) = http("POST", "/dev/cashu/verify", Some(&cashu_payload));
+    assert_eq!(code, 200, "Cashu BAT should verify");
+    let (code, body) = http("POST", "/dev/cashu/verify", Some(&cashu_payload));
+    assert_eq!(code, 400, "Cashu replay should be rejected");
+    assert!(
+        String::from_utf8_lossy(&body).contains("spent"),
+        "expected already-spent rejection, got {}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let _ = std::fs::remove_file(&arc_key);
+    let _ = std::fs::remove_file(&cashu_key);
+}

--- a/docs/RATELIMIT_DEMO.md
+++ b/docs/RATELIMIT_DEMO.md
@@ -1,0 +1,109 @@
+# Anonymous Rate-Limiting Demo (ARC + Cashu)
+
+A self-contained, browser-runnable demo of the two anonymous rate-limiting
+schemes, end-to-end: **mint → obtain → present → verify**, with a live quota
+meter, exhaustion, and replay/double-spend rejection.
+
+It exists so the headline claim — *rate-limit queries without deanonymizing
+the user* — can be seen working, not just asserted. Every byte boundary is
+also covered by automated tests (see "What's tested" below); the demo is the
+human-visible capstone.
+
+## Run it
+
+Two processes, no Lightning, no PIR database:
+
+```bash
+cargo run -p dev-issuer            # issuer + verify gate on http://127.0.0.1:5601
+npm --prefix web run dev           # Vite on http://localhost:3001
+# open http://localhost:3001/ratelimit-demo.html
+```
+
+The page checks issuer reachability on load (green banner = good; red banner
+tells you to start the dev-issuer).
+
+## What you'll see
+
+**ARC column (multi-show):** one credential authorises *N* unlinkable
+presentations.
+- **Mint credential** → blinds a request in WASM (226 B), sends it to the
+  issuer, finalises the 454 B response into a 131 B credential.
+- **Present once** → each presentation is accepted by the gate; the quota
+  meter ticks 8→0; at 0 the button disables (exhausted).
+- **Replay last (rejected)** → re-sends the previous presentation; the gate
+  rejects it (`duplicate ARC tag — nonce reused`). Each nonce is single-use
+  even though the credential is multi-show.
+- **Run to exhaustion** → mints then presents until the meter empties.
+
+**Cashu column (single-show):** a pool of one-time Blind Auth Tokens (BATs).
+- **Mint BAT pool** → for each BAT: blind a fresh secret (WASM), batch the
+  blinded points to the mint, unblind each returned signature.
+- **Spend one** → each BAT is accepted once; the meter drains.
+- **Replay last (double-spend)** → re-spends a used BAT; the gate rejects it
+  (`BAT already spent`).
+- **Mint + spend all** → mints then spends the whole pool.
+
+## ARC vs Cashu
+
+| | ARC | Cashu Blind Auth |
+|---|---|---|
+| Shape | One credential, *N* presentations | Pool of *N* one-time tokens |
+| Crypto | Algebraic MAC (P-256) + range proof | BDHKE (secp256k1) |
+| Rate limit | Range proof bounds the nonce to `[0, limit)`; tags dedup per context | One token = one query; spent-set dedup |
+| Unlinkability | Presentations are mutually unlinkable | Tokens are unlinkable to issuance |
+| Wire (present) | `REQ_CREDENTIAL_PRESENT` (0x08) | `REQ_CASHU_BAT_PRESENT` (0x09), `authA…` |
+| Issued blob | 131-byte credential | `{id, secret, C}` per BAT |
+| Best when | Many queries per credential, fixed budget | Simple pay-per-query metering |
+
+Both are redundant for the basic goal; the project ships both so the
+trade-off can be demonstrated.
+
+## Architecture
+
+```
+mint ── dev-issuer ── obtain ── browser (WASM) ── present ── dev-issuer gate ── verify
+        (free, HTTP)            blind / finalize             (same crypto as the
+                                                              PIR server's gate)
+```
+
+- **mint / obtain** — `WasmArcCredentialRequest` (`pir-sdk-wasm/src/arc.rs`) and
+  `WasmCashuBlind` (`pir-sdk-wasm/src/cashu.rs`) do the blinding/finalising in
+  WASM so secrets never reach JS; `web/src/payment-client.ts` +
+  `web/src/cashu-bat.ts` orchestrate the HTTP calls.
+- **present / verify** — `presentArc` / `presentCashu` post the *exact*
+  `0x08` / `0x09` frame payloads (built by `ArcCredentialManager` /
+  `CashuBatPool`) to the dev-issuer's `/dev/arc/verify` /
+  `/dev/cashu/verify`.
+
+> **Demo vs production.** The dev-issuer co-locates the verify gate so the demo
+> needs no PIR database. The gate runs the *identical* crypto to
+> `pir_runtime_core::{arc_verifier, cashu_verifier}` (the same
+> `arc::verify_presentation`; the same Cashu `C == k·hash_to_curve(secret)` +
+> spent-set). In production the same present frames go over **WebSocket** to
+> the PIR server's gate (`unified_server --require-arc --arc-key … --require-cashu
+> --cashu-keyset …`, which the dev-issuer prints a launch line for); only the
+> transport differs.
+
+The credential issuer here is **free** (no payment). In production the same
+endpoints would be served by a Lightning-backed mint after a paid invoice.
+
+## What's tested (no browser required)
+
+- `cargo test -p pir-runtime-core --lib arc_verifier` — full ARC issue →
+  present → verify loop with a shared key; wrong-key + replay rejection.
+- `cargo test -p pir-sdk-wasm --lib` — WASM ARC obtain leg; a WASM-blinded
+  Cashu BAT verified under the real `CashuVerifier` (h2c + BDHKE cross-check).
+- `cargo test -p dev-issuer` — HTTP round-trips for ARC + Cashu, and the
+  verify gate (present → accept, replay → reject) for both schemes.
+- `npm --prefix web test` — `payment-client` HTTP + present helpers.
+
+## Files
+
+| Area | File |
+|---|---|
+| Issuer + gate | [`dev-issuer/`](../dev-issuer/) (`README.md` has endpoint details) |
+| WASM obtain | [`pir-sdk-wasm/src/arc.rs`](../pir-sdk-wasm/src/arc.rs), [`pir-sdk-wasm/src/cashu.rs`](../pir-sdk-wasm/src/cashu.rs) |
+| HTTP client | [`web/src/payment-client.ts`](../web/src/payment-client.ts) |
+| BAT pool | [`web/src/cashu-bat.ts`](../web/src/cashu-bat.ts), [`web/src/credential-manager.ts`](../web/src/credential-manager.ts) |
+| Demo page | [`web/ratelimit-demo.html`](../web/ratelimit-demo.html), [`web/src/ratelimit-demo.ts`](../web/src/ratelimit-demo.ts) |
+| Server gate (prod) | [`runtime/src/bin/unified_server.rs`](../runtime/src/bin/unified_server.rs) (`--require-arc` / `--require-cashu`) |

--- a/pir-runtime-core/src/arc_verifier.rs
+++ b/pir-runtime-core/src/arc_verifier.rs
@@ -4,11 +4,16 @@
 //! seen tags in a per-`presentation_context` double-spend set to enforce the
 //! per-credential rate limit.
 
-use arc::group::serialize_element;
+use arc::group::{deserialize_scalar, serialize_element, serialize_scalar};
 use arc::{
     verify_presentation, Presentation, ServerPrivateKey, ServerPublicKey,
 };
 use std::collections::HashMap;
+
+/// Serialized size of an ARC private key: 4 × 32-byte scalars
+/// (`x0 || x1 || x2 || x0_blinding`). Must match the layout the issuer
+/// (`dev-issuer` / payment service `ArcIssuer`) writes to `arc_key.bin`.
+pub const ARC_PRIVKEY_SIZE: usize = 128;
 
 /// The fixed `request_context` that the payment service and the PIR server agree
 /// on. The client receives this value from the payment service alongside the
@@ -55,20 +60,30 @@ pub struct ArcVerifier {
 }
 
 impl ArcVerifier {
-    /// Create a new verifier from a serialized server keypair.
+    /// Load a verifier from a serialized 128-byte ARC private key
+    /// (`x0 || x1 || x2 || x0_blinding`, each a 32-byte big-endian scalar).
+    /// The public key is *derived* from the private key, so issuer and
+    /// verifier sharing the same `arc_key.bin` are guaranteed to agree.
     ///
-    /// `secret_key_bytes`: 128 bytes (4 × 32-byte scalars, big-endian).
-    /// `public_key_bytes`:  99 bytes (3 × 33-byte compressed P-256 points).
-    pub fn from_bytes(secret_key_bytes: &[u8], public_key_bytes: &[u8]) -> Result<Self, String> {
-        // secret_key_bytes is not directly deserializable from the arc crate's
-        // public API (ServerPrivateKey fields are private); the caller must
-        // use setup_server() + serialize with serde, or reconstruct field-by-field.
-        //
-        // For now, we generate a fresh keypair at startup to avoid exposing
-        // internal field layout.
-        let mut rng = rand_core::OsRng;
-        let (sk, pk) = arc::setup_server(&mut rng);
-        let _ = (secret_key_bytes, public_key_bytes);
+    /// This is the layout written by the `dev-issuer` and the payment
+    /// service's `ArcIssuer::load_or_generate`.
+    pub fn from_secret_key_bytes(secret_key_bytes: &[u8]) -> Result<Self, String> {
+        if secret_key_bytes.len() != ARC_PRIVKEY_SIZE {
+            return Err(format!(
+                "ARC private key must be {ARC_PRIVKEY_SIZE} bytes, got {}",
+                secret_key_bytes.len()
+            ));
+        }
+        let x0 = deserialize_scalar(&secret_key_bytes[0..32])
+            .map_err(|e| format!("bad x0 scalar: {e}"))?;
+        let x1 = deserialize_scalar(&secret_key_bytes[32..64])
+            .map_err(|e| format!("bad x1 scalar: {e}"))?;
+        let x2 = deserialize_scalar(&secret_key_bytes[64..96])
+            .map_err(|e| format!("bad x2 scalar: {e}"))?;
+        let x0_blinding = deserialize_scalar(&secret_key_bytes[96..128])
+            .map_err(|e| format!("bad x0_blinding scalar: {e}"))?;
+        let sk = ServerPrivateKey { x0, x1, x2, x0_blinding };
+        let pk = sk.public_key();
         Ok(Self {
             secret_key: sk,
             public_key: pk,
@@ -76,7 +91,19 @@ impl ArcVerifier {
         })
     }
 
+    /// Load a verifier from an `arc_key.bin` file written by the issuer.
+    pub fn from_secret_key_file(path: &std::path::Path) -> Result<Self, String> {
+        let bytes = std::fs::read(path)
+            .map_err(|e| format!("failed to read ARC key file {}: {e}", path.display()))?;
+        Self::from_secret_key_bytes(&bytes)
+    }
+
     /// Generate a fresh keypair. Used for testing or first-run setup.
+    ///
+    /// NOTE: a verifier created this way holds a random key, so credentials
+    /// issued by any *other* party will not verify. Production / demo
+    /// deployments must instead load a shared key via
+    /// [`Self::from_secret_key_file`].
     pub fn generate() -> Self {
         let mut rng = rand_core::OsRng;
         let (sk, pk) = arc::setup_server(&mut rng);
@@ -85,6 +112,18 @@ impl ArcVerifier {
             public_key: pk,
             seen_tags: HashMap::new(),
         }
+    }
+
+    /// Serialize the private key to the canonical 128-byte
+    /// `x0 || x1 || x2 || x0_blinding` layout (so the issuer can persist a
+    /// freshly generated key and the verifier can reload it).
+    pub fn secret_key_bytes(&self) -> [u8; ARC_PRIVKEY_SIZE] {
+        let mut out = [0u8; ARC_PRIVKEY_SIZE];
+        out[0..32].copy_from_slice(&serialize_scalar(&self.secret_key.x0));
+        out[32..64].copy_from_slice(&serialize_scalar(&self.secret_key.x1));
+        out[64..96].copy_from_slice(&serialize_scalar(&self.secret_key.x2));
+        out[96..128].copy_from_slice(&serialize_scalar(&self.secret_key.x0_blinding));
+        out
     }
 
     /// Serialize the public key for distribution to clients / payment service.
@@ -169,5 +208,112 @@ mod tests {
         let mut verifier = ArcVerifier::generate();
         verifier.remove_context(b"test");
         assert_eq!(verifier.context_count(), 0);
+    }
+
+    #[test]
+    fn test_secret_key_roundtrip() {
+        let v1 = ArcVerifier::generate();
+        let kb = v1.secret_key_bytes();
+        assert_eq!(kb.len(), ARC_PRIVKEY_SIZE);
+        // A verifier reloaded from the serialized key derives the same pubkey.
+        let v2 = ArcVerifier::from_secret_key_bytes(&kb).unwrap();
+        assert_eq!(v1.public_key_bytes(), v2.public_key_bytes());
+    }
+
+    #[test]
+    fn test_from_secret_key_bytes_rejects_wrong_size() {
+        assert!(ArcVerifier::from_secret_key_bytes(&[0u8; 64]).is_err());
+    }
+
+    /// The core de-risk: a credential issued under key K must present-and-verify
+    /// against a verifier that loaded the SAME key K from bytes. This exercises
+    /// the entire ARC path the demo depends on
+    /// (create_request → create_response → finalize → present → verify).
+    #[test]
+    fn test_full_issue_present_verify_loop_shared_key() {
+        let mut rng = rand_core::OsRng;
+
+        // Issuer generates a key and serializes it the way `arc_key.bin` is stored.
+        let (sk, _pk) = arc::setup_server(&mut rng);
+        let mut key_bytes = [0u8; ARC_PRIVKEY_SIZE];
+        key_bytes[0..32].copy_from_slice(&serialize_scalar(&sk.x0));
+        key_bytes[32..64].copy_from_slice(&serialize_scalar(&sk.x1));
+        key_bytes[64..96].copy_from_slice(&serialize_scalar(&sk.x2));
+        key_bytes[96..128].copy_from_slice(&serialize_scalar(&sk.x0_blinding));
+
+        // Verifier loads the SAME key from bytes (the from_secret_key_bytes fix).
+        let mut verifier = ArcVerifier::from_secret_key_bytes(&key_bytes).unwrap();
+
+        let limit = 50u64;
+        let request_context = DEFAULT_REQUEST_CONTEXT;
+        let presentation_context = b"demo-session-001";
+
+        // 1. Client builds a blinded credential request.
+        let (secrets, request) =
+            arc::create_credential_request(request_context, &mut rng).unwrap();
+
+        // 2. Issuer signs it with the shared key.
+        let response = arc::create_credential_response(
+            &verifier.secret_key,
+            &verifier.public_key,
+            &request,
+            &mut rng,
+        )
+        .unwrap();
+
+        // 3. Client finalizes into a 4-tuple credential.
+        let credential =
+            arc::finalize_credential(&secrets, &verifier.public_key, &request, &response).unwrap();
+
+        // 4. Client produces a presentation.
+        let state = arc::make_presentation_state(credential, presentation_context, limit);
+        let (_next_state, _nonce, presentation) = arc::present(&state, &mut rng).unwrap();
+
+        // 5. Server verifies — must succeed because it holds the same key.
+        let ok = verifier.verify(
+            request_context,
+            presentation_context,
+            &presentation.to_bytes(),
+            limit,
+        );
+        assert!(ok.is_ok(), "verify under shared key failed: {:?}", ok.err());
+
+        // 6. Replaying the exact same presentation is a duplicate tag.
+        let dup = verifier.verify(
+            request_context,
+            presentation_context,
+            &presentation.to_bytes(),
+            limit,
+        );
+        assert!(
+            matches!(dup, Err(ArcVerifyError::DuplicateTag)),
+            "expected DuplicateTag on replay, got {dup:?}"
+        );
+    }
+
+    /// Negative: a presentation issued under key A must NOT verify under a
+    /// different key B. Guards against the old `generate()`-on-startup bug
+    /// silently "passing" by checking against an unrelated random key.
+    #[test]
+    fn test_presentation_rejected_under_wrong_key() {
+        let mut rng = rand_core::OsRng;
+        let request_context = DEFAULT_REQUEST_CONTEXT;
+
+        // Issue + present under key A.
+        let (sk_a, pk_a) = arc::setup_server(&mut rng);
+        let (secrets, request) =
+            arc::create_credential_request(request_context, &mut rng).unwrap();
+        let response =
+            arc::create_credential_response(&sk_a, &pk_a, &request, &mut rng).unwrap();
+        let credential =
+            arc::finalize_credential(&secrets, &pk_a, &request, &response).unwrap();
+        let state = arc::make_presentation_state(credential, b"ctx", 50);
+        let (_s, _n, presentation) = arc::present(&state, &mut rng).unwrap();
+
+        // Verify under an unrelated key B.
+        let mut verifier_b = ArcVerifier::generate();
+        let result =
+            verifier_b.verify(request_context, b"ctx", &presentation.to_bytes(), 50);
+        assert!(result.is_err(), "presentation verified under the wrong key!");
     }
 }

--- a/pir-sdk-wasm/Cargo.toml
+++ b/pir-sdk-wasm/Cargo.toml
@@ -45,6 +45,13 @@ pir-sdk-client = { version = "0.1.0", path = "../pir-sdk-client" }
 # subsequent `upgradeToSecureChannel` handshake).
 pir-channel = { version = "0.1.0", path = "../pir-channel" }
 arc = { git = "https://github.com/Bitcoin-PIR/arc.git", rev = "de6c1709eee0faa32985d5a452be11904ee95de4" }
+# Cashu BDHKE blind/unblind (the `cashu` module's WasmCashuBlind). k256 +
+# sha2 compile cleanly to wasm32; the hash_to_curve here is byte-identical
+# to pir_runtime_core::cashu_verifier (asserted by the native cross-check
+# test, which presents a WASM-blinded BAT to the real CashuVerifier).
+k256 = { version = "0.13", features = ["arithmetic"] }
+sha2 = "0.10"
+hex = "0.4"
 rand_core = { version = "0.6", features = ["getrandom"] }
 # Browser-side AMD VCEK chain verifier (Slice D). Pure-Rust crypto
 # so the browser can chain-validate the SEV-SNP report's signature

--- a/pir-sdk-wasm/src/arc.rs
+++ b/pir-sdk-wasm/src/arc.rs
@@ -5,7 +5,9 @@
 
 use arc::group::{deserialize_element, deserialize_scalar, serialize_element, serialize_scalar};
 use arc::{
-    make_presentation_state, present, Credential, Presentation, PresentationState,
+    create_credential_request, finalize_credential, make_presentation_state, present,
+    ClientSecrets, Credential, CredentialRequest, CredentialResponse, PresentationState,
+    ServerPublicKey,
 };
 use wasm_bindgen::prelude::*;
 
@@ -132,6 +134,66 @@ impl WasmArcPresentationState {
     }
 }
 
+/// Opaque handle for the client side of ARC issuance ("obtain" leg).
+///
+/// Holds the per-request `ClientSecrets` (the blinding factors) **inside
+/// WASM** so they never cross into JS, alongside the `CredentialRequest`.
+/// Lifecycle:
+///
+/// 1. `new(request_context)` — build a blinded request (fresh `m1`, etc.).
+/// 2. `request_bytes()` — 226-byte body to POST to the issuer
+///    (`/dev/arc/issue`).
+/// 3. `finalize(pubkey, response)` — combine the issuer's 454-byte response
+///    with the held secrets into a 131-byte credential, ready for
+///    [`WasmArcPresentationState::new`].
+///
+/// `request_context` MUST match the value the verifier expects
+/// (`pir_runtime_core::arc_verifier::DEFAULT_REQUEST_CONTEXT` =
+/// `b"bitcoin-pir-v1"`); the issuer's `m2` is re-derived from it at
+/// presentation time.
+#[wasm_bindgen]
+pub struct WasmArcCredentialRequest {
+    secrets: ClientSecrets,
+    request: CredentialRequest,
+}
+
+#[wasm_bindgen]
+impl WasmArcCredentialRequest {
+    /// Build a fresh blinded credential request for `request_context`.
+    #[wasm_bindgen(constructor)]
+    pub fn new(request_context: &[u8]) -> Result<WasmArcCredentialRequest, JsError> {
+        let mut rng = rand_core::OsRng;
+        let (secrets, request) = create_credential_request(request_context, &mut rng)
+            .map_err(|e| JsError::new(&format!("create_credential_request failed: {}", e)))?;
+        Ok(WasmArcCredentialRequest { secrets, request })
+    }
+
+    /// The 226-byte `CredentialRequest` to POST to the issuer.
+    pub fn request_bytes(&self) -> Vec<u8> {
+        self.request.to_bytes().to_vec()
+    }
+
+    /// Finalize: combine the issuer's response with the held secrets.
+    ///
+    /// `pubkey_bytes`: 99-byte issuer `ServerPublicKey` (from
+    /// `GET /dev/arc/pubkey`).
+    /// `response_bytes`: 454-byte `CredentialResponse` (from
+    /// `POST /dev/arc/issue`).
+    ///
+    /// Returns the 131-byte credential blob for
+    /// [`WasmArcPresentationState::new`]. Throws if the response proof is
+    /// invalid (e.g. wrong issuer key).
+    pub fn finalize(&self, pubkey_bytes: &[u8], response_bytes: &[u8]) -> Result<Vec<u8>, JsError> {
+        let pk = ServerPublicKey::from_bytes(pubkey_bytes)
+            .map_err(|e| JsError::new(&format!("invalid issuer pubkey: {}", e)))?;
+        let response = CredentialResponse::from_bytes(response_bytes)
+            .map_err(|e| JsError::new(&format!("invalid credential response: {}", e)))?;
+        let credential = finalize_credential(&self.secrets, &pk, &self.request, &response)
+            .map_err(|e| JsError::new(&format!("finalize_credential failed: {}", e)))?;
+        Ok(serialize_credential(&credential).to_vec())
+    }
+}
+
 /// Serialize a credential to 131 bytes: `m1(32) || u(33) || u_prime(33) || x1(33)`.
 fn serialize_credential(cred: &Credential) -> [u8; 131] {
     let mut out = [0u8; 131];
@@ -140,4 +202,83 @@ fn serialize_credential(cred: &Credential) -> [u8; 131] {
     out[65..98].copy_from_slice(&serialize_element(&cred.u_prime));
     out[98..131].copy_from_slice(&serialize_element(&cred.x1));
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REQUEST_CONTEXT: &[u8] = b"bitcoin-pir-v1";
+
+    #[test]
+    fn request_bytes_is_226() {
+        let req = WasmArcCredentialRequest::new(REQUEST_CONTEXT)
+            .ok()
+            .expect("new request");
+        assert_eq!(req.request_bytes().len(), 226);
+    }
+
+    /// Full obtain leg in-process: request → (issuer responds) → finalize →
+    /// 131-byte credential → presentation state → present. Mirrors the
+    /// browser path with the HTTP hop replaced by a direct issuer call.
+    #[test]
+    fn wasm_obtain_leg_request_issue_finalize_present() {
+        let mut rng = rand_core::OsRng;
+        let (sk, pk) = arc::setup_server(&mut rng);
+
+        // Client builds the request via the WASM binding.
+        let req = WasmArcCredentialRequest::new(REQUEST_CONTEXT)
+            .ok()
+            .expect("new request");
+        let req_bytes = req.request_bytes();
+        assert_eq!(req_bytes.len(), 226);
+
+        // Issuer side (what dev-issuer does).
+        let parsed = CredentialRequest::from_bytes(&req_bytes).expect("parse request");
+        let response =
+            arc::create_credential_response(&sk, &pk, &parsed, &mut rng).expect("issue");
+        let resp_bytes = response.to_bytes();
+        assert_eq!(resp_bytes.len(), 454);
+
+        // Client finalizes via the WASM binding.
+        let pk_bytes = pk.to_bytes();
+        let cred = req
+            .finalize(&pk_bytes, &resp_bytes)
+            .ok()
+            .expect("finalize");
+        assert_eq!(cred.len(), 131);
+
+        // Feed into the presentation-state binding and present once.
+        let mut state = WasmArcPresentationState::new(&cred, b"wasm-sess", 16)
+            .ok()
+            .expect("presentation state");
+        assert_eq!(state.remaining(), 16);
+        let presentation = state.present().ok().expect("present");
+        assert!(!presentation.is_empty());
+        assert_eq!(state.remaining(), 15);
+    }
+
+    /// Finalizing against the WRONG issuer pubkey must fail (response proof
+    /// is bound to the issuing key).
+    ///
+    /// NOTE: we assert the underlying `arc::finalize_credential` rejection
+    /// rather than calling `WasmArcCredentialRequest::finalize` directly,
+    /// because that wrapper's error path constructs a `JsError`, which traps
+    /// ("cannot call wasm-bindgen imported functions") on non-wasm test
+    /// targets. The wrapper simply maps this `Err` to that `JsError`.
+    #[test]
+    fn finalize_rejects_wrong_pubkey() {
+        let mut rng = rand_core::OsRng;
+        let (sk, pk) = arc::setup_server(&mut rng);
+        let (_other_sk, other_pk) = arc::setup_server(&mut rng);
+
+        let (secrets, request) =
+            create_credential_request(REQUEST_CONTEXT, &mut rng).expect("request");
+        let response =
+            arc::create_credential_response(&sk, &pk, &request, &mut rng).expect("issue");
+
+        // Finalize with a different pubkey → must error at the arc layer.
+        let result = finalize_credential(&secrets, &other_pk, &request, &response);
+        assert!(result.is_err(), "finalize accepted the wrong issuer pubkey");
+    }
 }

--- a/pir-sdk-wasm/src/cashu.rs
+++ b/pir-sdk-wasm/src/cashu.rs
@@ -1,0 +1,225 @@
+//! WASM bindings for the Cashu Blind Auth (NUT-22) "obtain" leg.
+//!
+//! BDHKE over secp256k1: the client blinds a fresh secret, the mint
+//! blind-signs it, and the client unblinds the result into a single-use
+//! Blind Auth Token (BAT). The unblinded `(secret, C)` pair is then wrapped
+//! by `web/src/cashu-bat.ts`'s `CashuBatPool` into the `authA` wire token the
+//! PIR server's `CashuVerifier` checks.
+//!
+//! `hash_to_curve` here is byte-identical to
+//! `pir_runtime_core::cashu_verifier::hash_to_curve_cashu`; the native
+//! cross-check test presents a WASM-blinded BAT to the real `CashuVerifier`
+//! and asserts it verifies (the same WASM-mirror+cross-check pattern as
+//! `harmony_wire`).
+
+use k256::elliptic_curve::group::GroupEncoding;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::elliptic_curve::Group;
+use k256::{ProjectivePoint, Scalar};
+use rand_core::{OsRng, RngCore};
+use sha2::{Digest, Sha256};
+use wasm_bindgen::prelude::*;
+
+/// One in-flight Cashu blind/unblind. Holds the blinding scalar `r` and the
+/// secret **inside WASM** so neither crosses into JS until the BAT is
+/// assembled. Create one per BAT you want to mint.
+///
+/// Flow (one BAT):
+/// 1. `new()` — pick a fresh secret + `r`, compute `B' = Y + r·G`.
+/// 2. `blinded_message()` — 33-byte `B'` to POST to the mint.
+/// 3. `unblind(keyset_pubkey, signature)` — combine the mint's 33-byte `C'`
+///    into the unblinded 33-byte `C`.
+/// 4. wrap `{ secret_string(), hex(C) }` (+ keyset id) into a `Bat`.
+#[wasm_bindgen]
+pub struct WasmCashuBlind {
+    /// The Cashu "secret" as a 64-char hex string. `hash_to_curve` is taken
+    /// over its UTF-8 bytes (matching the verifier's `secret.into_bytes()`).
+    secret_hex: String,
+    /// Blinding factor, retained for unblinding.
+    r: Scalar,
+    /// Precomputed `B' = hash_to_curve(secret) + r·G`.
+    b_prime: [u8; 33],
+}
+
+#[wasm_bindgen]
+impl WasmCashuBlind {
+    /// Pick a fresh random secret + blinding factor and compute `B'`.
+    #[wasm_bindgen(constructor)]
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> WasmCashuBlind {
+        let mut rng = OsRng;
+        let mut secret_raw = [0u8; 32];
+        rng.fill_bytes(&mut secret_raw);
+        let secret_hex = hex::encode(secret_raw);
+        let r = Scalar::generate_vartime(&mut rng);
+
+        let y = hash_to_curve_cashu(secret_hex.as_bytes());
+        let b_prime_point = y + ProjectivePoint::GENERATOR * r;
+
+        WasmCashuBlind {
+            secret_hex,
+            r,
+            b_prime: compress(&b_prime_point),
+        }
+    }
+
+    /// The Cashu "secret" string (64-char hex) for the `authA` token.
+    pub fn secret_string(&self) -> String {
+        self.secret_hex.clone()
+    }
+
+    /// The 33-byte blinded message `B'` to POST to the mint
+    /// (`/dev/cashu/mint`).
+    pub fn blinded_message(&self) -> Vec<u8> {
+        self.b_prime.to_vec()
+    }
+
+    /// Unblind the mint's 33-byte `C'` with the keyset public key `K`
+    /// (33 bytes): `C = C' − r·K`. Returns the 33-byte unblinded signature
+    /// `C` (hex-encode it for the token's `C` field).
+    ///
+    /// Throws on a malformed point. (`C` verifies as `C == k·hash_to_curve
+    /// (secret)` on the server.)
+    pub fn unblind(&self, keyset_pubkey: &[u8], signature: &[u8]) -> Result<Vec<u8>, JsError> {
+        let k_point =
+            parse_point(keyset_pubkey).ok_or_else(|| JsError::new("invalid keyset pubkey (want 33-byte compressed point)"))?;
+        let c_prime =
+            parse_point(signature).ok_or_else(|| JsError::new("invalid blind signature (want 33-byte compressed point)"))?;
+        let c = c_prime - k_point * self.r;
+        Ok(compress(&c).to_vec())
+    }
+}
+
+/// Cashu NUT-00 hash-to-curve. Byte-identical to
+/// `pir_runtime_core::cashu_verifier::hash_to_curve_cashu`:
+/// `msg = SHA256("Secp256k1_HashToCurve_Cashu_" || secret)`, then for
+/// `counter = 0,1,…` lift `0x02 || SHA256(msg || u32_le(counter))` until a
+/// valid non-identity point is found.
+fn hash_to_curve_cashu(secret: &[u8]) -> ProjectivePoint {
+    let mut hasher = Sha256::new();
+    hasher.update(b"Secp256k1_HashToCurve_Cashu_");
+    hasher.update(secret);
+    let msg_hash = hasher.finalize();
+
+    for counter in 0u32.. {
+        let mut h = Sha256::new();
+        h.update(msg_hash);
+        h.update(counter.to_le_bytes());
+        let digest: [u8; 32] = h.finalize().into();
+
+        let mut point_bytes = [0u8; 33];
+        point_bytes[0] = 0x02;
+        point_bytes[1..].copy_from_slice(&digest);
+
+        if let Some(point) =
+            Option::<ProjectivePoint>::from(ProjectivePoint::from_bytes(&point_bytes.into()))
+        {
+            if !bool::from(point.is_identity()) {
+                return point;
+            }
+        }
+    }
+    unreachable!("secp256k1 has ~2^256 points; a valid lift is found well within 2^32 counters")
+}
+
+/// Parse a 33-byte compressed point.
+fn parse_point(bytes: &[u8]) -> Option<ProjectivePoint> {
+    let arr: [u8; 33] = bytes.try_into().ok()?;
+    Option::<ProjectivePoint>::from(ProjectivePoint::from_bytes(&arr.into()))
+}
+
+/// Compress a point to 33 bytes (SEC1).
+fn compress(p: &ProjectivePoint) -> [u8; 33] {
+    let enc = p.to_affine().to_encoded_point(true);
+    let mut out = [0u8; 33];
+    out.copy_from_slice(enc.as_bytes());
+    out
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    /// URL-safe base64 without padding (matches `cashu_verifier::base64url_decode`).
+    fn base64url_nopad(data: &[u8]) -> String {
+        const ALPHA: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        let mut out = String::new();
+        for chunk in data.chunks(3) {
+            let b0 = chunk[0];
+            let b1 = *chunk.get(1).unwrap_or(&0);
+            let b2 = *chunk.get(2).unwrap_or(&0);
+            out.push(ALPHA[(b0 >> 2) as usize] as char);
+            out.push(ALPHA[(((b0 & 0x03) << 4) | (b1 >> 4)) as usize] as char);
+            if chunk.len() > 1 {
+                out.push(ALPHA[(((b1 & 0x0f) << 2) | (b2 >> 6)) as usize] as char);
+            }
+            if chunk.len() > 2 {
+                out.push(ALPHA[(b2 & 0x3f) as usize] as char);
+            }
+        }
+        out
+    }
+
+    /// The ultimate cross-check: a BAT blinded+unblinded entirely via
+    /// `WasmCashuBlind`, blind-signed by a k256 mint key, must verify under
+    /// the REAL `pir_runtime_core::cashu_verifier::CashuVerifier`. If this
+    /// module's hash_to_curve or the BDHKE math drifted from the server, the
+    /// verify would fail.
+    #[test]
+    fn wasm_blinded_bat_verifies_under_real_cashu_verifier() {
+        let mut rng = OsRng;
+
+        // Mint keyset.
+        let k = Scalar::generate_vartime(&mut rng);
+        let keyset_pubkey = compress(&(ProjectivePoint::GENERATOR * k));
+        let keyset_id = format!("{}-auth", &hex::encode(keyset_pubkey)[..16]);
+        let k_hex = hex::encode(k.to_bytes());
+
+        // Client blinds via the WASM binding.
+        let blind = WasmCashuBlind::new();
+        let secret = blind.secret_string();
+        let b_prime = blind.blinded_message();
+        assert_eq!(b_prime.len(), 33);
+
+        // Mint: C' = k · B'.
+        let b_point = parse_point(&b_prime).expect("B' point");
+        let c_prime = compress(&(b_point * k));
+
+        // Client unblinds via the WASM binding.
+        let c = blind.unblind(&keyset_pubkey, &c_prime).ok().expect("unblind");
+        let c_hex = hex::encode(&c);
+
+        // Assemble the authA token exactly as cashu-bat.ts does.
+        let json = format!(
+            "{{\"id\":\"{}\",\"secret\":\"{}\",\"C\":\"{}\"}}",
+            keyset_id, secret, c_hex
+        );
+        let token = format!("authA{}", base64url_nopad(json.as_bytes()));
+
+        // Verify under the real server verifier.
+        let mut verifier = pir_runtime_core::cashu_verifier::CashuVerifier::from_keys(&[(
+            keyset_id.clone(),
+            k_hex,
+        )])
+        .expect("verifier");
+        assert!(
+            verifier.verify(&token).is_ok(),
+            "WASM-blinded BAT failed verification under the real CashuVerifier"
+        );
+
+        // Single-use: replay must be rejected as already spent.
+        assert!(
+            verifier.verify(&token).is_err(),
+            "replaying the same BAT should fail (double-spend)"
+        );
+    }
+
+    #[test]
+    fn distinct_blinds_have_distinct_secrets() {
+        let a = WasmCashuBlind::new();
+        let b = WasmCashuBlind::new();
+        assert_ne!(a.secret_string(), b.secret_string());
+        assert_ne!(a.blinded_message(), b.blinded_message());
+        assert_eq!(a.secret_string().len(), 64);
+    }
+}

--- a/pir-sdk-wasm/src/lib.rs
+++ b/pir-sdk-wasm/src/lib.rs
@@ -54,6 +54,11 @@ pub use merkle_verify::{
 /// unlinkable rate-limited credential presentations.
 pub mod arc;
 
+/// Cashu Blind Auth (NUT-22) client-side BDHKE. Exposes `WasmCashuBlind`
+/// for the browser to blind a secret, send it to the mint, and unblind the
+/// returned signature into a single-use BAT.
+pub mod cashu;
+
 /// Async PIR clients (`WasmDpfClient` / `WasmHarmonyClient`) wrapping the
 /// native `pir-sdk-client` structs. On wasm32 they use
 /// `WasmWebSocketTransport` under the hood; on native (for unit tests)
@@ -1104,6 +1109,12 @@ mod tests {
             dpf_n_index: 13,
             dpf_n_chunk: 14,
             has_bucket_merkle,
+            // Chain-anchored fields added to DatabaseInfo after this helper
+            // was written; default to legacy (no seeds / no anchor).
+            index_master_seed: 0,
+            chunk_master_seed: 0,
+            anchor_kind: 0,
+            anchor_bytes: Vec::new(),
         }
     }
 

--- a/runtime/src/bin/unified_server.rs
+++ b/runtime/src/bin/unified_server.rs
@@ -116,6 +116,11 @@ struct CliArgs {
     pool_dir: Option<PathBuf>,
     /// Require ARC credential presentation before serving PIR queries.
     require_arc: bool,
+    /// Path to the 128-byte ARC private key (`arc_key.bin`) shared with the
+    /// issuer. When set with `--require-arc`, the verifier loads this key so
+    /// externally-issued credentials verify. Without it, a random key is
+    /// generated (no external credential can verify — dev/test only).
+    arc_key_path: Option<PathBuf>,
     require_cashu: bool,
     cashu_keysets: Vec<(String, String)>,
     /// Whether this server accepts HarmonyPIR hint requests
@@ -167,6 +172,7 @@ fn parse_args() -> CliArgs {
     let mut pool_size: usize = 0; // 0 = pool disabled
     let mut pool_dir: Option<PathBuf> = None;
     let mut require_arc = false;
+    let mut arc_key_path: Option<PathBuf> = None;
     let mut require_cashu = false;
     let mut cashu_keysets: Vec<(String, String)> = Vec::new();
     let mut serve_hints = false;
@@ -255,6 +261,12 @@ fn parse_args() -> CliArgs {
             "--require-arc" => {
                 require_arc = true;
             }
+            "--arc-key" => {
+                if let Some(p) = args.get(i + 1) {
+                    arc_key_path = Some(PathBuf::from(p));
+                }
+                i += 1;
+            }
             "--require-cashu" => {
                 require_cashu = true;
             }
@@ -297,7 +309,7 @@ fn parse_args() -> CliArgs {
         i += 1;
     }
 
-    CliArgs { port, data_dir, role, warmup, config_path, checkpoints, deltas, admin_pubkey_hex, disable_onion, vcek_dir, pool_size, pool_dir, require_arc, require_cashu, cashu_keysets, serve_hints, serve_queries, identity_key_path, identity_cert_path, identity_server_id }
+    CliArgs { port, data_dir, role, warmup, config_path, checkpoints, deltas, admin_pubkey_hex, disable_onion, vcek_dir, pool_size, pool_dir, require_arc, arc_key_path, require_cashu, cashu_keysets, serve_hints, serve_queries, identity_key_path, identity_cert_path, identity_server_id }
 }
 
 // ─── OnionPIR worker thread ─────────────────────────────────────────────────
@@ -2491,8 +2503,26 @@ async fn main() {
 
     // ── Initialize HarmonyPIR V2 hint pool (if enabled) ──────────────────
     let (arc_verifier, require_arc) = if args.require_arc {
-        let verifier = pir_runtime_core::arc_verifier::ArcVerifier::generate();
-        println!("  ARC: enabled — credential verification required");
+        let verifier = match &args.arc_key_path {
+            Some(path) => {
+                let v = pir_runtime_core::arc_verifier::ArcVerifier::from_secret_key_file(path)
+                    .unwrap_or_else(|e| panic!("failed to load ARC key from {}: {e}", path.display()));
+                println!(
+                    "  ARC: enabled — verification required (shared key loaded from {})",
+                    path.display()
+                );
+                v
+            }
+            None => {
+                let v = pir_runtime_core::arc_verifier::ArcVerifier::generate();
+                eprintln!(
+                    "  ARC: WARNING — --require-arc set without --arc-key; generated a random \
+                     key. No externally-issued credential will verify. Pass --arc-key <arc_key.bin> \
+                     to share the issuer's key."
+                );
+                v
+            }
+        };
         (Some(std::sync::Mutex::new(verifier)), true)
     } else {
         println!("  ARC: disabled (use --require-arc to enable)");

--- a/web/ratelimit-demo.html
+++ b/web/ratelimit-demo.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bitcoin PIR — Anonymous Rate-Limiting Demo (ARC + Cashu)</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body {
+        font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+        max-width: 960px; margin: 0 auto; padding: 24px; line-height: 1.5;
+      }
+      h1 { font-size: 1.5rem; margin-bottom: 4px; }
+      .sub { color: #666; margin-top: 0; }
+      .note {
+        background: #fff7e6; border: 1px solid #f0d28a; border-radius: 8px;
+        padding: 12px 16px; font-size: 0.9rem; margin: 16px 0;
+      }
+      .note code { background: #00000010; padding: 1px 5px; border-radius: 4px; }
+      .config { margin: 16px 0; }
+      .config label { font-weight: 600; margin-right: 8px; }
+      .config input { padding: 6px 8px; border: 1px solid #ccc; border-radius: 6px; }
+      .banner {
+        margin: 10px 0; padding: 8px 12px; border-radius: 6px; font-size: 0.85rem;
+        font-family: ui-monospace, monospace;
+      }
+      .banner.ok { background: #e6f7ec; border: 1px solid #8ad6a4; color: #0a5; }
+      .banner.err { background: #fdecec; border: 1px solid #f0a0a0; color: #c33; }
+      .banner.checking { background: #eef; border: 1px solid #aac; color: #559; }
+      .cols { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+      @media (max-width: 720px) { .cols { grid-template-columns: 1fr; } }
+      .card { border: 1px solid #ddd; border-radius: 10px; padding: 16px; }
+      .card h2 { font-size: 1.15rem; margin: 0 0 4px; }
+      .card .tag { font-size: 0.8rem; color: #666; margin-bottom: 12px; }
+      .row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 8px 0; }
+      .row input[type="number"] { width: 64px; padding: 4px 6px; }
+      button {
+        padding: 7px 12px; border: 1px solid #0a5; background: #0a5; color: #fff;
+        border-radius: 6px; cursor: pointer; font-size: 0.9rem;
+      }
+      button.secondary { background: #fff; color: #0a5; }
+      button:disabled { opacity: 0.45; cursor: not-allowed; }
+      .status { font-weight: 600; margin: 10px 0 6px; }
+      .meter { display: flex; gap: 3px; flex-wrap: wrap; margin-bottom: 10px; min-height: 16px; }
+      .meter .cell { width: 14px; height: 14px; border-radius: 3px; }
+      .meter .full { background: #0a5; }
+      .meter .spent { background: #ddd; }
+      .log {
+        background: #1118; color: #cde; font-family: ui-monospace, monospace;
+        font-size: 0.78rem; border-radius: 6px; padding: 8px; height: 180px;
+        overflow-y: auto; white-space: pre-wrap;
+      }
+      .log .line.ok { color: #8f8; }
+      .log .line.err { color: #f99; }
+      .log .line.info { color: #bcd; }
+    </style>
+  </head>
+  <body>
+    <h1>Anonymous Rate-Limiting Demo</h1>
+    <p class="sub">
+      ARC (multi-show credential) vs Cashu Blind Auth (single-show tokens),
+      end-to-end: <strong>mint → obtain → present → verify</strong>.
+    </p>
+
+    <div class="note">
+      This demo is self-contained — it talks only to the <strong>dev-issuer</strong>
+      (free issuance, no Lightning, no PIR database). Start it first:
+      <br /><code>cargo run -p dev-issuer</code>
+      &nbsp;then&nbsp;<code>cd web &amp;&amp; npm run dev</code>.
+      <br />The dev-issuer co-locates the <em>verify</em> gate (identical crypto to
+      the PIR server's <code>unified_server</code> gate), so no PIR server is needed.
+      In production the same present frames go over WebSocket to the PIR server.
+    </div>
+
+    <div class="config">
+      <label for="issuer">Issuer URL</label>
+      <input id="issuer" type="text" size="32" value="http://127.0.0.1:5601" />
+      <button id="issuer-check" class="secondary">Check</button>
+    </div>
+    <div class="banner checking" id="issuer-banner">Checking issuer…</div>
+
+    <div class="cols">
+      <!-- ARC -->
+      <div class="card">
+        <h2>ARC</h2>
+        <div class="tag">Multi-show: one credential → N unlinkable presentations.</div>
+        <div class="row">
+          <label for="arc-limit">limit</label>
+          <input id="arc-limit" type="number" min="1" max="64" value="8" />
+          <button id="arc-mint">Mint credential</button>
+          <button id="arc-run" class="secondary">Run to exhaustion</button>
+        </div>
+        <div class="row">
+          <button id="arc-present" class="secondary" disabled>Present once</button>
+          <button id="arc-replay" class="secondary" disabled>Replay last (rejected)</button>
+        </div>
+        <div class="status" id="arc-status">No credential yet.</div>
+        <div class="meter" id="arc-meter"></div>
+        <div class="log" id="arc-log"></div>
+      </div>
+
+      <!-- Cashu -->
+      <div class="card">
+        <h2>Cashu Blind Auth</h2>
+        <div class="tag">Single-show: a pool of one-time BATs, each spent once.</div>
+        <div class="row">
+          <label for="cashu-count">count</label>
+          <input id="cashu-count" type="number" min="1" max="64" value="5" />
+          <button id="cashu-mint">Mint BAT pool</button>
+          <button id="cashu-run" class="secondary">Mint + spend all</button>
+        </div>
+        <div class="row">
+          <button id="cashu-present" class="secondary" disabled>Spend one</button>
+          <button id="cashu-replay" class="secondary" disabled>Replay last (double-spend)</button>
+        </div>
+        <div class="status" id="cashu-status">No pool yet.</div>
+        <div class="meter" id="cashu-meter"></div>
+        <div class="log" id="cashu-log"></div>
+      </div>
+    </div>
+
+    <script type="module" src="/src/ratelimit-demo.ts"></script>
+  </body>
+</html>

--- a/web/src/__tests__/payment-client.test.ts
+++ b/web/src/__tests__/payment-client.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  getArcPubkey,
+  issueArcCredential,
+  getCashuKeyset,
+  mintCashuBats,
+  presentArc,
+  presentCashu,
+  ARC_PUBKEY_BYTES,
+  ARC_REQUEST_BYTES,
+  ARC_RESPONSE_BYTES,
+  CASHU_POINT_BYTES,
+} from '../payment-client.js';
+
+function okResponse(bytes: Uint8Array): Response {
+  return new Response(bytes as BodyInit, { status: 200 });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('getArcPubkey', () => {
+  it('returns the 99-byte pubkey and hits the right URL', async () => {
+    const pubkey = new Uint8Array(ARC_PUBKEY_BYTES).fill(7);
+    const fetchMock = vi.fn(async () => okResponse(pubkey));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const out = await getArcPubkey('http://localhost:5601');
+    expect(out.length).toBe(ARC_PUBKEY_BYTES);
+    expect(out[0]).toBe(7);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:5601/dev/arc/pubkey',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('normalizes a trailing slash in the base URL', async () => {
+    const fetchMock = vi.fn(async () => okResponse(new Uint8Array(ARC_PUBKEY_BYTES)));
+    vi.stubGlobal('fetch', fetchMock);
+    await getArcPubkey('http://localhost:5601/');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:5601/dev/arc/pubkey',
+      expect.anything(),
+    );
+  });
+
+  it('throws on a wrong-length pubkey', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okResponse(new Uint8Array(98))));
+    await expect(getArcPubkey('http://x')).rejects.toThrow(/expected 99 bytes, got 98/);
+  });
+
+  it('throws on an HTTP error status', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 500 })));
+    await expect(getArcPubkey('http://x')).rejects.toThrow(/HTTP 500/);
+  });
+
+  it('throws a clear error when the issuer is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+    await expect(getArcPubkey('http://x')).rejects.toThrow(/unreachable/);
+  });
+});
+
+describe('issueArcCredential', () => {
+  it('rejects a wrong-length request before fetching', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(
+      issueArcCredential('http://x', new Uint8Array(10)),
+    ).rejects.toThrow(/expected 226 bytes, got 10/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts the request and returns the 454-byte response', async () => {
+    const response = new Uint8Array(ARC_RESPONSE_BYTES).fill(3);
+    const fetchMock = vi.fn(async () => okResponse(response));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const out = await issueArcCredential(
+      'http://localhost:5601',
+      new Uint8Array(ARC_REQUEST_BYTES).fill(9),
+    );
+    expect(out.length).toBe(ARC_RESPONSE_BYTES);
+    expect(out[0]).toBe(3);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('http://localhost:5601/dev/arc/issue');
+    expect(init.method).toBe('POST');
+  });
+
+  it('surfaces the issuer error body on HTTP 400', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('invalid CredentialRequest', { status: 400 })),
+    );
+    await expect(
+      issueArcCredential('http://x', new Uint8Array(ARC_REQUEST_BYTES)),
+    ).rejects.toThrow(/HTTP 400 — invalid CredentialRequest/);
+  });
+
+  it('throws on a wrong-length response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okResponse(new Uint8Array(100))));
+    await expect(
+      issueArcCredential('http://x', new Uint8Array(ARC_REQUEST_BYTES)),
+    ).rejects.toThrow(/expected 454 bytes, got 100/);
+  });
+});
+
+function jsonResponse(obj: unknown): Response {
+  return new Response(JSON.stringify(obj), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const PUBKEY_HEX = '02' + 'ab'.repeat(32); // 66 hex chars → 33 bytes
+
+describe('getCashuKeyset', () => {
+  it('returns {id, pubkey(33)} and hits the right URL', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ id: '02abcd-auth', pubkey: PUBKEY_HEX }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const keyset = await getCashuKeyset('http://localhost:5601/');
+    expect(keyset.id).toBe('02abcd-auth');
+    expect(keyset.pubkey.length).toBe(CASHU_POINT_BYTES);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:5601/dev/cashu/keyset',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('throws on a non-33-byte pubkey', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ id: 'x', pubkey: '02ab' })));
+    await expect(getCashuKeyset('http://x')).rejects.toThrow(/expected 33 bytes/);
+  });
+
+  it('throws on missing fields', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ id: 'x' })));
+    await expect(getCashuKeyset('http://x')).rejects.toThrow(/missing string id\/pubkey/);
+  });
+
+  it('throws on an HTTP error status', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 503 })));
+    await expect(getCashuKeyset('http://x')).rejects.toThrow(/HTTP 503/);
+  });
+});
+
+describe('mintCashuBats', () => {
+  it('rejects a non-multiple-of-33 batch before fetching', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(mintCashuBats('http://x', new Uint8Array(40))).rejects.toThrow(
+      /non-empty multiple of 33 bytes, got 40/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty batch', async () => {
+    vi.stubGlobal('fetch', vi.fn());
+    await expect(mintCashuBats('http://x', new Uint8Array(0))).rejects.toThrow(
+      /non-empty multiple of 33/,
+    );
+  });
+
+  it('posts N×33 and returns N×33 signatures', async () => {
+    const sigs = new Uint8Array(2 * CASHU_POINT_BYTES).fill(5);
+    const fetchMock = vi.fn(async () => okResponse(sigs));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const out = await mintCashuBats(
+      'http://localhost:5601',
+      new Uint8Array(2 * CASHU_POINT_BYTES).fill(2),
+    );
+    expect(out.length).toBe(2 * CASHU_POINT_BYTES);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('http://localhost:5601/dev/cashu/mint');
+    expect(init.method).toBe('POST');
+  });
+
+  it('throws when the response count does not match the request', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => okResponse(new Uint8Array(CASHU_POINT_BYTES))));
+    await expect(
+      mintCashuBats('http://x', new Uint8Array(2 * CASHU_POINT_BYTES)),
+    ).rejects.toThrow(/expected 66 bytes back/);
+  });
+
+  it('surfaces the mint error body on HTTP 400', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('invalid blinded point encoding', { status: 400 })),
+    );
+    await expect(
+      mintCashuBats('http://x', new Uint8Array(CASHU_POINT_BYTES)),
+    ).rejects.toThrow(/HTTP 400 — invalid blinded point encoding/);
+  });
+});
+
+describe('presentArc / presentCashu', () => {
+  // A fake present frame: [4B len][payload]. The helper strips the 4B prefix.
+  const frame = new Uint8Array([99, 0, 0, 0, 0x08, 0xaa, 0xbb, 0xcc]);
+
+  it('presentArc returns {ok:true} on 200 and strips the length prefix', async () => {
+    const fetchMock = vi.fn(async () => new Response('ok\n', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await presentArc('http://localhost:5601', frame);
+    expect(result.ok).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('http://localhost:5601/dev/arc/verify');
+    // Body is the frame minus the 4-byte length prefix → [0x08,0xaa,0xbb,0xcc].
+    expect((init.body as Uint8Array).length).toBe(frame.length - 4);
+    expect((init.body as Uint8Array)[0]).toBe(0x08);
+  });
+
+  it('presentArc returns {ok:false, reason} on 400', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('duplicate ARC tag — nonce reused', { status: 400 })),
+    );
+    const result = await presentArc('http://x', frame);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/duplicate ARC tag/);
+  });
+
+  it('presentCashu hits the cashu verify endpoint', async () => {
+    const fetchMock = vi.fn(async () => new Response('ok\n', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const cashuFrame = new Uint8Array([5, 0, 0, 0, 0x09, 0x61, 0x75, 0x74, 0x68]);
+    const result = await presentCashu('http://x', cashuFrame);
+    expect(result.ok).toBe(true);
+    const [url] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('http://x/dev/cashu/verify');
+  });
+
+  it('presentCashu reports double-spend rejection', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('BAT already spent', { status: 400 })));
+    const result = await presentCashu('http://x', new Uint8Array([1, 0, 0, 0, 0x09]));
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/already spent/);
+  });
+});

--- a/web/src/cashu-bat.ts
+++ b/web/src/cashu-bat.ts
@@ -21,6 +21,13 @@
  */
 
 import { REQ_CASHU_BAT_PRESENT } from './constants';
+import { bytesToHex } from './hash.js';
+import { initSdkWasm, requireSdkWasm } from './sdk-bridge.js';
+import {
+  getCashuKeyset,
+  mintCashuBats,
+  CASHU_POINT_BYTES,
+} from './payment-client.js';
 
 /**
  * A single unspent Blind Auth Token.
@@ -98,4 +105,56 @@ export class CashuBatPool {
     frame.set(payload, 4);
     return frame;
   }
+}
+
+/**
+ * Mint a pool of `count` single-use BATs from a Cashu mint (the "obtain" leg).
+ *
+ * Runs the full BDHKE flow: for each BAT, blind a fresh secret in WASM
+ * (`WasmCashuBlind`), batch the blinded messages to the mint, then unblind
+ * each returned signature into a `Bat`. The blinding factors never leave
+ * WASM.
+ *
+ * Requires the SDK WASM module (initialised here, idempotently). In the demo
+ * `issuerUrl` is the `dev-issuer`; in production it would be the
+ * Lightning-backed mint after a paid invoice.
+ *
+ * @throws if `count` is not a positive integer, the mint is unreachable, or
+ *   the response is malformed (errors surface from `payment-client`).
+ */
+export async function mintBatPool(
+  issuerUrl: string,
+  count: number,
+): Promise<CashuBatPool> {
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new Error(`mintBatPool: count must be a positive integer, got ${count}`);
+  }
+
+  await initSdkWasm();
+  const sdk = requireSdkWasm();
+
+  const keyset = await getCashuKeyset(issuerUrl);
+
+  // One blind per BAT; concatenate the 33-byte blinded messages.
+  const blinds = Array.from({ length: count }, () => new sdk.WasmCashuBlind());
+  const blinded = new Uint8Array(count * CASHU_POINT_BYTES);
+  blinds.forEach((b, i) => blinded.set(b.blinded_message(), i * CASHU_POINT_BYTES));
+
+  // Mint → N blind signatures C', in the same order.
+  const sigs = await mintCashuBats(issuerUrl, blinded);
+
+  // Unblind each into a BAT, then release the WASM handle.
+  const bats: Bat[] = blinds.map((b, i) => {
+    const sig = sigs.slice(i * CASHU_POINT_BYTES, (i + 1) * CASHU_POINT_BYTES);
+    const c = b.unblind(keyset.pubkey, sig);
+    const bat: Bat = {
+      keysetId: keyset.id,
+      secret: b.secret_string(),
+      signature: bytesToHex(c),
+    };
+    b.free();
+    return bat;
+  });
+
+  return new CashuBatPool(bats);
 }

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -197,3 +197,22 @@ export {
 export { ArcCredentialManager, ARC_LOW_WARNING } from './credential-manager.js';
 export type { ArcCredentialState } from './credential-manager.js';
 export { sendArcPresentation } from './arc-present.js';
+
+// Cashu Blind Auth (NUT-22) rate limiting
+export { CashuBatPool, mintBatPool } from './cashu-bat.js';
+export type { Bat } from './cashu-bat.js';
+
+// Credential issuer HTTP client (the "obtain" leg)
+export {
+  getArcPubkey,
+  issueArcCredential,
+  getCashuKeyset,
+  mintCashuBats,
+  presentArc,
+  presentCashu,
+  ARC_PUBKEY_BYTES,
+  ARC_REQUEST_BYTES,
+  ARC_RESPONSE_BYTES,
+  CASHU_POINT_BYTES,
+} from './payment-client.js';
+export type { CashuKeyset, PresentResult } from './payment-client.js';

--- a/web/src/payment-client.ts
+++ b/web/src/payment-client.ts
@@ -1,0 +1,268 @@
+/**
+ * HTTP client for the credential issuer (the "obtain" leg of anonymous
+ * rate-limiting).
+ *
+ * In the demo this talks to `dev-issuer` — a DEV-ONLY free issuer with no
+ * payment. In production the same endpoints would be served by the
+ * Lightning-backed payment service after a paid invoice. Either way the wire
+ * shapes are identical: raw binary bodies, no JSON.
+ *
+ * Typical ARC obtain flow (pairs with the `WasmArcCredentialRequest` WASM
+ * binding and `ArcCredentialManager`):
+ *
+ *   import { WasmArcCredentialRequest } from '<wasm pkg>';
+ *   import { getArcPubkey, issueArcCredential } from './payment-client';
+ *   import { ArcCredentialManager } from './credential-manager';
+ *
+ *   const req = new WasmArcCredentialRequest(REQUEST_CONTEXT);   // 1. build request
+ *   const pubkey   = await getArcPubkey(issuerUrl);              // 2. issuer pubkey
+ *   const response = await issueArcCredential(issuerUrl,
+ *                                             req.request_bytes()); // 3. issue
+ *   const credBytes = req.finalize(pubkey, response);            // 4. finalize → 131B
+ *   const mgr = new ArcCredentialManager(credBytes, presCtx, limit);
+ *
+ * (Cashu mint method added in Phase 2.)
+ */
+
+import { hexToBytes } from './hash.js';
+
+/** Byte sizes pinned to the arc crate's wire formats (P-256, NE=33, NS=32). */
+export const ARC_PUBKEY_BYTES = 99;
+export const ARC_REQUEST_BYTES = 226;
+export const ARC_RESPONSE_BYTES = 454;
+
+/** Compressed secp256k1 point size (Cashu blinded messages / signatures). */
+export const CASHU_POINT_BYTES = 33;
+
+/** Trim a trailing slash so `${base}/dev/...` never doubles up. */
+function normalizeBase(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+async function readBytes(resp: Response): Promise<Uint8Array> {
+  const buf = await resp.arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+/**
+ * Fetch the issuer's ARC public key (99-byte `ServerPublicKey`).
+ *
+ * Pass this to `WasmArcCredentialRequest.finalize(pubkey, response)`.
+ * @throws if the issuer is unreachable, errors, or returns the wrong length.
+ */
+export async function getArcPubkey(issuerUrl: string): Promise<Uint8Array> {
+  const url = `${normalizeBase(issuerUrl)}/dev/arc/pubkey`;
+  let resp: Response;
+  try {
+    resp = await fetch(url, { method: 'GET' });
+  } catch (e) {
+    throw new Error(`issuer unreachable at ${url}: ${(e as Error).message}`);
+  }
+  if (!resp.ok) {
+    throw new Error(`GET ${url} failed: HTTP ${resp.status}`);
+  }
+  const bytes = await readBytes(resp);
+  if (bytes.length !== ARC_PUBKEY_BYTES) {
+    throw new Error(
+      `ARC pubkey: expected ${ARC_PUBKEY_BYTES} bytes, got ${bytes.length}`,
+    );
+  }
+  return bytes;
+}
+
+/**
+ * Submit a blinded 226-byte `CredentialRequest` and receive the issuer's
+ * 454-byte `CredentialResponse`.
+ *
+ * `requestBytes` comes from `WasmArcCredentialRequest.request_bytes()`; feed
+ * the returned bytes to `.finalize(pubkey, response)`.
+ * @throws if the request length is wrong, the issuer rejects it (HTTP 4xx),
+ *   or the response length is unexpected.
+ */
+export async function issueArcCredential(
+  issuerUrl: string,
+  requestBytes: Uint8Array,
+): Promise<Uint8Array> {
+  if (requestBytes.length !== ARC_REQUEST_BYTES) {
+    throw new Error(
+      `ARC request: expected ${ARC_REQUEST_BYTES} bytes, got ${requestBytes.length}`,
+    );
+  }
+  const url = `${normalizeBase(issuerUrl)}/dev/arc/issue`;
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      // Copy into a fresh ArrayBuffer so a Uint8Array view with a non-zero
+      // byteOffset (e.g. a subarray) is sent correctly.
+      body: requestBytes.slice(),
+    });
+  } catch (e) {
+    throw new Error(`issuer unreachable at ${url}: ${(e as Error).message}`);
+  }
+  if (!resp.ok) {
+    const detail = await resp.text().catch(() => '');
+    throw new Error(
+      `POST ${url} failed: HTTP ${resp.status}${detail ? ` — ${detail.trim()}` : ''}`,
+    );
+  }
+  const bytes = await readBytes(resp);
+  if (bytes.length !== ARC_RESPONSE_BYTES) {
+    throw new Error(
+      `ARC response: expected ${ARC_RESPONSE_BYTES} bytes, got ${bytes.length}`,
+    );
+  }
+  return bytes;
+}
+
+// ─── Cashu Blind Auth (NUT-22) ────────────────────────────────────────────
+
+/** A Cashu keyset as published by the mint. */
+export interface CashuKeyset {
+  /** Keyset id string (e.g. `02ab…-auth`); goes in the authA token's `id`. */
+  id: string;
+  /** Mint public key `K = k·G` (33-byte compressed point), for unblinding. */
+  pubkey: Uint8Array;
+}
+
+/**
+ * Fetch the mint's Cashu keyset (`{id, pubkey}`).
+ *
+ * Pass `pubkey` to `WasmCashuBlind.unblind(pubkey, signature)` and `id` into
+ * each minted `Bat`.
+ * @throws if unreachable, errors, or the pubkey isn't a 33-byte point.
+ */
+export async function getCashuKeyset(issuerUrl: string): Promise<CashuKeyset> {
+  const url = `${normalizeBase(issuerUrl)}/dev/cashu/keyset`;
+  let resp: Response;
+  try {
+    resp = await fetch(url, { method: 'GET' });
+  } catch (e) {
+    throw new Error(`issuer unreachable at ${url}: ${(e as Error).message}`);
+  }
+  if (!resp.ok) {
+    throw new Error(`GET ${url} failed: HTTP ${resp.status}`);
+  }
+  let json: { id?: unknown; pubkey?: unknown };
+  try {
+    json = (await resp.json()) as { id?: unknown; pubkey?: unknown };
+  } catch (e) {
+    throw new Error(`Cashu keyset: invalid JSON: ${(e as Error).message}`);
+  }
+  if (typeof json.id !== 'string' || typeof json.pubkey !== 'string') {
+    throw new Error('Cashu keyset: response missing string id/pubkey');
+  }
+  const pubkey = hexToBytes(json.pubkey);
+  if (pubkey.length !== CASHU_POINT_BYTES) {
+    throw new Error(
+      `Cashu keyset pubkey: expected ${CASHU_POINT_BYTES} bytes, got ${pubkey.length}`,
+    );
+  }
+  return { id: json.id, pubkey };
+}
+
+/**
+ * Blind-sign a batch of blinded messages.
+ *
+ * `blindedMessages` is `N × 33` concatenated compressed points (each from
+ * `WasmCashuBlind.blinded_message()`); the response is `N × 33` blind
+ * signatures `C'` in the same order.
+ * @throws if the input isn't a non-empty multiple of 33 bytes, the mint
+ *   rejects it, or the response length doesn't match the request.
+ */
+export async function mintCashuBats(
+  issuerUrl: string,
+  blindedMessages: Uint8Array,
+): Promise<Uint8Array> {
+  if (
+    blindedMessages.length === 0 ||
+    blindedMessages.length % CASHU_POINT_BYTES !== 0
+  ) {
+    throw new Error(
+      `Cashu mint: blinded messages must be a non-empty multiple of ${CASHU_POINT_BYTES} bytes, got ${blindedMessages.length}`,
+    );
+  }
+  const url = `${normalizeBase(issuerUrl)}/dev/cashu/mint`;
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: blindedMessages.slice(),
+    });
+  } catch (e) {
+    throw new Error(`issuer unreachable at ${url}: ${(e as Error).message}`);
+  }
+  if (!resp.ok) {
+    const detail = await resp.text().catch(() => '');
+    throw new Error(
+      `POST ${url} failed: HTTP ${resp.status}${detail ? ` — ${detail.trim()}` : ''}`,
+    );
+  }
+  const bytes = await readBytes(resp);
+  if (bytes.length !== blindedMessages.length) {
+    throw new Error(
+      `Cashu mint: expected ${blindedMessages.length} bytes back (one signature per blinded message), got ${bytes.length}`,
+    );
+  }
+  return bytes;
+}
+
+// ─── Credential presentation (the "verify" leg) ───────────────────────────
+
+/** Outcome of presenting a credential to the gate. */
+export interface PresentResult {
+  /** True if the gate accepted the credential. */
+  ok: boolean;
+  /** Rejection reason (e.g. "BAT already spent") when `ok` is false. */
+  reason?: string;
+}
+
+/**
+ * Present an ARC credential to the verify gate.
+ *
+ * `presentFrame` is the full frame from `ArcCredentialManager.buildPresentFrame`
+ * (`[4B len][0x08]…`). In the demo this POSTs to the dev-issuer's co-located
+ * gate; in production the identical `[0x08]…` payload is sent over WebSocket to
+ * the PIR server (`sendArcPresentation`). Rejection (exhausted / duplicate /
+ * bad proof) returns `{ok:false}` rather than throwing.
+ */
+export async function presentArc(
+  issuerUrl: string,
+  presentFrame: Uint8Array,
+): Promise<PresentResult> {
+  return presentPayload(`${normalizeBase(issuerUrl)}/dev/arc/verify`, presentFrame);
+}
+
+/**
+ * Present a Cashu BAT to the verify gate. `presentFrame` is the full frame
+ * from `CashuBatPool.buildPresentFrame` (`[4B len][0x09]…`).
+ */
+export async function presentCashu(
+  issuerUrl: string,
+  presentFrame: Uint8Array,
+): Promise<PresentResult> {
+  return presentPayload(`${normalizeBase(issuerUrl)}/dev/cashu/verify`, presentFrame);
+}
+
+async function presentPayload(url: string, presentFrame: Uint8Array): Promise<PresentResult> {
+  // Strip the 4-byte WS length prefix → the [variant][body] payload the gate
+  // parses (byte-identical to the PIR server's WS frame payload).
+  const payload = presentFrame.length >= 4 ? presentFrame.slice(4) : presentFrame.slice();
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: payload,
+    });
+  } catch (e) {
+    throw new Error(`issuer unreachable at ${url}: ${(e as Error).message}`);
+  }
+  if (resp.ok) {
+    return { ok: true };
+  }
+  const reason = (await resp.text().catch(() => '')).trim();
+  return { ok: false, reason: reason || `HTTP ${resp.status}` };
+}

--- a/web/src/ratelimit-demo.ts
+++ b/web/src/ratelimit-demo.ts
@@ -1,0 +1,279 @@
+/**
+ * Standalone demo of anonymous rate-limiting credentials (ARC + Cashu),
+ * end-to-end: mint → obtain → present → verify, with quota + exhaustion.
+ *
+ * This page is intentionally separate from the main PIR client and the wire
+ * explorer. It talks only to the `dev-issuer` (one process, free issuance, no
+ * Lightning, no PIR database):
+ *
+ *   cargo run -p dev-issuer            # http://127.0.0.1:5601
+ *   cd web && npm run dev              # open /ratelimit-demo.html
+ *
+ * The dev-issuer co-locates the credential *verify* gate (same crypto as the
+ * PIR server's `unified_server` gate) so the demo needs no PIR database. In
+ * production the identical present frames go over WebSocket to the PIR
+ * server's gate; here they go over HTTP to the dev-issuer verify endpoints.
+ */
+
+import { initSdkWasm, requireSdkWasm } from './sdk-bridge.js';
+import { ArcCredentialManager } from './credential-manager.js';
+import { CashuBatPool, mintBatPool } from './cashu-bat.js';
+import { getArcPubkey, issueArcCredential, presentArc, presentCashu } from './payment-client.js';
+
+/** Must match the verifier's DEFAULT_REQUEST_CONTEXT and the dev-issuer. */
+const REQUEST_CONTEXT = new TextEncoder().encode('bitcoin-pir-v1');
+
+type Col = 'arc' | 'cashu';
+type Kind = 'info' | 'ok' | 'err';
+
+const el = (id: string) => document.getElementById(id) as HTMLElement;
+const input = (id: string) => document.getElementById(id) as HTMLInputElement;
+const button = (id: string) => document.getElementById(id) as HTMLButtonElement;
+
+function issuerUrl(): string {
+  return input('issuer').value.trim().replace(/\/+$/, '');
+}
+
+function log(col: Col, msg: string, kind: Kind = 'info') {
+  const pre = el(`${col}-log`);
+  const line = document.createElement('div');
+  line.className = `line ${kind}`;
+  line.textContent = `${new Date().toLocaleTimeString()}  ${msg}`;
+  pre.appendChild(line);
+  pre.scrollTop = pre.scrollHeight;
+}
+
+function setStatus(col: Col, msg: string) {
+  el(`${col}-status`).textContent = msg;
+}
+
+/** Render an N-of-M quota meter (used boxes filled). */
+function setMeter(col: Col, remaining: number, total: number) {
+  const meter = el(`${col}-meter`);
+  meter.innerHTML = '';
+  for (let i = 0; i < total; i++) {
+    const cell = document.createElement('span');
+    cell.className = 'cell ' + (i < remaining ? 'full' : 'spent');
+    meter.appendChild(cell);
+  }
+}
+
+function randomBytes(n: number): Uint8Array {
+  const b = new Uint8Array(n);
+  crypto.getRandomValues(b);
+  return b;
+}
+
+// ─── ARC (multi-show: one credential, N presentations) ────────────────────
+
+let credMgr: ArcCredentialManager | null = null;
+let lastArcFrame: Uint8Array | null = null;
+
+async function arcMint() {
+  button('arc-mint').disabled = true;
+  try {
+    const limit = Math.max(1, parseInt(input('arc-limit').value, 10) || 8);
+    log('arc', `Minting ARC credential (limit ${limit})…`);
+
+    await initSdkWasm();
+    const sdk = requireSdkWasm();
+
+    const req = new sdk.WasmArcCredentialRequest(REQUEST_CONTEXT);
+    log('arc', `Built blinded credential request (${req.request_bytes().length} B).`);
+
+    const pubkey = await getArcPubkey(issuerUrl());
+    const response = await issueArcCredential(issuerUrl(), req.request_bytes());
+    log('arc', `Issuer signed it (response ${response.length} B).`);
+
+    const credBytes = req.finalize(pubkey, response);
+    log('arc', `Finalized → ${credBytes.length}-byte credential.`, 'ok');
+
+    const presCtx = randomBytes(32);
+    credMgr = new ArcCredentialManager(credBytes, presCtx, limit);
+
+    setStatus('arc', `Credential ready — ${credMgr.remaining}/${limit} presentations left`);
+    setMeter('arc', credMgr.remaining, limit);
+    button('arc-present').disabled = false;
+  } catch (e) {
+    log('arc', `Mint failed: ${(e as Error).message}`, 'err');
+  } finally {
+    button('arc-mint').disabled = false;
+  }
+}
+
+async function arcPresent() {
+  if (!credMgr) return;
+  button('arc-present').disabled = true;
+  try {
+    if (credMgr.exhausted) {
+      log('arc', 'Credential exhausted — mint a new one.', 'err');
+      return;
+    }
+    // buildPresentFrame() advances the nonce (throws once exhausted).
+    const frame = await credMgr.buildPresentFrame(REQUEST_CONTEXT);
+    lastArcFrame = frame;
+    const result = await presentArc(issuerUrl(), frame);
+
+    if (result.ok) {
+      log('arc', `Presented #${credMgr.used} → accepted ✓`, 'ok');
+    } else {
+      log('arc', `Presented → rejected: ${result.reason}`, 'err');
+    }
+    setStatus('arc', `${credMgr.remaining}/${credMgr.limit} presentations left`);
+    setMeter('arc', credMgr.remaining, credMgr.limit);
+    button('arc-replay').disabled = false;
+  } catch (e) {
+    log('arc', `Exhausted client-side: ${(e as Error).message}`, 'err');
+    setStatus('arc', `0/${credMgr.limit} — exhausted`);
+  } finally {
+    button('arc-present').disabled = credMgr.exhausted;
+  }
+}
+
+// ─── Cashu (single-show: a pool of one-time BATs) ─────────────────────────
+
+let pool: CashuBatPool | null = null;
+let lastBatFrame: Uint8Array | null = null;
+let cashuTotal = 0;
+
+async function cashuMint() {
+  button('cashu-mint').disabled = true;
+  try {
+    const count = Math.max(1, parseInt(input('cashu-count').value, 10) || 5);
+    log('cashu', `Minting a pool of ${count} BATs…`);
+    pool = await mintBatPool(issuerUrl(), count);
+    cashuTotal = count;
+    lastBatFrame = null;
+    setStatus('cashu', `Pool ready — ${pool.remaining} BATs`);
+    setMeter('cashu', pool.remaining, cashuTotal);
+    button('cashu-present').disabled = false;
+    button('cashu-replay').disabled = true;
+    log('cashu', `Pool minted (${pool.remaining} single-use BATs).`, 'ok');
+  } catch (e) {
+    log('cashu', `Mint failed: ${(e as Error).message}`, 'err');
+  } finally {
+    button('cashu-mint').disabled = false;
+  }
+}
+
+async function cashuPresent() {
+  if (!pool) return;
+  button('cashu-present').disabled = true;
+  try {
+    if (pool.exhausted) {
+      log('cashu', 'Pool empty — mint more BATs.', 'err');
+      return;
+    }
+    const frame = pool.buildPresentFrame(); // pops one BAT
+    lastBatFrame = frame;
+    const result = await presentCashu(issuerUrl(), frame);
+    if (result.ok) {
+      log('cashu', `Spent a BAT → accepted ✓ (${pool.remaining} left)`, 'ok');
+    } else {
+      log('cashu', `Rejected: ${result.reason}`, 'err');
+    }
+    setStatus('cashu', `${pool.remaining} BATs left`);
+    setMeter('cashu', pool.remaining, cashuTotal);
+    button('cashu-replay').disabled = false;
+  } catch (e) {
+    log('cashu', `Present failed: ${(e as Error).message}`, 'err');
+  } finally {
+    button('cashu-present').disabled = pool.exhausted;
+  }
+}
+
+async function cashuReplay() {
+  if (!lastBatFrame) return;
+  log('cashu', 'Re-presenting the last (already-spent) BAT…');
+  try {
+    const result = await presentCashu(issuerUrl(), lastBatFrame);
+    if (result.ok) {
+      log('cashu', 'Accepted again?! (unexpected — double-spend not caught)', 'err');
+    } else {
+      log('cashu', `Rejected as expected: ${result.reason} ✓`, 'ok');
+    }
+  } catch (e) {
+    log('cashu', `Replay failed: ${(e as Error).message}`, 'err');
+  }
+}
+
+/** Re-send the last ARC presentation → the gate rejects it (duplicate tag).
+ *  Demonstrates ARC's server-side anti-replay (each nonce is single-use even
+ *  though the credential is multi-show). */
+async function arcReplay() {
+  if (!lastArcFrame) return;
+  log('arc', 'Re-presenting the last (already-used) presentation…');
+  try {
+    const result = await presentArc(issuerUrl(), lastArcFrame);
+    if (result.ok) {
+      log('arc', 'Accepted again?! (unexpected — replay not caught)', 'err');
+    } else {
+      log('arc', `Rejected as expected: ${result.reason} ✓`, 'ok');
+    }
+  } catch (e) {
+    log('arc', `Replay failed: ${(e as Error).message}`, 'err');
+  }
+}
+
+// ─── Auto-run (mint, then present to exhaustion) ──────────────────────────
+
+async function arcRunAll() {
+  button('arc-run').disabled = true;
+  try {
+    await arcMint();
+    if (!credMgr) return;
+    while (!credMgr.exhausted) await arcPresent();
+    log('arc', 'Auto-run complete — credential exhausted.', 'ok');
+  } finally {
+    button('arc-run').disabled = false;
+  }
+}
+
+async function cashuRunAll() {
+  button('cashu-run').disabled = true;
+  try {
+    await cashuMint();
+    if (!pool) return;
+    while (!pool.exhausted) await cashuPresent();
+    log('cashu', 'Auto-run complete — pool empty.', 'ok');
+  } finally {
+    button('cashu-run').disabled = false;
+  }
+}
+
+// ─── Issuer reachability banner ───────────────────────────────────────────
+
+async function checkIssuer() {
+  const banner = el('issuer-banner');
+  banner.className = 'banner checking';
+  banner.textContent = 'Checking issuer…';
+  try {
+    const resp = await fetch(`${issuerUrl()}/health`);
+    if (resp.ok) {
+      banner.className = 'banner ok';
+      banner.textContent = `✓ Issuer reachable at ${issuerUrl()}`;
+    } else {
+      banner.className = 'banner err';
+      banner.textContent = `Issuer responded HTTP ${resp.status} — is this the dev-issuer?`;
+    }
+  } catch {
+    banner.className = 'banner err';
+    banner.textContent = `✗ Issuer unreachable at ${issuerUrl()} — start it with:  cargo run -p dev-issuer`;
+  }
+}
+
+// ─── Wire up ──────────────────────────────────────────────────────────────
+
+button('arc-mint').onclick = arcMint;
+button('arc-present').onclick = arcPresent;
+button('arc-replay').onclick = arcReplay;
+button('arc-run').onclick = arcRunAll;
+button('cashu-mint').onclick = cashuMint;
+button('cashu-present').onclick = cashuPresent;
+button('cashu-replay').onclick = cashuReplay;
+button('cashu-run').onclick = cashuRunAll;
+button('issuer-check').onclick = checkIssuer;
+
+log('arc', 'Ready. Start the dev-issuer, then click "Mint credential".');
+log('cashu', 'Ready. Start the dev-issuer, then click "Mint BAT pool".');
+void checkIssuer();

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -99,6 +99,19 @@ interface PirSdkWasm {
     ): WasmArcPresentationState;
     deserialize(bytes: Uint8Array): WasmArcPresentationState;
   };
+  // ARC "obtain" leg — `WasmArcCredentialRequest`. `request_bytes()` is the
+  // 226-byte CredentialRequest POSTed to the issuer; `finalize()` combines
+  // the issuer's 99-byte pubkey + 454-byte response into the 131-byte
+  // credential consumed by `WasmArcPresentationState`.
+  WasmArcCredentialRequest: {
+    new(requestContext: Uint8Array): WasmArcCredentialRequest;
+  };
+  // Cashu Blind Auth (NUT-22) "obtain" leg — `WasmCashuBlind`. One per BAT:
+  // `blinded_message()` is POSTed to the mint, `unblind()` combines the
+  // returned 33-byte blind signature into the unblinded BAT signature.
+  WasmCashuBlind: {
+    new(): WasmCashuBlind;
+  };
   PRP_HMR12: () => number;
   PRP_FASTPRP: () => number;
   /**
@@ -584,6 +597,39 @@ interface WasmArcPresentationState {
   nonce(): bigint;
   /** Serialise full state (credential + presCtx + nonce + limit) for persistence. */
   serialize(): Uint8Array;
+}
+
+/**
+ * Opaque WASM handle for the ARC issuance "obtain" leg (pir-sdk-wasm
+ * `arc.rs`). Holds the per-request `ClientSecrets` inside WASM so the
+ * blinding factors never reach JS.
+ */
+interface WasmArcCredentialRequest {
+  free(): void;
+  /** 226-byte `CredentialRequest` to POST to the issuer (`/dev/arc/issue`). */
+  request_bytes(): Uint8Array;
+  /**
+   * Combine the issuer's 99-byte pubkey + 454-byte `CredentialResponse`
+   * into the 131-byte credential blob for `WasmArcPresentationState`.
+   */
+  finalize(pubkeyBytes: Uint8Array, responseBytes: Uint8Array): Uint8Array;
+}
+
+/**
+ * Opaque WASM handle for one Cashu blind/unblind (pir-sdk-wasm `cashu.rs`).
+ * Holds the blinding scalar + secret inside WASM. Create one per BAT.
+ */
+interface WasmCashuBlind {
+  free(): void;
+  /** The Cashu "secret" string (64-char hex) for the authA token. */
+  secret_string(): string;
+  /** 33-byte blinded message `B'` to POST to the mint (`/dev/cashu/mint`). */
+  blinded_message(): Uint8Array;
+  /**
+   * Unblind the mint's 33-byte `C'` with the 33-byte keyset pubkey `K`:
+   * `C = C' − r·K`. Returns the 33-byte unblinded signature.
+   */
+  unblind(keysetPubkey: Uint8Array, signature: Uint8Array): Uint8Array;
 }
 
 interface WasmAtomicMetrics {

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -25,6 +25,9 @@ export default defineConfig({
         // to verify the SEV-SNP MEASUREMENT pin against the chip-signed
         // value via sev-snp-measure + bpir-admin attest.
         reproduce: 'reproduce.html',
+        // Anonymous rate-limiting demo (ARC + Cashu) — self-contained,
+        // talks only to the dev-issuer (free issuance + co-located gate).
+        'ratelimit-demo': 'ratelimit-demo.html',
       },
     },
   },


### PR DESCRIPTION
Adds the browser **obtain** + **present** legs for anonymous rate-limiting (ARC multi-show + Cashu single-show) and a self-contained, runnable demo. Live at https://sdk.bitcoinpir.org/rate-limiting (issuer fronted at issuer.bitcoinpir.org).

## What's in it
- **Core fix:** `ArcVerifier::from_secret_key_bytes/_file` (the old `from_bytes` was a stub; `generate()` used a random key so no externally-issued credential could verify) + `unified_server --arc-key` so issuer/verifier share a key.
- **WASM:** `WasmArcCredentialRequest` (ARC request/finalize) + `WasmCashuBlind` (Cashu blind/unblind, hash_to_curve cross-checked against the real `CashuVerifier`).
- **dev-issuer crate** (`publish=false`, dependency-light): free ARC+Cashu issuance + co-located verify gate (same crypto as `unified_server`), so the demo needs no PIR DB. HTTP round-trip + verify-gate integration tests.
- **Web:** `payment-client.ts`, `cashu-bat.ts` mintBatPool, `ratelimit-demo` page.
- **Docs:** `docs/RATELIMIT_DEMO.md`, `dev-issuer/README.md`, `deploy/systemd/dev-issuer.service`.

## Safety
- **Does NOT gate the live PIR servers.** `--require-arc`/`--require-cashu` are opt-in (off by default; systemd units don't pass them). `unified_server` default behavior is unchanged.
- The hosted issuer is a **free-issuance demo backend** (a mechanism demo, not a real rate limiter).

## Tests (local)
pir-sdk 78 · pir-sdk-client 199 · pir-runtime-core 74 · pir-sdk-wasm 69 · dev-issuer 3 integration · web vitest 164 · tsc clean. Browser-smoke-tested end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)