### PR TITLE
Add BitcoinPIR logo to web header

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bitcoin PIR</title>
+    <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -64,19 +65,8 @@
             padding: 0 20px; gap: 16px;
             position: sticky; top: 0; z-index: 40;
         }
-        .brand { display: flex; align-items: center; gap: 10px; font-weight: 600; letter-spacing: -0.01em; color: var(--ink); text-decoration: none; }
-        .brand-mark {
-            width: 22px; height: 22px; border-radius: 5px;
-            background: conic-gradient(from 210deg at 50% 50%, var(--accent) 0deg 120deg, oklch(82% 0.12 55) 120deg 240deg, var(--accent-ink) 240deg 360deg);
-            position: relative; box-shadow: inset 0 0 0 1px oklch(0% 0 0 / .08);
-        }
-        .brand-mark::after {
-            content: "₿"; position: absolute; inset: 0;
-            display: grid; place-items: center;
-            font-family: var(--sans); font-weight: 700;
-            color: oklch(100% 0 0 / .92); font-size: 13px;
-            text-shadow: 0 1px 0 oklch(0% 0 0 / .15);
-        }
+        .brand { display: flex; align-items: center; color: var(--ink); text-decoration: none; flex: 0 0 auto; }
+        .brand-logo { display: block; width: 130px; height: auto; }
         .topbar-spacer { flex: 1; }
         .topbar-meta {
             display: flex; align-items: center; gap: 14px;
@@ -817,10 +807,9 @@
 
     <!-- ── TOP BAR ──────────────────────────────────────────────── -->
     <header class="topbar">
-        <div class="brand">
-            <span class="brand-mark" aria-hidden="true"></span>
-            <span>Bitcoin PIR</span>
-        </div>
+        <a class="brand" href="/" aria-label="BitcoinPIR home">
+            <img class="brand-logo" src="/brand/bitcoinpir-logo.svg" width="430" height="128" alt="BitcoinPIR" />
+        </a>
         <div class="topbar-spacer"></div>
         <a class="topbar-btn" href="/reproduce.html" title="How to independently verify the SEV-SNP MEASUREMENT pin">Reproducibility</a>
         <a class="topbar-btn" href="https://github.com/Bitcoin-PIR/Bitcoin-PIR" target="_blank" rel="noopener">

--- a/web/public/brand/bitcoinpir-logo.svg
+++ b/web/public/brand/bitcoinpir-logo.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 430 128" role="img" aria-labelledby="title desc">
+  <title id="title">BitcoinPIR</title>
+  <desc id="desc">BitcoinPIR private Bitcoin wallet lookups.</desc>
+  <path fill="#111820" d="M60 8 17 33l31 18a23 23 0 0 1 12-7V8ZM13 40v49l31-18a23 23 0 0 1 0-14L13 40ZM17 96l43 25V84a23 23 0 0 1-12-7L17 96Z"/>
+  <path fill="#F59E0B" d="m68 8 43 25-31 18a23 23 0 0 0-12-7V8ZM115 40v49L84 71a23 23 0 0 0 0-14l31-17ZM111 96l-43 25V84a23 23 0 0 0 12-7l31 19Z"/>
+  <path fill="#22D3EE" d="M62 39h4v8h-4zM62 81h4v8h-4z"/>
+  <g fill="#FFF">
+    <path d="m31 32 5-3 5 3v6l-5 3-5-3zM43 25l5-3 5 3v6l-5 3-5-3zM75 25l5-3 5 3v6l-5 3-5-3zM87 32l5-3 5 3v6l-5 3-5-3z"/>
+    <path d="m24 53 5-3 5 3v6l-5 3-5-3zM24 69l5-3 5 3v6l-5 3-5-3zM94 53l5-3 5 3v6l-5 3-5-3zM94 69l5-3 5 3v6l-5 3-5-3z"/>
+    <path d="m31 90 5-3 5 3v6l-5 3-5-3zM43 97l5-3 5 3v6l-5 3-5-3zM75 97l5-3 5 3v6l-5 3-5-3zM87 90l5-3 5 3v6l-5 3-5-3z"/>
+  </g>
+  <circle cx="64" cy="64" r="17" fill="#FFF"/>
+  <path stroke="#FFF" stroke-linecap="round" stroke-width="10" d="m76 76 18 18"/>
+  <text x="137" y="82" fill="#111820" font-family="Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif" font-size="52" font-weight="750" letter-spacing="-2.4">Bitcoin<tspan fill="#F59E0B">PIR</tspan></text>
+</svg>

--- a/web/public/brand/bitcoinpir-mark.svg
+++ b/web/public/brand/bitcoinpir-mark.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">BitcoinPIR symbol</title>
+  <desc id="desc">A private query aperture surrounded by six distributed data blocks.</desc>
+  <path fill="#111820" d="M60 8 17 33l31 18a23 23 0 0 1 12-7V8ZM13 40v49l31-18a23 23 0 0 1 0-14L13 40ZM17 96l43 25V84a23 23 0 0 1-12-7L17 96Z"/>
+  <path fill="#F59E0B" d="m68 8 43 25-31 18a23 23 0 0 0-12-7V8ZM115 40v49L84 71a23 23 0 0 0 0-14l31-17ZM111 96l-43 25V84a23 23 0 0 0 12-7l31 19Z"/>
+  <path fill="#22D3EE" d="M62 39h4v8h-4zM62 81h4v8h-4z"/>
+  <g fill="#FFF">
+    <path d="m31 32 5-3 5 3v6l-5 3-5-3zM43 25l5-3 5 3v6l-5 3-5-3zM75 25l5-3 5 3v6l-5 3-5-3zM87 32l5-3 5 3v6l-5 3-5-3z"/>
+    <path d="m24 53 5-3 5 3v6l-5 3-5-3zM24 69l5-3 5 3v6l-5 3-5-3zM94 53l5-3 5 3v6l-5 3-5-3zM94 69l5-3 5 3v6l-5 3-5-3z"/>
+    <path d="m31 90 5-3 5 3v6l-5 3-5-3zM43 97l5-3 5 3v6l-5 3-5-3zM75 97l5-3 5 3v6l-5 3-5-3zM87 90l5-3 5 3v6l-5 3-5-3z"/>
+  </g>
+  <circle cx="64" cy="64" r="17" fill="#FFF"/>
+  <path stroke="#FFF" stroke-linecap="round" stroke-width="10" d="m76 76 18 18"/>
+</svg>

--- a/web/ratelimit-demo.html
+++ b/web/ratelimit-demo.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Bitcoin PIR — Anonymous Rate-Limiting Demo (ARC + Cashu)</title>
+    <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>
       :root { color-scheme: light dark; }
       body {

--- a/web/reproduce.html
+++ b/web/reproduce.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Reproducing runtime and database attestation — Bitcoin PIR</title>
+    <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
@@ -47,11 +48,10 @@
         .brand {
             display: flex; align-items: center; gap: 8px;
             font-weight: 600;
+            color: var(--ink);
+            text-decoration: none;
         }
-        .brand-mark {
-            width: 14px; height: 14px; border-radius: 4px;
-            background: linear-gradient(135deg, var(--accent), var(--accent-ink));
-        }
+        .brand-logo { display: block; width: 130px; height: auto; }
         .topbar small { color: var(--ink-mute); font-weight: 400; margin-left: 4px; }
         .topbar-spacer { flex: 1; }
         .topbar-btn {
@@ -300,11 +300,10 @@
 </head>
 <body>
     <header class="topbar">
-        <div class="brand">
-            <span class="brand-mark" aria-hidden="true"></span>
-            <span>Bitcoin PIR</span>
+        <a class="brand" href="/" aria-label="BitcoinPIR home">
+            <img class="brand-logo" src="/brand/bitcoinpir-logo.svg" width="430" height="128" alt="BitcoinPIR" />
             <small>reproducibility</small>
-        </div>
+        </a>
         <div class="topbar-spacer"></div>
         <a class="topbar-btn" href="/">← Back to app</a>
         <a class="topbar-btn" href="https://github.com/Bitcoin-PIR/Bitcoin-PIR" target="_blank" rel="noopener">


### PR DESCRIPTION
## What changed

- replace the generic Bitcoin PIR text/gradient mark in the main web header with the new BitcoinPIR horizontal logo
- use the same logo on the reproducibility page
- add the compact brand mark as the favicon for all web entry pages
- add reusable SVG logo assets under `web/public/brand/`

## Why

The existing header used a temporary CSS gradient square and text. This gives the web UI a consistent, production-ready BitcoinPIR identity while retaining accessible alt text and a home link.

## Validation

- `npm ci`
- `npm run build`
- `xmllint --noout public/brand/bitcoinpir-mark.svg public/brand/bitcoinpir-logo.svg`
- `git diff --check`
