### PR TITLE
Add privacy canary and publishing hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+version: 2
+
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:10"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      rust-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directories:
+      - /web
+      - /explorer
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:10"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        group-by: dependency-name
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+      time: "07:10"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/pir-sdk-integration.yml
+++ b/.github/workflows/pir-sdk-integration.yml
@@ -177,3 +177,87 @@ jobs:
         # already ran in the `integration` job without the feature.
         # (Quoted to keep YAML from parsing `::` as a mapping.)
         run: "cargo test -p pir-sdk-client --features onion --test integration_test -- --ignored --test-threads=1 --nocapture onion_tests::"
+
+  leakage-canary:
+    # The leakage suite opens many live WebSocket connections. Run it only
+    # after both ordinary integration jobs succeed on scheduled/manual runs,
+    # with every selected invariant serialized in this one job.
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    needs: [integration, integration-onion]
+    name: privacy leakage canary (DPF, HarmonyPIR, OnionPIR)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CARGO_TERM_COLOR: always
+      PIR_DPF_SERVER0_URL: wss://weikeng1.bitcoinpir.org
+      PIR_DPF_SERVER1_URL: wss://weikeng2.bitcoinpir.org
+      PIR_HARMONY_HINT_URL: wss://weikeng1.bitcoinpir.org
+      PIR_HARMONY_QUERY_URL: wss://weikeng2.bitcoinpir.org
+      PIR_ONION_URL: wss://weikeng1.bitcoinpir.org
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install --profile minimal
+
+      - name: Install C++ toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential cmake libgomp1
+
+      - name: Rewrite SSH GitHub URLs to HTTPS (for SEAL submodule)
+        run: |
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+
+      - name: Cache Cargo registry + target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-sdk-leakage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sdk-leakage-
+            ${{ runner.os }}-cargo-sdk-onion-
+
+      - name: Run DPF leakage invariants
+        run: |
+          for test_name in \
+            dpf_per_message_invariants_not_found \
+            dpf_found_vs_not_found_have_byte_identical_profiles
+          do
+            cargo test -p pir-sdk-client --test leakage_integration_test \
+              --release "$test_name" -- \
+              --ignored --exact --test-threads=1 --nocapture
+          done
+
+      - name: Run HarmonyPIR leakage invariants (one retry)
+        run: |
+          run_harmony_invariants() {
+            for test_name in \
+              harmony_per_message_invariants_not_found \
+              harmony_found_vs_not_found_have_byte_identical_profiles
+            do
+              cargo test -p pir-sdk-client --test leakage_integration_test \
+                --release "$test_name" -- \
+                --ignored --exact --test-threads=1 --nocapture || return 1
+            done
+          }
+          run_harmony_invariants || run_harmony_invariants
+
+      - name: Run OnionPIR leakage invariants
+        run: |
+          for test_name in \
+            onion_per_message_invariants_not_found \
+            onion_found_vs_not_found_have_byte_identical_profiles
+          do
+            cargo test -p pir-sdk-client --features onion \
+              --test leakage_integration_test --release "$test_name" -- \
+              --ignored --exact --test-threads=1 --nocapture
+          done

--- a/.github/workflows/pir-sdk-integration.yml
+++ b/.github/workflows/pir-sdk-integration.yml
@@ -230,6 +230,7 @@ jobs:
         run: |
           for test_name in \
             dpf_per_message_invariants_not_found \
+            dpf_simulator_property_two_not_found \
             dpf_found_vs_not_found_have_byte_identical_profiles
           do
             cargo test -p pir-sdk-client --test leakage_integration_test \
