### PR TITLE
feat(web): verified-operator identity badge (DPF + HarmonyPIR)

### DIFF
--- a/docs/OPERATOR_IDENTITY.md
+++ b/docs/OPERATOR_IDENTITY.md
@@ -5,12 +5,13 @@ exactly what a client learns when it verifies one. This covers the
 end-to-end **operator runbook** (generate → sign → deploy) and the
 **client trust model** (what each check proves, and what it does not).
 
-> **Status (2026-05-24).** The full path is wired and live-verified
-> end-to-end (`bpir-admin` → `unified_server --identity-*` → client
-> `announce()`), but **not yet deployed on pir1/pir2** and the pinned
-> operator pubkey in `web/src/attest-pin.ts` is currently a **DEV
-> stand-in** (the e2e test key), not a real published key. See
-> [Current status](#current-status).
+> **Status (2026-05-28).** **LIVE.** Deployed and live-verified end-to-end
+> on both production servers: pir1 + pir2 serve REQ_ANNOUNCE on the
+> announce-enabled binary (v22 `f7df82d0…` → current v23 `57ac525b…`). The
+> pinned operator pubkey in `web/src/attest-pin.ts` is the **real**
+> published key (`256fb106…`), and the "verified operator" badge is wired
+> into the www client (DPF + HarmonyPIR cards) and the playground, gated on
+> `state === 'verified'`. See [Current status](#current-status).
 
 ---
 
@@ -259,30 +260,35 @@ await adapter.connect();
   dispatch arm, `PirServerBuilder::with_announcement_bundle`, admin CLI,
   client `announce` / `announce_with_pinned_operator` / `announce_bound`
   / `check_pinned_operator` / `check_channel_binding`, WASM bindings.
-- ✅ Live-verified e2e (`test_announce_operator_identity_end_to_end`).
+- ✅ Live-verified e2e (`test_announce_operator_identity_end_to_end`) — ok
+  against pir1 (weikeng1) AND pir2 (weikeng2).
 - ✅ Real operator key minted (2026-05-25) + pinned in `attest-pin.ts`
   (`PIR_OPERATOR_PUBKEY_HEX = 256fb106…`; secret offline at
   `~/.config/bpir-admin/operator.key`).
-- 🟡 pir1 **staged** with `--identity-*` (server_id=pir1, cert valid to
-  2029) — see Deployment status below. pir2 not yet staged.
-- ✅ `BatchPirClientAdapter` exposes a gated `operatorIdentity` snapshot
-  (opt-in via `verifyOperatorIdentity`); `gateOperatorIdentity` unit-tested.
+- ✅ **Deployed (2026-05-28):** pir1 + pir2 both run the announce-enabled
+  binary (v22 `f7df82d0…` → v23 `57ac525b…`); both answer REQ_ANNOUNCE and
+  verify under the pinned operator key.
+- ✅ `BatchPirClientAdapter` (DPF) and `HarmonyPirClientAdapter` expose a
+  gated `operatorIdentity` snapshot (opt-in via `verifyOperatorIdentity`);
+  `gateOperatorIdentity` unit-tested.
 - ✅ Standalone TS `OnionPirWebClient.announce()` — reuses the Rust
   parser/chain check via the WASM `verifyAnnounceResponse` binding
   (operator-pin + chain; channel-binding N/A — no attest/channel there).
-- ⏳ Playground still needs to render the badge from the snapshot;
-  `check_freshness(now, maxAge)` available (Rust + WASM + adapter
-  `maxAnnounceAgeSeconds`); validity enforced via real `now`.
+- ✅ **"Verified operator" badge wired** into the www client (DPF +
+  HarmonyPIR cards, `web/index.html`) and the playground
+  (`OperatorIdentityBadge.tsx`), gated on `state === 'verified'`. OnionPIR
+  excluded (single-server, no secure channel → channel binding N/A).
 
-## Deployment status (2026-05-25)
+## Deployment status — RESOLVED (2026-05-28)
 
-The dispatch arm is **merged to main** (PR #9) and the new binary is
-**built + reproducible**, but it is **not yet deployed** — the running
-servers still execute the old reproducible binary
-(`binarySha256Hex 71a041ae…`), which predates the dispatch arm, so
-`announce()` against `wss://weikeng1.bitcoinpir.org` still returns
-`unsupported request 0x07`. The remaining work is the coordinated binary
-deploy + re-pin below.
+**Done.** The announce-enabled binary was deployed to **both** servers
+(v22 `f7df82d0…`, then current v23 `57ac525b…` = v22 + the DPF/Harmony
+anchor-offset fix) and the shared `binarySha256Hex` + pir2 `measurementHex`
+re-pinned in `attest-pin.ts`. `announce()` against both
+`wss://weikeng1.bitcoinpir.org` and `wss://weikeng2.bitcoinpir.org` returns
+an operator-endorsed bundle that verifies under the pinned operator key
+(`256fb106…`). The original coordinated-deploy checklist is retained below
+as a historical record.
 
 Done:
 - Operator key + pir1/pir2 `IdentityCert`s signed (valid to 2029).
@@ -353,10 +359,11 @@ PIR_ANNOUNCE_SERVER_ID=pir1 \
 
 ### Remaining work
 
-- **C (binary release)** — the 6 steps above; needs a merge + reproducible
-  build + the VPSBG portal for pir2. pir1 identity is staged and will
-  activate the instant the dispatch-arm binary lands.
-- **D (playground)** — render the badge from
-  `adapter.operatorIdentity.serverN.state` / `onOperatorIdentity`. The
-  gating already lives in the adapter; the badge is the only remaining
-  piece, in the playground repo.
+- ✅ **C (binary release) — DONE (2026-05-28).** Announce-enabled binary
+  (v23 `57ac525b…`) live on pir1 + pir2; pins updated.
+- ✅ **D (UI badge) — DONE (2026-05-28).** "Verified operator" badge wired
+  into the www client (DPF + HarmonyPIR cards) and the playground
+  (`OperatorIdentityBadge.tsx` ← `BatchPirClientAdapter.operatorIdentity` /
+  the `attestAndUpgrade` operator-identity verdict), gated on
+  `state === 'verified'`. OnionPIR excluded (no secure channel).
+- _Nothing outstanding._

--- a/web/index.html
+++ b/web/index.html
@@ -787,6 +787,11 @@
         .attest-badge-mismatch      { border-left-color: var(--err); background: #fef2f2; }
         .attest-badge-plaintext     { border-left-color: var(--ink-mute); background: var(--bg); }
         .attest-badge-unattested    { border-left-color: var(--ink-mute); background: var(--bg); color: var(--ink-mute); }
+        /* Operator-signed identity badge (REQ_ANNOUNCE). Green once the
+           operator-pinned cert + channel binding verify; red on a failed
+           check. Hidden for unconfigured / error / not-checked. */
+        .attest-badge-op-verified   { border-left-color: #2e7d32; background: #f0fdf4; }
+        .attest-badge-op-unverified { border-left-color: var(--err); background: #fef2f2; }
     </style>
     <!-- OnionPIR WASM (post-port ES module) loaded dynamically via
          `await import('/wasm/onionpir_client.mjs')` in
@@ -1024,12 +1029,14 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                             <input type="text" id="server0Url" class="input" value="wss://weikeng1.bitcoinpir.org" spellcheck="false">
                         </div>
                         <div id="attestBadge0" class="attest-badge attest-badge-unattested" data-server="0" style="display: none;"></div>
+                        <div id="operatorBadge0" class="attest-badge attest-badge-op-verified" data-server="0" style="display: none;"></div>
 
                         <div class="status-row">
                             <label for="server1Url">Server 1</label>
                             <input type="text" id="server1Url" class="input" value="wss://weikeng2.bitcoinpir.org" spellcheck="false">
                         </div>
                         <div id="attestBadge1" class="attest-badge attest-badge-unattested" data-server="1" style="display: none;"></div>
+                        <div id="operatorBadge1" class="attest-badge attest-badge-op-verified" data-server="1" style="display: none;"></div>
 
                         <div id="syncStateRow" style="display: none; margin-top: 14px;">
                             <span>Sync state:</span>
@@ -1355,12 +1362,14 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                             <input type="text" id="hp-hintServerUrl" class="input" value="wss://weikeng1.bitcoinpir.org" spellcheck="false">
                         </div>
                         <div id="hp-attestBadgeHint" class="attest-badge attest-badge-unattested" style="display: none;"></div>
+                        <div id="hp-operatorBadgeHint" class="attest-badge attest-badge-op-verified" style="display: none;"></div>
 
                         <div class="status-row">
                             <label for="hp-queryServerUrl">Query server</label>
                             <input type="text" id="hp-queryServerUrl" class="input" value="wss://weikeng2.bitcoinpir.org" spellcheck="false">
                         </div>
                         <div id="hp-attestBadgeQuery" class="attest-badge attest-badge-unattested" style="display: none;"></div>
+                        <div id="hp-operatorBadgeQuery" class="attest-badge attest-badge-op-verified" style="display: none;"></div>
                         <div class="status-row">
                             <label for="hp-prpSelect">PRP backend</label>
                             <div style="display: flex; align-items: center; gap: 10px;">
@@ -1564,6 +1573,42 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             }
             if (info.sevStatus) {
                 rows.push(`<div class="ab-row"><span class="ab-label">sev status</span><span class="ab-val">${info.sevStatus}</span></div>`);
+            }
+            el.innerHTML = rows.join('');
+        }
+
+        // Operator-signed identity badge, populated from the adapter's
+        // onOperatorIdentity callback. Only a definitive verdict is shown:
+        // 'verified' (green) or 'unverified' (red). 'unconfigured' (server
+        // opted out), 'error' (transient/no attestation) and 'not-checked'
+        // stay hidden — they are not security-relevant to surface.
+        function renderOperatorBadge(idElem, serverTag, oid) {
+            const el = typeof idElem === 'string' ? document.getElementById(idElem) : idElem;
+            if (!el) return;
+            if (oid.state !== 'verified' && oid.state !== 'unverified') {
+                el.style.display = 'none';
+                return;
+            }
+            const truncate = (hex, n = 16) =>
+                hex && hex.length > n ? `${hex.slice(0, n)}…` : (hex || '—');
+            el.className = `attest-badge attest-badge-op-${oid.state}`;
+            el.style.display = 'block';
+
+            const rows = [];
+            if (oid.state === 'verified') {
+                rows.push(`<span class="ab-state">🔏 Operator-endorsed — ${oid.serverId || 'identity'} verified</span>`);
+                if (oid.operatorPubkeyHex) {
+                    rows.push(`<div class="ab-row"><span class="ab-label">operator</span><span class="ab-val" title="${oid.operatorPubkeyHex}">${truncate(oid.operatorPubkeyHex, 24)}</span></div>`);
+                }
+                if (oid.identityPubkeyHex) {
+                    rows.push(`<div class="ab-row"><span class="ab-label">identity</span><span class="ab-val" title="${oid.identityPubkeyHex}">${truncate(oid.identityPubkeyHex, 24)}</span></div>`);
+                }
+                if (oid.gitRev) {
+                    rows.push(`<div class="ab-row"><span class="ab-label">git rev</span><span class="ab-val" title="${oid.gitRev}">${truncate(oid.gitRev, 12)}</span></div>`);
+                }
+            } else {
+                rows.push(`<span class="ab-state">⚠ Operator identity UNVERIFIED</span>`);
+                rows.push(`<div class="ab-row"><span class="ab-label">reason</span><span class="ab-val" title="${oid.error || ''}">${oid.error || 'check failed'}</span></div>`);
             }
             el.innerHTML = rows.join('');
         }
@@ -2069,6 +2114,20 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                         // Slice 3: persistent badge under the server URL input
                         // surfacing binary sha + MEASUREMENT + channel pk + git rev.
                         renderAttestBadge(`attestBadge${idx}`, tag, info);
+                    },
+                    // Operator-signed identity (REQ_ANNOUNCE). The adapter
+                    // fetches each server's bundle after attest, checks it
+                    // against the pinned operator key + the attested channel
+                    // key, and reports the verdict here. Gated on 'verified'.
+                    verifyOperatorIdentity: true,
+                    onOperatorIdentity: (idx, info) => {
+                        const tag = `server${idx}`;
+                        if (info.state === 'verified') {
+                            log(`🔏 ${tag}: operator-endorsed identity verified (${info.serverId})`, 'success');
+                        } else if (info.state === 'unverified') {
+                            log(`⚠ ${tag}: operator identity UNVERIFIED — ${info.error}`, 'error');
+                        }
+                        renderOperatorBadge(`operatorBadge${idx}`, tag, info);
                     },
                     onConnectionStateChange: (state, message) => {
                         log(`Connection: ${state}${message ? ' - ' + message : ''}`,
@@ -3546,6 +3605,20 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                         // Slice 3: persistent badge under each server URL.
                         const badgeId = idx === 0 ? 'hp-attestBadgeHint' : 'hp-attestBadgeQuery';
                         renderAttestBadge(badgeId, `HarmonyPIR ${tag}`, info);
+                    },
+                    // Operator-signed identity (REQ_ANNOUNCE) — same opt-in as
+                    // the DPF card. Verifies each server's bundle against the
+                    // pinned operator key + the attested channel key.
+                    verifyOperatorIdentity: true,
+                    onOperatorIdentity: (idx, info) => {
+                        const tag = idx === 0 ? 'hint' : 'query';
+                        if (info.state === 'verified') {
+                            log(`🔏 HarmonyPIR ${tag}: operator-endorsed identity verified (${info.serverId})`, 'success');
+                        } else if (info.state === 'unverified') {
+                            log(`⚠ HarmonyPIR ${tag}: operator identity UNVERIFIED — ${info.error}`, 'error');
+                        }
+                        const badgeId = idx === 0 ? 'hp-operatorBadgeHint' : 'hp-operatorBadgeQuery';
+                        renderOperatorBadge(badgeId, `HarmonyPIR ${tag}`, info);
                     },
                     onProgress: (msg) => {
                         log(`HarmonyPIR: ${msg}`);

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -191,15 +191,14 @@ export const PIR1_PIN: ServerAttestPin = {
  * backed up out-of-band) and signs the pir1 / pir2 `IdentityCert`s
  * (`bpir-admin sign-identity`, valid_until 2029-05).
  *
- * ⚠️ NOT YET LIVE END-TO-END. pir1/pir2 are *staged* with `--identity-*`
- * (the bundle is built + logged "Identity announce: enabled"), but the
- * deployed reproducible binary predates the REQ_ANNOUNCE *dispatch* arm,
- * so the servers still answer "unsupported request 0x07". Announce goes
- * live only once a binary carrying the dispatch arm is reproducibly
- * rebuilt + deployed to pir1 AND baked into the pir2 Tier-3 UKI, with
- * `binarySha256Hex` (both pins) + pir2 `measurementHex` re-pinned. Keep
- * any "verified operator" UI gated until then. See
- * docs/OPERATOR_IDENTITY.md §"Deployment status".
+ * LIVE END-TO-END (verified 2026-05-28). pir1 + pir2 both serve
+ * REQ_ANNOUNCE on the announce-enabled binary (v22 `f7df82d0…` → current
+ * v23 `57ac525b…`); `announce()` against either returns an
+ * operator-endorsed bundle that verifies under this pinned key
+ * (operator-pin + cert signature + validity + chain + channel binding).
+ * The "verified operator" badge is wired into the DPF + HarmonyPIR cards
+ * (web/index.html) and the playground, gated on `state === 'verified'`.
+ * See docs/OPERATOR_IDENTITY.md.
  */
 export const PIR_OPERATOR_PUBKEY_HEX =
   '256fb106c039f8009d3caa431a9634ff3fe5db3b9e4d9ae7282bbde66772c97a';

--- a/web/src/harmonypir-adapter.ts
+++ b/web/src/harmonypir-adapter.ts
@@ -67,12 +67,13 @@ import {
 } from './server-info.js';
 import {
   requireSdkWasm,
+  type WasmAnnounceVerification,
   type WasmAttestVerification,
   type WasmHarmonyClient,
   type WasmQueryResult,
 } from './sdk-bridge.js';
-import { getAmdTurinArkFingerprint } from './attest-pin.js';
-import type { ServerAttestation } from './dpf-adapter.js';
+import { getAmdTurinArkFingerprint, PIR_OPERATOR_PUBKEY } from './attest-pin.js';
+import { gateOperatorIdentity, type OperatorIdentity, type ServerAttestation } from './dpf-adapter.js';
 import type {
   HarmonyQueryResult,
   HarmonyUtxoEntry,
@@ -129,6 +130,25 @@ export interface HarmonyPirClientConfig {
    */
   expectedServer0Pin?: import('./attest-pin.js').ServerAttestPin;
   expectedServer1Pin?: import('./attest-pin.js').ServerAttestPin;
+  /**
+   * Opt-in operator-signed identity (REQ_ANNOUNCE) verification, mirroring
+   * `BatchPirClientConfig`. When `true`, after attesting both servers the
+   * adapter fetches each server's announce bundle and verifies it against
+   * `pinnedOperatorPubkey` + the attested channel key, populating
+   * `operatorIdentity`. Default `false`.
+   */
+  verifyOperatorIdentity?: boolean;
+  /** Operator (Tier-1) pubkey to pin announce bundles against. Defaults to
+   *  `PIR_OPERATOR_PUBKEY` from `./attest-pin.ts`. */
+  pinnedOperatorPubkey?: Uint8Array;
+  /** Replay/staleness cap (seconds) on the bundle's `issued_at`. Default
+   *  `0` = no cap (issued_at is the server's boot time, so a staleness cap
+   *  would wrongly reject long-uptime servers). */
+  maxAnnounceAgeSeconds?: number;
+  /** Fires once per server after attest resolves the operator-identity
+   *  check (only when `verifyOperatorIdentity`). Index 0 = hint, 1 = query.
+   *  Gate any "verified operator" badge on `state === 'verified'`. */
+  onOperatorIdentity?: (serverIndex: 0 | 1, info: OperatorIdentity) => void;
 }
 
 // ─── Adapter ─────────────────────────────────────────────────────────────────
@@ -159,6 +179,17 @@ export class HarmonyPirClientAdapter {
   attestation: { hint: ServerAttestation; query: ServerAttestation } = {
     hint: { state: 'unattested' },
     query: { state: 'unattested' },
+  };
+  /**
+   * Per-server operator-signed-identity snapshot, mirroring
+   * `BatchPirClientAdapter.operatorIdentity`. Populated by
+   * `attestAndUpgrade()` only when `verifyOperatorIdentity` is set; stays
+   * `'not-checked'` otherwise. Index 0 = hint, 1 = query. Gate any
+   * "verified operator" badge on `state === 'verified'`.
+   */
+  operatorIdentity: { hint: OperatorIdentity; query: OperatorIdentity } = {
+    hint: { state: 'not-checked' },
+    query: { state: 'not-checked' },
   };
   /**
    * Inspector data populated by the most recent `queryBatch`. The native
@@ -344,8 +375,69 @@ export class HarmonyPirClientAdapter {
         + ` query=${this.attestation.query.state})`,
       );
     }
+
+    // Operator-signed identity (REQ_ANNOUNCE), opt-in. After the channel
+    // decision so announce() rides the encrypted channel when it came up;
+    // binds against the attested serverStaticPub from hintAtt/queryAtt
+    // (still alive here — freed just below). Mirrors the DPF adapter.
+    if (this.config.verifyOperatorIdentity) {
+      const pin = this.config.pinnedOperatorPubkey ?? PIR_OPERATOR_PUBKEY;
+      this.operatorIdentity.hint = await this.verifyOperatorIdentityOne(0, hintAtt, pin);
+      this.operatorIdentity.query = await this.verifyOperatorIdentityOne(1, queryAtt, pin);
+      this.config.onOperatorIdentity?.(0, this.operatorIdentity.hint);
+      this.config.onOperatorIdentity?.(1, this.operatorIdentity.query);
+    }
+
     hintAtt?.free();
     queryAtt?.free();
+  }
+
+  /**
+   * Fetch + verify one server's operator-signed identity. Never throws;
+   * returns an `OperatorIdentity` snapshot. `att` supplies the attested
+   * `serverStaticPub` the bundle's `channel_pub` is bound against, so a
+   * `null` att (attest failed) yields `state: 'error'`. Mirrors
+   * `dpf-adapter.ts::verifyOperatorIdentityOne`.
+   */
+  private async verifyOperatorIdentityOne(
+    idx: 0 | 1,
+    att: WasmAttestVerification | null,
+    pin: Uint8Array,
+  ): Promise<OperatorIdentity> {
+    const which = idx === 0 ? 'hint' : 'query';
+    if (!this.wasmClient) {
+      return { state: 'error', error: 'wasm client not initialised' };
+    }
+    if (!att) {
+      return { state: 'error', error: 'attestation unavailable; cannot bind channel key' };
+    }
+    let v: WasmAnnounceVerification;
+    try {
+      v = await this.wasmClient.announce(idx);
+    } catch (e) {
+      const msg = (e as Error)?.message ?? String(e);
+      // A server started without --identity-* answers RESP_ERROR
+      // "announce not configured" — an expected, benign state.
+      if (/not configured/i.test(msg)) {
+        this.log(`HarmonyPIR ${which}: operator identity not configured`);
+        return { state: 'unconfigured' };
+      }
+      this.log(`HarmonyPIR announce(${which}) failed: ${msg}`);
+      return { state: 'error', error: msg };
+    }
+    try {
+      const nowSecs = BigInt(Math.floor(Date.now() / 1000));
+      const maxAge = BigInt(this.config.maxAnnounceAgeSeconds ?? 0);
+      const result = gateOperatorIdentity(v, pin, att.serverStaticPub, nowSecs, maxAge);
+      if (result.state === 'verified') {
+        this.log(`HarmonyPIR ${which}: operator identity verified (${result.serverId})`);
+      } else {
+        this.log(`HarmonyPIR ${which}: operator identity UNVERIFIED — ${result.error}`);
+      }
+      return result;
+    } finally {
+      v.free();
+    }
   }
 
   // ══ Setup / WASM loading ════════════════════════════════════════════════

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -444,6 +444,10 @@ interface WasmHarmonyClient {
   /** Same as `WasmDpfClient.attest`. `serverIndex` 0 = hint server,
    *  1 = query server (matches `serverUrls()` order). */
   attest(serverIndex: number): Promise<WasmAttestVerification>;
+  /** Same as `WasmDpfClient.announce`. `serverIndex` 0 = hint server,
+   *  1 = query server. Rejects with "announce not configured" when the
+   *  server was started without `--identity-*` flags. */
+  announce(serverIndex: number): Promise<WasmAnnounceVerification>;
   /** Same as `WasmDpfClient.upgradeToSecureChannel`. Argument order
    *  matches `serverUrls()` — `(hintServerStaticPub, queryServerStaticPub)`. */
   upgradeToSecureChannel(hintServerStaticPub: Uint8Array, queryServerStaticPub: Uint8Array): Promise<void>;


### PR DESCRIPTION
Wires the operator-signed identity (REQ_ANNOUNCE) "verified operator" badge into the www client.

## What
- DPF + HarmonyPIR cards now run `verifyOperatorIdentity` and render a per-server badge, gated on `state === 'verified'` (green) / `'unverified'` (red), hidden for unconfigured/error/not-checked.
- `harmonypir-adapter.ts` gains the operator-identity plumbing (mirrors `dpf-adapter.ts::verifyOperatorIdentityOne`); `sdk-bridge.ts` declares `announce()` on the `WasmHarmonyClient` interface (the WASM already exported it).
- `attest-pin.ts` + `docs/OPERATOR_IDENTITY.md` status refreshed to LIVE.
- OnionPIR excluded (single-server, no secure channel → channel binding N/A).

## Verification
- `tsc --noEmit` clean; web vitest 164 pass.
- Live announce e2e `ok` against pir1 (weikeng1) + pir2 (weikeng2).
- Live browser connect: both DPF badges render green ("operator-endorsed — pir1/pir2 verified", operator `256fb106…`), confirming channel-binding passes in the real WASM gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
