### PR TITLE
Close client and server security-review findings

### DIFF
--- a/docs/CODE_REVIEW_2026-06.md
+++ b/docs/CODE_REVIEW_2026-06.md
@@ -190,6 +190,20 @@ the live demo** (pir1/Hetzner has no SEV measurement).
 - **W7** (minor): `onionpir_client.ts:1102` `keygenClient` leaks on a
   keygen throw — move creation inside the `try`.
 
+### Status update (2026-07-13): S6/S7/C5 closed
+
+- **S6**: `pir-sdk-server` now applies conservative global connection and
+  CPU-heavy request concurrency caps, runs PIR evaluation on Tokio's blocking
+  pool, and bounds WebSocket handshake/idle time. Configuration validation,
+  cap/backpressure tests, and a real loopback WebSocket allowed-traffic test
+  cover the public defaults and tuning surface.
+- **S7**: removed the ineffective `catch_unwind` wrappers and stale
+  panic-isolation logging from `unified_server`; comments now state that the
+  active `panic = 'abort'` policy requires a process boundary for isolation.
+- **C5**: malformed or wrong-sized Merkle sibling evidence is tracked per item
+  and forces verification failure after the privacy-padded round shape
+  completes. Tests cover valid, missing, short, and oversized rows.
+
 ### Status update (2026-06-26): small nits closed
 
 - **S8**: ed25519 signature checks in `pir-runtime-core::admin` and

