### PR TITLE
fix(wasm): detach WS handlers before dropping closures on teardown

### DIFF
--- a/pir-sdk-client/src/wasm_transport.rs
+++ b/pir-sdk-client/src/wasm_transport.rs
@@ -172,6 +172,21 @@ fn take_record_from_buf(buf: &mut Vec<u8>) -> PirResult<Option<Vec<u8>>> {
     Ok(Some(record))
 }
 
+/// Clear every JS-side event handler from `ws`.
+///
+/// Called on teardown (`close()` and `Drop`) *before* the owning
+/// `Closure`s are freed, so a late `close` / `error` / `message` event
+/// can't invoke a dropped closure — the wasm-bindgen runtime would
+/// otherwise throw "closure invoked recursively or after being dropped".
+/// Idempotent: setting an already-cleared handler to `None` is a no-op,
+/// so calling this from `close()` and again from `Drop` is fine.
+fn detach_ws_handlers(ws: &WebSocket) {
+    ws.set_onopen(None);
+    ws.set_onmessage(None);
+    ws.set_onerror(None);
+    ws.set_onclose(None);
+}
+
 /// Owning handles for the four JS-side callbacks.
 ///
 /// `Closure<dyn FnMut(...)>` is the idiomatic `wasm-bindgen` shape for a
@@ -524,12 +539,22 @@ impl PirTransport for WasmWebSocketTransport {
         // the socket closed for any concurrent code path that might
         // still be holding a reference.
         self.closed.set(true);
+        // Detach the JS event handlers BEFORE the owning `Closure`s drop
+        // below. `ws.close()` only *initiates* the close handshake — the
+        // browser fires the `close` event on a later tick. If the socket
+        // still held `set_onclose(&closure)` at that point, the late event
+        // would invoke a closure we already freed and wasm-bindgen would
+        // throw "closure invoked recursively or after being dropped".
+        // Clearing the handlers here also breaks the Browser → Closure →
+        // Channel cycle, so dropping the closures afterwards is purely
+        // freeing memory.
+        detach_ws_handlers(&self.ws);
         if self.ws.ready_state() != WebSocket::CLOSED {
             let _ = self.ws.close();
         }
-        // Drop the callbacks to break the cycle Browser → Closure →
-        // Channel. The `Rc<RefCell<_>>` lets us do it without needing
-        // `&mut self` over the full teardown.
+        // Now safe to drop the callbacks — no live handler references them.
+        // The `Rc<RefCell<_>>` lets us do it without needing `&mut self`
+        // over the full teardown.
         let mut cb = self.callbacks.borrow_mut();
         cb.on_open.take();
         cb.on_message.take();
@@ -549,5 +574,22 @@ impl PirTransport for WasmWebSocketTransport {
     ) {
         self.metrics_recorder = recorder;
         self.metrics_backend = backend;
+    }
+}
+
+impl Drop for WasmWebSocketTransport {
+    /// Detach the JS event handlers before the struct's fields drop.
+    ///
+    /// `Drop::drop` runs before any field is dropped, so `self.ws` is
+    /// still live here while `callbacks` (which owns the `Closure`s) has
+    /// not been freed yet. Detaching now covers the teardown paths that
+    /// don't go through `close()` — e.g. the WASM client being `free()`d
+    /// or dropped — which would otherwise leave the socket holding
+    /// handlers pointing at closures about to be freed, so a late event
+    /// would throw "closure invoked recursively or after being dropped".
+    /// Redundant after an explicit `close()` (handlers already cleared)
+    /// and harmless thanks to `detach_ws_handlers`' idempotence.
+    fn drop(&mut self) {
+        detach_ws_handlers(&self.ws);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the `closure invoked recursively or after being dropped` error that wasm-bindgen threw after **every** DPF / HarmonyPIR query during WebSocket teardown in the browser.

Reported by the [Bitcoin-PIR/playground](https://github.com/Bitcoin-PIR/playground) agent. The error fired *after* correct results returned (so not a correctness bug) and surfaced only in the Next.js dev overlay; the production static export hid it, but it was still an unhandled exception/rejection.

## Root cause

`WasmWebSocketTransport::close()` called `ws.close()` — which only *initiates* the async close handshake — and then immediately dropped the four owned event `Closure`s, **without first clearing them off the socket**. The `WebSocket` still held `set_onclose(&closure)`, so when the browser fired the `close` event on a later tick it invoked an already-freed closure → the throw. The struct also had no `Drop` impl, so the `client.free()` / drop path dangled the same way (which is why `free()` after `disconnect()` didn't suppress it — the explicit `close()` path was already the trigger).

This is the classic wasm-bindgen Closure lifetime bug, hypothesis (a): a closure invoked after the Rust-side `Closure` was dropped while the JS side still holds the function and an event fires. Not re-entrancy, and not a `Closure::forget()` leak — the closures are owned in the struct and dropped deterministically.

## Fix (wasm32-only; no wire / protocol / server change)

- Add `detach_ws_handlers(ws)`: clears `onopen` / `onmessage` / `onerror` / `onclose` to `None`. Idempotent, so calling it from both `close()` and `Drop` is safe.
- `close()` now detaches the handlers **before** `ws.close()` and before dropping the closures, so the late `close` event has no handler to invoke. (Clearing the handlers also breaks the Browser → Closure → Channel cycle the old explicit drop was there for.)
- Add `impl Drop for WasmWebSocketTransport` calling the same helper, covering the `free()` / drop-without-`close()` path. `Drop::drop` runs before the fields drop, so `self.ws` is still live while the `Closure`s have not been freed yet.

## Validation

- `cargo check -p pir-sdk-client --target wasm32-unknown-unknown` — clean
- `wasm-pack build --target web --out-dir pkg` — clean

The module is `#![cfg(target_arch = "wasm32")]`, so it is compiled out of the native x86_64 build: the `pir-sdk-integration` native build/tests are unaffected, and `web-build` exercises the wasm32 path. Live-browser confirmation is being done by the playground agent after it re-vendors the rebuilt `pir_sdk_wasm.{js,d.ts,_bg.wasm}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
