### PR TITLE
Verify both delta block anchors in the browser

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -688,6 +688,13 @@
             text-overflow: ellipsis;
             white-space: nowrap;
         }
+        .attest-badge .ab-row .ab-val a {
+            color: var(--accent-ink);
+            cursor: pointer;
+            text-decoration: underline;
+            text-decoration-thickness: 1px;
+            text-underline-offset: 2px;
+        }
         .attest-badge-verified-vcek { border-left-color: #2e7d32; background: #f0fdf4; }
         .attest-badge-verified      { border-left-color: #f57f17; background: #fffbe6; }
         .attest-badge-mismatch      { border-left-color: var(--err); background: #fef2f2; }
@@ -1558,7 +1565,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
     </section>
 
     <script type="module">
-        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, DELTA_940611_948454_DB_PROOF_PIN, MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN, databaseProofAnchorLabel, verifyProductionTrustChain, verifyOramSourceProof } from './src/index.ts';
+        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, DELTA_940611_948454_DB_PROOF_PIN, MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN, databaseProofAnchorLabel, databaseProofAnchorPoints, mempoolSpaceBlockUrl, verifyProductionTrustChain, verifyOramSourceProof } from './src/index.ts';
         // Initialize SDK WASM (optional - falls back to TS if unavailable)
         initSdkWasm().then(ok => {
             if (ok) console.log('[PIR] SDK WASM loaded');
@@ -1831,6 +1838,14 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             })[ch]);
         }
 
