### PR TITLE
Web/WASM database proof attestation wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,6 +1835,7 @@ dependencies = [
  "pir-attest-verify",
  "pir-channel",
  "pir-core",
+ "pir-db-attest",
  "pir-runtime-core",
  "pir-sdk",
  "pir-sdk-client",

--- a/doc/WEB.md
+++ b/doc/WEB.md
@@ -4,6 +4,12 @@
 
 The PIR system uses WebSocket for all client-server communication. This enables direct browser connections without any intermediary.
 
+Current browser flows use the Rust SDK through `pir-sdk-wasm` for DPF and
+HarmonyPIR. The TypeScript adapters are responsible for UI state, IndexedDB hint
+storage, address parsing, and status badges; padding, Merkle verification,
+runtime attestation, encrypted-channel setup, and database-build proof
+verification live below the WASM boundary.
+
 ## Architecture
 
 ```
@@ -49,14 +55,37 @@ runtime/src/
 └── lib.rs                 # Module exports
 
 web/src/
-├── client.ts              # Browser WebSocket PIR client
-├── dpf.ts                 # DPF key generation
-├── hash.ts                # HASH160, cuckoo hash functions
-├── constants.ts           # Database IDs and parameters
-├── bincode.ts             # Binary serialization
-├── sbp.ts                 # Simple Binary Protocol codec
-└── index.ts               # Main entry point
+├── dpf-adapter.ts         # DPF UI adapter over WasmDpfClient
+├── harmonypir-adapter.ts  # HarmonyPIR UI adapter over WasmHarmonyClient
+├── db-proof.ts            # Browser-side DB proof status/pin helpers
+├── attest-pin.ts          # Runtime + DB proof production pins
+├── sdk-bridge.ts          # pir-sdk-wasm loader/type bridge
+├── hash.ts                # Address/script hashing helpers
+├── server-info.ts         # Catalog, server-info, residency helpers
+└── index.ts               # Public web exports
 ```
+
+## Runtime and Database Attestation
+
+The browser renders two distinct badges:
+
+- Runtime attestation: DPF and HarmonyPIR call the WASM attestation API against
+  pir1 and pir2. pir2 is checked against the SEV-SNP Tier 3 measurement,
+  binary hash, AMD ARK/VCEK chain, encrypted-channel binding, and operator
+  identity pins in `web/src/attest-pin.ts`.
+- Database build attestation: DPF and HarmonyPIR fetch `REQ_GET_DB_PROOF`
+  (`0x0a`) for each configured `PRODUCTION_DB_PROOF_PINS` entry, verify the
+  attested-builder evidence in WASM, and compare the result to the pinned block
+  range, Bitcoin Core MuHash, bucket Merkle root, onion Merkle root, builder
+  binary hash, builder commit, network magic, and params hash.
+
+The current production DB proof is `delta_940611_948454` (`db_id = 1`) with
+MuHash `cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee`
+at block `948454`
+(`00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4`).
+This is advisory in the UI today; the remaining strict-mode work is to make
+query-path Merkle verification consume the verified roots directly and to add
+the same proof path to standalone OnionPIR.
 
 ## Running the System
 

--- a/docs/DB_BUILD_ATTESTATION_PLAN.md
+++ b/docs/DB_BUILD_ATTESTATION_PLAN.md
@@ -1,7 +1,9 @@
 # Database Build Attestation Plan
 
-Status: server/API proof distribution deployed for the production delta DB;
-web UX and strict query-path enforcement remain.
+Status: server/API proof distribution is deployed for the production delta DB.
+The web frontend now fetches and verifies the production delta proof for DPF
+and HarmonyPIR and renders an advisory DB/MuHash badge. Strict query-path root
+installation and standalone OnionPIR proof verification remain.
 
 Goal: bind BitcoinPIR database Merkle roots to an independently verifiable
 Bitcoin Core UTXO MuHash computation. The runtime server attestation proves
@@ -13,6 +15,12 @@ Bitcoin Core UTXO MuHash computation. The runtime server attestation proves
 The first production-grade artifact is the VPSBG SEV-SNP roots-only delta run:
 
 - range: `940611 -> 948454`
+- from block hash:
+  `000000000000000000002c41243b3d74d135942031ef15f547bca1ce8f85eb99`
+- block hash:
+  `00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4`
+- MuHash:
+  `cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee`
 - deployed proof dir on Hetzner and VPSBG:
   `/home/pir/data/attestations/delta_940611_948454_sev_snp`
 - local mirror:
@@ -21,6 +29,12 @@ The first production-grade artifact is the VPSBG SEV-SNP roots-only delta run:
   `01e8db91d76037cd5562fce85c40e832ad156431`
 - builder binary sha256:
   `34a677847b9be6580385c73f163279c81561772f8d3ad782d0ca08f1c01fad4a`
+- Bitcoin Core version:
+  `Bitcoin Core v31.0.0`
+- params hash:
+  `2b3e488c04433ed8bd293fd3adab72b49bf52346b81160365486d76f9b4d4e39`
+- network magic:
+  `f9beb4d9`
 - build evidence sha256:
   `977abca3ca8dc5dfce06d69006feeb6c0df5e7df3d7c1d758fc717254ff10697`
 - SEV-SNP report sha256:
@@ -105,20 +119,24 @@ Known cleanups:
 
 ### 6. Web/WASM Policy
 
-- `pir-sdk-wasm` should expose:
-  - `WasmDpfClient.verifyDatabaseProof(dbId, policy)`
-  - `WasmHarmonyClient.verifyDatabaseProof(dbId, policy)`
+- `pir-sdk-wasm` exposes:
+  - `WasmDpfClient.verifyDatabaseProof(dbId, params_hash, builder_hash,
+    builder_commit)`
+  - `WasmHarmonyClient.verifyDatabaseProof(dbId, params_hash, builder_hash,
+    builder_commit)`
   - `verifyDatabaseProofResponse(dbInfo, rawResponse, policy)` for the
-    standalone TypeScript OnionPIR client.
-- Web adapters should accept `databaseProofPolicy`, `requireDatabaseProofs`, and
-  `onDatabaseProof`.
+    standalone TypeScript OnionPIR client remains.
+- DPF and Harmony web adapters accept `databaseProofPins` and
+  `onDatabaseProof`, fetch `REQ_GET_DB_PROOF`, verify in WASM, compare against
+  `web/src/attest-pin.ts::PRODUCTION_DB_PROOF_PINS`, and store status in
+  `databaseProofs`.
+- The demo UI renders a DB proof badge with the verified MuHash, block range,
+  bucket root, onion root, and builder pins.
 - DPF and Harmony should install verified bucket/onion roots into their native WASM
   clients before queries.
 - standalone OnionPIR should fetch `REQ_GET_DB_PROOF` directly, verify it through
   the WASM verifier, and use the attested onion super-root as the Merkle
   anchor instead of trusting `server-info`'s `super_root`.
-- The demo UI should render a separate `DB build attested` badge for DPF,
-  HarmonyPIR, and OnionPIR using the `onDatabaseProof` callbacks.
 - `scripts/smoke_db_proof_attestation.sh` wraps local and live proof checks
   with the pinned expected values below.
 
@@ -146,9 +164,12 @@ if the client must verify the whole sync chain from zero. Run the same UKI in
 - [x] Client proof fetch and strict verification.
 - [x] Post-deploy smoke helper script.
 - [x] Production delta proof deployment and live smoke tests.
+- [x] Web/WASM proof policy for DPF and HarmonyPIR.
+- [x] Dedicated UI badge/status rendering for DPF and HarmonyPIR database
+      build attestation.
 - [ ] Merkle verification consumes verified roots in strict query paths.
-- [ ] Web/WASM proof policy and client root installation.
-- [ ] Dedicated UI badge/status rendering for database build attestation.
+- [ ] Web/WASM verified-root installation before queries.
+- [ ] standalone OnionPIR DB proof verifier and UI badge.
 
 ## Production Deployment Record
 

--- a/docs/PHASE3_ROADMAP.md
+++ b/docs/PHASE3_ROADMAP.md
@@ -361,64 +361,54 @@ recovery checklist.
 
 ## Web frontend updates
 
-The web client (`web/`) has two relevant concerns this work introduces:
+The web client (`web/`) now shows two separate trust checks:
 
-### 1. Display attestation status in the UI
+### 1. Runtime attestation status
 
-Right now the SDK has the attestation primitives
-(`pir_sdk_client::attest::attest`) but the web wrapper doesn't expose
-them. Add a small UI element to the existing client page (`web/src/`):
+DPF and HarmonyPIR adapters call the WASM attestation surface after connect.
+The UI renders:
 
-- Periodic background `/attest` against pir1 + pir2.
-- For pir1 (Hetzner, no SEV): green badge "self-reported attestation
-  (no hardware backing)" with binary_sha256 + git_rev visible.
-- For pir2 (VPSBG, SEV-SNP): green badge "✓ Verified via SEV-SNP"
-  showing the launch MEASUREMENT and a tooltip explaining what was
-  attested. Cross-check against operator-published values baked into
-  the page bundle at build time (so any divergence is immediately
-  visible).
+- pir1 (Hetzner, no SEV): binary-hash/operator-identity status only.
+- pir2 (VPSBG, SEV-SNP Tier 3): launch MEASUREMENT, binary hash, AMD ARK/VCEK
+  chain validation, encrypted-channel upgrade, and operator identity.
 
-Implementation surface:
-- New `web/src/attest-badge.ts` (or similar) — runs the attest call
-  via the existing `WasmDpfClient` connection, parses the response,
-  renders status.
-- Add a build-time constant for expected MEASUREMENT (like
-  `VITE_BPIR_EXPECTED_MEASUREMENT_PIR2=f568fc1f…`).
-- Document the publication flow: when the operator uploads a new UKI
-  to VPSBG, they:
-  1. Re-bake UKI, capture new MEASUREMENT.
-  2. Update `VITE_BPIR_EXPECTED_MEASUREMENT_PIR2` in `.env`.
-  3. Rebuild + redeploy the web client.
+Pins live in `web/src/attest-pin.ts` as `PIR1_PIN`, `PIR2_TIER3_PIN`, and
+`AMD_TURIN_ARK_FINGERPRINT_HEX`.
 
-### 2. AMD VCEK chain verification (optional, deferred)
+### 2. Database build attestation status
 
-Currently `bpir-admin attest` (and the analogous browser flow) trust
-that the SEV-SNP report's signature is valid. To be truly
-independent, the verifier should:
-- Fetch AMD's ARK + ASK + VCEK for the chip from
-  `https://kdsintf.amd.com/vcek/v1/Turin/<chip-id>?...`
-- Verify the cert chain: ARK self-signed → ARK signs ASK → ASK signs VCEK.
-- Verify the SEV report's ECDSA-P384 signature against the VCEK.
+DPF and HarmonyPIR adapters also fetch `REQ_GET_DB_PROOF = 0x0a` for configured
+`databaseProofPins`, verify the attested-builder bundle in WASM, compare the
+result against `PRODUCTION_DB_PROOF_PINS`, and render a separate DB proof badge.
 
-Doing this in browser context requires either:
-- A WASM build of the verification code (cleanest; reuses
-  `pir_core::attest` + ed25519/ECDSA crates compiled to wasm32).
-- A Cloudflare Worker that does the verification and returns a
-  signed assertion (more centralized, less ideal).
+Current production DB proof pin:
 
-Recommend: WASM build, ship as part of the SDK. Estimate ~3 days.
+| Field | Value |
+|---|---|
+| DB | `delta_940611_948454` (`db_id = 1`) |
+| from block | `940611`, `000000000000000000002c41243b3d74d135942031ef15f547bca1ce8f85eb99` |
+| to block | `948454`, `00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4` |
+| MuHash | `cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee` |
+| bucket super-root | `e2ba2eee6788424309a95f771893d5401cc8e3ceec6188dc2708900e211a910a` |
+| onion super-root | `f86baa3966a61cdcd70d8c0ad9bed233f591806eb351db2ae35ac0192a3fe997` |
+| builder binary | `34a677847b9be6580385c73f163279c81561772f8d3ad782d0ca08f1c01fad4a` |
+| builder commit | `01e8db91d76037cd5562fce85c40e832ad156431` |
+
+Open work: strict query-path root installation still needs to make DPF/Harmony
+Merkle checks consume the verified bucket root directly, and standalone
+OnionPIR still needs the direct `REQ_GET_DB_PROOF` verifier plus UI badge.
 
 ### 3. Confirm `--role secondary` doesn't break existing client flows
 
 The web client expects:
-- pir1 (Hetzner primary) handles `REQ_HARMONY_QUERY` and `REQ_HARMONY_BATCH_QUERY` (online).
-- pir2 (VPSBG, now also primary's-equivalent in topology) handles `REQ_HARMONY_HINTS` (offline).
+- pir1 (Hetzner primary) handles HarmonyPIR hints/offline preprocessing.
+- pir2 (VPSBG Tier 3) handles HarmonyPIR online queries.
+- DPF uses pir1 as server 0 and pir2 as server 1.
 
-This is the existing topology. `--role secondary` on VPSBG matches.
-
-After today's `e68df9b` dual-stack bind fix, the connection should
-succeed. **Open**: actually run the web client end-to-end with a real
-HarmonyPIR query and confirm.
+This is the existing production topology. **Open**: after every new web build,
+run one real DPF and one real HarmonyPIR query and confirm that runtime
+attestation, operator identity, and DB proof badges all settle before the
+query path proceeds.
 
 ---
 

--- a/pir-sdk-client/src/dpf.rs
+++ b/pir-sdk-client/src/dpf.rs
@@ -5,6 +5,9 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::connection::WsConnection;
+use crate::db_proof::{
+    fetch_database_proof, verify_database_proof, DatabaseProofPolicy, VerifiedDatabaseRoots,
+};
 use crate::merkle_verify::{
     fetch_tree_tops, verify_bucket_merkle_batch_dpf, BucketMerkleItem,
 };
@@ -456,6 +459,35 @@ impl DpfClient {
             metrics_recorder: None,
             leakage_recorder: None,
         }
+    }
+
+    /// Fetch and verify the attested-builder proof bundle for `db_id`.
+    ///
+    /// The proof is checked against the cached database catalog, fetching the
+    /// catalog first if needed. The returned roots are the attested builder
+    /// output: chain anchor, UTXO MuHash, bucket Merkle super-root, OnionPIR
+    /// super-root, and builder metadata.
+    pub async fn verify_database_proof(
+        &mut self,
+        db_id: u8,
+        policy: &DatabaseProofPolicy,
+    ) -> PirResult<VerifiedDatabaseRoots> {
+        if !self.is_connected() {
+            return Err(PirError::NotConnected);
+        }
+        let catalog = match &self.catalog {
+            Some(c) => c.clone(),
+            None => self.fetch_catalog().await?,
+        };
+        let db_info = catalog
+            .databases
+            .iter()
+            .find(|db| db.db_id == db_id)
+            .cloned()
+            .ok_or_else(|| PirError::Protocol(format!("db_id {} not present in catalog", db_id)))?;
+        let conn0 = self.conn0.as_mut().ok_or(PirError::NotConnected)?;
+        let bundle = fetch_database_proof(conn0.as_mut(), db_id).await?;
+        verify_database_proof(&db_info, &bundle, policy)
     }
 
     /// Install (or replace) a metrics recorder.

--- a/pir-sdk-client/src/harmony.rs
+++ b/pir-sdk-client/src/harmony.rs
@@ -31,6 +31,9 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::connection::WsConnection;
+use crate::db_proof::{
+    fetch_database_proof, verify_database_proof, DatabaseProofPolicy, VerifiedDatabaseRoots,
+};
 use crate::hint_cache;
 use crate::merkle_verify::{
     fetch_tree_tops, verify_bucket_merkle_batch_generic,
@@ -609,6 +612,36 @@ impl HarmonyClient {
             leakage_recorder: None,
             use_v2_protocol: true,
         }
+    }
+
+    /// Fetch and verify the attested-builder proof bundle for `db_id`.
+    ///
+    /// The proof is checked against the cached database catalog, fetching the
+    /// catalog first if needed. Harmony servers answer the catalog/proof
+    /// requests before role-specific hint/query dispatch, so the hint
+    /// connection is sufficient and keeps this method consistent with
+    /// `fetch_catalog`.
+    pub async fn verify_database_proof(
+        &mut self,
+        db_id: u8,
+        policy: &DatabaseProofPolicy,
+    ) -> PirResult<VerifiedDatabaseRoots> {
+        if !self.is_connected() {
+            return Err(PirError::NotConnected);
+        }
+        let catalog = match &self.catalog {
+            Some(c) => c.clone(),
+            None => self.fetch_catalog().await?,
+        };
+        let db_info = catalog
+            .databases
+            .iter()
+            .find(|db| db.db_id == db_id)
+            .cloned()
+            .ok_or_else(|| PirError::Protocol(format!("db_id {} not present in catalog", db_id)))?;
+        let conn = self.hint_conn.as_mut().ok_or(PirError::NotConnected)?;
+        let bundle = fetch_database_proof(conn.as_mut(), db_id).await?;
+        verify_database_proof(&db_info, &bundle, policy)
     }
 
     // ─── Metrics recorder ──────────────────────────────────────────────────

--- a/pir-sdk-wasm/Cargo.toml
+++ b/pir-sdk-wasm/Cargo.toml
@@ -58,6 +58,9 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 # back to AMD's known root without talking to kdsintf.amd.com
 # (CORS-blocked from browser context).
 pir-attest-verify = { version = "0.1.0", path = "../pir-attest-verify" }
+# JS-facing DB proof summaries use the same build-kind labels and hash display
+# helpers as the native verifier.
+pir-db-attest = { path = "../pir-db-attest" }
 # Per-handshake nonce + ephemeral seed in `WasmDpfClient::attest`. The
 # "js" feature lets it use `crypto.getRandomValues` on wasm32; on
 # native (used only by `cargo test`) it reads /dev/urandom.

--- a/pir-sdk-wasm/src/client.rs
+++ b/pir-sdk-wasm/src/client.rs
@@ -34,9 +34,11 @@
 use js_sys::{Array, Uint8Array};
 use pir_sdk::{PirClient, QueryResult, ScriptHash, SyncResult};
 use pir_sdk_client::attest::{AttestVerification, SevStatus};
-use pir_sdk_client::{DpfClient, HarmonyClient, PRP_FASTPRP, PRP_HMR12};
 #[cfg(target_arch = "wasm32")]
 use pir_sdk_client::HintProgress;
+use pir_sdk_client::{
+    DatabaseProofPolicy, DpfClient, HarmonyClient, VerifiedDatabaseRoots, PRP_FASTPRP, PRP_HMR12,
+};
 use wasm_bindgen::prelude::*;
 
 use crate::{
@@ -117,6 +119,71 @@ fn err_to_js(e: pir_sdk::PirError) -> JsError {
 
 fn hex_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn parse_optional_hex_array<const N: usize>(
+    field: &str,
+    value: Option<String>,
+) -> Result<Option<[u8; N]>, JsError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(None);
+    }
+    let bytes =
+        hex::decode(value).map_err(|e| JsError::new(&format!("{field}: invalid hex: {e}")))?;
+    let arr: [u8; N] = bytes.as_slice().try_into().map_err(|_| {
+        JsError::new(&format!(
+            "{field}: expected {} bytes ({} hex chars), got {} bytes",
+            N,
+            N * 2,
+            bytes.len()
+        ))
+    })?;
+    Ok(Some(arr))
+}
+
+fn database_proof_policy(
+    expected_params_hash_hex: Option<String>,
+    allowed_builder_binary_sha256_hex: Option<String>,
+    allowed_builder_git_commit: Option<String>,
+) -> Result<DatabaseProofPolicy, JsError> {
+    let mut policy = DatabaseProofPolicy::mainnet();
+    policy.expected_params_hash =
+        parse_optional_hex_array::<32>("expectedParamsHashHex", expected_params_hash_hex)?;
+    if let Some(hash) = parse_optional_hex_array::<32>(
+        "allowedBuilderBinarySha256Hex",
+        allowed_builder_binary_sha256_hex,
+    )? {
+        policy.allowed_builder_binary_sha256.push(hash);
+    }
+    if let Some(commit) = allowed_builder_git_commit {
+        let commit = commit.trim();
+        if !commit.is_empty() {
+            policy.allowed_builder_git_commits.push(commit.to_owned());
+        }
+    }
+    Ok(policy)
+}
+
+fn database_proof_json(roots: &VerifiedDatabaseRoots) -> serde_json::Value {
+    serde_json::json!({
+        "dbId": roots.db_id,
+        "buildKind": pir_db_attest::build_kind_label(roots.build_kind),
+        "fromHeight": roots.from_height,
+        "fromBlockHashHex": roots.from_block_hash_hex(),
+        "height": roots.height,
+        "blockHashHex": roots.block_hash_hex(),
+        "muhashHex": roots.muhash_hex(),
+        "bucketSuperRootHex": roots.bucket_super_root_hex(),
+        "onionSuperRootHex": roots.onion_super_root_hex(),
+        "paramsHashHex": hex_encode(&roots.params_hash),
+        "networkMagicHex": hex_encode(&roots.network_magic),
+        "builderBinarySha256Hex": hex_encode(&roots.builder_binary_sha256),
+        "builderGitCommit": roots.builder_git_commit,
+    })
 }
 
 /// Build the JS-facing JSON shape of a `SyncResult`. Mirrors
@@ -757,6 +824,93 @@ pub fn turin_ark_fingerprint() -> Uint8Array {
     Uint8Array::from(&pir_attest_verify::TURIN_ARK_FINGERPRINT_SHA256[..])
 }
 
+// ─── WasmDatabaseProof ─────────────────────────────────────────────────────
+
+/// JS-visible summary of a verified attested-builder database proof.
+///
+/// The Rust side has already checked the proof bundle against the database
+/// catalog and policy before constructing this object. Hex values are display
+/// oriented: block hashes and MuHash use Bitcoin Core display order; Merkle
+/// roots and SHA-256 values are raw hex.
+#[wasm_bindgen]
+pub struct WasmDatabaseProof {
+    inner: VerifiedDatabaseRoots,
+}
+
+#[wasm_bindgen]
+impl WasmDatabaseProof {
+    #[wasm_bindgen(getter, js_name = dbId)]
+    pub fn db_id(&self) -> u8 {
+        self.inner.db_id
+    }
+
+    #[wasm_bindgen(getter, js_name = buildKind)]
+    pub fn build_kind(&self) -> String {
+        pir_db_attest::build_kind_label(self.inner.build_kind).to_owned()
+    }
+
+    #[wasm_bindgen(getter, js_name = fromHeight)]
+    pub fn from_height(&self) -> u32 {
+        self.inner.from_height
+    }
+
+    #[wasm_bindgen(getter, js_name = fromBlockHashHex)]
+    pub fn from_block_hash_hex(&self) -> String {
+        self.inner.from_block_hash_hex()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn height(&self) -> u32 {
+        self.inner.height
+    }
+
+    #[wasm_bindgen(getter, js_name = blockHashHex)]
+    pub fn block_hash_hex(&self) -> String {
+        self.inner.block_hash_hex()
+    }
+
+    #[wasm_bindgen(getter, js_name = muhashHex)]
+    pub fn muhash_hex(&self) -> String {
+        self.inner.muhash_hex()
+    }
+
+    #[wasm_bindgen(getter, js_name = bucketSuperRootHex)]
+    pub fn bucket_super_root_hex(&self) -> String {
+        self.inner.bucket_super_root_hex()
+    }
+
+    #[wasm_bindgen(getter, js_name = onionSuperRootHex)]
+    pub fn onion_super_root_hex(&self) -> String {
+        self.inner.onion_super_root_hex()
+    }
+
+    #[wasm_bindgen(getter, js_name = paramsHashHex)]
+    pub fn params_hash_hex(&self) -> String {
+        hex_encode(&self.inner.params_hash)
+    }
+
+    #[wasm_bindgen(getter, js_name = networkMagicHex)]
+    pub fn network_magic_hex(&self) -> String {
+        hex_encode(&self.inner.network_magic)
+    }
+
+    #[wasm_bindgen(getter, js_name = builderBinarySha256Hex)]
+    pub fn builder_binary_sha256_hex(&self) -> String {
+        hex_encode(&self.inner.builder_binary_sha256)
+    }
+
+    #[wasm_bindgen(getter, js_name = builderGitCommit)]
+    pub fn builder_git_commit(&self) -> String {
+        self.inner.builder_git_commit.clone()
+    }
+
+    /// Convert to a plain JS object for UI state and callbacks.
+    #[wasm_bindgen(js_name = toJson)]
+    pub fn to_json(&self) -> JsValue {
+        to_js_object(&database_proof_json(&self.inner))
+    }
+}
+
 // ─── WasmAnnounceVerification ──────────────────────────────────────────────
 
 /// JS-visible result of a `WasmDpfClient.announce()` (or
@@ -949,9 +1103,7 @@ impl WasmAnnounceVerification {
 /// instead of reimplementing Ed25519 verification in TS. Mirrors the
 /// Rust `pir_sdk_client::announce::parse_announce_response`.
 #[wasm_bindgen(js_name = verifyAnnounceResponse)]
-pub fn verify_announce_response(
-    resp_payload: &[u8],
-) -> Result<WasmAnnounceVerification, JsError> {
+pub fn verify_announce_response(resp_payload: &[u8]) -> Result<WasmAnnounceVerification, JsError> {
     let inner = pir_sdk_client::announce::parse_announce_response(resp_payload)
         .map_err(|e| JsError::new(&e.to_string()))?;
     Ok(WasmAnnounceVerification { inner })
@@ -1030,6 +1182,34 @@ impl WasmDpfClient {
     pub async fn fetch_catalog(&mut self) -> Result<WasmDatabaseCatalog, JsError> {
         let catalog = self.inner.fetch_catalog().await.map_err(err_to_js)?;
         Ok(WasmDatabaseCatalog::from_native(catalog))
+    }
+
+    /// Fetch and verify the attested-builder proof bundle for `dbId`.
+    ///
+    /// The proof is checked against the database catalog plus the supplied
+    /// production policy pins. `expectedParamsHashHex`,
+    /// `allowedBuilderBinarySha256Hex`, and `allowedBuilderGitCommit` may be
+    /// `undefined` / empty to skip that particular policy check. Mainnet
+    /// network magic is always enforced.
+    #[wasm_bindgen(js_name = verifyDatabaseProof)]
+    pub async fn verify_database_proof(
+        &mut self,
+        db_id: u8,
+        expected_params_hash_hex: Option<String>,
+        allowed_builder_binary_sha256_hex: Option<String>,
+        allowed_builder_git_commit: Option<String>,
+    ) -> Result<WasmDatabaseProof, JsError> {
+        let policy = database_proof_policy(
+            expected_params_hash_hex,
+            allowed_builder_binary_sha256_hex,
+            allowed_builder_git_commit,
+        )?;
+        let roots = self
+            .inner
+            .verify_database_proof(db_id, &policy)
+            .await
+            .map_err(err_to_js)?;
+        Ok(WasmDatabaseProof { inner: roots })
     }
 
     /// End-to-end sync: fetch catalog, plan, execute all steps, merge
@@ -1142,10 +1322,7 @@ impl WasmDpfClient {
     /// the cached seed (the prior eph is dropped). Callers should call
     /// `attest` for *both* servers before `upgradeToSecureChannel`.
     #[wasm_bindgen(js_name = attest)]
-    pub async fn attest(
-        &mut self,
-        server_index: u8,
-    ) -> Result<WasmAttestVerification, JsError> {
+    pub async fn attest(&mut self, server_index: u8) -> Result<WasmAttestVerification, JsError> {
         if server_index >= 2 {
             return Err(JsError::new(&format!(
                 "attest: serverIndex must be 0 or 1, got {}",
@@ -1191,11 +1368,7 @@ impl WasmDpfClient {
                 server_index
             )));
         }
-        let v = self
-            .inner
-            .announce(server_index)
-            .await
-            .map_err(err_to_js)?;
+        let v = self.inner.announce(server_index).await.map_err(err_to_js)?;
         Ok(WasmAnnounceVerification { inner: v })
     }
 
@@ -1553,6 +1726,31 @@ impl WasmHarmonyClient {
         Ok(WasmDatabaseCatalog::from_native(catalog))
     }
 
+    /// Fetch and verify the attested-builder proof bundle for `dbId`.
+    ///
+    /// See [`WasmDpfClient::verify_database_proof`] for policy argument
+    /// semantics. Mainnet network magic is always enforced.
+    #[wasm_bindgen(js_name = verifyDatabaseProof)]
+    pub async fn verify_database_proof(
+        &mut self,
+        db_id: u8,
+        expected_params_hash_hex: Option<String>,
+        allowed_builder_binary_sha256_hex: Option<String>,
+        allowed_builder_git_commit: Option<String>,
+    ) -> Result<WasmDatabaseProof, JsError> {
+        let policy = database_proof_policy(
+            expected_params_hash_hex,
+            allowed_builder_binary_sha256_hex,
+            allowed_builder_git_commit,
+        )?;
+        let roots = self
+            .inner
+            .verify_database_proof(db_id, &policy)
+            .await
+            .map_err(err_to_js)?;
+        Ok(WasmDatabaseProof { inner: roots })
+    }
+
     /// End-to-end sync. See [`WasmDpfClient::sync`] for argument
     /// semantics — the wire path differs but the JS-facing shape is
     /// identical.
@@ -1638,10 +1836,7 @@ impl WasmHarmonyClient {
     /// the bound-nonce derivation that ties this attestation to the
     /// subsequent handshake).
     #[wasm_bindgen(js_name = attest)]
-    pub async fn attest(
-        &mut self,
-        server_index: u8,
-    ) -> Result<WasmAttestVerification, JsError> {
+    pub async fn attest(&mut self, server_index: u8) -> Result<WasmAttestVerification, JsError> {
         if server_index >= 2 {
             return Err(JsError::new(&format!(
                 "attest: serverIndex must be 0 or 1, got {}",
@@ -1679,11 +1874,7 @@ impl WasmHarmonyClient {
                 server_index
             )));
         }
-        let v = self
-            .inner
-            .announce(server_index)
-            .await
-            .map_err(err_to_js)?;
+        let v = self.inner.announce(server_index).await.map_err(err_to_js)?;
         Ok(WasmAnnounceVerification { inner: v })
     }
 
@@ -1922,7 +2113,9 @@ impl WasmHarmonyClient {
             .inner()
             .get(db_id)
             .ok_or_else(|| JsError::new(&format!("no database with db_id={}", db_id)))?;
-        self.inner.load_hints_bytes(bytes, db_info).map_err(err_to_js)
+        self.inner
+            .load_hints_bytes(bytes, db_info)
+            .map_err(err_to_js)
     }
 
     /// Install a [`WasmAtomicMetrics`] recorder.
@@ -2217,10 +2410,7 @@ mod tests {
 
         let json = sync_result_to_json(&sync);
         assert_eq!(json["results"][0]["merkleVerified"], false);
-        assert_eq!(
-            json["results"][0]["entries"].as_array().unwrap().len(),
-            0
-        );
+        assert_eq!(json["results"][0]["entries"].as_array().unwrap().len(), 0);
     }
 
     // Note: we deliberately don't have a unit test that calls `err_to_js`

--- a/pir-sdk-wasm/src/lib.rs
+++ b/pir-sdk-wasm/src/lib.rs
@@ -68,7 +68,7 @@ pub mod cashu;
 /// depends on C++/SEAL which does not compile to wasm32. Browsers that
 /// want OnionPIR must keep the TypeScript client for now.
 pub mod client;
-pub use client::{WasmDpfClient, WasmHarmonyClient, WasmSyncResult};
+pub use client::{WasmDatabaseProof, WasmDpfClient, WasmHarmonyClient, WasmSyncResult};
 
 /// Phase 2+ observability bridge — exposes `pir_sdk::AtomicMetrics` to
 /// JavaScript so a browser tools panel / dashboard can poll live PIR

--- a/web/index.html
+++ b/web/index.html
@@ -792,6 +792,9 @@
            check. Hidden for unconfigured / error / not-checked. */
         .attest-badge-op-verified   { border-left-color: #2e7d32; background: #f0fdf4; }
         .attest-badge-op-unverified { border-left-color: var(--err); background: #fef2f2; }
+        .attest-badge-db-verified   { border-left-color: #1565c0; background: #eff6ff; }
+        .attest-badge-db-unverified { border-left-color: var(--err); background: #fef2f2; }
+        .attest-badge-db-unavailable { border-left-color: var(--ink-mute); background: var(--bg); color: var(--ink-mute); }
     </style>
     <!-- OnionPIR WASM (post-port ES module) loaded dynamically via
          `await import('/wasm/onionpir_client.mjs')` in
@@ -1040,6 +1043,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                         </div>
                         <div id="attestBadge1" class="attest-badge attest-badge-unattested" data-server="1" style="display: none;"></div>
                         <div id="operatorBadge1" class="attest-badge attest-badge-op-verified" data-server="1" style="display: none;"></div>
+                        <div id="dbProofBadge" class="attest-badge attest-badge-db-unavailable" style="display: none;"></div>
 
                         <div id="syncStateRow" style="display: none; margin-top: 14px;">
                             <span>Sync state:</span>
@@ -1373,6 +1377,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                         </div>
                         <div id="hp-attestBadgeQuery" class="attest-badge attest-badge-unattested" style="display: none;"></div>
                         <div id="hp-operatorBadgeQuery" class="attest-badge attest-badge-op-verified" style="display: none;"></div>
+                        <div id="hp-dbProofBadge" class="attest-badge attest-badge-db-unavailable" style="display: none;"></div>
                         <div class="status-row">
                             <label for="hp-prpSelect">PRP backend</label>
                             <div style="display: flex; align-items: center; gap: 10px;">
@@ -1432,7 +1437,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
     </section>
 
     <script type="module">
-        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN } from './src/index.ts';
+        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, databaseProofAnchorLabel } from './src/index.ts';
         import { fetchResidency } from './src/server-info.ts';
 
         // Initialize SDK WASM (optional - falls back to TS if unavailable)
@@ -1612,6 +1617,55 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             } else {
                 rows.push(`<span class="ab-state">⚠ Operator identity UNVERIFIED</span>`);
                 rows.push(`<div class="ab-row"><span class="ab-label">reason</span><span class="ab-val" title="${oid.error || ''}">${oid.error || 'check failed'}</span></div>`);
+            }
+            el.innerHTML = rows.join('');
+        }
+
+        function escapeHtml(value) {
+            return String(value ?? '').replace(/[&<>"']/g, ch => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;',
+            })[ch]);
+        }
+
+        function renderDatabaseProofBadge(idElem, label, info) {
+            const el = typeof idElem === 'string' ? document.getElementById(idElem) : idElem;
+            if (!el) return;
+            const truncate = (hex, n = 16) =>
+                hex && hex.length > n ? `${hex.slice(0, n)}...` : (hex || '—');
+            const proof = info.proof;
+            const pin = info.pin;
+            const anchor = proof ? databaseProofAnchorLabel(proof)
+                : pin ? databaseProofAnchorLabel(pin)
+                : `db ${info.dbId}`;
+            const stateLabel = info.state === 'verified'
+                ? `Verified DB proof — ${anchor}`
+                : info.state === 'unverified'
+                    ? `DB proof mismatch — ${anchor}`
+                    : `DB proof unavailable — ${anchor}`;
+
+            el.className = `attest-badge attest-badge-db-${info.state}`;
+            el.style.display = 'block';
+
+            const rows = [];
+            rows.push(`<span class="ab-state">${escapeHtml(label)}: ${escapeHtml(stateLabel)}</span>`);
+            if (proof) {
+                rows.push(`<div class="ab-row"><span class="ab-label">muhash</span><span class="ab-val" title="${proof.muhashHex}">${truncate(proof.muhashHex, 24)}</span></div>`);
+                rows.push(`<div class="ab-row"><span class="ab-label">block</span><span class="ab-val" title="${proof.blockHashHex}">${proof.height.toLocaleString()} · ${truncate(proof.blockHashHex, 24)}</span></div>`);
+                if (proof.buildKind === 'delta') {
+                    rows.push(`<div class="ab-row"><span class="ab-label">from</span><span class="ab-val" title="${proof.fromBlockHashHex}">${proof.fromHeight.toLocaleString()} · ${truncate(proof.fromBlockHashHex, 24)}</span></div>`);
+                }
+                rows.push(`<div class="ab-row"><span class="ab-label">bucket root</span><span class="ab-val" title="${proof.bucketSuperRootHex}">${truncate(proof.bucketSuperRootHex, 24)}</span></div>`);
+                rows.push(`<div class="ab-row"><span class="ab-label">onion root</span><span class="ab-val" title="${proof.onionSuperRootHex}">${truncate(proof.onionSuperRootHex, 24)}</span></div>`);
+                rows.push(`<div class="ab-row"><span class="ab-label">builder</span><span class="ab-val" title="${proof.builderBinarySha256Hex}">${truncate(proof.builderGitCommit, 12)} · ${truncate(proof.builderBinarySha256Hex, 16)}</span></div>`);
+            }
+            if (info.mismatches?.length) {
+                rows.push(`<div class="ab-row"><span class="ab-label">reason</span><span class="ab-val" title="${escapeHtml(info.mismatches.join('\\n'))}">${escapeHtml(info.mismatches[0])}</span></div>`);
+            } else if (info.error) {
+                rows.push(`<div class="ab-row"><span class="ab-label">reason</span><span class="ab-val" title="${escapeHtml(info.error)}">${escapeHtml(info.error)}</span></div>`);
             }
             el.innerHTML = rows.join('');
         }
@@ -2105,6 +2159,17 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     // the operator re-bakes + republishes.
                     expectedServer0Pin: PIR1_PIN,
                     expectedServer1Pin: PIR2_TIER3_PIN,
+                    databaseProofPins: PRODUCTION_DB_PROOF_PINS,
+                    onDatabaseProof: (dbId, info) => {
+                        if (info.state === 'verified') {
+                            log(`DB proof db ${dbId}: MuHash ${info.proof.muhashHex.slice(0, 16)}... anchored at ${info.proof.fromHeight} -> ${info.proof.height}`, 'success');
+                        } else if (info.state === 'unverified') {
+                            log(`DB proof db ${dbId}: UNVERIFIED — ${info.mismatches?.[0] || info.error || 'check failed'}`, 'error');
+                        } else {
+                            log(`DB proof db ${dbId}: unavailable — ${info.error || 'not configured'}`, 'info');
+                        }
+                        renderDatabaseProofBadge('dbProofBadge', 'DPF-PIR', info);
+                    },
                     onAttestation: (idx, info) => {
                         const tag = `server${idx}`;
                         if (info.state === 'verified-vcek') {
@@ -3596,6 +3661,17 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     // Slice 3 pins. Hint server = pir1 (no SEV), query server = pir2 (Tier 3).
                     expectedServer0Pin: PIR1_PIN,
                     expectedServer1Pin: PIR2_TIER3_PIN,
+                    databaseProofPins: PRODUCTION_DB_PROOF_PINS,
+                    onDatabaseProof: (dbId, info) => {
+                        if (info.state === 'verified') {
+                            log(`HarmonyPIR DB proof db ${dbId}: MuHash ${info.proof.muhashHex.slice(0, 16)}... anchored at ${info.proof.fromHeight} -> ${info.proof.height}`, 'success');
+                        } else if (info.state === 'unverified') {
+                            log(`HarmonyPIR DB proof db ${dbId}: UNVERIFIED — ${info.mismatches?.[0] || info.error || 'check failed'}`, 'error');
+                        } else {
+                            log(`HarmonyPIR DB proof db ${dbId}: unavailable — ${info.error || 'not configured'}`);
+                        }
+                        renderDatabaseProofBadge('hp-dbProofBadge', 'HarmonyPIR', info);
+                    },
                     onAttestation: (idx, info) => {
                         const tag = idx === 0 ? 'hint' : 'query';
                         if (info.state === 'verified-vcek') {

--- a/web/reproduce.html
+++ b/web/reproduce.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Reproducing the MEASUREMENT — Bitcoin PIR</title>
+    <title>Reproducing runtime and database attestation — Bitcoin PIR</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -220,12 +220,14 @@
     </header>
 
     <main>
-        <h1>Reproducing the SEV-SNP MEASUREMENT</h1>
+        <h1>Reproducing runtime and database attestation</h1>
         <p class="lede">
             Independently verify that <code>weikeng2.bitcoinpir.org</code>'s
             attestation report — signed by the AMD chip — actually corresponds
-            to the source code published in this repo. No need to trust the
-            operator's claimed MEASUREMENT.
+            to the source code published in this repo, then verify that the
+            served database roots bind to a Bitcoin Core MuHash at the pinned
+            block range. No need to trust the operator's claimed MEASUREMENT
+            or database anchor.
         </p>
 
         <section id="non-collusion">
@@ -285,8 +287,8 @@
                 are observable in the browser's attestation badge,
                 and both are version-controlled in
                 <code>web/src/attest-pin.ts</code>. The rest of this
-                page documents how to reproduce the pinned value
-                yourself from the published source.
+                page documents how to reproduce the pinned runtime value
+                and how to check the database/MuHash proof yourself.
             </p>
         </section>
 
@@ -337,20 +339,20 @@
         </section>
 
         <section>
-            <h2>Currently pinned values <span class="badge ok">v23 — 2026-05-26</span></h2>
+            <h2>Currently pinned runtime values <span class="badge ok">db-proof UKI — 2026-06-16</span></h2>
             <div class="panel accent">
                 <table class="pin-table">
                     <tr>
                         <td>MEASUREMENT</td>
-                        <td>4fb0ad57b28b7c33e6b2977f911fd6bf407ccf28bbab3ef9d24dceec579464a5961e10f5297a294c7dde24839eca4c6e</td>
+                        <td>892bb625705e8df9ff587553b11900e4fa7c28df732a77cf0d417446d63d2dff82fbefac334e0d97eaf3a5c0d1ce1013</td>
                     </tr>
                     <tr>
                         <td>UKI sha256</td>
-                        <td>747988fb57b94eb2c26944c17b949a1e77060487ab71245893a725d4191117cd</td>
+                        <td>01d0dc3f3fbff98886e8ba8bd9108a5a13fd55305806eeaeffeafe7307e68aab</td>
                     </tr>
                     <tr>
                         <td>binary sha256</td>
-                        <td>57ac525b1d92656a0ae39d6def562d6fc2889a8c6337b8b34f71a59d6ac44d59</td>
+                        <td>d01e5b7aab2b3075eed4dd154ffc2079aae394b418a40155128166a50ace750a</td>
                     </tr>
                     <tr>
                         <td>OVMF sha256</td>
@@ -366,6 +368,64 @@
                 Source of truth: <a href="https://github.com/Bitcoin-PIR/Bitcoin-PIR/blob/main/web/src/attest-pin.ts" target="_blank" rel="noopener"><code>web/src/attest-pin.ts</code></a>.
                 These values change with every Tier 3 UKI redeploy; this page
                 tracks the current pin.
+            </p>
+        </section>
+
+        <section>
+            <h2>Currently pinned database proof <span class="badge ok">delta 940611 to 948454</span></h2>
+            <p>
+                Runtime attestation proves which server binary is running.
+                Database build attestation proves that the served PIR Merkle
+                roots were produced by the SEV-SNP attested builder from the
+                claimed Bitcoin Core UTXO snapshots.
+            </p>
+            <div class="panel accent">
+                <table class="pin-table">
+                    <tr>
+                        <td>db_id</td>
+                        <td>1</td>
+                    </tr>
+                    <tr>
+                        <td>build kind</td>
+                        <td>delta</td>
+                    </tr>
+                    <tr>
+                        <td>from block</td>
+                        <td>940611 · 000000000000000000002c41243b3d74d135942031ef15f547bca1ce8f85eb99</td>
+                    </tr>
+                    <tr>
+                        <td>to block</td>
+                        <td>948454 · 00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4</td>
+                    </tr>
+                    <tr>
+                        <td>MuHash</td>
+                        <td>cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee</td>
+                    </tr>
+                    <tr>
+                        <td>bucket root</td>
+                        <td>e2ba2eee6788424309a95f771893d5401cc8e3ceec6188dc2708900e211a910a</td>
+                    </tr>
+                    <tr>
+                        <td>onion root</td>
+                        <td>f86baa3966a61cdcd70d8c0ad9bed233f591806eb351db2ae35ac0192a3fe997</td>
+                    </tr>
+                    <tr>
+                        <td>builder binary</td>
+                        <td>34a677847b9be6580385c73f163279c81561772f8d3ad782d0ca08f1c01fad4a</td>
+                    </tr>
+                    <tr>
+                        <td>builder commit</td>
+                        <td>01e8db91d76037cd5562fce85c40e832ad156431</td>
+                    </tr>
+                    <tr>
+                        <td>params hash</td>
+                        <td>2b3e488c04433ed8bd293fd3adab72b49bf52346b81160365486d76f9b4d4e39</td>
+                    </tr>
+                </table>
+            </div>
+            <p class="meta">
+                Source of truth: <a href="https://github.com/Bitcoin-PIR/Bitcoin-PIR/blob/main/web/src/attest-pin.ts" target="_blank" rel="noopener"><code>web/src/attest-pin.ts::PRODUCTION_DB_PROOF_PINS</code></a>
+                and <a href="https://github.com/Bitcoin-PIR/Bitcoin-PIR/blob/main/docs/DB_BUILD_ATTESTATION_PLAN.md" target="_blank" rel="noopener"><code>docs/DB_BUILD_ATTESTATION_PLAN.md</code></a>.
             </p>
         </section>
 
@@ -400,10 +460,14 @@
                         initramfs (with <code>unified_server</code> baked in) +
                         cmdline, packaged as a single PE/EFI file.
                     </p>
-                    <a class="download-link" href="https://github.com/Bitcoin-PIR/Bitcoin-PIR/releases/download/tier3-v23/bpir-tier3-v23.efi">bpir-tier3-v23.efi <span class="meta">(85&nbsp;MB, GitHub release)</span></a>
+                    <p>
+                        The current operator-published artifact is
+                        <code>bpir-tier3-dbproof-d01e5b7a.efi</code>, the
+                        Tier 3 UKI that serves the database-proof sidecar.
+                    </p>
                     <p class="meta" style="margin-top: 6px;">
-                        Verify: <code>sha256sum bpir-tier3-v23.efi</code> →
-                        <code>747988fb57b94eb2c26944c17b949a1e77060487ab71245893a725d4191117cd</code>
+                        Verify: <code>sha256sum bpir-tier3-dbproof-d01e5b7a.efi</code> →
+                        <code>01d0dc3f3fbff98886e8ba8bd9108a5a13fd55305806eeaeffeafe7307e68aab</code>
                     </p>
                     <p class="meta" style="margin-top: 6px;">
                         Or rebuild from source with Nix — the reproducible
@@ -431,7 +495,7 @@
 	    --vcpus 2 \
 	    --vcpu-sig 0x00B10F10 \
 	    --ovmf OVMF_SEV_MEASUREDBOOT_4M.fd \
-	    --kernel bpir-tier3-v23.efi \
+	    --kernel bpir-tier3-dbproof-d01e5b7a.efi \
 	    --guest-features 0x1</code></pre>
                     <p>
                         Output should be the same hex as the
@@ -455,8 +519,8 @@
                     </p>
 	<pre><code>cargo build --release --bin bpir-admin -p bpir-admin
 	./target/release/bpir-admin attest wss://weikeng2.bitcoinpir.org \
-	    --expect-measurement 4fb0ad57b28b7c33e6b2977f911fd6bf407ccf28bbab3ef9d24dceec579464a5961e10f5297a294c7dde24839eca4c6e \
-	    --expect-binary      57ac525b1d92656a0ae39d6def562d6fc2889a8c6337b8b34f71a59d6ac44d59</code></pre>
+	    --expect-measurement 892bb625705e8df9ff587553b11900e4fa7c28df732a77cf0d417446d63d2dff82fbefac334e0d97eaf3a5c0d1ce1013 \
+	    --expect-binary      d01e5b7aab2b3075eed4dd154ffc2079aae394b418a40155128166a50ace750a</code></pre>
                     <p>
                         Three checkmarks:
                         <code>SEV-SNP REPORT_DATA binding verified</code>,
@@ -465,6 +529,38 @@
                     </p>
                 </li>
             </ol>
+        </section>
+
+        <section>
+            <h2>Verify the database proof</h2>
+            <p>
+                The live servers also serve the attested-builder proof bundle
+                for <code>delta_940611_948454</code>. The verifier checks the
+                SEV-SNP report-data binding, builder evidence, root bundle,
+                live catalog chain anchors, Bitcoin Core MuHash, and the
+                bucket/onion Merkle roots.
+            </p>
+	<pre><code>cargo build --release --bin bpir-admin -p bpir-admin
+	./target/release/bpir-admin db-proof verify-live \
+	    --server wss://weikeng2.bitcoinpir.org \
+	    --db-id 1 \
+	    --expect-build-kind delta \
+	    --expect-from-height 940611 \
+	    --expect-height 948454 \
+	    --expect-from-block-hash 000000000000000000002c41243b3d74d135942031ef15f547bca1ce8f85eb99 \
+	    --expect-block-hash 00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4 \
+	    --expect-muhash cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee \
+	    --expect-bucket-root e2ba2eee6788424309a95f771893d5401cc8e3ceec6188dc2708900e211a910a \
+	    --expect-onion-root f86baa3966a61cdcd70d8c0ad9bed233f591806eb351db2ae35ac0192a3fe997 \
+	    --expect-builder-binary-sha256 34a677847b9be6580385c73f163279c81561772f8d3ad782d0ca08f1c01fad4a \
+	    --expect-builder-git-commit 01e8db91d76037cd5562fce85c40e832ad156431 \
+	    --expect-network-magic f9beb4d9 \
+	    --expect-params-hash 2b3e488c04433ed8bd293fd3adab72b49bf52346b81160365486d76f9b4d4e39</code></pre>
+            <p>
+                Repeat with <code>--server wss://weikeng1.bitcoinpir.org</code>
+                to confirm both hosts serve the same self-verifying proof
+                bundle.
+            </p>
         </section>
 
         <section>
@@ -485,7 +581,7 @@
                 <table class="pin-table">
                     <tr>
                         <td>binary sha256</td>
-                        <td>57ac525b1d92656a0ae39d6def562d6fc2889a8c6337b8b34f71a59d6ac44d59</td>
+                        <td>d01e5b7aab2b3075eed4dd154ffc2079aae394b418a40155128166a50ace750a</td>
                     </tr>
                 </table>
             </div>
@@ -494,7 +590,7 @@
             </p>
 	<pre><code>cargo build --release --bin bpir-admin -p bpir-admin
 	./target/release/bpir-admin attest wss://weikeng1.bitcoinpir.org \
-	    --expect-binary 57ac525b1d92656a0ae39d6def562d6fc2889a8c6337b8b34f71a59d6ac44d59</code></pre>
+	    --expect-binary d01e5b7aab2b3075eed4dd154ffc2079aae394b418a40155128166a50ace750a</code></pre>
             <p>
                 Or directly: <code>sha256sum /home/pir/BitcoinPIR/target/release/unified_server</code>
                 on the Hetzner host should return the same hash.
@@ -515,6 +611,10 @@
                     <a href="https://kdsintf.amd.com/vcek/v1/Turin/cert_chain" target="_blank" rel="noopener">AMD KDS</a>.</li>
                 <li>For pir1: the binary hash is cross-checked against the same
                     pinned value, ensuring the same code runs on both servers.</li>
+                <li>The database proof binds <code>delta_940611_948454</code>'s
+                    bucket and OnionPIR Merkle roots to Bitcoin Core's MuHash
+                    at block <code>948454</code>, with the claimed delta base at
+                    block <code>940611</code>.</li>
                 <li>The web client refuses to upgrade to the encrypted channel
                     if the pinned values don't match what the server reports —
                     so a tampered server is silent, not silently-trusted.</li>
@@ -537,6 +637,10 @@
                 <li>AMD's signing keys themselves are trust roots (we can't
                     verify "AMD didn't sign this maliciously"). Mitigated by
                     pinning the ARK fingerprint locally.</li>
+                <li>The web DB proof badge is advisory today for DPF and
+                    HarmonyPIR. Strict mode still needs to wire verified roots
+                    directly into query-path Merkle verification, and standalone
+                    OnionPIR still needs its browser-side DB proof verifier.</li>
             </ul>
         </section>
     </main>

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -1,4 +1,5 @@
 import { requireSdkWasm } from './sdk-bridge.js';
+import type { DatabaseProofPin } from './db-proof.js';
 
 /**
  * Operator-pinned 32-byte SHA-256 fingerprint of the AMD ARK (Root
@@ -168,6 +169,43 @@ export const PIR1_PIN: ServerAttestPin = {
     'd01e5b7aab2b3075eed4dd154ffc2079aae394b418a40155128166a50ace750a',
   description: 'weikeng1.bitcoinpir.org (Hetzner i7-8700, no SEV)',
 };
+
+/**
+ * Production database proof pins.
+ *
+ * These are not server-binary pins. They are the public chain/database anchor
+ * the browser expects the attested-builder proof to reproduce. The live proof
+ * must first verify in WASM, then match these exact values before the frontend
+ * marks the DB/MuHash binding as verified.
+ */
+export const DELTA_940611_948454_DB_PROOF_PIN: DatabaseProofPin = {
+  dbId: 1,
+  buildKind: 'delta',
+  fromHeight: 940611,
+  height: 948454,
+  fromBlockHashHex:
+    '000000000000000000002c41243b3d74d135942031ef15f547bca1ce8f85eb99',
+  blockHashHex:
+    '00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4',
+  muhashHex:
+    'cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee',
+  bucketSuperRootHex:
+    'e2ba2eee6788424309a95f771893d5401cc8e3ceec6188dc2708900e211a910a',
+  onionSuperRootHex:
+    'f86baa3966a61cdcd70d8c0ad9bed233f591806eb351db2ae35ac0192a3fe997',
+  paramsHashHex:
+    '2b3e488c04433ed8bd293fd3adab72b49bf52346b81160365486d76f9b4d4e39',
+  networkMagicHex: 'f9beb4d9',
+  builderBinarySha256Hex:
+    '34a677847b9be6580385c73f163279c81561772f8d3ad782d0ca08f1c01fad4a',
+  builderGitCommit: '01e8db91d76037cd5562fce85c40e832ad156431',
+  description:
+    'delta_940611_948454: Bitcoin Core MuHash and PIR Merkle roots from the SEV-SNP attested builder',
+};
+
+export const PRODUCTION_DB_PROOF_PINS: DatabaseProofPin[] = [
+  DELTA_940611_948454_DB_PROOF_PIN,
+];
 
 /**
  * Operator identity pin (Tier-1) for the REQ_ANNOUNCE operator-signed

--- a/web/src/db-proof.ts
+++ b/web/src/db-proof.ts
@@ -1,0 +1,128 @@
+import type { WasmDatabaseProof } from './sdk-bridge.js';
+
+export interface VerifiedDatabaseProof {
+  dbId: number;
+  buildKind: 'snapshot' | 'delta' | string;
+  fromHeight: number;
+  fromBlockHashHex: string;
+  height: number;
+  blockHashHex: string;
+  muhashHex: string;
+  bucketSuperRootHex: string;
+  onionSuperRootHex: string;
+  paramsHashHex: string;
+  networkMagicHex: string;
+  builderBinarySha256Hex: string;
+  builderGitCommit: string;
+}
+
+export interface DatabaseProofPin {
+  dbId: number;
+  buildKind: 'snapshot' | 'delta';
+  fromHeight: number;
+  height: number;
+  fromBlockHashHex: string;
+  blockHashHex: string;
+  muhashHex: string;
+  bucketSuperRootHex: string;
+  onionSuperRootHex: string;
+  paramsHashHex: string;
+  networkMagicHex: string;
+  builderBinarySha256Hex: string;
+  builderGitCommit: string;
+  description?: string;
+}
+
+export interface DatabaseProofStatus {
+  state: 'not-checked' | 'verified' | 'unverified' | 'unavailable';
+  dbId: number;
+  pin?: DatabaseProofPin;
+  proof?: VerifiedDatabaseProof;
+  mismatches?: string[];
+  error?: string;
+}
+
+export function verifiedDatabaseProofFromWasm(proof: WasmDatabaseProof): VerifiedDatabaseProof {
+  return {
+    dbId: proof.dbId,
+    buildKind: proof.buildKind,
+    fromHeight: proof.fromHeight,
+    fromBlockHashHex: proof.fromBlockHashHex,
+    height: proof.height,
+    blockHashHex: proof.blockHashHex,
+    muhashHex: proof.muhashHex,
+    bucketSuperRootHex: proof.bucketSuperRootHex,
+    onionSuperRootHex: proof.onionSuperRootHex,
+    paramsHashHex: proof.paramsHashHex,
+    networkMagicHex: proof.networkMagicHex,
+    builderBinarySha256Hex: proof.builderBinarySha256Hex,
+    builderGitCommit: proof.builderGitCommit,
+  };
+}
+
+export function verifyDatabaseProofAgainstPin(
+  proof: VerifiedDatabaseProof,
+  pin: DatabaseProofPin,
+): DatabaseProofStatus {
+  const mismatches: string[] = [];
+  const cmp = (field: keyof DatabaseProofPin & keyof VerifiedDatabaseProof, hex = false) => {
+    const expected = pin[field];
+    const actual = proof[field];
+    if (hex) {
+      if (normalizeHex(String(expected)) !== normalizeHex(String(actual))) {
+        mismatches.push(`${field}: expected ${expected}, got ${actual}`);
+      }
+      return;
+    }
+    if (expected !== actual) {
+      mismatches.push(`${field}: expected ${expected}, got ${actual}`);
+    }
+  };
+
+  cmp('dbId');
+  cmp('buildKind');
+  cmp('fromHeight');
+  cmp('height');
+  cmp('fromBlockHashHex', true);
+  cmp('blockHashHex', true);
+  cmp('muhashHex', true);
+  cmp('bucketSuperRootHex', true);
+  cmp('onionSuperRootHex', true);
+  cmp('paramsHashHex', true);
+  cmp('networkMagicHex', true);
+  cmp('builderBinarySha256Hex', true);
+  cmp('builderGitCommit');
+
+  return {
+    state: mismatches.length === 0 ? 'verified' : 'unverified',
+    dbId: pin.dbId,
+    pin,
+    proof,
+    mismatches,
+  };
+}
+
+export function databaseProofUnavailable(
+  pin: DatabaseProofPin,
+  error: unknown,
+): DatabaseProofStatus {
+  const message = (error as Error)?.message ?? String(error);
+  const unavailable = /not configured|server returned error|db proof/i.test(message);
+  return {
+    state: unavailable ? 'unavailable' : 'unverified',
+    dbId: pin.dbId,
+    pin,
+    error: message,
+  };
+}
+
+export function databaseProofAnchorLabel(proof: VerifiedDatabaseProof | DatabaseProofPin): string {
+  if (proof.buildKind === 'delta') {
+    return `${proof.fromHeight.toLocaleString()} to ${proof.height.toLocaleString()}`;
+  }
+  return proof.height.toLocaleString();
+}
+
+function normalizeHex(hex: string): string {
+  return hex.trim().toLowerCase().replace(/^0x/, '');
+}

--- a/web/src/dpf-adapter.ts
+++ b/web/src/dpf-adapter.ts
@@ -52,6 +52,13 @@ import {
   type WasmDpfClient,
   type WasmQueryResult,
 } from './sdk-bridge.js';
+import {
+  databaseProofUnavailable,
+  verifiedDatabaseProofFromWasm,
+  verifyDatabaseProofAgainstPin,
+  type DatabaseProofPin,
+  type DatabaseProofStatus,
+} from './db-proof.js';
 import { getAmdTurinArkFingerprint, PIR_OPERATOR_PUBKEY } from './attest-pin.js';
 import type { ConnectionState, QueryResult, UtxoEntry } from './types.js';
 import { ManagedWebSocket } from './ws.js';
@@ -288,6 +295,12 @@ export interface BatchPirClientConfig {
    *  operator-identity check (only when `verifyOperatorIdentity`). Use to
    *  surface a "verified operator" badge — gate it on `state === 'verified'`. */
   onOperatorIdentity?: (serverIndex: 0 | 1, info: OperatorIdentity) => void;
+  /** Database proof pins the frontend should fetch and verify after the
+   * catalog is loaded. Empty/default means no db-proof UI check. */
+  databaseProofPins?: DatabaseProofPin[];
+  /** Fires once per configured database proof pin after verification,
+   * mismatch, or "not configured" is known. */
+  onDatabaseProof?: (dbId: number, info: DatabaseProofStatus) => void;
 }
 
 // ─── Adapter ─────────────────────────────────────────────────────────────────
@@ -337,6 +350,9 @@ export class BatchPirClientAdapter {
     server0: { state: 'not-checked' },
     server1: { state: 'not-checked' },
   };
+
+  /** Per-database attested-builder proof status, keyed by db_id. */
+  databaseProofs: Map<number, DatabaseProofStatus> = new Map();
 
   constructor(config: BatchPirClientConfig) {
     this.config = config;
@@ -400,6 +416,7 @@ export class BatchPirClientAdapter {
       // in-memory catalog to resolve `db_id` against. The side-channel
       // fetch above only populates the TS-side `this.catalog`.
       await this.wasmClient.fetchCatalog();
+      await this.verifyConfiguredDatabaseProofs();
       this.connected = true;
       // Emit a final `connected` in case the native client's own
       // `onStateChange` fired before we registered the listener or got
@@ -467,6 +484,10 @@ export class BatchPirClientAdapter {
 
   getCatalogEntry(dbId: number): DatabaseCatalogEntry | undefined {
     return this.catalog?.databases.find((d) => d.dbId === dbId);
+  }
+
+  getDatabaseProofStatus(dbId: number): DatabaseProofStatus | undefined {
+    return this.databaseProofs.get(dbId);
   }
 
   // ── Merkle accessors (all read cached server info) ────────────────────
@@ -618,6 +639,45 @@ export class BatchPirClientAdapter {
       client.free();
     }
     this.connected = false;
+  }
+
+  private async verifyConfiguredDatabaseProofs(): Promise<void> {
+    if (!this.wasmClient) return;
+    const pins = this.config.databaseProofPins ?? [];
+    for (const pin of pins) {
+      let status: DatabaseProofStatus;
+      try {
+        const proofHandle = await this.wasmClient.verifyDatabaseProof(
+          pin.dbId,
+          pin.paramsHashHex,
+          pin.builderBinarySha256Hex,
+          pin.builderGitCommit,
+        );
+        try {
+          const proof = verifiedDatabaseProofFromWasm(proofHandle);
+          status = verifyDatabaseProofAgainstPin(proof, pin);
+        } finally {
+          proofHandle.free();
+        }
+      } catch (e) {
+        status = databaseProofUnavailable(pin, e);
+      }
+      this.databaseProofs.set(pin.dbId, status);
+      this.config.onDatabaseProof?.(pin.dbId, status);
+      if (status.state === 'verified') {
+        this.log(
+          `DB proof db ${pin.dbId}: verified MuHash ${status.proof?.muhashHex.slice(0, 16)}...`,
+          'success',
+        );
+      } else if (status.state === 'unavailable') {
+        this.log(`DB proof db ${pin.dbId}: unavailable (${status.error})`, 'info');
+      } else {
+        this.log(
+          `DB proof db ${pin.dbId}: unverified (${status.mismatches?.[0] ?? status.error ?? 'check failed'})`,
+          'error',
+        );
+      }
+    }
   }
 
   private setState(state: ConnectionState, message?: string): void {

--- a/web/src/harmonypir-adapter.ts
+++ b/web/src/harmonypir-adapter.ts
@@ -72,6 +72,13 @@ import {
   type WasmHarmonyClient,
   type WasmQueryResult,
 } from './sdk-bridge.js';
+import {
+  databaseProofUnavailable,
+  verifiedDatabaseProofFromWasm,
+  verifyDatabaseProofAgainstPin,
+  type DatabaseProofPin,
+  type DatabaseProofStatus,
+} from './db-proof.js';
 import { getAmdTurinArkFingerprint, PIR_OPERATOR_PUBKEY } from './attest-pin.js';
 import { gateOperatorIdentity, type OperatorIdentity, type ServerAttestation } from './dpf-adapter.js';
 import type {
@@ -149,6 +156,12 @@ export interface HarmonyPirClientConfig {
    *  check (only when `verifyOperatorIdentity`). Index 0 = hint, 1 = query.
    *  Gate any "verified operator" badge on `state === 'verified'`. */
   onOperatorIdentity?: (serverIndex: 0 | 1, info: OperatorIdentity) => void;
+  /** Database proof pins the frontend should fetch and verify after the
+   * catalog is loaded. Empty/default means no db-proof UI check. */
+  databaseProofPins?: DatabaseProofPin[];
+  /** Fires once per configured database proof pin after verification,
+   * mismatch, or "not configured" is known. */
+  onDatabaseProof?: (dbId: number, info: DatabaseProofStatus) => void;
 }
 
 // ─── Adapter ─────────────────────────────────────────────────────────────────
@@ -191,6 +204,8 @@ export class HarmonyPirClientAdapter {
     hint: { state: 'not-checked' },
     query: { state: 'not-checked' },
   };
+  /** Per-database attested-builder proof status, keyed by db_id. */
+  databaseProofs: Map<number, DatabaseProofStatus> = new Map();
   /**
    * Inspector data populated by the most recent `queryBatch`. The native
    * `HarmonyClient` doesn't surface placement-round / per-chunk timing
@@ -496,6 +511,7 @@ export class HarmonyPirClientAdapter {
     // `db_id`. The side-channel `fetchServerInfo` below only populates
     // the TS-side `this.catalog`. Matches the DPF adapter pattern.
     await this.wasmClient.fetchCatalog();
+    await this.verifyConfiguredDatabaseProofs();
 
     // Side-channel for residency / server-info JSON requests.
     this.queryWs = new ManagedWebSocket({
@@ -581,6 +597,47 @@ export class HarmonyPirClientAdapter {
 
   getCatalogEntry(dbId: number): DatabaseCatalogEntry | undefined {
     return this.catalog?.databases.find((d) => d.dbId === dbId);
+  }
+
+  getDatabaseProofStatus(dbId: number): DatabaseProofStatus | undefined {
+    return this.databaseProofs.get(dbId);
+  }
+
+  private async verifyConfiguredDatabaseProofs(): Promise<void> {
+    if (!this.wasmClient) return;
+    const pins = this.config.databaseProofPins ?? [];
+    for (const pin of pins) {
+      let status: DatabaseProofStatus;
+      try {
+        const proofHandle = await this.wasmClient.verifyDatabaseProof(
+          pin.dbId,
+          pin.paramsHashHex,
+          pin.builderBinarySha256Hex,
+          pin.builderGitCommit,
+        );
+        try {
+          const proof = verifiedDatabaseProofFromWasm(proofHandle);
+          status = verifyDatabaseProofAgainstPin(proof, pin);
+        } finally {
+          proofHandle.free();
+        }
+      } catch (e) {
+        status = databaseProofUnavailable(pin, e);
+      }
+      this.databaseProofs.set(pin.dbId, status);
+      this.config.onDatabaseProof?.(pin.dbId, status);
+      if (status.state === 'verified') {
+        this.log(
+          `DB proof db ${pin.dbId}: verified MuHash ${status.proof?.muhashHex.slice(0, 16)}...`,
+        );
+      } else if (status.state === 'unavailable') {
+        this.log(`DB proof db ${pin.dbId}: unavailable (${status.error})`);
+      } else {
+        this.log(
+          `DB proof db ${pin.dbId}: unverified (${status.mismatches?.[0] ?? status.error ?? 'check failed'})`,
+        );
+      }
+    }
   }
 
   // ══ Query path ═══════════════════════════════════════════════════════

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -108,10 +108,22 @@ export {
 export {
   AMD_TURIN_ARK_FINGERPRINT,
   AMD_TURIN_ARK_FINGERPRINT_HEX,
+  DELTA_940611_948454_DB_PROOF_PIN,
   PIR1_PIN,
   PIR2_TIER3_PIN,
+  PRODUCTION_DB_PROOF_PINS,
   type ServerAttestPin,
 } from './attest-pin.js';
+
+export {
+  databaseProofAnchorLabel,
+  databaseProofUnavailable,
+  verifiedDatabaseProofFromWasm,
+  verifyDatabaseProofAgainstPin,
+  type DatabaseProofPin,
+  type DatabaseProofStatus,
+  type VerifiedDatabaseProof,
+} from './db-proof.js';
 
 export type {
   HarmonyQueryResult,

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -360,7 +360,25 @@ export interface WasmAnnounceVerification {
   free(): void;
 }
 
-interface WasmDpfClient {
+export interface WasmDatabaseProof {
+  free(): void;
+  readonly dbId: number;
+  readonly buildKind: 'snapshot' | 'delta' | string;
+  readonly fromHeight: number;
+  readonly fromBlockHashHex: string;
+  readonly height: number;
+  readonly blockHashHex: string;
+  readonly muhashHex: string;
+  readonly bucketSuperRootHex: string;
+  readonly onionSuperRootHex: string;
+  readonly paramsHashHex: string;
+  readonly networkMagicHex: string;
+  readonly builderBinarySha256Hex: string;
+  readonly builderGitCommit: string;
+  toJson(): any;
+}
+
+export interface WasmDpfClient {
   free(): void;
   readonly isConnected: boolean;
   connect(): Promise<void>;
@@ -392,6 +410,15 @@ interface WasmDpfClient {
    * (which go through `query_batch_with_inspector`) can resolve `db_id`
    * against an in-memory catalog. Returns the freshly fetched catalog. */
   fetchCatalog(): Promise<unknown>;
+  /** Fetch and verify an attested-builder database proof against the
+   * native catalog. Optional string policy pins may be `undefined` or empty.
+   * Mainnet network magic is always enforced by the WASM method. */
+  verifyDatabaseProof(
+    dbId: number,
+    expectedParamsHashHex?: string | null,
+    allowedBuilderBinarySha256Hex?: string | null,
+    allowedBuilderGitCommit?: string | null,
+  ): Promise<WasmDatabaseProof>;
   /** Inspector-path batch query. Returns an `Array<WasmQueryResult>` of
    * length `N` (one per packed scripthash). Every slot is non-null —
    * not-found queries are synthesised as empty inspector-populated
@@ -436,7 +463,7 @@ interface WasmSyncPlan {
  * superset (notably `queryBatch` + `fetchCatalog`, which the adapter doesn't
  * need because PIR rounds go through `queryBatchRaw`).
  */
-interface WasmHarmonyClient {
+export interface WasmHarmonyClient {
   free(): void;
   readonly isConnected: boolean;
   connect(): Promise<void>;
@@ -456,6 +483,13 @@ interface WasmHarmonyClient {
    *  caller can pass back into `fetchHintsWithProgress` / `loadHints`
    *  / `fingerprint`. */
   fetchCatalog(): Promise<WasmDatabaseCatalog>;
+  /** Same as `WasmDpfClient.verifyDatabaseProof`. */
+  verifyDatabaseProof(
+    dbId: number,
+    expectedParamsHashHex?: string | null,
+    allowedBuilderBinarySha256Hex?: string | null,
+    allowedBuilderGitCommit?: string | null,
+  ): Promise<WasmDatabaseProof>;
   serverUrls(): [string, string];
   /** Returns the active `db_id`, or `undefined` if no hints are loaded. */
   dbId(): number | undefined;
@@ -656,7 +690,7 @@ interface WasmAtomicMetrics {
   snapshot(): AtomicMetricsSnapshot;
 }
 
-interface WasmQueryResult {
+export interface WasmQueryResult {
   free(): void;
   readonly entryCount: number;
   readonly totalBalance: bigint;
@@ -1221,7 +1255,7 @@ export function requireSdkWasm(): PirSdkWasm {
 // Re-export the adapter-facing interface types so `dpf-adapter.ts` can
 // import them without having to reach into this module's type-only
 // `PirSdkWasm` shape.
-export type { WasmDpfClient, WasmHarmonyClient, WasmQueryResult, WasmDatabaseCatalog };
+export type { WasmDatabaseCatalog };
 
 // ─── Metrics bridge (Phase 2+ observability) ───────────────────────────────
 //


### PR DESCRIPTION
Depends on #38.

Surfaces the database proof attestation to browser users of the web demo.

## WASM bindings

`WasmDpfClient` and `WasmHarmonyClient` gain `verifyDatabaseProof()` returning
a `WasmDatabaseProof` JS object with all anchor fields (block hashes, MuHash,
Merkle roots, builder identity).

## JS verification layer

`web/src/db-proof.ts` — `verifyDatabaseProofAgainstPin()` compares the
WASM-verified proof against pinned `DatabaseProofPin` values. Returns
`verified`, `unverified` (with mismatch details), or `unavailable`.

## Production pins

`DELTA_940611_948454_DB_PROOF_PIN` in `web/src/attest-pin.ts` with 14
anchored fields: block hashes, MuHash, bucket/onion super-roots, params hash,
builder binary hash, and git commit.

## Adapter integration

Both `dpf-adapter.ts` and `harmonypir-adapter.ts` automatically fetch and
verify DB proofs on catalog load, firing an `onDatabaseProof` callback.

## UI badge

Blue "Verified DB proof" badge rendered in both DPF-PIR and HarmonyPIR demo
sections showing the anchor range, MuHash, and builder identity. Red badge
with mismatch details on verification failure.

## Reproducibility page

Updated `reproduce.html` with DB proof status display.