### PR TITLE
Bind ORAM source proof to binary BuildEvidence

### DIFF
--- a/docs/DB_BUILD_ATTESTATION_PLAN.md
+++ b/docs/DB_BUILD_ATTESTATION_PLAN.md
@@ -1,9 +1,11 @@
 # Database Build Attestation Plan
 
 Status: server/API proof distribution is deployed for the production delta DB.
-The web frontend now fetches and verifies the production delta proof for DPF
-and HarmonyPIR and renders an advisory DB/MuHash badge. Strict query-path root
-installation and standalone OnionPIR proof verification remain.
+The web frontend now fetches and verifies that proof for DPF and HarmonyPIR and
+renders an advisory DB/MuHash badge. A separate static proof chain now binds the
+mainnet snapshot's attested-builder evidence to the inputs and outputs of the
+strict direct ORAM build. Strict query-path root installation, standalone
+OnionPIR proof verification, and live serving-state binding remain.
 
 Goal: bind BitcoinPIR database Merkle roots to an independently verifiable
 Bitcoin Core UTXO MuHash computation. The runtime server attestation proves
@@ -124,21 +126,40 @@ Known cleanups:
     builder_commit)`
   - `WasmHarmonyClient.verifyDatabaseProof(dbId, params_hash, builder_hash,
     builder_commit)`
-  - `verifyDatabaseProofResponse(dbInfo, rawResponse, policy)` for the
-    standalone TypeScript OnionPIR client remains.
+  - **planned authoritative standalone API:** a stateless WASM
+    `verifyDatabaseProofResponse(dbInfo, rawResponse, policy)` export. The
+    TypeScript OnionPIR client will transport the raw response and compare the
+    returned structured proof to its pin; it will not maintain a second proof
+    parser/verifier in TypeScript.
 - DPF and Harmony web adapters accept `databaseProofPins` and
   `onDatabaseProof`, fetch `REQ_GET_DB_PROOF`, verify in WASM, compare against
   `web/src/attest-pin.ts::PRODUCTION_DB_PROOF_PINS`, and store status in
   `databaseProofs`.
 - The demo UI renders a DB proof badge with the verified MuHash, block range,
   bucket root, onion root, and builder pins.
-- DPF and Harmony should install verified bucket/onion roots into their native WASM
-  clients before queries.
-- standalone OnionPIR should fetch `REQ_GET_DB_PROOF` directly, verify it through
-  the WASM verifier, and use the attested onion super-root as the Merkle
-  anchor instead of trusting `server-info`'s `super_root`.
+- DPF and Harmony should install only the verified **bucket** super-root into
+  their native WASM Merkle verifiers before queries. The standalone OnionPIR
+  client owns installation of the verified **onion** super-root; the two-server
+  adapters must not imply that they enforce OnionPIR's root.
+- standalone OnionPIR should fetch `REQ_GET_DB_PROOF` directly, pass the raw
+  response to that stateless WASM verifier, and use the attested onion
+  super-root as the Merkle anchor instead of trusting `server-info`'s
+  `super_root`.
 - `scripts/smoke_db_proof_attestation.sh` wraps local and live proof checks
   with the pinned expected values below.
+- `web/src/oram-source-proof.ts::verifyOramSourceProof` checks the published
+  `/proofs/oram-source/mainnet_948454.json` artifact chain for internal
+  consistency. It hashes every listed compact artifact, recomputes
+  `BuildEvidence::report_data()` from the binary `build-evidence.bin`, checks
+  that value against the SNP report and report-data sidecar, binds the direct
+  input hashes to ORAM output metadata/build logs, checks output hashes and
+  initial controller/auth roots, and requires the explicit
+  `MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN` before returning `verified`.
+- The static TypeScript verifier does **not** validate the builder SNP signature
+  or AMD certificate chain and does not prove which ORAM image the live runtime
+  has open. The manifest's `liveDeployment` field is informational only. Those
+  are separate trust gates; do not describe the static proof as live-serving
+  attestation.
 
 ### 7. Deployment
 
@@ -150,9 +171,11 @@ Known cleanups:
 
 ### 8. Missing Artifact
 
-Current production strict mode still needs a full snapshot proof for the full DB
-if the client must verify the whole sync chain from zero. Run the same UKI in
-`BUILD_KIND=snapshot` for height `948454` and bind its bucket/onion roots.
+The `mainnet_948454` snapshot now has a published static source-binding proof
+for the direct ORAM rebuild. The live `REQ_GET_DB_PROOF` path still lacks a
+full-snapshot proof bundle suitable for installing strict DPF/Harmony/Onion
+query roots and verifying a complete sync chain from zero. Do not treat the
+static ORAM rebuild proof as a substitute for that live query-path bundle.
 
 ## Progress Log
 
@@ -167,6 +190,9 @@ if the client must verify the whole sync chain from zero. Run the same UKI in
 - [x] Web/WASM proof policy for DPF and HarmonyPIR.
 - [x] Dedicated UI badge/status rendering for DPF and HarmonyPIR database
       build attestation.
+- [x] Static mainnet snapshot -> direct-input -> ORAM-output source-binding
+      proof and frontend verifier, including binary BuildEvidence REPORT_DATA
+      recomputation and an explicit expected DB pin.
 - [ ] Merkle verification consumes verified roots in strict query paths.
 - [ ] Web/WASM verified-root installation before queries.
 - [ ] standalone OnionPIR DB proof verifier and UI badge.

--- a/web/src/__tests__/oram-source-proof.test.ts
+++ b/web/src/__tests__/oram-source-proof.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN } from '../attest-pin.js';
 import {
   DEFAULT_ORAM_SOURCE_PROOF_MANIFEST_PATH,
+  reportDataForBuildEvidence,
   verifyOramSourceProof,
 } from '../oram-source-proof.js';
+import { bytesToHex } from '../hash.js';
 
 const publicRoot = new URL('../../public/', import.meta.url);
 
@@ -53,6 +55,30 @@ describe('ORAM source-binding proof', () => {
     expect(status.state).toBe('unverified');
     expect(status.mismatches.some((m) => m.includes('DB certification MuHash'))).toBe(true);
     expect(status.mismatches.some((m) => m.includes('manifest DB pin'))).toBe(true);
+  });
+
+  it('recomputes the SNP REPORT_DATA binding from build-evidence.bin', async () => {
+    const manifest = JSON.parse(
+      new TextDecoder().decode(await publicArtifactLoader(DEFAULT_ORAM_SOURCE_PROOF_MANIFEST_PATH)),
+    );
+    const evidence = await publicArtifactLoader(
+      manifest.attestedBuilder.artifacts.buildEvidence.path,
+    );
+
+    expect(bytesToHex(reportDataForBuildEvidence(evidence))).toBe(
+      manifest.attestedBuilder.sevSnp.reportDataHex,
+    );
+  });
+
+  it('does not call an unpinned source proof verified', async () => {
+    const status = await verifyOramSourceProof({
+      artifactLoader: publicArtifactLoader,
+    });
+
+    expect(status.state).toBe('unverified');
+    expect(status.mismatches).toContain(
+      'expectedDbPin is required before an ORAM source proof can be trusted',
+    );
   });
 
   it('keeps the 64-bit ORAM index seed exact instead of rounding in JavaScript', async () => {

--- a/web/src/oram-source-proof.ts
+++ b/web/src/oram-source-proof.ts
@@ -3,6 +3,13 @@ import type { DatabaseProofPin } from './db-proof.js';
 import { verifyDatabaseProofAgainstPin } from './db-proof.js';
 import { bytesToHex, sha256 } from './hash.js';
 
+const DB_EVIDENCE_DOMAIN = new TextEncoder().encode(
+  'BitcoinPIR/attested-builder/build-evidence/v1\0',
+);
+const DB_REPORT_DATA_DOMAIN = new TextEncoder().encode(
+  'BitcoinPIR/attested-builder/build-evidence/report-data/v1\0',
+);
+
 export const DEFAULT_ORAM_SOURCE_PROOF_MANIFEST_PATH =
   '/proofs/oram-source/mainnet_948454.json';
 
@@ -257,7 +264,15 @@ export async function verifyOramSourceProof(
     checks.push(checkFromMismatches('build logs matched manifest', mismatches, logsBefore));
 
     const reportBefore = mismatches.length;
+    const buildEvidence = requiredArtifact(artifacts, 'attestedBuilder.buildEvidence');
+    const expectedReportData = reportDataForBuildEvidence(buildEvidence);
     const report = requiredArtifact(artifacts, 'attestedBuilder.sevSnpReport');
+    compareHex(
+      'BuildEvidence-derived REPORT_DATA',
+      bytesToHex(expectedReportData),
+      manifest.attestedBuilder.sevSnp.reportDataHex,
+      mismatches,
+    );
     compareHex(
       'attested-builder SNP REPORT_DATA field',
       bytesToHex(extractSnpReportData(report)),
@@ -288,12 +303,19 @@ export async function verifyOramSourceProof(
         mismatches.push(...(status.mismatches ?? []).map((m) => `manifest DB pin: ${m}`));
       }
       checks.push(checkFromMismatches('manifest matches ORAM DB pin', mismatches, pinBefore));
+    } else {
+      mismatches.push('expectedDbPin is required before an ORAM source proof can be trusted');
+      checks.push({
+        name: 'manifest matches ORAM DB pin',
+        state: 'unverified',
+        message: 'no expectedDbPin supplied',
+      });
     }
 
     checks.push({
-      name: 'live deployment claim',
-      state: 'verified',
-      message: manifest.liveDeployment.status,
+      name: 'live deployment claim (informational)',
+      state: 'unverified',
+      message: `${manifest.liveDeployment.status}; verify the live runtime attestation separately`,
     });
 
     return {
@@ -318,6 +340,30 @@ export async function verifyOramSourceProof(
       error: message,
     };
   }
+}
+
+/**
+ * Reproduce `pir_db_attest::report_data_for_evidence_bytes` exactly.
+ * The low half commits to the domain-separated binary BuildEvidence bytes;
+ * the high half commits to that digest under a second domain. This check is
+ * what turns the SNP report's REPORT_DATA from a manifest assertion into a
+ * binding to the actual `build-evidence.bin` artifact.
+ */
+export function reportDataForBuildEvidence(evidenceBytes: Uint8Array): Uint8Array {
+  const evidenceHash = sha256(concatBytes(DB_EVIDENCE_DOMAIN, evidenceBytes));
+  const high = sha256(concatBytes(DB_REPORT_DATA_DOMAIN, evidenceHash));
+  return concatBytes(evidenceHash, high);
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const length = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(length);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
 }
 
 export function oramSourcePinFromManifest(manifest: OramSourceProofManifest): DatabaseProofPin {


### PR DESCRIPTION
## Summary

- recompute the domain-separated 64-byte SEV-SNP `REPORT_DATA` from the actual binary `build-evidence.bin`
- compare that recomputed value with both the manifest and the SNP report field
- require an independently supplied expected database proof pin before returning `verified`
- render `liveDeployment` as informational rather than treating it as a verified static-proof check
- document the boundary between static source binding, SNP chain validation, and live-serving attestation

## Why

Previously, a self-consistent manifest could assert its own `reportDataHex`, and callers that omitted `expectedDbPin` could still receive a verified result. The verifier now binds the binary BuildEvidence artifact to the report and fails closed without an external database pin.

This change intentionally does **not** claim to validate the SNP signature/AMD certificate chain or prove which ORAM image a live runtime currently has open.

Closes #47

## Validation

- `npm test -- --run src/__tests__/oram-source-proof.test.ts` — 5 passed
- `npm run build` — TypeScript strict build passed
- `git diff --check`