@@ -242,6 +243,7 @@ jobs:
           run_harmony_invariants() {
             for test_name in \
               harmony_per_message_invariants_not_found \
+              harmony_simulator_property_two_not_found \
               harmony_found_vs_not_found_have_byte_identical_profiles
             do
               cargo test -p pir-sdk-client --test leakage_integration_test \
@@ -255,6 +257,7 @@ jobs:
         run: |
           for test_name in \
             onion_per_message_invariants_not_found \
+            onion_simulator_property_two_not_found \
             onion_found_vs_not_found_have_byte_identical_profiles
           do
             cargo test -p pir-sdk-client --features onion \

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ deploy/
 # rules above (target/, build/, .DS_Store, .claude/, Cargo.lock) don't
 # bite vendored crates.
 !vendor/**
+# The vendor re-include above also re-opens files matched by the global
+# macOS metadata rule. Keep local Finder state out of vendored sources.
+/vendor/**/.DS_Store
 # dev-issuer demo key files (never commit)
 arc_key.bin
 cashu_key.bin

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -9,74 +9,75 @@ resolved first. Each blocker is listed below with a suggested fix.
 
 ## Publishable artefacts
 
-| Artefact                          | Registry   | Status                                              |
-|-----------------------------------|------------|-----------------------------------------------------|
-| `pir-core`                        | crates.io  | 🟢 Ready (no git deps, no path-only deps).          |
-| `pir-sdk`                         | crates.io  | 🟢 Ready (path dep on `pir-core` only).             |
-| `pir-runtime-core`                | crates.io  | 🟡 Blocked — git dep on `libdpf`.                   |
-| `pir-sdk-client`                  | crates.io  | 🟡 Blocked — git deps on `libdpf` / `harmonypir`.   |
-| `pir-sdk-wasm` (as a crate)       | crates.io  | 🟡 Blocked — transitively via `pir-sdk-client`.     |
-| `pir-sdk-wasm` (as npm package)   | npm        | 🟢 Ready (wasm-pack bundles all Rust deps).         |
-| `pir-sdk-server`                  | crates.io  | 🟡 Blocked — transitively via `pir-runtime-core`.   |
+| Artefact                          | Registry   | Status                                                    |
+|-----------------------------------|------------|-----------------------------------------------------------|
+| `pir-core`                        | crates.io  | 🟢 Packageable (registry dependencies only).              |
+| `pir-sdk`                         | crates.io  | 🟢 Packageable after `pir-core` is published.             |
+| `pir-channel`                     | crates.io  | 🟢 Packageable (registry dependencies only).              |
+| `pir-identity`                    | crates.io  | 🟢 Packageable (registry dependencies only).              |
+| `pir-attest-verify`               | crates.io  | 🟢 Packageable (registry dependencies only).              |
+| `pir-runtime-core`                | crates.io  | 🟡 Blocked — git deps on `libdpf` and `arc`.               |
+| `pir-sdk-client`                  | crates.io  | 🟡 Blocked — git deps and unpublished internal path deps. |
+| `pir-sdk-wasm` (as a crate)       | crates.io  | 🟡 Blocked — direct and transitive non-registry deps.     |
+| `pir-sdk-wasm` (as npm package)   | npm        | 🟢 Packageable (wasm-pack bundles all Rust deps).         |
+| `pir-sdk-server`                  | crates.io  | 🟡 Blocked — transitively via `pir-runtime-core`.         |
 
 🟢 = ready; 🟡 = blocked, unblocking is tracked below; 🔴 = needs
 upstream refactoring, no ETA.
 
-## Blocker 1 — git dependencies on `libdpf` / `harmonypir`
+## Blocker 1 — dependencies that crates.io cannot resolve
 
 ### Current state
 
-`pir-sdk-client` pulls `libdpf` directly and `harmonypir` transitively
-(through the `path`-dep on the workspace-internal `harmonypir-wasm`
-shim) from GitHub:
+The affected packages currently contain these non-registry dependencies:
 
 ```toml
-# pir-sdk-client/Cargo.toml
-libdpf = { git = "https://github.com/weikengchen/libdpf.git" }
+# pir-runtime-core/Cargo.toml
+libdpf = { git = "...", rev = "..." }
+arc = { git = "...", rev = "..." }
 
-# harmonypir-wasm/Cargo.toml (path dep from pir-sdk-client)
-harmonypir = { git = "https://github.com/Bitcoin-PIR/harmonypir.git",
-               rev = "a849dedfe0b0ab283c7c9ad9e20f8775b01b4543",
-               default-features = false }
+# pir-sdk-client/Cargo.toml
+libdpf = { git = "...", rev = "..." }
+harmonypir-wasm = { path = "../harmonypir-wasm" }
+pir-db-attest = { path = "../pir-db-attest" }
+onionpir = { git = "...", rev = "...", optional = true }
+
+# pir-sdk-wasm/Cargo.toml
+arc = { git = "...", rev = "..." }
+pir-db-attest = { path = "../pir-db-attest" }
+pir-sdk-client = { path = "../pir-sdk-client", version = "0.1.0" }
 ```
 
-crates.io requires all dependencies to be resolvable from the registry
-(or be `optional = true` + gated behind a feature that's off in the
-default-features set). Git deps in the non-optional path fail the
-`cargo publish` sanity check even with `--allow-dirty`.
+`harmonypir-wasm` and `pir-db-attest` are currently `publish = false`;
+the latter also has an unpublished path dependency on `rootbundle`.
+`harmonypir-wasm` in turn depends on the git-only `harmonypir` crate.
+
+All git dependencies above are revision-pinned, which is appropriate
+for reproducible workspace builds, but a pin is not a crates.io source.
+Every non-development dependency in a published package must resolve
+from a registry. That includes optional dependencies such as
+`onionpir`: disabling its feature by default does not remove it from
+the published manifest. A local `git` or `path` source may be retained
+for development only when the same dependency also has a compatible
+registry `version` fallback.
 
 ### Fixes (in increasing order of work)
 
-1. **Publish `libdpf` and `harmonypir` to crates.io first.**
-   Both crates are owned by weikengchen / Bitcoin-PIR. A single pass
-   of `cargo publish` on each, followed by updating
-   `pir-sdk-client/Cargo.toml` and `harmonypir-wasm/Cargo.toml` to
-   registry versions with a pinned semver range, unblocks
-   `pir-sdk-client`. `libdpf` currently has no pinned `rev` — pin one
-   before publishing to avoid a floating-HEAD supply-chain risk.
+1. **Publish or replace the external crates.** Publish compatible
+   versions of `libdpf`, `arc`, `harmonypir`, and `onionpir`, then add
+   registry `version` fallbacks to every git dependency. If a crate is
+   not intended for crates.io, move the required code behind a
+   publishable workspace interface instead.
 
-2. **Vendor the code into `pir-core`.** Move the ≈1.5 kLOC
-   `libdpf` / `harmonypir` cores into `pir-core` as submodules.
-   Heavier surgery but produces a self-contained publishable crate
-   with no external git deps. Only pursue if #1 stalls on upstream
-   coordination.
+2. **Resolve the internal path-only crates.** Make `rootbundle`,
+   `pir-db-attest`, and `harmonypir-wasm` publishable in dependency
+   order and give each path dependency a `version`, or fold their
+   public functionality into an already-publishable crate.
 
-### Note on the `onion` feature
-
-The `onion` feature is **not** a blocker:
-
-```toml
-onionpir = { git = "...", rev = "...", optional = true }
-```
-
-Because `onion` is off by default, crates.io ignores the git URL when
-verifying `default-features` — publishing `pir-sdk-client` with the
-`onion` feature still present is legal, it simply means `cargo install
-pir-sdk-client --features onion` fails on the registry copy (same as
-if the user tried `--features onion` on a crates.io-only machine). If
-the `onionpir` crate ever lands on crates.io, switch the git URL to a
-semver range and `cargo install … --features onion` starts working
-from the registry too.
+3. **Re-run packaging from the registry form.** Run `cargo package`
+   and `cargo publish --dry-run` for each dependent crate. `--list`
+   checks the file set but does not prove that the packaged dependency
+   graph can be resolved from crates.io.
 
 ## Blocker 2 — `pir-sdk-server` depends on internal binary crates (RESOLVED)
 
@@ -90,25 +91,13 @@ binary crate now depend on `pir-runtime-core` instead of maintaining
 parallel copies. `pir-sdk-server` dropped its unused `build` dep and
 the `publish = false` gate.
 
-Verification: `cargo package --list -p pir-runtime-core` and `-p
-pir-sdk-server` both produce clean tarballs with the expected metadata
-files. Full workspace test surface preserved:
-- `pir-core --lib` 25/25
-- `pir-sdk --lib` 56/56
-- `pir-sdk-client --lib` 125/125
-- `pir-sdk-wasm --lib` 51/51
-- `pir-sdk-server --lib` 0/0 (unchanged — no library tests)
-- `pir-runtime-core --lib` 0/0 (library-only, no unit tests in the
-  extracted modules — all semantic coverage lives in `pir-core`
-  and end-to-end coverage lives in the `runtime/` bin integration
-  tests, neither affected by the code move).
-
-`pir-sdk-server` is now blocked only transitively via Blocker 1
-(`libdpf` git dep in `pir-runtime-core`). Once `libdpf` lands on
-crates.io, the publish order is:
+The extraction itself is complete. `pir-sdk-server` is now blocked
+only transitively by `pir-runtime-core`, whose remaining registry
+incompatibilities are the git-only `libdpf` and `arc` dependencies.
+After both have registry versions, the server-side publish order is:
 
 ```
-pir-core → pir-sdk → pir-runtime-core → pir-sdk-server
+pir-core + pir-channel + pir-identity → pir-sdk → pir-runtime-core → pir-sdk-server
 ```
 
 🔒 PIR invariants preserved. The extraction is a pure code move; the
@@ -123,15 +112,18 @@ queries uniformly.
 Once the blockers above are cleared, publish in this order to respect
 the dependency graph:
 
-1. `pir-core` (no workspace deps).
+1. `pir-core`, `pir-channel`, `pir-identity`, and `pir-attest-verify`
+   (registry dependencies only).
 2. `pir-sdk` (depends on `pir-core`).
-3. `libdpf`, `harmonypir` (upstream — see Blocker 1).
-4. `pir-runtime-core` (depends on `pir-core` + `libdpf`).
-5. `pir-sdk-client` (depends on `pir-core`, `pir-sdk`, `libdpf`,
-   `harmonypir`).
-6. `pir-sdk-wasm` (depends on everything above).
-7. `pir-sdk-server` (depends on `pir-core`, `pir-sdk`,
-   `pir-runtime-core`).
+3. Registry releases for `libdpf`, `arc`, `harmonypir`, and `onionpir`.
+4. `rootbundle`, `pir-db-attest`, and `harmonypir-wasm`, if they remain
+   separate crates rather than being folded into publishable parents.
+5. `pir-runtime-core` (depends on `pir-core`, `pir-channel`,
+   `pir-identity`, `libdpf`, and `arc`).
+6. `pir-sdk-server` and `pir-sdk-client` after their respective
+   dependency graphs are available from crates.io.
+7. `pir-sdk-wasm` as a crate (depends on `pir-sdk-client`,
+   `pir-attest-verify`, `pir-db-attest`, and `arc`).
 
 Between each step, wait ~30 s for crates.io's index propagation
 before the next `cargo publish` so Cargo can resolve the
@@ -146,15 +138,16 @@ For each crate:
    (`0.1.0` → `0.2.0`). Workspace crates currently ship in lockstep
    at the first release, with per-crate semver freedom afterward.
 
-2. **Update `CHANGELOG.md`**: move the `Unreleased` section's contents
-   under a new version heading, add a fresh empty `Unreleased`.
+2. **Update release notes**: if the crate has a `CHANGELOG.md`, move the
+   `Unreleased` section under a new version heading and add a fresh empty
+   `Unreleased`. Add a changelog before the first public release if the
+   crate is intended to maintain one.
 
 3. **Verify clean package**: `cargo package -p <crate> --list` to see
    what ships, `cargo package -p <crate>` to build the tarball.
    Sanity-check: the tarball should include `LICENSE-MIT`,
-   `LICENSE-APACHE`, `README.md`, `CHANGELOG.md`, and only the `src/`
-   / `build.rs` / `Cargo.toml` / `Cargo.lock` files (not the whole
-   workspace).
+   `LICENSE-APACHE`, `README.md`, any maintained `CHANGELOG.md`, and only
+   the required source/metadata files (not the whole workspace).
 
 4. **Dry run**: `cargo publish -p <crate> --dry-run`.
 

--- a/docs/CODE_REVIEW_2026-06.md
+++ b/docs/CODE_REVIEW_2026-06.md
@@ -160,6 +160,22 @@ the live demo** (pir1/Hetzner has no SEV measurement).
 - **I7**: partially closed by the cargo-audit CI job added in June;
   dependabot / cargo-deny remain optional future hygiene.
 
+### Status update (2026-07-13): I1/I7/I8 closed
+
+- **I1**: the scheduled/manual SDK workflow now runs serialized core leakage
+  invariants for DPF, HarmonyPIR, and OnionPIR after the ordinary live
+  integration jobs pass. Each backend covers per-message shape, the
+  two-not-found simulator property, and found/not-found byte-identical
+  profiles; HarmonyPIR receives one transport-only retry.
+- **I7**: Dependabot now covers the Cargo workspace, both npm applications,
+  and GitHub Actions on a weekly grouped cadence. Together with the existing
+  cargo-audit workflow this closes the selected dependency-hygiene scope;
+  cargo-deny remains an optional future policy layer rather than a blocker.
+- **I8**: `pir-channel`, `pir-identity`, and `pir-attest-verify` now ship the
+  declared MIT/Apache-2.0 license texts. All three complete `cargo package`
+  packaging, verification, and compilation; remaining downstream registry
+  blockers are recorded in `PUBLISHING.md`.
+
 ---
 
 ## Lower-severity / nits (not auto-fixing)

--- a/pir-attest-verify/LICENSE-APACHE
+++ b/pir-attest-verify/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Bitcoin PIR contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pir-attest-verify/LICENSE-MIT
+++ b/pir-attest-verify/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Bitcoin PIR contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pir-channel/LICENSE-APACHE
+++ b/pir-channel/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Bitcoin PIR contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pir-channel/LICENSE-MIT
+++ b/pir-channel/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Bitcoin PIR contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pir-identity/LICENSE-APACHE
+++ b/pir-identity/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Bitcoin PIR contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pir-identity/LICENSE-MIT
+++ b/pir-identity/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Bitcoin PIR contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pir-identity/README.md
+++ b/pir-identity/README.md
@@ -1,0 +1,20 @@
+# pir-identity
+
+Operator-signed server identity primitives for BitcoinPIR.
+
+The crate implements a two-tier Ed25519 chain:
+
+1. An offline operator key signs an `IdentityCert` for a server identity key.
+2. That identity key signs a per-boot `ChannelManifest` binding the server ID,
+   encrypted-channel public key, binary hash, git revision, and database
+   manifest roots.
+
+Clients with the operator public key pinned can authenticate the encrypted
+channel on servers without hardware attestation and add defense in depth on
+SEV-SNP hosts. The crate contains only canonical encoding and cryptographic
+sign/verify logic; filesystem, network, and operator tooling live elsewhere in
+the BitcoinPIR workspace.
+
+See the module documentation in `src/lib.rs` and
+[`docs/OPERATOR_IDENTITY.md`](../docs/OPERATOR_IDENTITY.md) for the protocol and
+deployment model.


### PR DESCRIPTION
## Summary

- add a scheduled/manual privacy leakage canary for DPF, HarmonyPIR, and OnionPIR after the ordinary live integration jobs pass
- run three explicit core invariants per backend sequentially, with one HarmonyPIR transport retry and no broad benchmark/diagnostic filters
- add grouped weekly Dependabot coverage for Cargo, both npm applications, and GitHub Actions
- add the declared MIT/Apache-2.0 license files and missing identity README needed to package the standalone attestation crates
- correct the current crates.io dependency blockers in `PUBLISHING.md`
- keep Finder metadata out of vendored sources and record I1/I7/I8 as closed

## Why

This closes the remaining CI/dependency/publishing hygiene findings without reintroducing the removed server warmup system or carrying forward stale deployment documentation.

Closes #31
Closes #34
Closes #35

## Validation

- both workflow YAML files parse successfully
- all nine explicit leakage filters resolve to exactly one test and zero benchmarks; the three added simulator-property filters were rechecked on this branch
- `cargo package --allow-dirty -p pir-channel` — packaged, verified, and compiled
- `cargo package --allow-dirty -p pir-identity` — packaged, verified, and compiled
- `cargo package --allow-dirty -p pir-attest-verify` — packaged, verified, and compiled
- root and nested vendor `.DS_Store` paths match the new ignore rule
- `git diff --check`

After the ordinary PR checks pass, the same branch will be exercised with a manual `workflow_dispatch` so the leakage canary itself runs before merge.