--- a/pir-sdk-client/src/merkle_verify.rs
+++ b/pir-sdk-client/src/merkle_verify.rs
@@ -414,8 +414,9 @@ pub async fn fetch_tree_tops(
 ///   `rows[g]` must be `None`.
 ///
 /// Returned rows MUST be exactly [`BUCKET_MERKLE_SIB_ROW_SIZE`] (= 256)
-/// bytes; shorter rows are treated as an error and coerced to `ZERO_HASH`
-/// by the caller.
+/// bytes. The caller records missing or wrong-sized rows as malformed
+/// evidence, completes every padded sibling round, and then forces that
+/// item's result to verification failure.
 ///
 /// `table_type` is `0` for INDEX trees and `1` for CHUNK trees. `level` is
 /// the sibling level (0-indexed, bottom-up).
@@ -987,6 +988,13 @@ async fn verify_sibling_levels(
     // Per-item running state.
     let mut current_hash: Vec<Hash256> = Vec::with_capacity(n_items);
     let mut node_idx: Vec<u32> = Vec::with_capacity(n_items);
+    // Keep evidence quality separate from the running hash. Substituting a
+    // sentinel hash alone is unsafe as an API contract: a later refactor (or
+    // an unusual tree whose root happens to match the sentinel-derived walk)
+    // could mistake a completed walk for a well-formed proof. We still finish
+    // every padded round before reporting failure so malformed evidence cannot
+    // change the privacy-visible request shape.
+    let mut malformed_evidence = vec![false; n_items];
     for it in items {
         current_hash.push(compute_bin_leaf_hash(it.bin_index, &it.bin_content));
         node_idx.push(it.bin_index);
@@ -1087,18 +1095,22 @@ async fn verify_sibling_levels(
                         "[PIR-AUDIT] Merkle L{} pass {}: missing sibling row for group {} (item {})",
                         level, pass, g, item_idx
                     );
+                    malformed_evidence[item_idx] = true;
                     current_hash[item_idx] = ZERO_HASH;
+                    node_idx[item_idx] /= arity as u32;
                     continue;
                 };
-                if row.len() < BUCKET_MERKLE_SIB_ROW_SIZE {
+                if row.len() != BUCKET_MERKLE_SIB_ROW_SIZE {
                     log::warn!(
-                        "[PIR-AUDIT] Merkle L{} group {}: sibling row too short ({} bytes, need {})",
+                        "[PIR-AUDIT] Merkle L{} group {}: sibling row has wrong size ({} bytes, expected {})",
                         level,
                         g,
                         row.len(),
                         BUCKET_MERKLE_SIB_ROW_SIZE
                     );
+                    malformed_evidence[item_idx] = true;
                     current_hash[item_idx] = ZERO_HASH;
+                    node_idx[item_idx] /= arity as u32;
                     continue;
                 }
 
@@ -1173,7 +1185,14 @@ async fn verify_sibling_levels(
         // manifest roots is tracked follow-up (docs/CODE_REVIEW_2026-06.md,
         // C1 — opt-in strict mode).
         let expected_root = top.root().unwrap_or(ZERO_HASH);
-        let ok = hash == expected_root;
+        let ok = !malformed_evidence[i] && hash == expected_root;
+        if malformed_evidence[i] {
+            log::warn!(
+                "[PIR-AUDIT] Merkle: group {} item {} FAILED due to malformed sibling evidence",
+                g,
+                i
+            );
+        }
         if !ok {
             log::warn!(
                 "[PIR-AUDIT] Merkle: group {} item {} root MISMATCH (got {:02x}{:02x}{:02x}{:02x}..., expected {:02x}{:02x}{:02x}{:02x}...)",
@@ -1230,6 +1249,54 @@ impl SimpleRng {
 mod tests {
     use super::*;
     use pir_core::merkle::{compute_bin_leaf_hash, MerkleTreeN};
+
+    struct StaticSiblingQuerier {
+        row: Option<Vec<u8>>,
+        calls: usize,
+    }
+
+    #[async_trait]
+    impl BucketMerkleSiblingQuerier for StaticSiblingQuerier {
+        async fn query_pass(
+            &mut self,
+            _table_type: u8,
+            _level: usize,
+            _level_bins_per_table: u32,
+            pass_targets: &[Option<u32>],
+            _db_id: u8,
+        ) -> PirResult<Vec<Option<Vec<u8>>>> {
+            self.calls += 1;
+            Ok(pass_targets
+                .iter()
+                .map(|target| target.as_ref().and(self.row.clone()))
+                .collect())
+        }
+    }
+
+    async fn verify_one_sibling_row(row: Option<Vec<u8>>) -> (bool, usize) {
+        let bin_contents: Vec<Vec<u8>> = (0..64u32).map(|i| vec![i as u8; 68]).collect();
+        let leaves: Vec<Hash256> = bin_contents
+            .iter()
+            .enumerate()
+            .map(|(i, c)| compute_bin_leaf_hash(i as u32, c))
+            .collect();
+        let tree = MerkleTreeN::build(&leaves, BUCKET_MERKLE_ARITY);
+        let top = TreeTop {
+            cache_from_level: 1,
+            levels: tree.levels[1..].to_vec(),
+        };
+        let items = vec![SubItem {
+            pbc_group: 0,
+            bin_index: 7,
+            bin_content: bin_contents[7].clone(),
+        }];
+        let mut querier = StaticSiblingQuerier { row, calls: 0 };
+        let verified =
+            verify_sibling_levels(&mut querier, &items, 64, 1, 0, &[top], 0)
+                .await
+                .unwrap();
+        (verified[0], querier.calls)
+    }
 
     /// Build a small per-group Merkle tree, turn it into a `TreeTop` that
     /// caches the entire tree (so there are zero sibling levels to query),
@@ -1466,5 +1533,43 @@ mod tests {
             let root = walk_top_only(parent_hash, parent_idx, &top);
             assert_eq!(&root, tree.root());
         }
+    }
+
+    #[tokio::test]
+    async fn test_valid_sibling_row_verifies() {
+        let bin_contents: Vec<Vec<u8>> = (0..64u32).map(|i| vec![i as u8; 68]).collect();
+        let row: Vec<u8> = bin_contents
+            .iter()
+            .take(BUCKET_MERKLE_ARITY)
+            .enumerate()
+            .flat_map(|(i, content)| compute_bin_leaf_hash(i as u32, content))
+            .collect();
+
+        let (verified, calls) = verify_one_sibling_row(Some(row)).await;
+        assert!(verified);
+        assert_eq!(calls, 1);
+    }
+
+    #[tokio::test]
+    async fn test_missing_sibling_row_is_explicit_verification_failure() {
+        let (verified, calls) = verify_one_sibling_row(None).await;
+        assert!(!verified);
+        assert_eq!(calls, 1, "the padded sibling round must still complete");
+    }
+
+    #[tokio::test]
+    async fn test_short_sibling_row_is_explicit_verification_failure() {
+        let short = vec![0u8; BUCKET_MERKLE_SIB_ROW_SIZE - 1];
+        let (verified, calls) = verify_one_sibling_row(Some(short)).await;
+        assert!(!verified);
+        assert_eq!(calls, 1, "the padded sibling round must still complete");
+    }
+
+    #[tokio::test]
+    async fn test_oversized_sibling_row_is_explicit_verification_failure() {
+        let oversized = vec![0u8; BUCKET_MERKLE_SIB_ROW_SIZE + 1];
+        let (verified, calls) = verify_one_sibling_row(Some(oversized)).await;
+        assert!(!verified);
+        assert_eq!(calls, 1, "the padded sibling round must still complete");
     }
 }

--- a/pir-sdk-server/CHANGELOG.md
+++ b/pir-sdk-server/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to `pir-sdk-server` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> **Pre-publish note.** This crate depends on the `libdpf` git dependency
-> transitively through `pir-runtime-core`, which must land on crates.io
-> before `pir-sdk-server` itself can be published. See
+> **Pre-publish note.** This crate depends on the `libdpf` and `arc` Git
+> dependencies transitively through `pir-runtime-core`; registry releases are
+> required before `pir-sdk-server` itself can be published. See
 > [`PUBLISHING.md`](../PUBLISHING.md) Blocker 1 for the upstream path.
 
 ## [Unreleased]
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   database page at startup.
 
 ### Changed
+
+- Added configurable global connection and request-concurrency limits plus
+  WebSocket handshake and idle timeouts. PIR evaluation now runs on Tokio's
+  blocking pool so CPU-heavy work does not block async I/O workers.
 
 - Replaced `runtime` + `build` workspace-internal path dependencies with
   the new publishable `pir-runtime-core` library crate. No public API

--- a/pir-sdk-server/Cargo.toml
+++ b/pir-sdk-server/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
 
 # Async runtime
-tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "io-util"] }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "io-util", "time"] }
 tokio-tungstenite = "0.26"
 futures-util = "0.3"
 

--- a/pir-sdk-server/README.md
+++ b/pir-sdk-server/README.md
@@ -6,12 +6,11 @@ Server-side SDK for [Bitcoin PIR](https://github.com/Bitcoin-PIR/Bitcoin-PIR) �
 load pre-built PIR databases (snapshot + delta files) and serve DPF, HarmonyPIR,
 and OnionPIR queries over WebSocket.
 
-> **Pre-publish note.** This crate is not yet on crates.io. It depends on two
-> workspace-internal binary crates (`runtime`, `build`) that contain the PIR
-> protocol wire implementation. Publishing requires factoring out a
-> `pir-runtime-core` library. Until then, use this crate via a path dependency
-> from a Git checkout. See [`PUBLISHING.md`](../PUBLISHING.md) for the
-> refactoring sketch.
+> **Pre-publish note.** This crate is not yet on crates.io. Its shared
+> `pir-runtime-core` dependency still uses revision-pinned `libdpf` and `arc`
+> Git sources, which crates.io packages cannot resolve. Until registry releases
+> are available, use this crate via a path dependency from a Git checkout. See
+> [`PUBLISHING.md`](../PUBLISHING.md) for the current dependency blockers.
 
 ## What this crate provides
 
@@ -19,8 +18,12 @@ and OnionPIR queries over WebSocket.
   - `port(u16)` — WebSocket listen port.
   - `add_full_db(path, height)` — register a snapshot database.
   - `add_delta_db(path, base_height, tip_height)` — register a delta database.
-  - `role(ServerRole::Primary | Hint)` — pick Harmony hint-server vs.
-    query-server role.
+  - `role(ServerRole::Primary | Secondary | Standalone)` — select the server
+    role.
+  - `max_connections(usize)` — global connection cap (default 128).
+  - `max_in_flight_requests(usize)` — global CPU-work cap (default 8).
+  - `handshake_timeout_secs(u64)` / `idle_timeout_secs(u64)` — bound stalled
+    clients (defaults 10 s / 120 s).
   - `from_config(path)` — load all of the above from a TOML file.
 - [`PirServer`] — the built, ready-to-run server. `run().await` blocks until
   `ShutdownHandle::shutdown()` is called or a signal terminates the process.
@@ -54,13 +57,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```toml
 # server.toml
 port = 8091
-role = "Primary"   # or "Hint" for the HarmonyPIR hint server
+role = "primary"   # or "secondary" / "standalone"
+max_connections = 128
+max_in_flight_requests = 8
+handshake_timeout_secs = 10
+idle_timeout_secs = 120
 
-[[databases]]
+[[database]]
+name = "main"
+type = "full"
 path = "/data/snapshot_900000.bin"
 height = 900000
 
-[[databases]]
+[[database]]
+name = "delta_900000_910000"
+type = "delta"
 path = "/data/delta_900000_910000.bin"
 base_height = 900000
 height = 910000
@@ -73,6 +84,21 @@ let server = PirServerBuilder::new()
     .await?;
 server.run().await?;
 ```
+
+## Overload protection
+
+The defaults provide baseline protection for an Internet-facing
+`pir-sdk-server` endpoint:
+excess TCP connections are refused once the global connection cap is full,
+CPU-heavy PIR evaluation is queued behind a separate global semaphore, and
+evaluation runs on Tokio's blocking pool rather than an async reactor thread.
+Handshake and idle deadlines prevent stalled clients from retaining connection
+slots indefinitely.
+
+Deployments can tune the four fields in TOML or through the builder methods
+above. Zero is rejected as a configuration error rather than silently disabling
+protection. These settings apply to servers built with this crate; workspace
+runtime binaries have their own admission controls.
 
 ## Graceful shutdown
 

--- a/pir-sdk-server/examples/simple_server.rs
+++ b/pir-sdk-server/examples/simple_server.rs
@@ -128,7 +128,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
     println!("Building server...");
 
-    let mut builder = PirServerBuilder::new().port(config.port);
+    let mut builder = PirServerBuilder::new()
+        .port(config.port)
+        .max_connections(config.max_connections)
+        .max_in_flight_requests(config.max_in_flight_requests)
+        .handshake_timeout_secs(config.handshake_timeout_secs)
+        .idle_timeout_secs(config.idle_timeout_secs);
 
     // Forward parsed databases into the builder. Without this, the builder
     // would be empty even though the user passed --db or --config flags.

--- a/pir-sdk-server/src/config.rs
+++ b/pir-sdk-server/src/config.rs
@@ -72,7 +72,7 @@ impl DatabaseEntry {
 }
 
 /// Top-level server configuration.
-#[derive(Deserialize, Clone, Debug, Default)]
+#[derive(Deserialize, Clone, Debug)]
 pub struct ServerConfig {
     /// Server role.
     #[serde(default)]
@@ -92,6 +92,35 @@ pub struct ServerConfig {
     /// Whether to enable OnionPIR backend.
     #[serde(default = "default_true")]
     pub enable_onion: bool,
+    /// Maximum simultaneously open TCP/WebSocket connections.
+    #[serde(default = "default_max_connections")]
+    pub max_connections: usize,
+    /// Maximum CPU-heavy PIR requests evaluated at once across all clients.
+    #[serde(default = "default_max_in_flight_requests")]
+    pub max_in_flight_requests: usize,
+    /// Deadline for completing the WebSocket handshake.
+    #[serde(default = "default_handshake_timeout_secs")]
+    pub handshake_timeout_secs: u64,
+    /// Close a connection that sends no message within this interval.
+    #[serde(default = "default_idle_timeout_secs")]
+    pub idle_timeout_secs: u64,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            role: ServerRoleConfig::default(),
+            port: default_port(),
+            databases: Vec::new(),
+            enable_dpf: true,
+            enable_harmony: true,
+            enable_onion: true,
+            max_connections: default_max_connections(),
+            max_in_flight_requests: default_max_in_flight_requests(),
+            handshake_timeout_secs: default_handshake_timeout_secs(),
+            idle_timeout_secs: default_idle_timeout_secs(),
+        }
+    }
 }
 
 fn default_port() -> u16 {
@@ -100,6 +129,22 @@ fn default_port() -> u16 {
 
 fn default_true() -> bool {
     true
+}
+
+fn default_max_connections() -> usize {
+    128
+}
+
+fn default_max_in_flight_requests() -> usize {
+    8
+}
+
+fn default_handshake_timeout_secs() -> u64 {
+    10
+}
+
+fn default_idle_timeout_secs() -> u64 {
+    120
 }
 
 /// Server role configuration (for TOML parsing).
@@ -149,7 +194,47 @@ impl ServerConfig {
             }
         }
 
+        config.validate()?;
+
         Ok(config)
+    }
+
+    /// Reject settings that would disable overload protection or make Tokio's
+    /// semaphores panic when the server starts.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.max_connections == 0 {
+            return Err(ConfigError::Invalid(
+                "max_connections must be at least 1".into(),
+            ));
+        }
+        if self.max_connections > tokio::sync::Semaphore::MAX_PERMITS {
+            return Err(ConfigError::Invalid(format!(
+                "max_connections must not exceed {}",
+                tokio::sync::Semaphore::MAX_PERMITS
+            )));
+        }
+        if self.max_in_flight_requests == 0 {
+            return Err(ConfigError::Invalid(
+                "max_in_flight_requests must be at least 1".into(),
+            ));
+        }
+        if self.max_in_flight_requests > tokio::sync::Semaphore::MAX_PERMITS {
+            return Err(ConfigError::Invalid(format!(
+                "max_in_flight_requests must not exceed {}",
+                tokio::sync::Semaphore::MAX_PERMITS
+            )));
+        }
+        if self.handshake_timeout_secs == 0 {
+            return Err(ConfigError::Invalid(
+                "handshake_timeout_secs must be at least 1".into(),
+            ));
+        }
+        if self.idle_timeout_secs == 0 {
+            return Err(ConfigError::Invalid(
+                "idle_timeout_secs must be at least 1".into(),
+            ));
+        }
+        Ok(())
     }
 
     /// Add a full snapshot database.
