### PR TITLE
ci: respect pinned rust toolchain

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install --profile minimal
 
       # Plain `cargo install` (~2-3 min) instead of a cached or
       # prebuilt-binary action: this job runs weekly + on lockfile

--- a/.github/workflows/build-determinism.yml
+++ b/.github/workflows/build-determinism.yml
@@ -46,10 +46,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install --profile minimal
 
       - name: Cache Cargo registry + target
         uses: actions/cache@v5

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -28,10 +28,8 @@ jobs:
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install --profile minimal --target wasm32-unknown-unknown
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -69,4 +67,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
-  

--- a/.github/workflows/pir-sdk-integration.yml
+++ b/.github/workflows/pir-sdk-integration.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install --profile minimal
 
       - name: Cache Cargo registry + target
         uses: actions/cache@v5
@@ -128,8 +128,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install --profile minimal
 
       - name: Install C++ toolchain
         # ubuntu-latest already ships with gcc/g++/cmake, but we pin the

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -68,10 +68,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Rust toolchain (with wasm32 target)
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
+      - name: Install pinned Rust toolchain (with wasm32 target)
+        run: rustup toolchain install --profile minimal --target wasm32-unknown-unknown
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/docs/CODE_REVIEW_2026-06.md
+++ b/docs/CODE_REVIEW_2026-06.md
@@ -140,7 +140,7 @@ the live demo** (pir1/Hetzner has no SEV measurement).
 | I7 | minor | No dependabot / `cargo-audit` / `cargo-deny` — 317 vendored crates, no CVE signal |
 | I8 | minor | `pir-channel`, `pir-identity`, `pir-attest-verify` declare dual license but ship no in-crate LICENSE files and are not `publish = false` |
 
-### Status update (2026-06-26): I4/I5 closed
+### Status update (2026-06-26): I4/I5/I6 closed
 
 - **I4**: historical `PLAN_*.md` files are now tracked under
   `docs/plans/`, with root-level symlink shims preserving the old
@@ -152,6 +152,11 @@ the live demo** (pir1/Hetzner has no SEV measurement).
   describes a live committed `TUNNEL_TOKEN`; if a tunnel path returns,
   the doc now requires out-of-git token handling and a rotation
   procedure.
+- **I6**: first-party GitHub Actions workflows no longer install
+  `dtolnay/rust-toolchain@stable`. They invoke `rustup toolchain
+  install` without a toolchain argument, so rustup installs the active
+  toolchain from `rust-toolchain.toml`; WASM jobs add
+  `wasm32-unknown-unknown` to that pinned toolchain.
 - **I7**: partially closed by the cargo-audit CI job added in June;
   dependabot / cargo-deny remain optional future hygiene.
 


### PR DESCRIPTION
## Summary
- Replace first-party workflow uses of `dtolnay/rust-toolchain@stable` with `rustup toolchain install --profile minimal`, allowing rustup to use `rust-toolchain.toml`.
- Add `wasm32-unknown-unknown` to the pinned toolchain in WASM workflows.
- Mark code-review finding I6 closed.

## Checks
- `git diff --check`
- Verified no remaining `dtolnay/rust-toolchain@stable`, `RUSTUP_TOOLCHAIN`, or `uses: dtolnay/rust-toolchain` references under `.github/workflows`.

Closes #33