### PR TITLE
Wire direct ORAM into Tier 3 UKI startup

### DIFF
--- a/docs/ORAM_VPSBG_TEST_RUN.md
+++ b/docs/ORAM_VPSBG_TEST_RUN.md
@@ -496,6 +496,59 @@ The production service uses explicit per-db flags via
 The legacy `--cuckoo-oram-*` flags remain accepted for comparison runs only.
 `--cuckoo-oram-dir <dir>` maps to db_id 0.
 
+## Tier 3 UKI Wiring
+
+The ORAM image directories are too large and too mutable to bake into the UKI.
+For Tier 3, the UKI should instead measure:
+
+- the ORAM-enabled `unified_server` binary;
+- the runit service script that starts it;
+- the explicit direct ORAM flags and image paths.
+
+The bulk ORAM metadata/payload/hash/state files stay under the bind-mounted
+`/home/pir/data/oram/...` directories. The current measured startup script is:
+
+```text
+scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+```
+
+It starts `/usr/local/bin/unified_server` with:
+
+```text
+--direct-oram-db 0=/home/pir/data/oram/checkpoints/948454-direct-pack16-z2-div2-stash128-auth
+--direct-oram-db 1=/home/pir/data/oram/deltas/940611_948454_canonical-direct-pack16-z2-div2-stash128-auth
+--direct-oram-drain-per-access 2
+--direct-oram-access-budget 75
+--direct-oram-cache-levels 0
+--direct-oram-auth-store
+```
+
+Build the binary that will be copied into the UKI with ORAM support enabled:
+
+```bash
+cd /home/pir/BitcoinPIR
+cargo build --release -p runtime --features cuckoo-oram --bin unified_server
+sudo ./scripts/build_uki_tier3.sh
+```
+
+After uploading the new UKI in the VPSBG portal and rebooting, capture the new
+SEV-SNP MEASUREMENT and run:
+
+```bash
+bpir-admin channel-test wss://weikeng2.bitcoinpir.org \
+  --expect-ark-fingerprint 1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a
+
+PADDED_SLOTS=25 ./scripts/oram_vpsbg_test.sh server-smoke
+```
+
+The attestation/communication story is unchanged by ORAM: the client verifies
+the SEV-SNP VCEK chain and launch measurement, then checks that `REPORT_DATA`
+binds the ephemeral encrypted-channel key it is about to use. Since the UKI
+measurement covers the ORAM-enabled binary plus the fixed run script, a
+successful attestation proves the encrypted ORAM request channel terminates in
+that measured code path. Database-build proofs and ORAM page authentication
+remain separate evidence layers for data correctness and disk tamper detection.
+
 ## Memory And Disk Planning
 
 Disk:

--- a/docs/PHASE3_SLICE3_PLAN.md
+++ b/docs/PHASE3_SLICE3_PLAN.md
@@ -74,6 +74,7 @@ Browser auto-flips to `verified-vcek` on connect — see
 | sshd | available | **gone** |
 | Operator access | `ssh vpsbg-pir` | `bpir-admin` over WSS only (cf. `bpir-admin upload` for DBs) |
 | DB storage | `/home/pir/data/checkpoints/`, `/home/pir/data/deltas/` (rootfs, mutable) | Same — DBs (~14 GB) can't be in UKI; need a writable mount |
+| ORAM storage | not enabled in the original Slice 3 notes | ORAM images stay in `/home/pir/data/oram`, while the direct ORAM flags are baked into `/etc/sv/unified_server/run` inside the UKI |
 | VCEK chain | `/home/pir/data/vcek/{cert_chain.pem,vcek.pem}` (rootfs) | Same — operator-refreshable on TCB updates |
 | Binary update cadence | `cargo build && systemctl restart pir-vpsbg` | `cargo build → re-bake UKI → upload via portal → reboot` (every change) |
 | Recovery if UKI bricks | Portal "None" UKI fallback + SSH back in + cp .bak | **Portal "None" UKI fallback only** — no SSH to recover from |
@@ -430,7 +431,9 @@ initramfs alongside the binary itself.
   layer unchanged.
 - DB integrity — manifest roots in attestation already cover this;
   DBs continue to live on the writable mount with the same upload