@@ -250,5 +335,32 @@ height = 948454
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn safe_limits_are_enabled_by_default() {
+        let config = ServerConfig::new();
+        assert_eq!(config.max_connections, 128);
+        assert_eq!(config.max_in_flight_requests, 8);
+        assert_eq!(config.handshake_timeout_secs, 10);
+        assert_eq!(config.idle_timeout_secs, 120);
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn invalid_limits_are_rejected() {
+        let mut config = ServerConfig::new();
+        config.max_connections = 0;
+        assert!(config.validate().is_err());
+
+        config.max_connections = tokio::sync::Semaphore::MAX_PERMITS + 1;
+        assert!(config.validate().is_err());
+
+        config.max_connections = 1;
+        config.max_in_flight_requests = 0;
+        assert!(config.validate().is_err());
+
+        config.max_in_flight_requests = tokio::sync::Semaphore::MAX_PERMITS + 1;
+        assert!(config.validate().is_err());
     }
 }

--- a/pir-sdk-server/src/server.rs
+++ b/pir-sdk-server/src/server.rs
@@ -3,13 +3,14 @@
 use crate::config::{ConfigError, ServerConfig};
 use crate::loader::DatabaseLoader;
 use futures_util::{SinkExt, StreamExt};
-use pir_sdk::{DatabaseCatalog, PirError, PirResult, ServerRole};
 use pir_runtime_core::handler::RequestHandler;
 use pir_runtime_core::protocol::{Request, Response};