+        function renderBitcoinBlockLink(point, truncate) {
+            const hash = String(point?.blockHashHex || '');
+            const text = `${Number(point?.height || 0).toLocaleString()} · ${truncate(hash, 24)}`;
+            const href = mempoolSpaceBlockUrl(hash);
+            if (!href) return escapeHtml(text);
+            return `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer" title="Open block ${escapeHtml(point.height)} on mempool.space">${escapeHtml(text)} ↗</a>`;
+        }
+
         function renderDatabaseProofBadge(idElem, label, info) {
             const el = typeof idElem === 'string' ? document.getElementById(idElem) : idElem;
             if (!el) return;
@@ -1854,10 +1869,6 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             rows.push(`<span class="ab-state">${escapeHtml(label)}: ${escapeHtml(stateLabel)}</span>`);
             if (proof) {
                 rows.push(`<div class="ab-row"><span class="ab-label">muhash</span><span class="ab-val" title="${proof.muhashHex}">${truncate(proof.muhashHex, 24)}</span></div>`);
-                rows.push(`<div class="ab-row"><span class="ab-label">block</span><span class="ab-val" title="${proof.blockHashHex}">${proof.height.toLocaleString()} · ${truncate(proof.blockHashHex, 24)}</span></div>`);
-                if (proof.buildKind === 'delta') {
-                    rows.push(`<div class="ab-row"><span class="ab-label">from</span><span class="ab-val" title="${proof.fromBlockHashHex}">${proof.fromHeight.toLocaleString()} · ${truncate(proof.fromBlockHashHex, 24)}</span></div>`);
-                }
                 rows.push(`<div class="ab-row"><span class="ab-label">bucket root</span><span class="ab-val" title="${proof.bucketSuperRootHex}">${truncate(proof.bucketSuperRootHex, 24)}</span></div>`);
                 rows.push(`<div class="ab-row"><span class="ab-label">onion root</span><span class="ab-val" title="${proof.onionSuperRootHex}">${truncate(proof.onionSuperRootHex, 24)}</span></div>`);
                 rows.push(`<div class="ab-row"><span class="ab-label">builder</span><span class="ab-val" title="${proof.builderBinarySha256Hex}">${truncate(proof.builderGitCommit, 12)} · ${truncate(proof.builderBinarySha256Hex, 16)}</span></div>`);
@@ -1878,11 +1889,14 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             const state = status?.state || 'unavailable';
             const verified = status?.verified;
             const manifest = status?.manifest || verified?.manifest;
-            const anchor = manifest?.anchor;
+            // Prefer the live, cryptographically verified server proof for
+            // display. verifyProductionTrustChain checks that it matches the
+            // published manifest before this badge can become verified.
+            const anchor = status?.displayAnchor || manifest?.anchor;
             const bhtm = manifest?.bhtmProof;
 
             const stateLabel = state === 'verified'
-                ? `Verified Bitcoin/MuHash anchor — ${anchor?.height?.toLocaleString?.() || 'unknown'}`
+                ? `Bitcoin anchor verified — ${anchor?.height?.toLocaleString?.() || 'unknown'}`
                 : state === 'unverified'
                     ? `Bitcoin/MuHash anchor mismatch`
                     : `Bitcoin/MuHash anchor unavailable`;
@@ -1893,7 +1907,18 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             const rows = [];
             rows.push(`<span class="ab-state">${escapeHtml(label)}: ${escapeHtml(stateLabel)}</span>`);
             if (anchor) {
-                rows.push(`<div class="ab-row"><span class="ab-label">block</span><span class="ab-val" title="${anchor.blockHashHex}">${anchor.height.toLocaleString()} · ${truncate(anchor.blockHashHex, 24)}</span></div>`);
+                const anchorPoints = databaseProofAnchorPoints(anchor);
+                const fromPoint = anchorPoints.find(point => point.role === 'from');
+                const latestPoint = anchorPoints.find(point => point.role === 'latest');
+                if (latestPoint) {
+                    rows.push(`<div class="ab-row"><span class="ab-label">latest block</span><span class="ab-val" title="${escapeHtml(latestPoint.blockHashHex)}">${renderBitcoinBlockLink(latestPoint, truncate)}</span></div>`);
+                }
+                if (fromPoint) {
+                    const fromText = `${Number(fromPoint.height).toLocaleString()} · ${truncate(fromPoint.blockHashHex, 24)}`;
+                    const inclusionVerified = state === 'verified' && verified?.fromLeaf?.height === fromPoint.height;
+                    const verificationLabel = inclusionVerified ? ' · ✓ BHTM inclusion verified' : '';
+                    rows.push(`<div class="ab-row"><span class="ab-label">from block</span><span class="ab-val" title="${escapeHtml(fromPoint.blockHashHex)}">${escapeHtml(fromText + verificationLabel)}</span></div>`);
+                }
                 rows.push(`<div class="ab-row"><span class="ab-label">muhash</span><span class="ab-val" title="${anchor.muhashHex}">${truncate(anchor.muhashHex, 24)}</span></div>`);
             }
             if (bhtm?.treeRootHex) {
@@ -1930,8 +1955,12 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 state: 'unavailable',
                 checks: [],
                 mismatches: [],
+                displayAnchor: dbInfo.proof,
                 manifest: {
                     anchor: {
+                        buildKind: dbInfo.proof.buildKind,
+                        fromHeight: dbInfo.proof.fromHeight,
+                        fromBlockHashHex: dbInfo.proof.fromBlockHashHex,
                         height: dbInfo.proof.height,
                         blockHashHex: dbInfo.proof.blockHashHex,
                         muhashHex: dbInfo.proof.muhashHex,
@@ -1946,7 +1975,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 liveDatabaseProof: dbInfo.proof,
                 verifyAmdSignature: true,
             });
-            renderBitcoinAnchorBadge(idElem, label, status);
+            renderBitcoinAnchorBadge(idElem, label, { ...status, displayAnchor: dbInfo.proof });
             if (status.state === 'verified') {
                 log(`${label}: Bitcoin/MuHash anchor verified through BHTM SEV-SNP quote`, 'success');
             } else if (status.state === 'unverified') {

--- a/web/public/proofs/trust-chain/delta_940611_948454.json
+++ b/web/public/proofs/trust-chain/delta_940611_948454.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "proofType": "BitcoinPIR/database-authenticity/trust-chain/v1",
   "id": "delta_940611_948454",
-  "description": "Production DB proof anchor chained to the blockhash-to-muhash SEV-SNP proof for height 948454.",
+  "description": "Production delta DB proof endpoints chained to separate blockhash-to-muhash Merkle inclusion proofs under one SEV-SNP-attested root.",
   "anchor": {
     "network": "mainnet",
     "dbId": 1,
@@ -45,6 +45,8 @@
   },
   "bhtmProof": {
     "chunk": "mainnet-900000-954920",
+    "fromLeafIndex": 40611,
+    "fromLeafHashHex": "d36ee0c4a44b2a392993c7a6a8ffaa0c69225e2187a46fcbef64a79e67dcf856",
     "leafIndex": 48454,
     "treeSize": 54921,
     "leafHashHex": "0171a475dc43b97db594c7512039d12f5213d270b42e56babfa44d65359eeaaf",
@@ -56,6 +58,11 @@
     "reportDataDomain": "BitcoinPIR/blockhash-to-muhash/report-data/v2",
     "reportDataScheme": "sha512(domain || attestation)",
     "artifacts": {
+      "fromLeafProof": {
+        "path": "/proofs/trust-chain/delta_940611_948454/bhtm/height-940611.leaf-proof.json",
+        "sha256": "2e54cb56ae63d89036c1e74754b68a72e012ed775dff8b0204a6efc023b08195",
+        "size": 4294
+      },
       "leafProof": {
         "path": "/proofs/trust-chain/delta_940611_948454/bhtm/height-948454.leaf-proof.json",
         "sha256": "0a6d6631984a00635528ac9f1df3530469d238b5aaf8b4a3fdb4a4a0fa46a015",

--- a/web/public/proofs/trust-chain/delta_940611_948454/bhtm/height-940611.leaf-proof.json
+++ b/web/public/proofs/trust-chain/delta_940611_948454/bhtm/height-940611.leaf-proof.json
@@ -1,0 +1,107 @@
+{
+  "block_hash_display": "000000000000000000002c41243b3d74d135942031ef15f547bca1ce8f85eb99",
+  "block_hash_internal": "99eb858fcea1bc47f515ef31209435d1743d3b24412c00000000000000000000",
+  "chunk": {
+    "anchor_block_hash_display": "0000000000000000000196400396be46d0816dc462df4c3450972f589f4d7d24",
+    "anchor_block_hash_internal": "247d4d9f582f9750344cdf62c46d81d046be9603409601000000000000000000",
+    "anchor_height": 899999,
+    "end_block_hash_display": "00000000000000000001b0c7d606f5da5d39262dbfceb848fe0d19337fb9bf17",
+    "end_block_hash_internal": "17bfb97f33190dfe48b8cebf2d26395ddaf506d6c7b001000000000000000000",
+    "end_height": 954920,
+    "end_muhash_core_display": "c27e1fafa9dd154cfd16a78429477181febbecf49b3d49016c462b0764429470",
+    "first_block_height": 900000
+  },
+  "core_muhash_display": "aebb29df12e045ef5279036263aba3b8f8e9e816e05b04a58f57e63b3b25756b",
+  "core_muhash_internal": "6b75253b3be6578fa5045be016e8e9f8b8a3ab6362037952ef45e012df29bbae",
+  "height": 940611,
+  "leaf_hash": "d36ee0c4a44b2a392993c7a6a8ffaa0c69225e2187a46fcbef64a79e67dcf856",
+  "leaf_index": 40611,
+  "muhash": "fe41878f4454ab1e30ebebf095ec44f519e124cf00312fadf1f29dfec080fbd895688119e7f989f128ab64c8959cb105ed775be274afbcce12ec68b7e11f7355219fe387429fb0c9864ff25e3e8315bd5743a87c7a838363ef1636d055b68144a857a8a91555c54a510db30fd8dcd298115ce44f5b9b5eae5a1a1e9cf84cba6e61e019fb8d2cfd51de4ddc60737e84ce6930423ff1f50ef907b06cb3980ca2e69b5d930cfa7610ebdb132d03d31a3eaf84e6db8579110b3d129cdbd3af0940867dd1316631c7bd420712200f1c760d7860da79d2e67ab017570ff3ba237253d4470e83c3200517a784d4d7c646a4668af61126c385075324ad0c22116e0874337fa6a85d4bba155828f943279b46e005e62c2443887b3a77542ebe2f6fba492b5fe0bfcb9758cf5d59d24a84990e15803cdce760f03b9d7985d758e85635b8b1553d4e505c8198d6c41776b966beaeed103aa88e02908a3e0e35fb014e872c02d99ef49dcb37befecb23b95accd4bf08ac2d82249b4e14ac818835e71c4bdbc2",
+  "proof": [
+    {
+      "hash": "09c51aac3c580ddb72e8c9a9f2264706d633d48fce8cd496934b37e33776cc43",
+      "level": 0,
+      "side": "left"
+    },
+    {
+      "hash": "59597af4acac2db7b5930b2355e304b066223ba94aa83d2767f9a81925b43c94",
+      "level": 1,
+      "side": "left"
+    },
+    {
+      "hash": "2fb2fe833856e4279d3f1f5a34557485cd06d261cef7f8c18ca6c26ff9312bf3",
+      "level": 2,
+      "side": "right"
+    },
+    {
+      "hash": "cee2a75ae4e6345494693c073b328546110a4b80f8cd93ecc24bc136ac653f41",
+      "level": 3,
+      "side": "right"
+    },
+    {
+      "hash": "5eda3b7968773660c8fe17d8a06e969366724676aca8d06bb36a6b81342d8967",
+      "level": 4,
+      "side": "right"
+    },
+    {
+      "hash": "603047872dd18fc4384ab34fcbed6c74abfea65faf8d27bae7ab2c6be775fb4b",
+      "level": 5,
+      "side": "left"
+    },
+    {
+      "hash": "758891ab806fa6815fe3dda84703c774199feb13afc0f7abf0b8367011434295",
+      "level": 6,
+      "side": "right"
+    },
+    {
+      "hash": "c97c9522fa61de90fedf77db624029d9e22bd0e036dd19874af38a1bf2ceb9a4",
+      "level": 7,
+      "side": "left"
+    },
+    {
+      "hash": "314378a65499b015917de7cc28335d698ec7d970370add5b85e1fbb06af5540e",
+      "level": 8,
+      "side": "right"
+    },
+    {
+      "hash": "acbb09908ed727db6684e96255a23c3add28ea97836073f65e06fd0084ef1d66",
+      "level": 9,
+      "side": "left"
+    },
+    {
+      "hash": "6ee30935e8d62ab10e6f6d81c227a5cd548b436317a4dcf0cdaf8eecc45ccac8",
+      "level": 10,
+      "side": "left"
+    },
+    {
+      "hash": "5ed7a06267f65cc2d424673fbc0242c2abe85424e69debcdb0ddc42b634a954c",
+      "level": 11,
+      "side": "left"
+    },
+    {
+      "hash": "081e3c5efe3a8a0dcc3fbf99aa92d54b98ef9df5e938aaf943e366eabd4a77f2",
+      "level": 12,
+      "side": "left"
+    },
+    {
+      "hash": "82bbfee086347dbd01d2b6845361ed77ed0c3ed06494bc080c9811bd1aed1ee6",
+      "level": 13,
+      "side": "right"
+    },
+    {
+      "hash": "78aef487eccb43389d38a32af8b5980fbce1698e13b23e4af49020899dadd333",
+      "level": 14,
+      "side": "right"
+    },
+    {
+      "hash": "0cff9d5df75f090afc0805afe926f4b7fdb73946de6845acaeaed6b843e91361",
+      "level": 15,
+      "side": "left"
+    }
+  ],
+  "proof_type": "BitcoinPIR/blockhash-to-muhash/leaf-proof/v1",
+  "schema_version": 1,
+  "tree_root": "babeea635812c3b1a2d5f352ab0a5d1ee8a4e9c668c43c05d6603ef3c3766ba6",
+  "tree_size": 54921,
+  "verified_against_tree_root": true
+}

--- a/web/reproduce.html
+++ b/web/reproduce.html
@@ -385,10 +385,10 @@
                                 </li>
                                 <li>
                                     <strong>Bitcoin/MuHash anchor proof</strong> checks that
-                                    the database proof's block hash and MuHash appear as a
-                                    blockhash-to-muhash Merkle leaf under a SEV-SNP-attested
-                                    chunk root. A green Bitcoin anchor badge belongs to this
-                                    layer.
+                                    both database endpoint block hashes and the latest MuHash
+                                    appear as separate blockhash-to-muhash Merkle leaves under
+                                    one SEV-SNP-attested chunk root. A green Bitcoin anchor badge
+                                    belongs to this layer.
                                 </li>
                                 <li>
                                     <strong>ORAM source binding</strong> checks that
@@ -880,19 +880,23 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
 
                 <section id="bitcoin-anchor" class="tab-panel" role="tabpanel" aria-labelledby="tab-bitcoin-anchor">
                     <section>
-                        <h2>Bitcoin/MuHash anchor proof <span class="badge ok">height 948454</span></h2>
+                        <h2>Bitcoin/MuHash anchor proof <span class="badge ok">940611 → 948454</span></h2>
                         <p>
-                            The database proof uses Bitcoin Core's MuHash at block
-                            <code>948454</code>. The anchor proof checks that the same
-                            <code>height</code>, <code>block_hash</code>, and Core-display
-                            <code>MuHash</code> are present in the
-                            <code>mainnet-900000-954920</code> blockhash-to-muhash chunk.
+                            The delta database proof binds both endpoint block hashes and Bitcoin
+                            Core's MuHash at block <code>948454</code>. The browser verifies a
+                            separate BHTM Merkle inclusion proof for each endpoint against the same
+                            SEV-SNP-attested <code>mainnet-900000-954920</code> chunk root. The
+                            latest leaf also binds the database MuHash.
                         </p>
                         <div class="panel accent">
                             <table class="pin-table">
                                 <tr>
-                                    <td>block</td>
-                                    <td>948454 · 00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4</td>
+                                    <td>from block</td>
+                                    <td>940611 · 000000000000000000002c41243b3d74d135942031ef15f547bca1ce8f85eb99 · ✓ BHTM inclusion proof verified</td>
+                                </tr>
+                                <tr>
+                                    <td>latest block</td>
+                                    <td><a href="https://mempool.space/block/00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4" target="_blank" rel="noopener noreferrer">948454 · 00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4 ↗</a></td>
                                 </tr>
                                 <tr>
                                     <td>MuHash</td>
@@ -903,7 +907,11 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
                                     <td>mainnet-900000-954920</td>
                                 </tr>
                                 <tr>
-                                    <td>leaf</td>
+                                    <td>from leaf</td>
+                                    <td>index 40611 · d36ee0c4a44b2a392993c7a6a8ffaa0c69225e2187a46fcbef64a79e67dcf856</td>
+                                </tr>
+                                <tr>
+                                    <td>latest leaf</td>
                                     <td>index 48454 · 0171a475dc43b97db594c7512039d12f5213d270b42e56babfa44d65359eeaaf</td>
                                 </tr>
                                 <tr>
@@ -921,13 +929,20 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
                     <section>
                         <h2>What the browser checks</h2>
                         <ul>
-                            <li>The BHTM leaf proof recomputes the leaf hash and Merkle path to the pinned chunk tree root.</li>
+                            <li>The verified live server proof matches the published manifest at both delta endpoints, the MuHash, and both PIR Merkle roots.</li>
+                            <li>Separate BHTM proofs recompute both endpoint leaf hashes and Merkle paths to the same attested chunk tree root.</li>
                             <li><code>report-data.bin</code> equals <code>SHA512("BitcoinPIR/blockhash-to-muhash/report-data/v2" || attestation.bin)</code>.</li>
                             <li>The SNP report's raw <code>REPORT_DATA</code> field equals <code>report-data.bin</code>.</li>
                             <li>The SNP report's raw <code>MEASUREMENT</code> field equals the pinned BHTM UKI measurement.</li>
                             <li>The AMD VCEK chain and report signature verify through the same WASM verifier used for runtime attestation.</li>
-                            <li>The DB proof anchor equals the BHTM leaf's height, block hash, and Core-display MuHash.</li>
+                            <li>Both DB endpoint heights and block hashes equal their BHTM leaves; the latest leaf also equals the DB proof's Core-display MuHash.</li>
                         </ul>
+                        <p class="meta">
+                            The latest-block mempool.space link is an independent user cross-check,
+                            not an input to the cryptographic verifier. The earlier endpoint is
+                            checked by its own inclusion proof under the same attested root; the
+                            attested BHTM process also validates header linkage across the chunk.
+                        </p>
                     </section>
                 </section>
 
@@ -940,7 +955,8 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
                         </p>
                         <div class="panel">
                             <p><a class="download-link" href="/proofs/trust-chain/delta_940611_948454.json" target="_blank" rel="noopener">trust-chain manifest</a></p>
-                            <p><a class="download-link" href="/proofs/trust-chain/delta_940611_948454/bhtm/height-948454.leaf-proof.json" target="_blank" rel="noopener">BHTM leaf proof JSON</a></p>
+                            <p><a class="download-link" href="/proofs/trust-chain/delta_940611_948454/bhtm/height-940611.leaf-proof.json" target="_blank" rel="noopener">BHTM 940611 leaf proof JSON</a></p>
+                            <p><a class="download-link" href="/proofs/trust-chain/delta_940611_948454/bhtm/height-948454.leaf-proof.json" target="_blank" rel="noopener">BHTM 948454 leaf proof JSON</a></p>
                             <p><a class="download-link" href="/proofs/trust-chain/delta_940611_948454/bhtm/sev-snp-report.bin" download>BHTM SEV-SNP report</a></p>
                             <p><a class="download-link" href="/proofs/trust-chain/delta_940611_948454/db/build-evidence.bin" download>DB build evidence</a></p>
                             <p><a class="download-link" href="/proofs/oram-source/mainnet_948454.json" target="_blank" rel="noopener">ORAM source-binding manifest</a></p>
@@ -995,7 +1011,7 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
                             <li>For pir1, binary-hash pinning detects drift but does not provide a hardware root of trust.</li>
                             <li>The database proof binds <code>delta_940611_948454</code>'s bucket and OnionPIR Merkle roots to Bitcoin Core's MuHash at block <code>948454</code>.</li>
                             <li>The ORAM source-binding proof binds a strict direct ORAM rebuild to roots-only snapshot inputs preserved by the SEV-SNP attested builder for block <code>948454</code>.</li>
-                            <li>The Bitcoin anchor proof binds that same block hash and MuHash to a blockhash-to-muhash chunk tree root signed by a separate SEV-SNP BHTM proof run.</li>
+                            <li>The Bitcoin anchor proof binds both delta endpoint block hashes and the latest MuHash to one blockhash-to-muhash chunk tree root signed by a separate SEV-SNP BHTM proof run.</li>
                             <li>The web client refuses to upgrade to the encrypted channel if runtime pins do not match what the server reports.</li>
                             <li>The ORAM smoke route confirms the live attested binary accepts padded direct ORAM requests for both production databases.</li>
                         </ul>

--- a/web/src/__tests__/db-proof.test.ts
+++ b/web/src/__tests__/db-proof.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { DELTA_940611_948454_DB_PROOF_PIN } from '../attest-pin.js';
+import { databaseProofAnchorPoints, mempoolSpaceBlockUrl } from '../db-proof.js';
+
+describe('database proof Bitcoin anchors', () => {
+  it('returns both independently meaningful endpoints for a delta', () => {
+    expect(databaseProofAnchorPoints(DELTA_940611_948454_DB_PROOF_PIN)).toEqual([
+      {
+        role: 'from',
+        height: 940611,
+        blockHashHex: DELTA_940611_948454_DB_PROOF_PIN.fromBlockHashHex,
+      },
+      {
+        role: 'latest',
+        height: 948454,
+        blockHashHex: DELTA_940611_948454_DB_PROOF_PIN.blockHashHex,
+      },
+    ]);
+  });
+
+  it('only creates mempool.space links for canonical block hashes', () => {
+    expect(mempoolSpaceBlockUrl(DELTA_940611_948454_DB_PROOF_PIN.blockHashHex)).toBe(
+      `https://mempool.space/block/${DELTA_940611_948454_DB_PROOF_PIN.blockHashHex}`,
+    );
+    expect(mempoolSpaceBlockUrl('not-a-block-hash')).toBeUndefined();
+    expect(mempoolSpaceBlockUrl('00'.repeat(32) + '" onclick="alert(1)')).toBeUndefined();
+  });
+});

--- a/web/src/__tests__/trust-chain-proof.test.ts
+++ b/web/src/__tests__/trust-chain-proof.test.ts
@@ -1,8 +1,10 @@
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
 import { DELTA_940611_948454_DB_PROOF_PIN } from '../attest-pin.js';
 import {
   DEFAULT_TRUST_CHAIN_MANIFEST_PATH,
+  trustChainPinFromManifest,
   verifyProductionTrustChain,
 } from '../trust-chain-proof.js';
 
@@ -18,10 +20,16 @@ describe('database trust-chain proof', () => {
     const status = await verifyProductionTrustChain({
       artifactLoader: publicArtifactLoader,
       expectedDbPin: DELTA_940611_948454_DB_PROOF_PIN,
+      verifyAmdSignature: false,
     });
 
     expect(status.state).toBe('verified');
     expect(status.mismatches).toEqual([]);
+    expect(status.verified?.fromLeaf?.height).toBe(940611);
+    expect(status.verified?.fromLeaf?.leafIndex).toBe(40611);
+    expect(status.verified?.fromLeaf?.blockHashDisplayHex).toBe(
+      DELTA_940611_948454_DB_PROOF_PIN.fromBlockHashHex,
+    );
     expect(status.verified?.leaf.height).toBe(948454);
     expect(status.verified?.leaf.coreMuhashDisplayHex).toBe(
       DELTA_940611_948454_DB_PROOF_PIN.muhashHex,
@@ -29,6 +37,11 @@ describe('database trust-chain proof', () => {
     expect(status.verified?.attestation.treeRootHex).toBe(
       'babeea635812c3b1a2d5f352ab0a5d1ee8a4e9c668c43c05d6603ef3c3766ba6',
     );
+    expect(status.verified?.fromLeaf?.treeRootHex).toBe(status.verified?.leaf.treeRootHex);
+    expect(status.checks).toContainEqual({
+      name: 'BHTM delta from leaf proof verified',
+      state: 'verified',
+    });
   });
 
   it('reports unverified when manifest and BHTM leaf disagree', async () => {
@@ -42,6 +55,7 @@ describe('database trust-chain proof', () => {
     const status = await verifyProductionTrustChain({
       manifestPath: DEFAULT_TRUST_CHAIN_MANIFEST_PATH,
       expectedDbPin: DELTA_940611_948454_DB_PROOF_PIN,
+      verifyAmdSignature: false,
       artifactLoader: async (path) => (
         path === DEFAULT_TRUST_CHAIN_MANIFEST_PATH ? mutatedManifest : publicArtifactLoader(path)
       ),
@@ -50,5 +64,132 @@ describe('database trust-chain proof', () => {
     expect(status.state).toBe('unverified');
     expect(status.mismatches.some((m) => m.includes('BHTM leaf Core MuHash'))).toBe(true);
     expect(status.mismatches.some((m) => m.includes('manifest DB pin'))).toBe(true);
+  });
+
+  it('directly verifies both live delta endpoints against the manifest', async () => {
+    const manifest = JSON.parse(
+      new TextDecoder().decode(await publicArtifactLoader(DEFAULT_TRUST_CHAIN_MANIFEST_PATH)),
+    );
+    const liveProof = trustChainPinFromManifest(manifest);
+    liveProof.fromBlockHashHex = `${liveProof.fromBlockHashHex.slice(0, -1)}0`;
+
+    const status = await verifyProductionTrustChain({
+      artifactLoader: publicArtifactLoader,
+      liveDatabaseProof: liveProof,
+      verifyAmdSignature: false,
+    });
+
+    expect(status.state).toBe('unverified');
+    expect(status.mismatches.some((m) => (
+      m.includes('live DB proof vs manifest: fromBlockHashHex')
+    ))).toBe(true);
+    expect(status.checks.some((check) => (
+      check.name === 'live DB proof matches manifest anchors and roots'
+      && check.state === 'unverified'
+    ))).toBe(true);
+  });
+
+  it('reports unverified when the delta from block hash disagrees with its BHTM leaf', async () => {
+    const original = JSON.parse(
+      new TextDecoder().decode(await publicArtifactLoader(DEFAULT_TRUST_CHAIN_MANIFEST_PATH)),
+    );
+    original.anchor.fromBlockHashHex = `${original.anchor.fromBlockHashHex.slice(0, -1)}0`;
+    const mutatedManifest = new TextEncoder().encode(JSON.stringify(original));
+
+    const status = await verifyProductionTrustChain({
+      manifestPath: DEFAULT_TRUST_CHAIN_MANIFEST_PATH,
+      artifactLoader: async (path) => (
+        path === DEFAULT_TRUST_CHAIN_MANIFEST_PATH ? mutatedManifest : publicArtifactLoader(path)
+      ),
+      verifyAmdSignature: false,
+    });
+
+    expect(status.state).toBe('unverified');
+    expect(status.verified).toBeUndefined();
+    expect(status.mismatches.some((m) => m.includes('BHTM from leaf block hash'))).toBe(true);
+  });
+
+  it('fails closed when a delta manifest omits the from leaf proof', async () => {
+    const original = JSON.parse(
+      new TextDecoder().decode(await publicArtifactLoader(DEFAULT_TRUST_CHAIN_MANIFEST_PATH)),
+    );
+    delete original.bhtmProof.artifacts.fromLeafProof;
+    const mutatedManifest = new TextEncoder().encode(JSON.stringify(original));
+
+    const status = await verifyProductionTrustChain({
+      manifestPath: DEFAULT_TRUST_CHAIN_MANIFEST_PATH,
+      artifactLoader: async (path) => (
+        path === DEFAULT_TRUST_CHAIN_MANIFEST_PATH ? mutatedManifest : publicArtifactLoader(path)
+      ),
+      verifyAmdSignature: false,
+    });
+
+    expect(status.state).toBe('unverified');
+    expect(status.error).toContain('missing BHTM fromLeafProof artifact');
+  });
+
+  it('rejects substituting the latest leaf proof for the delta from leaf proof', async () => {
+    const original = JSON.parse(
+      new TextDecoder().decode(await publicArtifactLoader(DEFAULT_TRUST_CHAIN_MANIFEST_PATH)),
+    );
+    original.bhtmProof.artifacts.fromLeafProof = original.bhtmProof.artifacts.leafProof;
+    const mutatedManifest = new TextEncoder().encode(JSON.stringify(original));
+
+    const status = await verifyProductionTrustChain({
+      manifestPath: DEFAULT_TRUST_CHAIN_MANIFEST_PATH,
+      artifactLoader: async (path) => (
+        path === DEFAULT_TRUST_CHAIN_MANIFEST_PATH ? mutatedManifest : publicArtifactLoader(path)
+      ),
+      verifyAmdSignature: false,
+    });
+
+    expect(status.state).toBe('unverified');
+    expect(status.mismatches.some((m) => m.includes('BHTM from leaf height'))).toBe(true);
+  });
+
+  it('binds the published job bytes to the attested job hash', async () => {
+    const original = JSON.parse(
+      new TextDecoder().decode(await publicArtifactLoader(DEFAULT_TRUST_CHAIN_MANIFEST_PATH)),
+    );
+    const jobRef = original.bhtmProof.artifacts.job;
+    const job = JSON.parse(new TextDecoder().decode(await publicArtifactLoader(jobRef.path)));
+    job.chain = 'testnet';
+    const mutatedJob = new TextEncoder().encode(JSON.stringify(job));
+    jobRef.size = mutatedJob.length;
+    jobRef.sha256 = createHash('sha256').update(mutatedJob).digest('hex');
+    const mutatedManifest = new TextEncoder().encode(JSON.stringify(original));
+
+    const status = await verifyProductionTrustChain({
+      manifestPath: DEFAULT_TRUST_CHAIN_MANIFEST_PATH,
+      artifactLoader: async (path) => {
+        if (path === DEFAULT_TRUST_CHAIN_MANIFEST_PATH) return mutatedManifest;
+        if (path === jobRef.path) return mutatedJob;
+        return publicArtifactLoader(path);
+      },
+      verifyAmdSignature: false,
+    });
+
+    expect(status.state).toBe('unverified');
+    expect(status.mismatches.some((m) => m.includes('BHTM job artifact sha256'))).toBe(true);
+    expect(status.mismatches.some((m) => m.includes('BHTM job chain'))).toBe(true);
+  });
+
+  it('rejects an unknown build kind instead of bypassing delta checks', async () => {
+    const original = JSON.parse(
+      new TextDecoder().decode(await publicArtifactLoader(DEFAULT_TRUST_CHAIN_MANIFEST_PATH)),
+    );
+    original.anchor.buildKind = 'unknown';
+    const mutatedManifest = new TextEncoder().encode(JSON.stringify(original));
+
+    const status = await verifyProductionTrustChain({
+      manifestPath: DEFAULT_TRUST_CHAIN_MANIFEST_PATH,
+      artifactLoader: async (path) => (
+        path === DEFAULT_TRUST_CHAIN_MANIFEST_PATH ? mutatedManifest : publicArtifactLoader(path)
+      ),
+      verifyAmdSignature: false,
+    });
+
+    expect(status.state).toBe('unverified');
+    expect(status.error).toContain('unsupported trust-chain buildKind unknown');
   });
 });

--- a/web/src/db-proof.ts
+++ b/web/src/db-proof.ts
@@ -42,6 +42,12 @@ export interface DatabaseProofStatus {
   error?: string;
 }
 
+export interface DatabaseAnchorPoint {
+  role: 'from' | 'latest';
+  height: number;
+  blockHashHex: string;
+}
+
 export function verifiedDatabaseProofFromWasm(proof: WasmDatabaseProof): VerifiedDatabaseProof {
   return {
     dbId: proof.dbId,
@@ -121,6 +127,38 @@ export function databaseProofAnchorLabel(proof: VerifiedDatabaseProof | Database
     return `${proof.fromHeight.toLocaleString()} to ${proof.height.toLocaleString()}`;
   }
   return proof.height.toLocaleString();
+}
+
+/**
+ * Return every Bitcoin block hash that is an explicit input to the build.
+ * A delta has two independently meaningful endpoints; the latest header alone
+ * does not authenticate the claimed `from` hash unless the verifier also has
+ * the intervening headers or a Merkle inclusion proof for that earlier leaf.
+ */
+export function databaseProofAnchorPoints(
+  proof: VerifiedDatabaseProof | DatabaseProofPin,
+): DatabaseAnchorPoint[] {
+  const points: DatabaseAnchorPoint[] = [];
+  if (proof.buildKind === 'delta') {
+    points.push({
+      role: 'from',
+      height: proof.fromHeight,
+      blockHashHex: normalizeHex(proof.fromBlockHashHex),
+    });
+  }
+  points.push({
+    role: 'latest',
+    height: proof.height,
+    blockHashHex: normalizeHex(proof.blockHashHex),
+  });
+  return points;
+}
+
+/** Build a safe mainnet mempool.space URL for a server-provided block hash. */
+export function mempoolSpaceBlockUrl(blockHashHex: string): string | undefined {
+  const hash = normalizeHex(blockHashHex);
+  if (!/^[0-9a-f]{64}$/.test(hash)) return undefined;
+  return `https://mempool.space/block/${hash}`;
 }
 
 function normalizeHex(hex: string): string {

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -134,9 +134,12 @@ export {
 
 export {
   databaseProofAnchorLabel,
+  databaseProofAnchorPoints,
   databaseProofUnavailable,
+  mempoolSpaceBlockUrl,
   verifiedDatabaseProofFromWasm,
   verifyDatabaseProofAgainstPin,
+  type DatabaseAnchorPoint,
   type DatabaseProofPin,
   type DatabaseProofStatus,
   type VerifiedDatabaseProof,

--- a/web/src/trust-chain-proof.ts
+++ b/web/src/trust-chain-proof.ts
@@ -48,6 +48,8 @@ export interface TrustChainManifest {
   };
   bhtmProof: {
     chunk: string;
+    fromLeafIndex?: number;
+    fromLeafHashHex?: string;
     leafIndex: number;
     treeSize: number;
     leafHashHex: string;
@@ -70,6 +72,7 @@ export interface TrustChainCheck {
 
 export interface VerifiedTrustChain {
   manifest: TrustChainManifest;
+  fromLeaf?: VerifiedBhtmLeafProof;
   leaf: VerifiedBhtmLeafProof;
   attestation: BhtmAttestationV2;
 }
@@ -88,6 +91,7 @@ export interface VerifyTrustChainOptions {
   artifactLoader?: (path: string) => Promise<Uint8Array>;
   expectedDbPin?: DatabaseProofPin;
   liveDatabaseProof?: VerifiedDatabaseProof;
+  /** Defaults to true. Set false only for fixture/offline tests without initialized verifier WASM. */
   verifyAmdSignature?: boolean;
 }
 
@@ -113,6 +117,19 @@ export async function verifyProductionTrustChain(
       checks.push(checkFromMismatches('manifest matches DB pin', mismatches, before));
     }
 
+    if (options.liveDatabaseProof) {
+      const before = mismatches.length;
+      const manifestPin = trustChainPinFromManifest(manifest);
+      const dbStatus = verifyDatabaseProofAgainstPin(options.liveDatabaseProof, manifestPin);
+      if (dbStatus.state !== 'verified') {
+        mismatches.push(
+          ...(dbStatus.mismatches ?? [dbStatus.error ?? 'live DB proof did not match manifest'])
+            .map((m) => `live DB proof vs manifest: ${m}`),
+        );
+      }
+      checks.push(checkFromMismatches('live DB proof matches manifest anchors and roots', mismatches, before));
+    }
+
     if (options.liveDatabaseProof && options.expectedDbPin) {
       const dbStatus = verifyDatabaseProofAgainstPin(options.liveDatabaseProof, options.expectedDbPin);
       if (dbStatus.state === 'verified') {
@@ -128,10 +145,18 @@ export async function verifyProductionTrustChain(
       }
     }
 
+    let fromLeaf: VerifiedBhtmLeafProof | undefined;
+    if (manifest.anchor.buildKind === 'delta') {
+      fromLeaf = verifyBhtmLeafProofJson(
+        JSON.parse(decodeUtf8(requiredArtifact(bhtmArtifactBytes, 'fromLeafProof'))),
+      );
+      checks.push({ name: 'BHTM delta from leaf proof verified', state: 'verified' });
+    }
+
     const leaf = verifyBhtmLeafProofJson(
       JSON.parse(decodeUtf8(requiredArtifact(bhtmArtifactBytes, 'leafProof'))),
     );
-    checks.push({ name: 'BHTM leaf proof verified', state: 'verified' });
+    checks.push({ name: 'BHTM latest leaf proof verified', state: 'verified' });
 
     const attestationBytes = requiredArtifact(bhtmArtifactBytes, 'attestation');
     const attestation = parseBhtmAttestationV2(attestationBytes);
@@ -158,8 +183,21 @@ export async function verifyProductionTrustChain(
     checks.push(checkFromMismatches('BHTM report-data and measurement matched', mismatches, reportBefore));
 
     const leafBefore = mismatches.length;
+    if (fromLeaf) {
+      compareFromLeafToManifestAndDbAnchor(fromLeaf, manifest, mismatches);
+      compareLeafPositionToAttestation('BHTM from leaf', fromLeaf, attestation, mismatches);
+      compareHex('BHTM endpoint shared tree_root', fromLeaf.treeRootHex, leaf.treeRootHex, mismatches);
+      if (fromLeaf.treeSize !== leaf.treeSize) {
+        mismatches.push(`BHTM endpoint shared tree_size: expected ${leaf.treeSize}, got ${fromLeaf.treeSize}`);
+      }
+    }
     compareLeafToManifestAndDbAnchor(leaf, manifest, mismatches);
-    checks.push(checkFromMismatches('DB anchor matches BHTM leaf', mismatches, leafBefore));
+    compareLeafPositionToAttestation('BHTM latest leaf', leaf, attestation, mismatches);
+    checks.push(checkFromMismatches(
+      fromLeaf ? 'DB delta endpoints match BHTM leaves and shared root' : 'DB anchor matches BHTM leaf',
+      mismatches,
+      leafBefore,
+    ));
 
     const statsBefore = mismatches.length;
     compareStatsAndJobToManifest(bhtmArtifactBytes, manifest, mismatches);
@@ -169,15 +207,16 @@ export async function verifyProductionTrustChain(
       mismatches.push('database proof artifacts missing from manifest');
     }
 
-    if (options.verifyAmdSignature) {
+    if (options.verifyAmdSignature ?? true) {
       verifyStaticSnpReportSignature(bhtmArtifactBytes, sevSnpReport, manifest);
       checks.push({ name: 'BHTM AMD VCEK/report signature verified', state: 'verified' });
     }
 
+    const state = mismatches.length === 0 ? 'verified' : 'unverified';
     return {
-      state: mismatches.length === 0 ? 'verified' : 'unverified',
+      state,
       manifest,
-      verified: { manifest, leaf, attestation },
+      verified: state === 'verified' ? { manifest, fromLeaf, leaf, attestation } : undefined,
       checks,
       mismatches,
     };
@@ -296,6 +335,12 @@ function compareBhtmAttestationToManifest(
   if (attestation.treeSize !== BigInt(manifest.bhtmProof.treeSize)) {
     mismatches.push(`BHTM attestation tree_size: expected ${manifest.bhtmProof.treeSize}, got ${attestation.treeSize}`);
   }
+  const heightSpan = attestation.endHeight - attestation.startHeight;
+  if (heightSpan <= 0 || attestation.treeSize !== BigInt(heightSpan)) {
+    mismatches.push(
+      `BHTM attestation height span/tree_size: start ${attestation.startHeight}, end ${attestation.endHeight}, tree_size ${attestation.treeSize}`,
+    );
+  }
 }
 
 function compareLeafToManifestAndDbAnchor(
@@ -318,18 +363,64 @@ function compareLeafToManifestAndDbAnchor(
   compareHex('BHTM leaf tree_root', leaf.treeRootHex, manifest.bhtmProof.treeRootHex, mismatches);
 }
 
+function compareFromLeafToManifestAndDbAnchor(
+  leaf: VerifiedBhtmLeafProof,
+  manifest: TrustChainManifest,
+  mismatches: string[],
+): void {
+  if (leaf.height !== manifest.anchor.fromHeight) {
+    mismatches.push(`BHTM from leaf height: expected ${manifest.anchor.fromHeight}, got ${leaf.height}`);
+  }
+  if (leaf.leafIndex !== manifest.bhtmProof.fromLeafIndex) {
+    mismatches.push(`BHTM from leaf index: expected ${manifest.bhtmProof.fromLeafIndex}, got ${leaf.leafIndex}`);
+  }
+  if (leaf.treeSize !== manifest.bhtmProof.treeSize) {
+    mismatches.push(`BHTM from leaf tree size: expected ${manifest.bhtmProof.treeSize}, got ${leaf.treeSize}`);
+  }
+  compareHex('BHTM from leaf block hash', leaf.blockHashDisplayHex, manifest.anchor.fromBlockHashHex, mismatches);
+  compareHex('BHTM from leaf hash', leaf.leafHashHex, manifest.bhtmProof.fromLeafHashHex ?? '', mismatches);
+  compareHex('BHTM from leaf tree_root', leaf.treeRootHex, manifest.bhtmProof.treeRootHex, mismatches);
+}
+
+function compareLeafPositionToAttestation(
+  name: string,
+  leaf: VerifiedBhtmLeafProof,
+  attestation: BhtmAttestationV2,
+  mismatches: string[],
+): void {
+  if (leaf.height <= attestation.startHeight || leaf.height > attestation.endHeight) {
+    mismatches.push(
+      `${name} height ${leaf.height} is outside attested range ${attestation.startHeight + 1}..${attestation.endHeight}`,
+    );
+    return;
+  }
+  const expectedIndex = leaf.height - attestation.startHeight - 1;
+  if (leaf.leafIndex !== expectedIndex) {
+    mismatches.push(`${name} attested position: expected leaf index ${expectedIndex}, got ${leaf.leafIndex}`);
+  }
+  if (leaf.treeSize !== Number(attestation.treeSize)) {
+    mismatches.push(`${name} attested tree_size: expected ${attestation.treeSize}, got ${leaf.treeSize}`);
+  }
+  compareHex(`${name} attested tree_root`, leaf.treeRootHex, attestation.treeRootHex, mismatches);
+}
+
 function compareStatsAndJobToManifest(
   artifacts: Map<string, Uint8Array>,
   manifest: TrustChainManifest,
   mismatches: string[],
 ): void {
   const stats = JSON.parse(decodeUtf8(requiredArtifact(artifacts, 'stats'))) as Record<string, unknown>;
-  const job = JSON.parse(decodeUtf8(requiredArtifact(artifacts, 'job'))) as Record<string, unknown>;
+  const jobBytes = requiredArtifact(artifacts, 'job');
+  const job = JSON.parse(decodeUtf8(jobBytes)) as Record<string, unknown>;
   compareHex('BHTM stats tree_root', String(stats.tree_root ?? ''), manifest.bhtmProof.treeRootHex, mismatches);
   compareHex('BHTM stats job_sha256', String(stats.job_sha256 ?? ''), manifest.bhtmProof.jobSha256Hex, mismatches);
   compareHex('BHTM stats tee_report_data', String(stats.tee_report_data ?? ''), bytesToHex(requiredArtifact(artifacts, 'reportData')), mismatches);
+  compareHex('BHTM job artifact sha256', bytesToHex(sha256(jobBytes)), manifest.bhtmProof.jobSha256Hex, mismatches);
   if (stats.job_chunk !== manifest.bhtmProof.chunk) {
     mismatches.push(`BHTM stats job_chunk: expected ${manifest.bhtmProof.chunk}, got ${String(stats.job_chunk ?? '')}`);
+  }
+  if (job.chain !== manifest.anchor.network) {
+    mismatches.push(`BHTM job chain: expected ${manifest.anchor.network}, got ${String(job.chain ?? '')}`);
   }
   if (job.chunk !== manifest.bhtmProof.chunk) {
     mismatches.push(`BHTM job chunk: expected ${manifest.bhtmProof.chunk}, got ${String(job.chunk ?? '')}`);
@@ -369,6 +460,25 @@ function validateManifestShape(manifest: TrustChainManifest): void {
   if (!manifest.anchor || !manifest.databaseProof || !manifest.bhtmProof) {
     throw new Error('trust-chain manifest missing anchor/databaseProof/bhtmProof');
   }
+  if (manifest.anchor.buildKind !== 'snapshot' && manifest.anchor.buildKind !== 'delta') {
+    throw new Error(`unsupported trust-chain buildKind ${manifest.anchor.buildKind}`);
+  }
+  if (manifest.anchor.buildKind === 'delta') {
+    if (!manifest.bhtmProof.artifacts?.fromLeafProof) {
+      throw new Error('delta trust-chain manifest missing BHTM fromLeafProof artifact');
+    }
+    if (!Number.isInteger(manifest.bhtmProof.fromLeafIndex)) {
+      throw new Error('delta trust-chain manifest missing BHTM fromLeafIndex');
+    }
+    if (!isHexBytes(manifest.bhtmProof.fromLeafHashHex, 32)) {
+      throw new Error('delta trust-chain manifest missing or invalid BHTM fromLeafHashHex');
+    }
+  }
+}
+
+function isHexBytes(value: unknown, byteLength: number): value is string {
+  return typeof value === 'string'
+    && new RegExp(`^(?:0x)?[0-9a-fA-F]{${byteLength * 2}}$`).test(value.trim());
 }
 
 function decodeUtf8(bytes: Uint8Array): string {


### PR DESCRIPTION
## Summary

- publish and verify a BHTM inclusion proof for the delta starting block at height 940611
- require both delta endpoints to match the same attested tree root
- bind the live database proof to the manifest anchors and PIR roots
- expose safe mempool.space links for manual block-hash cross-checking
- fail closed on missing, substituted, or inconsistent endpoint evidence

## Why

A delta database has two independently meaningful Bitcoin anchor points. Verifying only the latest block does not directly authenticate the claimed starting block, so the browser now verifies an inclusion proof for each endpoint.

## Validation

- npm test: 190 passed, 2 skipped
- npm run build
- npm run build-web