-  path (`bpir-admin upload`).
+  path (`bpir-admin upload`). Direct ORAM image files also live on the
+  writable mount; the UKI measurement covers the ORAM-enabled binary and
+  fixed direct ORAM startup flags, not the mutable ORAM image bytes.
 - VCEK chain refresh — operator workflow stays the same
   (`snpguest fetch vcek` + replace files in `/data/vcek/`).
 - Web bundle / browser — `verified-vcek` flow keeps working; the

--- a/scripts/build_uki_tier3.sh
+++ b/scripts/build_uki_tier3.sh
@@ -85,7 +85,7 @@ done
 BINARY=${BINARY:-/home/pir/BitcoinPIR/target/release/unified_server}
 [ -x "$BINARY" ] || {
     echo "error: $BINARY not executable" >&2
-    echo "       run: cargo build --release -p unified_server" >&2
+    echo "       run: cargo build --release -p runtime --features cuckoo-oram --bin unified_server" >&2
     exit 1
 }
 

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -15,6 +15,10 @@
 #                       without it the binary exits code 2 → runit crash-loop.)
 #   --config /home/pir/data/databases.toml   (loaded from rootfs via
 #                                             bpir-tier3-init's bind mount)
+#   --direct-oram-db 0=... / 1=...
+#                       direct ORAM images stay on the bind-mounted rootfs, but
+#                       these paths and ORAM runtime parameters are baked into
+#                       the measured UKI run script.
 #   --admin-pubkey-hex <op key>   (auth for REQ_ADMIN_DB_UPLOAD etc.)
 #
 # Runs as root — Tier 3 initramfs has no /etc/passwd, so dropping
@@ -39,11 +43,28 @@ if [ ! -r /home/pir/data/databases.toml ]; then
     exit 1
 fi
 
+ORAM_FULL_DIR=/home/pir/data/oram/checkpoints/948454-direct-pack16-z2-div2-stash128-auth
+ORAM_DELTA_DIR=/home/pir/data/oram/deltas/940611_948454_canonical-direct-pack16-z2-div2-stash128-auth
+
+for dir in "$ORAM_FULL_DIR" "$ORAM_DELTA_DIR"; do
+    if [ ! -d "$dir" ]; then
+        echo "[unified-server-run] FATAL: direct ORAM image directory missing: $dir" >&2
+        sleep 5
+        exit 1
+    fi
+done
+
 exec /usr/local/bin/unified_server \
     --port 8091 \
     --role secondary \
     --serve-queries \
     --config /home/pir/data/databases.toml \
+    --direct-oram-db "0=$ORAM_FULL_DIR" \
+    --direct-oram-db "1=$ORAM_DELTA_DIR" \
+    --direct-oram-drain-per-access 2 \
+    --direct-oram-access-budget 75 \
+    --direct-oram-cache-levels 0 \
+    --direct-oram-auth-store \
     --admin-pubkey-hex 87d454db85266e10e55ed8b68417de9d79ceb1d5d944bae831a7877627efdad3 \
     --vcek-dir /home/pir/data/vcek \
     --identity-key-path /home/pir/data/pir2-identity.key \


### PR DESCRIPTION
## Summary
- add direct ORAM image checks and startup flags to the Tier 3 initramfs `unified_server` run script
- update the Tier 3 UKI build hint so the baked binary is built with `--features cuckoo-oram`
- document that UKI measurement covers the ORAM-enabled binary plus fixed ORAM startup flags, while ORAM image files remain on `/home/pir/data`

## Verification
- bash -n scripts/build_uki_tier3.sh
- bash -n scripts/dracut/96bpir-unified-server/module-setup.sh
- bash -n scripts/dracut/97bpir-tier3-init/module-setup.sh
- sh -n scripts/dracut/97bpir-tier3-init/unified-server-run.sh
- git diff --check -- scripts/build_uki_tier3.sh scripts/dracut/97bpir-tier3-init/unified-server-run.sh docs/ORAM_VPSBG_TEST_RUN.md docs/PHASE3_SLICE3_PLAN.md
- cargo check -p runtime --features cuckoo-oram --bin unified_server

## Not run
- Tier 3 UKI rebuild/upload, because that requires VPSBG root environment and portal reboot.