+use pir_sdk::{DatabaseCatalog, PirError, PirResult, ServerRole};
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::watch;
+use tokio::sync::{watch, OwnedSemaphorePermit, Semaphore};
 use tokio_tungstenite::tungstenite::Message;
 
 /// Handle for graceful shutdown.
@@ -72,6 +73,18 @@ impl PirServer {
             self.handler.databases().len(),
             self.config.role
         );
+        log::info!(
+            "Overload limits: max_connections={}, max_in_flight_requests={}, handshake_timeout={}s, idle_timeout={}s",
+            self.config.max_connections,
+            self.config.max_in_flight_requests,
+            self.config.handshake_timeout_secs,
+            self.config.idle_timeout_secs,
+        );
+
+        let connection_slots = Arc::new(Semaphore::new(self.config.max_connections));
+        let request_slots = Arc::new(Semaphore::new(self.config.max_in_flight_requests));
+        let handshake_timeout = Duration::from_secs(self.config.handshake_timeout_secs);
+        let idle_timeout = Duration::from_secs(self.config.idle_timeout_secs);
 
         // Main accept loop
         loop {
@@ -79,10 +92,30 @@ impl PirServer {
                 result = listener.accept() => {
                     match result {
                         Ok((stream, peer)) => {
+                            let connection_permit = match connection_slots.clone().try_acquire_owned() {
+                                Ok(permit) => permit,
+                                Err(_) => {
+                                    log::warn!(
+                                        "Refusing connection from {}: max_connections={} reached",
+                                        peer,
+                                        self.config.max_connections,
+                                    );
+                                    drop(stream);
+                                    continue;
+                                }
+                            };
                             log::debug!("New connection from {}", peer);
                             let handler = self.handler.clone();
+                            let request_slots = request_slots.clone();
                             tokio::spawn(async move {
-                                if let Err(e) = handle_connection(stream, handler).await {
+                                if let Err(e) = handle_connection(
+                                    stream,
+                                    handler,
+                                    connection_permit,
+                                    request_slots,
+                                    handshake_timeout,
+                                    idle_timeout,
+                                ).await {
                                     log::error!("Connection error from {}: {}", peer, e);
                                 }
                             });
@@ -107,14 +140,31 @@ impl PirServer {
 }
 
 /// Handle a single WebSocket connection.
-async fn handle_connection(stream: TcpStream, handler: Arc<RequestHandler>) -> PirResult<()> {
-    let ws_stream = tokio_tungstenite::accept_async(stream)
-        .await
-        .map_err(|e| PirError::ConnectionFailed(format!("WebSocket handshake failed: {}", e)))?;
+async fn handle_connection(
+    stream: TcpStream,
+    handler: Arc<RequestHandler>,
+    _connection_permit: OwnedSemaphorePermit,
+    request_slots: Arc<Semaphore>,
+    handshake_timeout: Duration,
+    idle_timeout: Duration,
+) -> PirResult<()> {
+    let ws_stream =
+        tokio::time::timeout(handshake_timeout, tokio_tungstenite::accept_async(stream))
+            .await
+            .map_err(|_| PirError::ConnectionFailed("WebSocket handshake timed out".into()))?
+            .map_err(|e| {
+                PirError::ConnectionFailed(format!("WebSocket handshake failed: {}", e))
+            })?;
 
     let (mut sink, mut stream) = ws_stream.split();
 
-    while let Some(msg) = stream.next().await {
+    loop {
+        let Some(msg) = tokio::time::timeout(idle_timeout, stream.next())
+            .await
+            .map_err(|_| PirError::ConnectionFailed("connection idle timeout".into()))?
+        else {
+            break;
+        };
         let msg = match msg {
             Ok(m) => m,
             Err(e) => {
@@ -143,8 +193,21 @@ async fn handle_connection(stream: TcpStream, handler: Arc<RequestHandler>) -> P
                     }
                 };
 
-                // Handle request
-                let response = handler.handle_request(&request);
+                // Bound CPU-heavy evaluation globally and keep it off Tokio's
+                // async worker threads. Waiting here applies backpressure to
+                // this connection without changing the wire protocol.
+                let permit = request_slots
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .map_err(|_| PirError::InvalidState("request limiter closed".into()))?;
+                let request_handler = handler.clone();
+                let response = tokio::task::spawn_blocking(move || {
+                    let _permit = permit;
+                    request_handler.handle_request(&request)
+                })
+                .await
+                .map_err(|e| PirError::InvalidState(format!("request worker failed: {}", e)))?;
 
                 // Send response
                 let encoded = response.encode();
@@ -213,6 +276,31 @@ impl PirServerBuilder {
         self
     }
 
+    /// Set the global connection cap. Values below 1 or above Tokio's
+    /// supported maximum are rejected by `build`.
+    pub fn max_connections(mut self, limit: usize) -> Self {
+        self.config.max_connections = limit;
+        self
+    }
+
+    /// Set the global CPU-heavy request concurrency cap.
+    pub fn max_in_flight_requests(mut self, limit: usize) -> Self {
+        self.config.max_in_flight_requests = limit;
+        self
+    }
+
+    /// Set the WebSocket handshake deadline in seconds.
+    pub fn handshake_timeout_secs(mut self, seconds: u64) -> Self {
+        self.config.handshake_timeout_secs = seconds;
+        self
+    }
+
+    /// Set the idle connection timeout in seconds.
+    pub fn idle_timeout_secs(mut self, seconds: u64) -> Self {
+        self.config.idle_timeout_secs = seconds;
+        self
+    }
+
     /// Add a full snapshot database.
     pub fn add_full_db(mut self, path: impl AsRef<Path>, height: u32) -> Self {
         self.config.add_full_db(path.as_ref(), height);
@@ -251,6 +339,10 @@ impl PirServerBuilder {
 
     /// Build and bind the server (but don't start accepting connections).
     pub async fn build(self) -> PirResult<PirServer> {
+        self.config
+            .validate()
+            .map_err(|e| PirError::Config(e.to_string()))?;
+
         // Load databases
         let mut loader = DatabaseLoader::new();
         loader.load_all(&self.config.databases)?;
@@ -302,5 +394,34 @@ impl PirServerBuilder {
 impl Default for PirServerBuilder {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connection_cap_refuses_excess_and_recovers_after_drop() {
+        let slots = Arc::new(Semaphore::new(2));
+        let first = slots.clone().try_acquire_owned().unwrap();
+        let _second = slots.clone().try_acquire_owned().unwrap();
+        assert!(slots.clone().try_acquire_owned().is_err());
+        drop(first);
+        assert!(slots.clone().try_acquire_owned().is_ok());
+    }
+
+    #[tokio::test]
+    async fn request_cap_queues_excess_work() {
+        let slots = Arc::new(Semaphore::new(1));
+        let first = slots.clone().acquire_owned().await.unwrap();
+        let waiting = slots.clone().acquire_owned();
+        tokio::pin!(waiting);
+        assert!(matches!(
+            futures_util::poll!(&mut waiting),
+            std::task::Poll::Pending
+        ));
+        drop(first);
+        assert!(waiting.await.is_ok());
     }
 }

--- a/pir-sdk-server/src/server.rs
+++ b/pir-sdk-server/src/server.rs
@@ -424,4 +424,46 @@ mod tests {
         drop(first);
         assert!(waiting.await.is_ok());
     }
+
+    #[tokio::test]
+    async fn ordinary_websocket_connection_is_served_and_releases_its_slot() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connection_slots = Arc::new(Semaphore::new(1));
+        let connection_permit = connection_slots.clone().try_acquire_owned().unwrap();
+        let request_slots = Arc::new(Semaphore::new(1));
+        let handler = Arc::new(RequestHandler::new(Vec::new()));
+
+        let server_task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            handle_connection(
+                stream,
+                handler,
+                connection_permit,
+                request_slots,
+                Duration::from_secs(5),
+                Duration::from_secs(5),
+            )
+            .await
+        });
+
+        let (mut client, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
+            .await
+            .unwrap();
+        client
+            .send(Message::Ping(vec![1, 2, 3].into()))
+            .await
+            .unwrap();
+
+        let reply = tokio::time::timeout(Duration::from_secs(5), client.next())
+            .await
+            .expect("server should answer an allowed connection")
+            .expect("server should keep the connection open")
+            .expect("Pong should decode");
+        assert!(matches!(reply, Message::Pong(data) if data.as_ref() == [1, 2, 3]));
+
+        client.close(None).await.unwrap();
+        server_task.await.unwrap().unwrap();
+        assert_eq!(connection_slots.available_permits(), 1);
+    }
 }

--- a/runtime/src/bin/unified_server.rs
+++ b/runtime/src/bin/unified_server.rs
@@ -5041,18 +5041,11 @@ async fn main() {
                                     .flat_map_iter(|(g, server)| {
                                         let q0 = &queries_ref[2 * g];
                                         let q1 = &queries_ref[2 * g + 1];
-                                        let r0 = match std::panic::catch_unwind(
-                                            std::panic::AssertUnwindSafe(|| server.answer_query(client_id, q0)),
-                                        ) {
-                                            Ok(r) => r,
-                                            Err(e) => { eprintln!("[OnionPIR:{}] panic in index group {} q0: {:?}", worker_label, g, e); Vec::new() }
-                                        };
-                                        let r1 = match std::panic::catch_unwind(
-                                            std::panic::AssertUnwindSafe(|| server.answer_query(client_id, q1)),
-                                        ) {
-                                            Ok(r) => r,
-                                            Err(e) => { eprintln!("[OnionPIR:{}] panic in index group {} q1: {:?}", worker_label, g, e); Vec::new() }
-                                        };
+                                        // The workspace uses panic=abort, so an OnionPIR panic
+                                        // terminates the process; there is no in-process isolation.
+                                        // A process boundary is required if that policy changes.
+                                        let r0 = server.answer_query(client_id, q0);
+                                        let r1 = server.answer_query(client_id, q1);
                                         std::iter::once(r0).chain(std::iter::once(r1))
                                     })
                                     .collect();
@@ -5062,20 +5055,7 @@ async fn main() {
                                     .par_iter_mut()
                                     .enumerate()
                                     .map(|(b, server)| {
-                                        match std::panic::catch_unwind(
-                                            std::panic::AssertUnwindSafe(|| {
-                                                server.answer_query(client_id, &queries_ref[b])
-                                            }),
-                                        ) {
-                                            Ok(r) => r,
-                                            Err(e) => {
-                                                eprintln!(
-                                                    "[OnionPIR:{}] panic in chunk group {}: {:?}",
-                                                    worker_label, b, e
-                                                );
-                                                Vec::new()
-                                            }
-                                        }
+                                        server.answer_query(client_id, &queries_ref[b])
                                     })
                                     .collect();
                                 ("chunk", results)
@@ -5091,20 +5071,7 @@ async fn main() {
                                     .par_iter_mut()
                                     .enumerate()
                                     .map(|(b, server)| {
-                                        match std::panic::catch_unwind(
-                                            std::panic::AssertUnwindSafe(|| {
-                                                server.answer_query(client_id, &queries_ref[b])
-                                            }),
-                                        ) {
-                                            Ok(r) => r,
-                                            Err(e) => {
-                                                eprintln!(
-                                                    "[OnionPIR:{}] panic in {} group {}: {:?}",
-                                                    worker_label, kind, b, e
-                                                );
-                                                Vec::new()
-                                            }
-                                        }
+                                        server.answer_query(client_id, &queries_ref[b])
                                     })
                                     .collect();
                                 (kind, results)
@@ -5116,9 +5083,9 @@ async fn main() {
                             // alongside the existing wall-clock log so a future
                             // "all-empty batch" client-side report (see
                             // `pir-sdk-client/src/onion.rs::batch_looks_evicted`)
-                            // can be triaged from server logs alone — either the
-                            // C++ answer_query catch fired (empty=N/N, fast wall
-                            // time → keystore drift or query malformed) or the
+                            // can be triaged from server logs alone — either
+                            // answer_query returned an all-empty batch quickly
+                            // (empty=N/N → keystore drift or query malformed) or the
                             // matmul completed (empty=0/N, full wall time →
                             // client decode / decryption-noise bug).
                             let empty_count = results.iter().filter(|r| r.is_empty()).count();


### PR DESCRIPTION
## Summary

- make malformed or wrong-sized Merkle sibling evidence fail verification explicitly while preserving the privacy-padded request shape
- remove ineffective OnionPIR `catch_unwind` wrappers under the workspace's `panic = "abort"` policy
- add conservative `pir-sdk-server` connection/request concurrency caps, handshake and idle timeouts, and offload CPU-heavy evaluation to Tokio's blocking pool
- document the closed C5/S6/S7 review findings and add a real loopback WebSocket allowed-traffic test

## Why

These changes close three deferred findings from `docs/CODE_REVIEW_2026-06.md`: an explicit-proof-quality hazard in the Merkle client, misleading panic-isolation code, and unbounded default work in the volunteer-facing server SDK.

Closes #32
Closes #36
Closes #37

## Validation

- `cargo test -p pir-sdk-client merkle_verify::tests --lib` — 16 passed
- `cargo check -p runtime --bin unified_server` — passed
- `cargo test -p pir-sdk-server` — 6 passed; doc test ignored
- `rustfmt --edition 2021 --check pir-sdk-server/src/server.rs`
- `git diff --check`
