### PR TITLE
Make results span the full content grid

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -176,6 +176,7 @@
             gap: 16px; align-items: start;
         }
         .col { display: flex; flex-direction: column; gap: 16px; min-width: 0; }
+        .results-card { grid-column: 1 / -1; min-width: 0; }
         .card {
             background: var(--panel);
             border: 1px solid var(--line);
@@ -965,15 +966,6 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     </div>
                 </section>
 
-                <!-- Results card -->
-                <section class="card">
-                    <div class="card-head">
-                        <div class="card-title"><span class="num">03</span><span>Results</span></div>
-                    </div>
-                    <div class="card-body">
-                        <div id="resultsContainer" class="results-container"></div>
-                    </div>
-                </section>
             </div>
 
             <!-- RIGHT COLUMN -->
@@ -1039,6 +1031,16 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     </div>
                 </section>
             </div>
+
+            <!-- Results card -->
+            <section class="card results-card">
+                <div class="card-head">
+                    <div class="card-title"><span class="num">03</span><span>Results</span></div>
+                </div>
+                <div class="card-body">
+                    <div id="resultsContainer" class="results-container"></div>
+                </div>
+            </section>
           </div>
         </div><!-- end tab-dpf -->
 
@@ -1150,14 +1152,6 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     </div>
                 </section>
 
-                <section class="card">
-                    <div class="card-head">
-                        <div class="card-title"><span class="num">03</span><span>Results</span></div>
-                    </div>
-                    <div class="card-body">
-                        <div id="op-resultsContainer" class="results-container"></div>
-                    </div>
-                </section>
             </div>
 
             <div class="col">
@@ -1207,6 +1201,15 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     </div>
                 </section>
             </div>
+
+            <section class="card results-card">
+                <div class="card-head">
+                    <div class="card-title"><span class="num">03</span><span>Results</span></div>
+                </div>
+                <div class="card-body">
+                    <div id="op-resultsContainer" class="results-container"></div>
+                </div>
+            </section>
           </div>
         </div><!-- end tab-onionpir -->
 
@@ -1332,14 +1335,6 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     </div>
                 </section>
 
-                <section class="card">
-                    <div class="card-head">
-                        <div class="card-title"><span class="num">03</span><span>Results</span></div>
-                    </div>
-                    <div class="card-body">
-                        <div id="hp-resultsContainer" class="results-container"></div>
-                    </div>
-                </section>
             </div>
 
             <div class="col">
@@ -1414,6 +1409,15 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     </div>
                 </section>
             </div>
+
+            <section class="card results-card">
+                <div class="card-head">
+                    <div class="card-title"><span class="num">03</span><span>Results</span></div>
+                </div>
+                <div class="card-body">
+                    <div id="hp-resultsContainer" class="results-container"></div>
+                </div>
+            </section>
           </div>
         </div><!-- end tab-harmonypir -->
 
@@ -1476,14 +1480,6 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     </div>
                 </section>
 
-                <section class="card">
-                    <div class="card-head">
-                        <div class="card-title"><span class="num">03</span><span>Results</span></div>
-                    </div>
-                    <div class="card-body">
-                        <div id="oram-resultsContainer" class="results-container"></div>
-                    </div>
-                </section>
             </div>
 
             <div class="col">
@@ -1531,6 +1527,15 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     </div>
                 </section>
             </div>
+
+            <section class="card results-card">
+                <div class="card-head">
+                    <div class="card-title"><span class="num">03</span><span>Results</span></div>
+                </div>
+                <div class="card-body">
+                    <div id="oram-resultsContainer" class="results-container"></div>
+                </div>
+            </section>
           </div>
         </div><!-- end tab-oram -->
 


### PR DESCRIPTION
## What changed

- move the Results card out of the query column for every frontend backend
- make Results span the full two-column content grid
- preserve the existing Query composer / Verification split and mobile single-column layout

## Why

Results were nested inside the left column, leaving the lower-right half of the page unused and constraining transaction details and UTXO tables to a narrow card.

## Validation

- `npm run build`
- `npm run build-web`
- `npm test` (180 passed, 2 skipped)
- browser layout check at 1440 px and 720 px widths
