### PR TITLE
chore(gitignore): ignore the dream audit-skill working dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ PLAN_*.md
 
 # Claude Code
 .claude/
+# dream audit-skill working dir (regenerable scratch)
+.dream/
 
 # Deployment artifacts (local configs, secrets, notes, SSH known_hosts)
 deploy/


### PR DESCRIPTION
Ignore `.dream/` (regenerable scratch from the dream audit skill) so it stays out of `git status` and fresh clones. One-line change; merging triggers an idempotent www rebuild (deploy-web.yml has no path filter).