### PR TITLE
web: enforce strict standalone OnionPIR verification

### DIFF
--- a/docs/STRICT_VERIFICATION_PROGRESS.md
+++ b/docs/STRICT_VERIFICATION_PROGRESS.md
@@ -33,20 +33,20 @@ Status: **merged** ([#54](https://github.com/Bitcoin-PIR/Bitcoin-PIR/pull/54)).
 
 ## PR C — strict WASM and DPF/Harmony web flow
 
-Status: **Draft PR open** ([#56](https://github.com/Bitcoin-PIR/Bitcoin-PIR/pull/56)).
-Implementation and validation are complete. The production proof prerequisite
-is also complete: on 2026-07-19, `bpir-admin db-proof verify-live` returned
-`status=ok` for db 0 and db 1 on both hosts. Strict DPF and HarmonyPIR browser
-queries passed end to end. Merge is now gated on review and CI.
+Status: **merged** ([#56](https://github.com/Bitcoin-PIR/Bitcoin-PIR/pull/56)).
+The production proof prerequisite is also complete: on 2026-07-19,
+`bpir-admin db-proof verify-live` returned `status=ok` for db 0 and db 1 on
+both hosts. On 2026-07-20, strict DPF and HarmonyPIR production browser queries
+passed end to end after the Pages deployment.
 
-- [ ] Verify DB proof in Rust/WASM and compare every field with the production
+- [x] Verify DB proof in Rust/WASM and compare every field with the production
       pin in TypeScript.
-- [ ] Install the same live `WasmDatabaseProof` handle into the client only
+- [x] Install the same live `WasmDatabaseProof` handle into the client only
       after the TypeScript pin comparison succeeds.
-- [ ] Preflight trusted tree-tops before querying.
-- [ ] Fail closed on runtime attestation/pin, secure-channel upgrade, and any
+- [x] Preflight trusted tree-tops before querying.
+- [x] Fail closed on runtime attestation/pin, secure-channel upgrade, and any
       configured operator-identity failure.
-- [ ] Describe Hetzner as operator identity + binary pin, and VPSBG as the
+- [x] Describe Hetzner as operator identity + binary pin, and VPSBG as the
       SEV-SNP deployment.
 - Production deployment complete: both hosts serve the snapshot and delta
   proof bundles and pass live proof verification.
@@ -71,10 +71,29 @@ Completed production proof activation for PR C:
 
 ## PR D — standalone OnionPIR web client
 
-Status: **not started**; depends on the proof/install contract established by
-PR B and the WASM patterns established by PR C.
+Status: **implementation and validation complete on
+`codex/strict-onion-web-flow`**; Draft PR pending. Checkboxes remain unchecked
+until the PR is merged, per this file's convention.
 
 - [ ] Add a stateless WASM verifier for `REQ_GET_DB_PROOF` responses.
 - [ ] Install `onion_super_root` only after production-pin matching.
 - [ ] Bind Onion tree-tops to the installed trusted root.
 - [ ] Treat `server-info.super_root` as diagnostics only.
+- [ ] Pin the remaining standalone OnionPIR query layout until a v2 database
+      proof commits those fields directly.
+- [ ] Verify every found, absent, and whale result before merging or committing
+      sync state, and disconnect at the end of every query.
+
+Branch validation completed on 2026-07-20:
+
+- Rust client: 276 unit tests passed; 6 non-network integration/doc tests
+  passed (network-dependent tests remain intentionally ignored).
+- WASM: 73 tests passed, `wasm32-unknown-unknown` check passed, and `wasm-pack`
+  produced the browser package.
+- Web: TypeScript build passed; 240 tests passed and 2 optional leakage tests
+  remained skipped.
+- Browser smoke against `wss://weikeng1.bitcoinpir.org`: both production DB
+  proofs and consolidated tree-tops passed preflight; both found and not-found
+  results received automatic `Verified` marks; each session ended disconnected.
+- This rollout uses the existing proof and OnionPIR Merkle protocol. It does
+  not require a new server binary or rebuilt UKI.

--- a/docs/STRICT_VERIFICATION_PROGRESS.md
+++ b/docs/STRICT_VERIFICATION_PROGRESS.md
@@ -71,9 +71,10 @@ Completed production proof activation for PR C:
 
 ## PR D — standalone OnionPIR web client
 
-Status: **implementation and validation complete on
-`codex/strict-onion-web-flow`**; Draft PR pending. Checkboxes remain unchecked
-until the PR is merged, per this file's convention.
+Status: **Draft PR open**
+([#57](https://github.com/Bitcoin-PIR/Bitcoin-PIR/pull/57)). Implementation and
+validation are complete. Checkboxes remain unchecked until the PR is merged,
+per this file's convention.
 
 - [ ] Add a stateless WASM verifier for `REQ_GET_DB_PROOF` responses.
 - [ ] Install `onion_super_root` only after production-pin matching.

--- a/pir-sdk-client/src/db_proof.rs
+++ b/pir-sdk-client/src/db_proof.rs
@@ -66,6 +66,7 @@ pub struct VerifiedDatabaseRoots {
     pub muhash: [u8; 32],
     pub bucket_super_root: [u8; 32],
     pub onion_super_root: [u8; 32],
+    pub onion_entry_size: u32,
     pub params_hash: [u8; 32],
     pub network_magic: [u8; 4],
     pub builder_binary_sha256: [u8; 32],
@@ -142,6 +143,25 @@ pub fn verify_database_proof(
     verify_against_catalog_and_policy(db_info, &verified, policy)
 }
 
+/// Decode and verify a raw `RESP_DB_PROOF` payload without owning a
+/// transport or client session.
+///
+/// `response_payload` starts at the response opcode and therefore does not
+/// include the outer four-byte wire length prefix.  This is the synchronous
+/// counterpart of [`fetch_database_proof`], intended for callers that own
+/// their transport separately (for example the standalone browser OnionPIR
+/// client).  Verification is deliberately side-effect free: the returned
+/// roots still have to be installed explicitly by the caller after any
+/// application-level production-pin comparison.
+pub fn verify_database_proof_response(
+    db_info: &DatabaseInfo,
+    response_payload: &[u8],
+    policy: &DatabaseProofPolicy,
+) -> PirResult<VerifiedDatabaseRoots> {
+    let bundle = decode_database_proof_response(response_payload)?;
+    verify_database_proof(db_info, &bundle, policy)
+}
+
 pub fn decode_database_proof_response(data: &[u8]) -> PirResult<DatabaseProofBundle> {
     if data.is_empty() {
         return Err(PirError::Decode("db proof response empty".into()));
@@ -192,6 +212,7 @@ fn verify_against_catalog_and_policy(
         evidence.chunk_bins_per_table,
     )?;
     verify_catalog_anchor(db_info, verified)?;
+    verify_catalog_query_parameters(db_info)?;
     if let Some(expected) = policy.expected_network_magic {
         expect_arr("network_magic", &expected, &evidence.network_magic)?;
     }
@@ -237,6 +258,7 @@ fn verify_against_catalog_and_policy(
         muhash: evidence.utxo_muhash,
         bucket_super_root: evidence.bucket_super_root,
         onion_super_root: evidence.onion_super_root,
+        onion_entry_size: evidence.onion_entry_size,
         params_hash: evidence.params_hash,
         network_magic: evidence.network_magic,
         builder_binary_sha256: evidence.builder_binary_sha256,
@@ -364,6 +386,61 @@ fn verify_catalog_anchor(db_info: &DatabaseInfo, verified: &ProofDirectory) -> P
     Ok(())
 }
 
+/// Bind every catalog field that controls client-side query placement to the
+/// chain anchor already authenticated by the database proof.
+fn verify_catalog_query_parameters(db_info: &DatabaseInfo) -> PirResult<()> {
+    use pir_core::cuckoo::HeaderAnchor;
+    use pir_core::params::{compute_dpf_n, K, K_CHUNK};
+    use pir_core::seeds::{DeltaSeeds, SnapshotSeeds};
+
+    crate::protocol::validate_db_geometry(db_info).map_err(|err| {
+        PirError::VerificationFailed(format!("db proof catalog geometry invalid: {err}"))
+    })?;
+    expect_usize("index_k", K, db_info.index_k as usize)?;
+    expect_usize("chunk_k", K_CHUNK, db_info.chunk_k as usize)?;
+    expect_usize(
+        "dpf_n_index",
+        compute_dpf_n(db_info.index_bins as usize) as usize,
+        db_info.dpf_n_index as usize,
+    )?;
+    expect_usize(
+        "dpf_n_chunk",
+        compute_dpf_n(db_info.chunk_bins as usize) as usize,
+        db_info.dpf_n_chunk as usize,
+    )?;
+
+    let (expected_tag_seed, expected_index_seed, expected_chunk_seed) = match db_info.chain_anchor()
+    {
+        Some(HeaderAnchor::Snapshot(anchor)) => {
+            let seeds = SnapshotSeeds::derive(&anchor);
+            (seeds.index_tag, seeds.index_master, seeds.chunk_master)
+        }
+        Some(HeaderAnchor::Delta(anchor)) => {
+            let seeds = DeltaSeeds::derive(&anchor);
+            (seeds.index_tag, seeds.index_master, seeds.chunk_master)
+        }
+        None => {
+            return Err(proof_mismatch(
+                "catalog_anchor",
+                "chain-anchored catalog entry".into(),
+                "missing or malformed catalog anchor".into(),
+            ));
+        }
+    };
+
+    expect_u64("tag_seed", expected_tag_seed, db_info.tag_seed)?;
+    expect_u64(
+        "index_master_seed",
+        expected_index_seed,
+        db_info.index_master_seed,
+    )?;
+    expect_u64(
+        "chunk_master_seed",
+        expected_chunk_seed,
+        db_info.chunk_master_seed,
+    )
+}
+
 fn expect_chain_anchor(
     field: &'static str,
     expected: &AttestedChainAnchor,
@@ -375,6 +452,30 @@ fn expect_chain_anchor(
 }
 
 fn expect_u32(field: &'static str, expected: u32, actual: u32) -> PirResult<()> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(proof_mismatch(
+            field,
+            expected.to_string(),
+            actual.to_string(),
+        ))
+    }
+}
+
+fn expect_u64(field: &'static str, expected: u64, actual: u64) -> PirResult<()> {
+    if expected == actual {
+        Ok(())
+    } else {
+        Err(proof_mismatch(
+            field,
+            expected.to_string(),
+            actual.to_string(),
+        ))
+    }
+}
+
+fn expect_usize(field: &'static str, expected: usize, actual: usize) -> PirResult<()> {
     if expected == actual {
         Ok(())
     } else {
@@ -414,7 +515,7 @@ mod tests {
     use super::*;
     use crate::transport::PirTransport;
     use async_trait::async_trait;
-    use pir_core::seeds::{ChainAnchor as CoreChainAnchor, DeltaAnchor, DeltaSeeds};
+    use pir_core::seeds::{ChainAnchor as CoreChainAnchor, DeltaAnchor, DeltaSeeds, SnapshotSeeds};
     use pir_db_attest::{ChainAnchor, RootBundlePayload};
     use pir_sdk::PirResult;
     use sha2::{Digest, Sha256};
@@ -534,8 +635,8 @@ mod tests {
             height: 948_454,
             index_bins: 53_282,
             chunk_bins: 112_332,
-            index_k: 75,
-            chunk_k: 80,
+            index_k: pir_core::params::K as u8,
+            chunk_k: pir_core::params::K_CHUNK as u8,
             tag_seed: seeds.index_tag,
             dpf_n_index: 16,
             dpf_n_chunk: 17,
@@ -639,6 +740,45 @@ mod tests {
         assert_eq!(decode_database_proof_response(&response).unwrap(), bundle);
     }
 
+    #[test]
+    fn verify_database_proof_response_is_stateless() {
+        let (bundle, db_info) = sample_bundle();
+        let response = encode_proof_response(&bundle);
+        let mut policy = DatabaseProofPolicy::mainnet();
+        policy.expected_params_hash = Some([6u8; 32]);
+        policy.allowed_builder_binary_sha256.push([1u8; 32]);
+        policy.allowed_builder_git_commits.push("abc123".into());
+
+        let verified = verify_database_proof_response(&db_info, &response, &policy).unwrap();
+        assert_eq!(verified.db_id, db_info.db_id);
+        assert_eq!(verified.onion_super_root, [8u8; 32]);
+        assert_eq!(verified.onion_entry_size, 3328);
+    }
+
+    #[test]
+    fn verify_database_proof_response_rejects_substituted_db_id() {
+        let (mut bundle, db_info) = sample_bundle();
+        bundle.db_id = db_info.db_id.wrapping_add(1);
+        let response = encode_proof_response(&bundle);
+
+        let err =
+            verify_database_proof_response(&db_info, &response, &DatabaseProofPolicy::mainnet())
+                .unwrap_err();
+        assert!(err.to_string().contains("db_id mismatch"));
+    }
+
+    #[test]
+    fn verify_database_proof_response_rejects_wrong_opcode() {
+        let (_, db_info) = sample_bundle();
+        let err = verify_database_proof_response(
+            &db_info,
+            &[RESP_DB_CATALOG],
+            &DatabaseProofPolicy::mainnet(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, PirError::UnexpectedResponse { .. }));
+    }
+
     #[tokio::test]
     async fn fetch_catalog_and_proof_over_transport() {
         let (bundle, db_info) = sample_bundle();
@@ -690,6 +830,93 @@ mod tests {
         assert_eq!(verified.from_height, 940_611);
         assert_eq!(verified.bucket_super_root, [7u8; 32]);
         assert_eq!(verified.onion_super_root, [8u8; 32]);
+        assert_eq!(verified.onion_entry_size, 3328);
+    }
+
+    #[test]
+    fn verify_database_proof_rejects_untrusted_catalog_query_parameters() {
+        let (bundle, db_info) = sample_bundle();
+        let cases = [
+            (
+                "index_k",
+                DatabaseInfo {
+                    index_k: db_info.index_k.wrapping_sub(1),
+                    ..db_info.clone()
+                },
+            ),
+            (
+                "chunk_k",
+                DatabaseInfo {
+                    chunk_k: db_info.chunk_k.wrapping_sub(1),
+                    ..db_info.clone()
+                },
+            ),
+            (
+                "tag_seed",
+                DatabaseInfo {
+                    tag_seed: db_info.tag_seed ^ 1,
+                    ..db_info.clone()
+                },
+            ),
+            (
+                "dpf_n_index",
+                DatabaseInfo {
+                    dpf_n_index: db_info.dpf_n_index.wrapping_add(1),
+                    ..db_info.clone()
+                },
+            ),
+            (
+                "dpf_n_chunk",
+                DatabaseInfo {
+                    dpf_n_chunk: db_info.dpf_n_chunk.wrapping_add(1),
+                    ..db_info.clone()
+                },
+            ),
+            (
+                "index_master_seed",
+                DatabaseInfo {
+                    index_master_seed: db_info.index_master_seed ^ 1,
+                    ..db_info.clone()
+                },
+            ),
+            (
+                "chunk_master_seed",
+                DatabaseInfo {
+                    chunk_master_seed: db_info.chunk_master_seed ^ 1,
+                    ..db_info.clone()
+                },
+            ),
+        ];
+
+        for (field, tampered) in cases {
+            let err = verify_database_proof(&tampered, &bundle, &DatabaseProofPolicy::mainnet())
+                .unwrap_err();
+            assert!(
+                err.to_string().contains(&format!("{} mismatch", field)),
+                "unexpected error for {field}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn catalog_query_parameters_accept_snapshot_derived_seeds() {
+        let (_, mut db_info) = sample_bundle();
+        let anchor = CoreChainAnchor {
+            block_hash: [9u8; 32],
+            block_height: 940_611,
+        };
+        let seeds = SnapshotSeeds::derive(&anchor);
+        db_info.kind = DatabaseKind::Full;
+        db_info.height = anchor.block_height;
+        db_info.index_k = pir_core::params::K as u8;
+        db_info.chunk_k = pir_core::params::K_CHUNK as u8;
+        db_info.tag_seed = seeds.index_tag;
+        db_info.index_master_seed = seeds.index_master;
+        db_info.chunk_master_seed = seeds.chunk_master;
+        db_info.anchor_kind = 1;
+        db_info.anchor_bytes = anchor.to_bytes().to_vec();
+
+        verify_catalog_query_parameters(&db_info).unwrap();
     }
 
     #[test]

--- a/pir-sdk-client/src/dpf.rs
+++ b/pir-sdk-client/src/dpf.rs
@@ -3456,6 +3456,7 @@ mod tests {
             muhash: [2; 32],
             bucket_super_root: [3; 32],
             onion_super_root: [4; 32],
+            onion_entry_size: 3328,
             params_hash: [5; 32],
             network_magic: [0xf9, 0xbe, 0xb4, 0xd9],
             builder_binary_sha256: [6; 32],

--- a/pir-sdk-client/src/harmony.rs
+++ b/pir-sdk-client/src/harmony.rs
@@ -6973,6 +6973,7 @@ mod tests {
             muhash: [2; 32],
             bucket_super_root: [3; 32],
             onion_super_root: [4; 32],
+            onion_entry_size: 3328,
             params_hash: [5; 32],
             network_magic: [0xf9, 0xbe, 0xb4, 0xd9],
             builder_binary_sha256: [6; 32],

--- a/pir-sdk-client/src/lib.rs
+++ b/pir-sdk-client/src/lib.rs
@@ -83,8 +83,8 @@ pub use connection::{
     DEFAULT_MAX_BACKOFF_DELAY, DEFAULT_MAX_CONNECT_ATTEMPTS, DEFAULT_REQUEST_TIMEOUT,
 };
 pub use db_proof::{
-    fetch_database_proof, verify_database_proof, DatabaseProofBundle, DatabaseProofPolicy,
-    VerifiedDatabaseRoots,
+    fetch_database_proof, verify_database_proof, verify_database_proof_response,
+    DatabaseProofBundle, DatabaseProofPolicy, VerifiedDatabaseRoots,
 };
 pub use dpf::DpfClient;
 pub use harmony::{HarmonyClient, HintProgress, PRP_FASTPRP, PRP_HMR12};

--- a/pir-sdk-client/src/onion_merkle.rs
+++ b/pir-sdk-client/src/onion_merkle.rs
@@ -644,7 +644,9 @@ pub(crate) async fn preflight_onion_tree_tops(
     let req = encode_tree_top_request(OnionTreeKind::Index.req_tree_top(), db_id);
     let resp = conn.roundtrip(&req).await?;
     if resp.is_empty() || resp[0] != OnionTreeKind::Index.resp_tree_top() {
-        return Err(PirError::Protocol("invalid OnionPIR tree-top preflight response".into()));
+        return Err(PirError::Protocol(
+            "invalid OnionPIR tree-top preflight response".into(),
+        ));
     }
     let blob = &resp[1..];
     let tops = parse_onion_tree_top_cache(blob)?;
@@ -709,6 +711,36 @@ fn walk_tree_top_to_root(
 /// notes for what this does and does not guarantee).
 pub type OnionMerkleVerdicts = HashMap<(OnionTreeKind, usize, u32), bool>;
 
+/// Reject contradictory claims for one Merkle leaf coordinate before any
+/// verification traffic is sent.
+///
+/// Repeating the same `(tree, pbc_group, bin, hash)` is harmless: the
+/// per-sub-tree verifier deduplicates it below. Repeating the coordinate with
+/// a different hash is ambiguous and must fail the whole batch. In
+/// particular, silently keeping the first hash would make the outcome depend
+/// on caller-controlled input order.
+fn validate_duplicate_leaf_hashes(leaves: &[OnionMerkleLeaf]) -> PirResult<()> {
+    let mut hashes: HashMap<(OnionTreeKind, usize, u32), Hash256> = HashMap::new();
+    for leaf in leaves {
+        let key = (leaf.tree, leaf.pbc_group, leaf.bin);
+        match hashes.get(&key) {
+            Some(hash) if hash != &leaf.hash => {
+                return Err(PirError::Protocol(format!(
+                    "OnionPIR Merkle {} group {} bin {} has conflicting duplicate leaf hashes",
+                    leaf.tree.name(),
+                    leaf.pbc_group,
+                    leaf.bin,
+                )));
+            }
+            Some(_) => {}
+            None => {
+                hashes.insert(key, leaf.hash);
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Verify all OnionPIR Merkle leaves across both INDEX and DATA sub-trees.
 ///
 /// * `conn` — the same WebSocket used for the regular queries. The caller
@@ -716,7 +748,9 @@ pub type OnionMerkleVerdicts = HashMap<(OnionTreeKind, usize, u32), bool>;
 /// * `info` — parsed [`OnionMerkleInfo`] for the current DB.
 /// * `leaves` — one entry per probed leaf, pre-populated with
 ///   `(tree, pbc_group, bin, hash, result_idx)`. Duplicates (same
-///   `(tree, pbc_group, bin)`) are deduplicated internally.
+///   `(tree, pbc_group, bin, hash)`) are deduplicated internally. If one
+///   coordinate appears with different hashes, the whole batch is rejected
+///   before any verification request is sent.
 /// * `client_id`, `secret_key` — FHE state from the `OnionClient`'s
 ///   `FheState`. The sibling FHE client is created from these.
 /// * `db_id` — DB under verification.
@@ -737,6 +771,11 @@ pub async fn verify_onion_merkle_batch(
     db_id: u8,
     leakage_recorder: Option<Arc<dyn LeakageRecorder>>,
 ) -> PirResult<OnionMerkleVerdicts> {
+    // Validate the whole INDEX + DATA batch before issuing either sub-tree's
+    // tree-top request. A contradictory duplicate in DATA must not allow the
+    // INDEX half to run first, and vice versa.
+    validate_duplicate_leaf_hashes(leaves)?;
+
     let mut verdicts: OnionMerkleVerdicts = HashMap::new();
 
     let index_leaves: Vec<&OnionMerkleLeaf> = leaves
@@ -1307,7 +1346,12 @@ mod tests {
         assert!(parse_onionpir_merkle(j).is_none());
     }
 
-    fn merkle_info(arity: usize, super_root: Hash256, hash: Hash256, size: usize) -> OnionMerkleInfo {
+    fn merkle_info(
+        arity: usize,
+        super_root: Hash256,
+        hash: Hash256,
+        size: usize,
+    ) -> OnionMerkleInfo {
         OnionMerkleInfo {
             arity,
             super_root,
@@ -1315,6 +1359,63 @@ mod tests {
             tree_tops_size: size,
             index: OnionMerkleKindInfo { k: 3, num_pt: 5 },
             data: OnionMerkleKindInfo { k: 2, num_pt: 5 },
+        }
+    }
+
+    fn leaf(tree: OnionTreeKind, pbc_group: usize, bin: u32, hash: Hash256) -> OnionMerkleLeaf {
+        OnionMerkleLeaf {
+            tree,
+            pbc_group,
+            bin,
+            hash,
+            result_idx: 0,
+        }
+    }
+
+    #[test]
+    fn test_duplicate_coordinate_with_same_hash_is_accepted() {
+        let first = leaf(OnionTreeKind::Index, 1, 17, h(3));
+        let mut duplicate = first.clone();
+        duplicate.result_idx = 9;
+
+        assert!(validate_duplicate_leaf_hashes(&[first, duplicate]).is_ok());
+    }
+
+    #[test]
+    fn test_same_coordinate_in_different_trees_is_not_a_conflict() {
+        let leaves = [
+            leaf(OnionTreeKind::Index, 1, 17, h(3)),
+            leaf(OnionTreeKind::Data, 1, 17, h(4)),
+        ];
+
+        assert!(validate_duplicate_leaf_hashes(&leaves).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_conflicting_duplicate_rejects_whole_batch_before_io_in_any_order() {
+        use crate::transport::mock::MockTransport;
+
+        let first = leaf(OnionTreeKind::Data, 1, 17, h(3));
+        let conflicting = leaf(OnionTreeKind::Data, 1, 17, h(4));
+        let info = merkle_info(8, ZERO_HASH, ZERO_HASH, 0);
+
+        for leaves in [
+            vec![first.clone(), conflicting.clone()],
+            vec![conflicting.clone(), first.clone()],
+        ] {
+            let mut conn = MockTransport::new("mock://duplicate-leaf");
+            let err = verify_onion_merkle_batch(&mut conn, &info, &leaves, 1, &[], 0, None)
+                .await
+                .expect_err("conflicting duplicate hash must reject the batch");
+
+            assert!(
+                matches!(err, PirError::Protocol(ref message) if message.contains("conflicting duplicate leaf hashes")),
+                "unexpected error: {err}",
+            );
+            assert!(
+                conn.sent.is_empty(),
+                "conflict must be rejected before either Merkle sub-tree sends traffic",
+            );
         }
     }
 
@@ -1417,11 +1518,7 @@ mod tests {
     fn test_walk_tree_top_deep_tree() {
         // 4096 leaves, arity 8 → levels [4096, 512, 64, 8, 1]. Cache from
         // level 1 → tree-top [[512],[64],[8],[1]]. Exercises a 3-level walk.
-        let leaves: Vec<Hash256> = (0..255u8)
-            .cycle()
-            .take(4096)
-            .map(h)
-            .collect();
+        let leaves: Vec<Hash256> = (0..255u8).cycle().take(4096).map(h).collect();
         let (levels, root) = build_tree(8, &leaves);
         assert_eq!(levels.len(), 5);
         let top = OnionTreeTopCache {
@@ -1438,10 +1535,22 @@ mod tests {
     #[test]
     fn test_wire_code_pairing() {
         // Request/response are the same variant byte per feature (server convention).
-        assert_eq!(REQ_ONIONPIR_MERKLE_INDEX_TREE_TOP, RESP_ONIONPIR_MERKLE_INDEX_TREE_TOP);
-        assert_eq!(REQ_ONIONPIR_MERKLE_INDEX_SIBLING, RESP_ONIONPIR_MERKLE_INDEX_SIBLING);
-        assert_eq!(REQ_ONIONPIR_MERKLE_DATA_TREE_TOP, RESP_ONIONPIR_MERKLE_DATA_TREE_TOP);
-        assert_eq!(REQ_ONIONPIR_MERKLE_DATA_SIBLING, RESP_ONIONPIR_MERKLE_DATA_SIBLING);
+        assert_eq!(
+            REQ_ONIONPIR_MERKLE_INDEX_TREE_TOP,
+            RESP_ONIONPIR_MERKLE_INDEX_TREE_TOP
+        );
+        assert_eq!(
+            REQ_ONIONPIR_MERKLE_INDEX_SIBLING,
+            RESP_ONIONPIR_MERKLE_INDEX_SIBLING
+        );
+        assert_eq!(
+            REQ_ONIONPIR_MERKLE_DATA_TREE_TOP,
+            RESP_ONIONPIR_MERKLE_DATA_TREE_TOP
+        );
+        assert_eq!(
+            REQ_ONIONPIR_MERKLE_DATA_SIBLING,
+            RESP_ONIONPIR_MERKLE_DATA_SIBLING
+        );
         assert_eq!(REQ_ONIONPIR_MERKLE_INDEX_TREE_TOP, 0x54);
         assert_eq!(REQ_ONIONPIR_MERKLE_INDEX_SIBLING, 0x53);
         assert_eq!(REQ_ONIONPIR_MERKLE_DATA_TREE_TOP, 0x56);

--- a/pir-sdk-client/src/verified_roots.rs
+++ b/pir-sdk-client/src/verified_roots.rs
@@ -29,6 +29,10 @@ struct CatalogIdentity {
     chunk_bins: u32,
     index_k: u8,
     chunk_k: u8,
+    tag_seed: u64,
+    dpf_n_index: u8,
+    dpf_n_chunk: u8,
+    has_bucket_merkle: bool,
     index_master_seed: u64,
     chunk_master_seed: u64,
     anchor_kind: u8,
@@ -70,7 +74,11 @@ impl VerifiedRootState {
     /// Drop roots whose catalog identity rotated while keeping unaffected DBs.
     pub(crate) fn reconcile_catalog(&mut self, catalog: &DatabaseCatalog) {
         let identity = catalog_identity(catalog);
-        if self.bound_catalog.as_ref().is_some_and(|old| old != &identity) {
+        if self
+            .bound_catalog
+            .as_ref()
+            .is_some_and(|old| old != &identity)
+        {
             self.clear();
             return;
         }
@@ -103,19 +111,27 @@ impl VerifiedRootState {
 }
 
 fn catalog_identity(catalog: &DatabaseCatalog) -> Vec<CatalogIdentity> {
-    catalog.databases.iter().map(|db| CatalogIdentity {
-        db_id: db.db_id,
-        kind: format!("{:?}", db.kind),
-        height: db.height,
-        index_bins: db.index_bins,
-        chunk_bins: db.chunk_bins,
-        index_k: db.index_k,
-        chunk_k: db.chunk_k,
-        index_master_seed: db.index_master_seed,
-        chunk_master_seed: db.chunk_master_seed,
-        anchor_kind: db.anchor_kind,
-        anchor_bytes: db.anchor_bytes.clone(),
-    }).collect()
+    catalog
+        .databases
+        .iter()
+        .map(|db| CatalogIdentity {
+            db_id: db.db_id,
+            kind: format!("{:?}", db.kind),
+            height: db.height,
+            index_bins: db.index_bins,
+            chunk_bins: db.chunk_bins,
+            index_k: db.index_k,
+            chunk_k: db.chunk_k,
+            tag_seed: db.tag_seed,
+            dpf_n_index: db.dpf_n_index,
+            dpf_n_chunk: db.dpf_n_chunk,
+            has_bucket_merkle: db.has_bucket_merkle,
+            index_master_seed: db.index_master_seed,
+            chunk_master_seed: db.chunk_master_seed,
+            anchor_kind: db.anchor_kind,
+            anchor_bytes: db.anchor_bytes.clone(),
+        })
+        .collect()
 }
 
 fn ensure_roots_match_catalog(db: &DatabaseInfo, roots: &VerifiedDatabaseRoots) -> PirResult<()> {
@@ -170,6 +186,7 @@ mod tests {
             muhash: [0; 32],
             bucket_super_root: [1; 32],
             onion_super_root: [2; 32],
+            onion_entry_size: 3328,
             params_hash: [0; 32],
             network_magic: [0; 4],
             builder_binary_sha256: [0; 32],
@@ -195,5 +212,45 @@ mod tests {
             databases: vec![db(11)],
         });
         assert!(state.require_db(7).is_err());
+    }
+
+    #[test]
+    fn query_parameter_rotation_invalidates_roots() {
+        let baseline = db(10);
+        let variants = [
+            DatabaseInfo {
+                tag_seed: 1,
+                ..baseline.clone()
+            },
+            DatabaseInfo {
+                dpf_n_index: 2,
+                ..baseline.clone()
+            },
+            DatabaseInfo {
+                dpf_n_chunk: 2,
+                ..baseline.clone()
+            },
+            DatabaseInfo {
+                has_bucket_merkle: false,
+                ..baseline.clone()
+            },
+        ];
+
+        for changed in variants {
+            let mut state = VerifiedRootState::default();
+            state.set_policy(RootPolicy::RequireVerified);
+            state
+                .install(
+                    &DatabaseCatalog {
+                        databases: vec![baseline.clone()],
+                    },
+                    roots(10),
+                )
+                .unwrap();
+            state.reconcile_catalog(&DatabaseCatalog {
+                databases: vec![changed],
+            });
+            assert!(state.require_db(7).is_err());
+        }
     }
 }

--- a/pir-sdk-wasm/src/client.rs
+++ b/pir-sdk-wasm/src/client.rs
@@ -37,8 +37,9 @@ use pir_sdk_client::attest::{AttestVerification, SevStatus};
 #[cfg(target_arch = "wasm32")]
 use pir_sdk_client::HintProgress;
 use pir_sdk_client::{
-    DatabaseProofPolicy, DpfClient, HarmonyClient, OramClient, RootPolicy,
-    VerifiedDatabaseRoots, PRP_FASTPRP, PRP_HMR12,
+    verify_database_proof_response as verify_database_proof_response_payload, DatabaseProofPolicy,
+    DpfClient, HarmonyClient, OramClient, RootPolicy, VerifiedDatabaseRoots, PRP_FASTPRP,
+    PRP_HMR12,
 };
 use wasm_bindgen::prelude::*;
 
@@ -180,11 +181,37 @@ fn database_proof_json(roots: &VerifiedDatabaseRoots) -> serde_json::Value {
         "muhashHex": roots.muhash_hex(),
         "bucketSuperRootHex": roots.bucket_super_root_hex(),
         "onionSuperRootHex": roots.onion_super_root_hex(),
+        "onionEntrySize": roots.onion_entry_size,
         "paramsHashHex": hex_encode(&roots.params_hash),
         "networkMagicHex": hex_encode(&roots.network_magic),
         "builderBinarySha256Hex": hex_encode(&roots.builder_binary_sha256),
         "builderGitCommit": roots.builder_git_commit,
     })
+}
+
+/// Validate and strip one complete length-prefixed PIR response frame.
+///
+/// The standalone TypeScript transport returns `[u32 len LE][payload]`,
+/// whereas `pir-sdk-client` proof decoders intentionally accept only the
+/// variant-first payload returned by `PirTransport::roundtrip`.  Keep this
+/// framing boundary explicit and reject truncated or concatenated records
+/// instead of guessing which shape the caller supplied.
+fn database_proof_payload_from_frame(frame: &[u8]) -> Result<&[u8], String> {
+    if frame.len() < 5 {
+        return Err(format!(
+            "database proof response frame too short: expected at least 5 bytes, got {}",
+            frame.len()
+        ));
+    }
+    let declared = u32::from_le_bytes(frame[0..4].try_into().unwrap()) as usize;
+    let actual = frame.len() - 4;
+    if declared != actual {
+        return Err(format!(
+            "database proof response frame length mismatch: declared {}, got {}",
+            declared, actual
+        ));
+    }
+    Ok(&frame[4..])
 }
 
 /// Build the JS-facing JSON shape of a `SyncResult`. Mirrors
@@ -934,6 +961,11 @@ impl WasmDatabaseProof {
         self.inner.onion_super_root_hex()
     }
 
+    #[wasm_bindgen(getter, js_name = onionEntrySize)]
+    pub fn onion_entry_size(&self) -> u32 {
+        self.inner.onion_entry_size
+    }
+
     #[wasm_bindgen(getter, js_name = paramsHashHex)]
     pub fn params_hash_hex(&self) -> String {
         hex_encode(&self.inner.params_hash)
@@ -959,6 +991,44 @@ impl WasmDatabaseProof {
     pub fn to_json(&self) -> JsValue {
         to_js_object(&database_proof_json(&self.inner))
     }
+}
+
+/// Verify a complete, length-prefixed `RESP_DB_PROOF` frame without owning a
+/// WebSocket or PIR client.
+///
+/// This is the authoritative verifier for transports that remain in
+/// JavaScript, notably the standalone OnionPIR browser client.  `responseFrame`
+/// must be exactly one record in the shape returned by that client's
+/// `ManagedWebSocket.sendRaw`: `[u32 payload_len LE][opcode][body...]`.
+/// The outer length, response opcode, requested database ID, catalog anchors,
+/// attested-builder proof, and supplied policy pins are all checked before an
+/// opaque [`WasmDatabaseProof`] is returned.
+///
+/// The function is stateless and does not install roots.  JavaScript must
+/// compare every exposed field with its production pin and then explicitly
+/// transfer the same handle into its OnionPIR session root store.
+#[wasm_bindgen(js_name = verifyDatabaseProofResponse)]
+pub fn verify_database_proof_response(
+    response_frame: &[u8],
+    catalog: &WasmDatabaseCatalog,
+    expected_db_id: u8,
+    expected_params_hash_hex: Option<String>,
+    allowed_builder_binary_sha256_hex: Option<String>,
+    allowed_builder_git_commit: Option<String>,
+) -> Result<WasmDatabaseProof, JsError> {
+    let response_payload =
+        database_proof_payload_from_frame(response_frame).map_err(|e| JsError::new(&e))?;
+    let db_info = catalog.inner().get(expected_db_id).ok_or_else(|| {
+        JsError::new(&format!("database {} not found in catalog", expected_db_id))
+    })?;
+    let policy = database_proof_policy(
+        expected_params_hash_hex,
+        allowed_builder_binary_sha256_hex,
+        allowed_builder_git_commit,
+    )?;
+    let roots = verify_database_proof_response_payload(db_info, response_payload, &policy)
+        .map_err(err_to_js)?;
+    Ok(WasmDatabaseProof { inner: roots })
 }
 
 // ─── WasmAnnounceVerification ──────────────────────────────────────────────
@@ -2577,6 +2647,54 @@ pub fn prp_fastprp() -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn database_proof_frame_requires_exact_length_prefix() {
+        let frame = [2, 0, 0, 0, 0x0a, 0x01];
+        assert_eq!(
+            database_proof_payload_from_frame(&frame).unwrap(),
+            &[0x0a, 0x01]
+        );
+
+        assert!(database_proof_payload_from_frame(&[]).is_err());
+        assert!(database_proof_payload_from_frame(&[0x0a]).is_err());
+        assert!(database_proof_payload_from_frame(&[1, 0, 0, 0]).is_err());
+
+        let truncated = [2, 0, 0, 0, 0x0a];
+        assert!(database_proof_payload_from_frame(&truncated)
+            .unwrap_err()
+            .contains("length mismatch"));
+
+        let concatenated = [1, 0, 0, 0, 0x0a, 1, 0, 0, 0, 0x0a];
+        assert!(database_proof_payload_from_frame(&concatenated)
+            .unwrap_err()
+            .contains("length mismatch"));
+    }
+
+    #[test]
+    fn database_proof_exposes_onion_entry_size() {
+        let roots = VerifiedDatabaseRoots {
+            db_id: 1,
+            build_kind: pir_db_attest::BuildKind::Snapshot,
+            from_height: 0,
+            from_block_hash: [0; 32],
+            height: 940_611,
+            block_hash: [1; 32],
+            muhash: [2; 32],
+            bucket_super_root: [3; 32],
+            onion_super_root: [4; 32],
+            onion_entry_size: 3328,
+            params_hash: [5; 32],
+            network_magic: [0xf9, 0xbe, 0xb4, 0xd9],
+            builder_binary_sha256: [6; 32],
+            builder_git_commit: "test".into(),
+        };
+
+        let json = database_proof_json(&roots);
+        assert_eq!(json["onionEntrySize"], 3328);
+        let proof = WasmDatabaseProof { inner: roots };
+        assert_eq!(proof.onion_entry_size(), 3328);
+    }
 
     #[test]
     fn unpack_script_hashes_empty_input_ok() {

--- a/web/index.html
+++ b/web/index.html
@@ -1158,8 +1158,8 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     <div class="card-body">
                         <div class="verification-summary">
                             <div class="verification-summary-row">
-                                <span class="verification-server">Server</span>
-                                <span class="verification-result unavailable" title="OnionPIR does not currently establish an attested channel">Unavailable</span>
+                                <span class="verification-server">Data integrity</span>
+                                <span id="onionVerification" class="verification-result pending">Not checked</span>
                             </div>
                         </div>
                         <div class="verification-actions">
@@ -1171,6 +1171,8 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                                     <label for="op-serverUrl">Server</label>
                                     <input type="text" id="op-serverUrl" class="input" value="wss://weikeng1.bitcoinpir.org" spellcheck="false">
                                 </div>
+                                <div id="op-dbProofBadge" class="attest-badge attest-badge-db-unavailable" style="display: none;"></div>
+                                <div id="op-bitcoinAnchorBadge" class="attest-badge attest-badge-chain-unavailable" style="display: none;"></div>
 
                                 <div id="op-syncStateRow" style="display: none; margin-top: 14px;">
                                     <span>Sync state:</span>
@@ -1565,7 +1567,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
     </section>
 
     <script type="module">
-        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, DELTA_940611_948454_DB_PROOF_PIN, MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN, databaseProofAnchorLabel, databaseProofAnchorPoints, mempoolSpaceBlockUrl, verifyProductionTrustChain, verifyOramSourceProof } from './src/index.ts';
+        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, PRODUCTION_ONION_QUERY_LAYOUT_PINS, DELTA_940611_948454_DB_PROOF_PIN, MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN, databaseProofAnchorLabel, databaseProofAnchorPoints, mempoolSpaceBlockUrl, verifyProductionTrustChain, verifyOramSourceProof } from './src/index.ts';
         // Initialize SDK WASM (optional - falls back to TS if unavailable)
         initSdkWasm().then(ok => {
             if (ok) console.log('[PIR] SDK WASM loaded');
@@ -3105,7 +3107,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     const spkHex = lines[qi];
                     const hashHex = bytesToHex(scriptHashes[qi]);
                     const r = merged[qi];
-                    if (r) found++;
+                    if (r && !r.isWhale && r.entries.length > 0) found++;
                     renderResult(resultsContainer, spkHex, hashHex, r);
 
                     // Append a "delta activity" card for each delta step that
@@ -3311,6 +3313,37 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         // OnionPIR tab logic
         // ═══════════════════════════════════════════════════════════════
         let opClient = null;
+        const opDatabaseProofs = new Map();
+
+        function opSetDataIntegrity(state, title = '') {
+            const el = document.getElementById('onionVerification');
+            if (!el) return;
+            if (state === 'yes') {
+                el.textContent = 'YES';
+                el.className = 'verification-result yes';
+            } else if (state === 'no') {
+                el.textContent = 'NO';
+                el.className = 'verification-result no';
+            } else {
+                el.textContent = state === 'checking' ? 'Checking' : 'Not checked';
+                el.className = 'verification-result pending';
+            }
+            el.title = title;
+        }
+
+        function opUpdateDataIntegritySummary() {
+            const statuses = PRODUCTION_DB_PROOF_PINS.map(pin => opDatabaseProofs.get(pin.dbId));
+            if (statuses.some(status => status && status.state !== 'verified')) {
+                opSetDataIntegrity('no', 'Database proof or trusted tree-top binding failed');
+            } else if (
+                statuses.every(status => status?.state === 'verified') &&
+                opClient?.isConnected()
+            ) {
+                opSetDataIntegrity('yes', 'Database proofs, production pins, and OnionPIR tree-tops verified');
+            } else {
+                opSetDataIntegrity('checking', 'Verifying database roots and tree-tops');
+            }
+        }
 
         // OnionPIR SyncController — owns snapshot cache + lastSyncedHeight for
         // the OnionPIR tab. setDbId is cheap for OnionPIR (just BFV params),
@@ -3422,10 +3455,18 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             const serverUrl = document.getElementById('op-serverUrl').value.trim();
             if (!serverUrl) { log('Please enter a server URL', 'error'); return; }
 
+            let candidate = null;
             try {
                 log('OnionPIR: Connecting...');
-                opClient = new OnionPirWebClient({
+                opDatabaseProofs.clear();
+                opSetDataIntegrity('checking', 'Verifying database roots and tree-tops');
+                const sdkReady = isSdkWasmReady() || await initSdkWasm();
+                if (!sdkReady) throw new Error('strict database-proof WASM failed to load');
+                candidate = new OnionPirWebClient({
                     serverUrl,
+                    strictVerification: true,
+                    databaseProofPins: PRODUCTION_DB_PROOF_PINS,
+                    onionQueryLayoutPins: PRODUCTION_ONION_QUERY_LAYOUT_PINS,
                     onConnectionStateChange: (state, message) => {
                         log(`OnionPIR: ${state}${message ? ' - ' + message : ''}`,
                             state === 'connected' ? 'success' : state === 'disconnected' ? 'error' : 'info');
@@ -3435,9 +3476,19 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                         if (state === 'connected') opSetButtons(true);
                         else if (state === 'disconnected') opSetButtons(false);
                     },
+                    onDatabaseProof: (dbId, info) => {
+                        opDatabaseProofs.set(dbId, info);
+                        renderDatabaseProofBadge('op-dbProofBadge', 'OnionPIR', info);
+                        verifyAndRenderBitcoinAnchorBadge('op-bitcoinAnchorBadge', 'OnionPIR', info)
+                            .catch(error => log(`OnionPIR anchor verification failed: ${error.message}`, 'error'));
+                        opUpdateDataIntegritySummary();
+                    },
                     onLog: (msg, level) => log(msg, level),
                 });
-                await opClient.connect();
+                await candidate.connect();
+                opClient = candidate;
+                candidate = null;
+                opUpdateDataIntegritySummary();
                 // Post-connect: just refresh the sync state UI. The Advanced
                 // DB selector and delta example buttons reveal after the
                 // first successful sync (see opExecuteSync).
@@ -3445,8 +3496,10 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 // Dev-only: expose client on window for browser console debugging.
                 window.opClient = opClient;
             } catch (error) {
+                candidate?.disconnect();
                 log(`OnionPIR connection failed: ${error.message}`, 'error');
                 opClient = null;
+                opSetDataIntegrity('no', error.message);
             }
         }
 
@@ -3593,6 +3646,18 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                             opSetProgress(pct, `${stepLabel} \u2014 ${s}: ${d}`);
                         }, step.dbId);
                     },
+                    verifyStep: async (step, stepResults) => {
+                        if (stepResults.some(result => result === null)) {
+                            throw new Error(`OnionPIR db ${step.dbId} returned an unverifiable result`);
+                        }
+                        const concrete = stepResults;
+                        const verdicts = await opClient.verifyMerkleBatch(concrete, (s, d) => {
+                            opSetProgress(92, `${describeStep(step)} — ${s}: ${d}`);
+                        });
+                        if (verdicts.length !== concrete.length || verdicts.some(ok => !ok)) {
+                            throw new Error(`OnionPIR db ${step.dbId} Merkle verification failed`);
+                        }
+                    },
                     mergeStep: (snapshot, delta) =>
                         mergeDeltaIntoSnapshot(snapshot, delta, (msg) => log(msg, 'error')),
                     onError: (msg) => log(msg, 'error'),
@@ -3605,7 +3670,8 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     const hashHex = bytesToHex(scriptHashes[qi]);
                     const r = merged[qi];
                     if (r) found++;
-                    renderResult(resultsContainer, spkHex, hashHex, r);
+                    const rendered = renderResult(resultsContainer, spkHex, hashHex, r);
+                    if (r) setResultMerkleState(rendered, 'verified');
 
                     for (let si = 0; si < verifiableSteps.length; si++) {
                         const vs = verifiableSteps[si];
@@ -3627,42 +3693,6 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 // load (see wireDeltaExampleButtons).
                 opPopulateDbSelector();
 
-                // Per-step Merkle verification buttons (OnionPIR per-bin).
-                // Steps are rendered in plan order.
-                const merkleSteps = verifiableSteps
-                    .map(({ step, stepResults }) => ({
-                        step,
-                        verifiable: stepResults.filter(r => r && !r.isWhale && r.indexBinHash !== undefined),
-                    }))
-                    .filter(({ step, verifiable }) =>
-                        verifiable.length > 0 && opClient.hasMerkleForDb(step.dbId));
-
-                if (merkleSteps.length > 0) {
-                    const note = document.createElement('div');
-                    note.style.cssText = 'margin: 12px 0; font-size: 12px; color: #666;';
-                    note.textContent = merkleSteps.length === 1
-                        ? `Merkle verification below applies to the ${merkleSteps[0].step.dbType} step of this sync.`
-                        : `Merkle verification below runs one proof batch per sync step (${merkleSteps.length} steps).`;
-                    resultsContainer.appendChild(note);
-                    for (let i = merkleSteps.length - 1; i >= 0; i--) {
-                        const { step, verifiable } = merkleSteps[i];
-                        const prefix = `op-sync-${step.dbType}-${step.dbId}`;
-                        const label = step.dbType === 'full'
-                            ? `full snapshot (db ${step.dbId}, height ${step.tipHeight.toLocaleString()})`
-                            : `delta (db ${step.dbId}, ${step.baseHeight.toLocaleString()} \u2192 ${step.tipHeight.toLocaleString()})`;
-                        // verifyMerkleBatch uses the client's active dbId; set
-                        // it for each proof batch so results line up with the
-                        // step's DB (mirrors per-step FHE key state).
-                        addBatchMerkleButton(resultsContainer, verifiable, prefix,
-                            (results, onProg) => {
-                                if (opClient.getDbId() !== step.dbId) opClient.setDbId(step.dbId);
-                                return opClient.verifyMerkleBatch(results, onProg);
-                            },
-                            () => opClient.getMerkleRootHexForDb(step.dbId),
-                            label);
-                    }
-                }
-
                 opSetProgress(100, `Sync complete! ${found}/${N} found at height ${plan.targetHeight.toLocaleString()}`);
                 setTimeout(opHideProgress, 2000);
                 log(`OnionPIR sync complete: ${found}/${N} found at height ${plan.targetHeight}`, 'success');
@@ -3670,6 +3700,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 opPendingSync = null;
             } catch (error) {
                 log(`OnionPIR sync error: ${error.message || error}`, 'error');
+                opSetDataIntegrity('no', error.message || String(error));
                 opSetProgress(0, '');
                 opHideProgress();
             } finally {
@@ -3683,6 +3714,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 document.getElementById('op-syncConfirmBtn').disabled = false;
                 document.getElementById('op-syncCancelBtn').disabled = false;
                 document.getElementById('op-resetSyncBtn').disabled = false;
+                opDisconnect(true);
             }
         }
 
@@ -3751,33 +3783,38 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     const spkHex = lines[qi];
                     const hashHex = bytesToHex(scriptHashes[qi]);
                     const result = results[qi];
-                    if (result) found++;
+                    if (result && !result.isWhale && result.entries.length > 0) found++;
                     opResultSections.push(renderResult(resultsContainer, spkHex, hashHex, result));
                     opQueryResults.push(result);
                 }
 
-                // Automatically verify after the result cards have painted.
-                const opVerifiablePairs = opQueryResults
-                    .map((result, index) => ({ result, section: opResultSections[index] }))
-                    .filter(({ result }) => result && !result.isWhale && result.indexBinHash !== undefined);
-                if (opVerifiablePairs.length > 0 && opClient.hasMerkle()) {
-                    let verificationRootHex = '';
-                    await addBatchMerkleButton(resultsContainer, opVerifiablePairs.map(pair => pair.result), 'onionpir',
-                        async (results, onProg) => {
-                            if (!opClient || !opClient.isConnected()) await opConnect();
-                            if (!opClient || !opClient.isConnected()) throw new Error('Unable to connect for verification');
-                            try {
-                                const verdicts = await opClient.verifyMerkleBatch(results, onProg);
-                                verificationRootHex = opClient.getMerkleRootHex() || '';
-                                return verdicts;
-                            } finally {
-                                opDisconnect(true);
-                            }
-                        },
-                        () => verificationRootHex,
-                        undefined,
-                        opVerifiablePairs.map(pair => pair.section),
-                        true);
+                // Verify every found, absent, and whale result in the same
+                // connection/FHE session. Only then turn the per-result state
+                // into the compact checkmark.
+                opResultSections.forEach(section => setResultMerkleState(section, 'verifying'));
+                await waitForResultPaint();
+                if (opQueryResults.some(result => result === null)) {
+                    opResultSections.forEach(section => setResultMerkleState(section, 'failed'));
+                    throw new Error('OnionPIR returned an unverifiable result');
+                }
+                try {
+                    const verdicts = await opClient.verifyMerkleBatch(opQueryResults, (step, detail) => {
+                        opSetProgress(94, `${step}: ${detail}`);
+                    });
+                    if (verdicts.length !== opQueryResults.length || verdicts.some(ok => !ok)) {
+                        opResultSections.forEach((section, index) =>
+                            setResultMerkleState(section, verdicts[index] ? 'verified' : 'failed'));
+                        throw new Error('OnionPIR Merkle verification failed');
+                    }
+                    opResultSections.forEach(section => setResultMerkleState(section, 'verified'));
+                } catch (error) {
+                    opResultSections.forEach(section => {
+                        const badge = section?.querySelector('.merkle-result-badge');
+                        if (!badge || badge.classList.contains('verifying')) {
+                            setResultMerkleState(section, 'error');
+                        }
+                    });
+                    throw error;
                 }
 
                 opSetProgress(100, `Done! ${found}/${N} addresses found`);
@@ -3785,6 +3822,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 log(`OnionPIR batch complete: ${found}/${N} found`, 'success');
             } catch (error) {
                 log(`OnionPIR error: ${error.message}`, 'error');
+                opSetDataIntegrity('no', error.message);
                 console.error(error);
                 opSetProgress(0, '');
                 opHideProgress();

--- a/web/src/__tests__/onion-strict-wire.test.ts
+++ b/web/src/__tests__/onion-strict-wire.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  assertConsistentOnionMerkleLeaves,
+  decodeBatchResult,
+  OnionPirWebClient,
+  responsePayloadFromFrame,
+} from '../onionpir_client.js';
+import { PRODUCTION_ONION_QUERY_LAYOUT_PINS } from '../attest-pin.js';
+
+function frame(payload: number[]): Uint8Array {
+  const out = new Uint8Array(4 + payload.length);
+  new DataView(out.buffer).setUint32(0, payload.length, true);
+  out.set(payload, 4);
+  return out;
+}
+
+describe('strict OnionPIR wire parsing', () => {
+  it('accepts exactly one complete length-prefixed response', () => {
+    expect([...responsePayloadFromFrame(frame([0x50, 0xaa]), 0x50)])
+      .toEqual([0x50, 0xaa]);
+  });
+
+  it('rejects payload-only, truncated, concatenated, and wrong-variant responses', () => {
+    expect(() => responsePayloadFromFrame(new Uint8Array([0x50, 0xaa])))
+      .toThrow('too short');
+    expect(() => responsePayloadFromFrame(new Uint8Array([2, 0, 0, 0, 0x50])))
+      .toThrow('length mismatch');
+    const concatenated = new Uint8Array([...frame([0x50]), ...frame([0x50])]);
+    expect(() => responsePayloadFromFrame(concatenated)).toThrow('length mismatch');
+    expect(() => responsePayloadFromFrame(frame([0x51]), 0x50))
+      .toThrow('Unexpected response variant');
+  });
+
+  it('binds batch results to the requested round/count and rejects trailing bytes', () => {
+    const payload = new Uint8Array([
+      0x51,
+      7, 0,
+      1,
+      2, 0, 0, 0,
+      0xaa, 0xbb,
+    ]);
+    expect([...decodeBatchResult(payload, 1, 7, 1).results[0]])
+      .toEqual([0xaa, 0xbb]);
+    expect(() => decodeBatchResult(payload, 1, 8, 1)).toThrow('round mismatch');
+    expect(() => decodeBatchResult(payload, 1, 7, 2)).toThrow('group count mismatch');
+    expect(() => decodeBatchResult(new Uint8Array([...payload, 0]), 1, 7, 1))
+      .toThrow('trailing bytes');
+    expect(() => decodeBatchResult(payload.slice(0, -1), 1, 7, 1))
+      .toThrow('truncated');
+  });
+});
+
+describe('strict OnionPIR duplicate Merkle coordinates', () => {
+  const a = new Uint8Array(32).fill(1);
+  const b = new Uint8Array(32).fill(2);
+
+  it('allows identical duplicates and keeps INDEX/DATA namespaces distinct', () => {
+    expect(() => assertConsistentOnionMerkleLeaves([
+      { tree: 'index', pbcGroup: 3, bin: 9, hash: a },
+      { tree: 'index', pbcGroup: 3, bin: 9, hash: a.slice() },
+      { tree: 'data', pbcGroup: 3, bin: 9, hash: b },
+    ])).not.toThrow();
+  });
+
+  it('rejects conflicting duplicates in either input order', () => {
+    const first = { tree: 'index' as const, pbcGroup: 3, bin: 9, hash: a };
+    const second = { tree: 'index' as const, pbcGroup: 3, bin: 9, hash: b };
+    expect(() => assertConsistentOnionMerkleLeaves([first, second]))
+      .toThrow('conflicting hashes');
+    expect(() => assertConsistentOnionMerkleLeaves([second, first]))
+      .toThrow('conflicting hashes');
+  });
+});
+
+describe('strict OnionPIR session lifecycle', () => {
+  it('rejects a query before any network traffic when no root is installed', async () => {
+    const sendRaw = vi.fn();
+    const client = new OnionPirWebClient({
+      serverUrl: 'wss://example.invalid',
+      strictVerification: true,
+    });
+    const internal = client as any;
+    internal.ws = { isOpen: () => true, sendRaw };
+    internal.strictReady = true;
+    internal.wasmModule = {};
+
+    await expect(client.queryBatch([new Uint8Array(32)]))
+      .rejects.toThrow('proof/layout/tree-tops are not ready');
+    expect(sendRaw).not.toHaveBeenCalled();
+  });
+
+  it('consumes the proof handle and clears the installed root on disconnect', () => {
+    const free = vi.fn();
+    const client = new OnionPirWebClient({
+      serverUrl: 'wss://example.invalid',
+      strictVerification: true,
+      onionQueryLayoutPins: PRODUCTION_ONION_QUERY_LAYOUT_PINS,
+    });
+    const internal = client as any;
+    internal.sessionGeneration = 7;
+    internal.catalog = {
+      databases: [{ dbId: 0, baseHeight: 0, height: 948_454 }],
+    };
+
+    client.installVerifiedDatabaseProof({
+      dbId: 0,
+      buildKind: 'snapshot',
+      fromHeight: 0,
+      height: 948_454,
+      onionSuperRootHex: 'ab'.repeat(32),
+      onionEntrySize: 3_328,
+      free,
+    } as any);
+
+    expect(free).toHaveBeenCalledOnce();
+    expect(client.getMerkleRootHexForDb(0)).toBe('ab'.repeat(32));
+    client.disconnect();
+    expect(client.getMerkleRootHexForDb(0)).toBeUndefined();
+  });
+});

--- a/web/src/__tests__/strict-verification.test.ts
+++ b/web/src/__tests__/strict-verification.test.ts
@@ -45,6 +45,7 @@ function proofHandle(pin: DatabaseProofPin, overrides: Partial<WasmDatabaseProof
     networkMagicHex: pin.networkMagicHex,
     builderBinarySha256Hex: pin.builderBinarySha256Hex,
     builderGitCommit: pin.builderGitCommit,
+    onionEntrySize: pin.onionEntrySize ?? 3_328,
     toJson: () => ({}),
     free: freeMock,
     freeMock,

--- a/web/src/__tests__/sync-controller.test.ts
+++ b/web/src/__tests__/sync-controller.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SyncController } from '../sync-controller.js';
+import type { SyncPlan } from '../sync.js';
+
+interface TestResult {
+  value: string;
+  rawChunkData?: Uint8Array;
+}
+
+function memoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() { return values.size; },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => { values.delete(key); },
+    setItem: (key, value) => { values.set(key, value); },
+  };
+}
+
+const scriptHash = new Uint8Array(32).fill(7);
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('SyncController verification barrier', () => {
+  it('verifies each step before merging it', async () => {
+    vi.stubGlobal('localStorage', memoryStorage());
+    const controller = new SyncController<TestResult>({ storageKey: () => 'sync-height' });
+    const trace: string[] = [];
+    const plan: SyncPlan = {
+      isFreshSync: true,
+      targetHeight: 110,
+      steps: [
+        { dbId: 0, dbType: 'full', name: 'snapshot', baseHeight: 0, tipHeight: 100 },
+        { dbId: 1, dbType: 'delta', name: 'delta', baseHeight: 100, tipHeight: 110 },
+      ],
+    };
+
+    await controller.execute(plan, {
+      scriptHashes: [scriptHash],
+      queryStep: async (_step, index) => {
+        trace.push(`query:${index}`);
+        return [{ value: index === 0 ? 'snapshot' : 'delta' }];
+      },
+      verifyStep: async (_step, _results, index) => {
+        trace.push(`verify:${index}`);
+      },
+      mergeStep: (snapshot, delta) => {
+        trace.push('merge:1');
+        return { value: `${snapshot?.value}+${delta?.value}` };
+      },
+    });
+
+    expect(trace).toEqual(['query:0', 'verify:0', 'query:1', 'verify:1', 'merge:1']);
+    expect(controller.getSnapshot(scriptHash)?.value).toBe('snapshot+delta');
+    expect(controller.loadLastSyncedHeight()).toBe(110);
+  });
+
+  it('leaves the prior cache and height untouched when verification fails', async () => {
+    vi.stubGlobal('localStorage', memoryStorage());
+    const controller = new SyncController<TestResult>({ storageKey: () => 'sync-height' });
+    const initial: SyncPlan = {
+      isFreshSync: true,
+      targetHeight: 100,
+      steps: [
+        { dbId: 0, dbType: 'full', name: 'snapshot', baseHeight: 0, tipHeight: 100 },
+      ],
+    };
+    await controller.execute(initial, {
+      scriptHashes: [scriptHash],
+      queryStep: async () => [{ value: 'trusted snapshot' }],
+      verifyStep: async () => {},
+      mergeStep: (_snapshot, next) => next,
+    });
+
+    const mergeStep = vi.fn((snapshot: TestResult | null) => snapshot);
+    const failing: SyncPlan = {
+      isFreshSync: false,
+      targetHeight: 110,
+      steps: [
+        { dbId: 1, dbType: 'delta', name: 'delta', baseHeight: 100, tipHeight: 110 },
+      ],
+    };
+
+    await expect(controller.execute(failing, {
+      scriptHashes: [scriptHash],
+      queryStep: async () => [{ value: 'unverified delta' }],
+      verifyStep: async () => { throw new Error('Merkle proof rejected'); },
+      mergeStep,
+    })).rejects.toThrow('Merkle proof rejected');
+
+    expect(mergeStep).not.toHaveBeenCalled();
+    expect(controller.getSnapshot(scriptHash)?.value).toBe('trusted snapshot');
+    expect(controller.loadLastSyncedHeight()).toBe(100);
+  });
+
+  it('rejects a partial result vector before verification or commit', async () => {
+    vi.stubGlobal('localStorage', memoryStorage());
+    const controller = new SyncController<TestResult>({ storageKey: () => 'sync-height' });
+    const verifyStep = vi.fn(async () => {});
+    const plan: SyncPlan = {
+      isFreshSync: true,
+      targetHeight: 100,
+      steps: [
+        { dbId: 0, dbType: 'full', name: 'snapshot', baseHeight: 0, tipHeight: 100 },
+      ],
+    };
+
+    await expect(controller.execute(plan, {
+      scriptHashes: [scriptHash, new Uint8Array(32).fill(8)],
+      queryStep: async () => [{ value: 'only one result' }],
+      verifyStep,
+      mergeStep: (_snapshot, next) => next,
+    })).rejects.toThrow('returned 1 results; expected 2');
+
+    expect(verifyStep).not.toHaveBeenCalled();
+    expect(controller.loadLastSyncedHeight()).toBe(0);
+    expect(controller.getSnapshot(scriptHash)).toBeUndefined();
+  });
+});

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -239,6 +239,77 @@ export const PRODUCTION_DB_PROOF_PINS: DatabaseProofPin[] = [
 ];
 
 /**
+ * Query-layout values needed by the standalone OnionPIR client.
+ *
+ * The v1 database proof authenticates the Onion super-root and the packed
+ * plaintext entry size, but its `index_bins_per_table` /
+ * `chunk_bins_per_table` fields describe the shared DPF tables rather than
+ * the separately packed OnionPIR tables.  Until a v2 proof commits the full
+ * Onion layout, production must pin this remaining query shape explicitly.
+ * A server-info response is only accepted when every field below matches.
+ */
+export interface OnionQueryLayoutPin {
+  dbId: number;
+  totalPackedEntries: number;
+  indexBinsPerTable: number;
+  chunkBinsPerTable: number;
+  indexK: number;
+  chunkK: number;
+  tagSeedHex: string;
+  indexMasterSeedHex: string;
+  chunkMasterSeedHex: string;
+  indexSlotsPerBin: number;
+  indexSlotSize: number;
+  onionEntrySize: number;
+  merkleArity: number;
+  merkleIndexK: number;
+  merkleDataK: number;
+  merkleIndexNumPt: number;
+  merkleDataNumPt: number;
+}
+
+export const PRODUCTION_ONION_QUERY_LAYOUT_PINS: OnionQueryLayoutPin[] = [
+  {
+    dbId: 0,
+    totalPackedEntries: 948_640,
+    indexBinsPerTable: 10_273,
+    chunkBinsPerTable: 37_954,
+    indexK: 75,
+    chunkK: 80,
+    tagSeedHex: 'f0b13554de8352f6',
+    indexMasterSeedHex: 'c97f21d6d9364b72',
+    chunkMasterSeedHex: '367867dd7bc05649',
+    indexSlotsPerBin: 221,
+    indexSlotSize: 15,
+    onionEntrySize: 3_328,
+    merkleArity: 104,
+    merkleIndexK: 75,
+    merkleDataK: 80,
+    merkleIndexNumPt: 99,
+    merkleDataNumPt: 365,
+  },
+  {
+    dbId: 1,
+    totalPackedEntries: 116_030,
+    indexBinsPerTable: 965,
+    chunkBinsPerTable: 4_792,
+    indexK: 75,
+    chunkK: 80,
+    tagSeedHex: 'ffa0120f182d4a0d',
+    indexMasterSeedHex: '1c353b0854eab60f',
+    chunkMasterSeedHex: '1545e02440952c73',
+    indexSlotsPerBin: 221,
+    indexSlotSize: 15,
+    onionEntrySize: 3_328,
+    merkleArity: 104,
+    merkleIndexK: 75,
+    merkleDataK: 80,
+    merkleIndexNumPt: 10,
+    merkleDataNumPt: 47,
+  },
+];
+
+/**
  * Operator identity pin (Tier-1) for the REQ_ANNOUNCE operator-signed
  * identity flow.
  *

--- a/web/src/db-proof.ts
+++ b/web/src/db-proof.ts
@@ -14,6 +14,7 @@ export interface VerifiedDatabaseProof {
   networkMagicHex: string;
   builderBinarySha256Hex: string;
   builderGitCommit: string;
+  onionEntrySize?: number;
 }
 
 export interface DatabaseProofPin {
@@ -30,6 +31,9 @@ export interface DatabaseProofPin {
   networkMagicHex: string;
   builderBinarySha256Hex: string;
   builderGitCommit: string;
+  /** Present in current attested-builder evidence; optional for older/static
+   * manifest-derived pins that predate this field. */
+  onionEntrySize?: number;
   description?: string;
 }
 
@@ -63,6 +67,7 @@ export function verifiedDatabaseProofFromWasm(proof: WasmDatabaseProof): Verifie
     networkMagicHex: proof.networkMagicHex,
     builderBinarySha256Hex: proof.builderBinarySha256Hex,
     builderGitCommit: proof.builderGitCommit,
+    onionEntrySize: proof.onionEntrySize,
   };
 }
 
@@ -98,6 +103,7 @@ export function verifyDatabaseProofAgainstPin(
   cmp('networkMagicHex', true);
   cmp('builderBinarySha256Hex', true);
   cmp('builderGitCommit');
+  if (pin.onionEntrySize !== undefined) cmp('onionEntrySize');
 
   return {
     state: mismatches.length === 0 ? 'verified' : 'unverified',

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -130,6 +130,8 @@ export {
   PIR1_PIN,
   PIR2_TIER3_PIN,
   PRODUCTION_DB_PROOF_PINS,
+  PRODUCTION_ONION_QUERY_LAYOUT_PINS,
+  type OnionQueryLayoutPin,
   type ServerAttestPin,
 } from './attest-pin.js';
 

--- a/web/src/onionpir_client.ts
+++ b/web/src/onionpir_client.ts
@@ -28,10 +28,20 @@ import { unpackOnionPlaintext } from './onion-unpack.js';
 import { findEntryInOnionPirIndexResult } from './scan.js';
 import { ManagedWebSocket } from './ws.js';
 import { fetchServerInfoJson } from './server-info.js';
-import { requireSdkWasm, type WasmAnnounceVerification } from './sdk-bridge.js';
+import {
+  requireSdkWasm,
+  type WasmAnnounceVerification,
+  type WasmDatabaseProof,
+} from './sdk-bridge.js';
 import { computeParentN, ZERO_HASH } from './merkle.js';
+import {
+  assertStrictDatabasePinCoverage,
+  verifyInstallAndPreflightDatabaseProofs,
+} from './strict-verification.js';
 
 import type { UtxoEntry, QueryResult, ConnectionState } from './types.js';
+import type { DatabaseProofPin, DatabaseProofStatus } from './db-proof.js';
+import type { OnionQueryLayoutPin } from './attest-pin.js';
 import type {
   DatabaseCatalog,
   OnionPirMerkleInfoJson,
@@ -66,6 +76,7 @@ const MASK64 = 0xFFFFFFFFFFFFFFFFn;
 
 // Operator-signed identity (shared across all backends; 0x07).
 const REQ_ANNOUNCE              = 0x07;
+const REQ_GET_DB_PROOF          = 0x0A;
 
 // NOTE: moved from 0x30-0x32 to 0x50-0x52 to avoid collision with
 // REQ_MERKLE_SIBLING_BATCH (0x31) and REQ_MERKLE_TREE_TOP (0x32).
@@ -163,7 +174,10 @@ async function loadWasmModule(): Promise<OnionPirModule> {
         // time. The browser fetches it from /wasm/onionpir_client.mjs
         // (Vite serves the public/ tree verbatim); node tests install
         // a factory via `globalThis.__onionpirWasmFactory`.
-        const wasmModuleUrl = '/wasm/onionpir_client.mjs';
+        // A fully-resolved URL keeps Vite's dev server from treating this
+        // public asset as source (`/wasm/...?...import`), while production
+        // browsers still import the exact same static module.
+        const wasmModuleUrl = new URL('/wasm/onionpir_client.mjs', globalThis.location.href).href;
         const mod = await import(/* @vite-ignore */ /* webpackIgnore: true */ wasmModuleUrl);
         factory = (mod as { default: OnionPirFactory }).default;
       }
@@ -354,15 +368,66 @@ function encodeBatchQuery(variant: number, roundId: number, queries: Uint8Array[
   return msg;
 }
 
-function decodeBatchResult(data: Uint8Array, pos: number): { roundId: number; results: Uint8Array[]; pos: number } {
-  const dv = new DataView(data.buffer, data.byteOffset);
+/** Validate one exact length-prefixed response record and return its payload. */
+export function responsePayloadFromFrame(frame: Uint8Array, expectedVariant?: number): Uint8Array {
+  if (frame.length < 5) {
+    throw new Error(`Response frame too short: ${frame.length} bytes`);
+  }
+  const declared = new DataView(frame.buffer, frame.byteOffset, frame.byteLength)
+    .getUint32(0, true);
+  if (declared !== frame.length - 4) {
+    throw new Error(
+      `Response frame length mismatch: declared ${declared}, got ${frame.length - 4}`,
+    );
+  }
+  const payload = frame.slice(4);
+  if (expectedVariant !== undefined && payload[0] !== expectedVariant) {
+    throw new Error(
+      `Unexpected response variant: expected 0x${expectedVariant.toString(16)}, ` +
+      `got 0x${(payload[0] ?? 0).toString(16)}`,
+    );
+  }
+  return payload;
+}
+
+export function decodeBatchResult(
+  data: Uint8Array,
+  pos: number,
+  expectedRoundId: number,
+  expectedGroups: number,
+): { roundId: number; results: Uint8Array[]; pos: number } {
+  if (pos < 0 || pos + 3 > data.length) {
+    throw new Error('OnionPIR batch response header truncated');
+  }
+  const dv = new DataView(data.buffer, data.byteOffset, data.byteLength);
   const roundId = dv.getUint16(pos, true); pos += 2;
   const numGroups = data[pos++];
+  if (roundId !== expectedRoundId) {
+    throw new Error(
+      `OnionPIR batch response round mismatch: expected ${expectedRoundId}, got ${roundId}`,
+    );
+  }
+  if (numGroups !== expectedGroups) {
+    throw new Error(
+      `OnionPIR batch response group count mismatch: expected ${expectedGroups}, got ${numGroups}`,
+    );
+  }
   const results: Uint8Array[] = [];
   for (let i = 0; i < numGroups; i++) {
+    if (pos + 4 > data.length) {
+      throw new Error(`OnionPIR batch response truncated before group ${i} length`);
+    }
     const len = dv.getUint32(pos, true); pos += 4;
+    if (pos + len > data.length) {
+      throw new Error(
+        `OnionPIR batch response group ${i} truncated: claimed ${len}, have ${data.length - pos}`,
+      );
+    }
     results.push(data.slice(pos, pos + len));
     pos += len;
+  }
+  if (pos !== data.length) {
+    throw new Error(`OnionPIR batch response has ${data.length - pos} trailing bytes`);
   }
   return { roundId, results, pos };
 }
@@ -380,11 +445,12 @@ function decodeBatchResult(data: Uint8Array, pos: number): { roundId: number; re
 // `planRounds`-over-gids sibling machinery they needed, are gone.
 //
 // The 155 per-group roots ride in the *untrusted*, server-supplied tree-top
-// blob; `super_root` (from the trusted server-info JSON) is the pinned
-// anchor. `checkTreeTopAnchor` binds the blob to that anchor — this is the
-// load-bearing check. Skip or weaken it and a malicious server can
-// fabricate a self-consistent blob + sibling responses, and every leaf
-// "verifies" against forged roots.
+// blob. In strict mode the pinned anchor is the installed database-proof
+// `onion_super_root`; `server-info.super_root` is diagnostic only. The
+// advisory compatibility path still uses the advertised value.
+// `checkTreeTopAnchor` is the load-bearing binding check. Skip or weaken it
+// and a malicious server can fabricate a self-consistent blob + sibling
+// responses, and every leaf "verifies" against forged roots.
 
 /**
  * One parsed per-group Merkle tree-top. `levels[0]` is the first cached
@@ -411,6 +477,31 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
     if (a[i] !== b[i]) return false;
   }
   return true;
+}
+
+export interface OnionMerkleLeafCoordinate {
+  tree: 'index' | 'data';
+  pbcGroup: number;
+  bin: number;
+  hash: Uint8Array;
+}
+
+/**
+ * Reject ambiguous Merkle batches before any proof request is sent. Duplicate
+ * consumers may share one coordinate only when they commit to the same hash.
+ */
+export function assertConsistentOnionMerkleLeaves(
+  leaves: readonly OnionMerkleLeafCoordinate[],
+): void {
+  const coordinateHashes = new Map<string, Uint8Array>();
+  for (const leaf of leaves) {
+    const key = `${leaf.tree}:${leaf.pbcGroup}:${leaf.bin}`;
+    const previous = coordinateHashes.get(key);
+    if (previous && !bytesEqual(previous, leaf.hash)) {
+      throw new Error(`OnionPIR conflicting hashes for Merkle leaf ${key}`);
+    }
+    if (!previous) coordinateHashes.set(key, leaf.hash);
+  }
 }
 
 /**
@@ -474,6 +565,9 @@ function parseOnionTreeTopCache(data: Uint8Array): OnionTreeTopCache[] {
       levels.push(nodes);
     }
     out.push({ cacheFromLevel, arity, levels });
+  }
+  if (off !== data.length) {
+    throw new Error(`onionpir tree-tops blob has ${data.length - off} trailing bytes`);
   }
   return out;
 }
@@ -603,8 +697,30 @@ function walkTreeTopToRoot(
 
 export interface OnionPirClientConfig {
   serverUrl: string;
+  /** Production enables this fail-closed proof/root gate. */
+  strictVerification?: boolean;
+  databaseProofPins?: readonly DatabaseProofPin[];
+  onionQueryLayoutPins?: readonly OnionQueryLayoutPin[];
+  onDatabaseProof?: (dbId: number, status: DatabaseProofStatus) => void;
   onConnectionStateChange?: (state: ConnectionState, message?: string) => void;
   onLog?: (message: string, level: 'info' | 'success' | 'error') => void;
+}
+
+interface InstalledOnionRoot {
+  dbId: number;
+  buildKind: string;
+  fromHeight: number;
+  height: number;
+  onionSuperRootHex: string;
+  onionEntrySize: number;
+  generation: number;
+}
+
+interface VerifiedTreeTopBinding {
+  dbId: number;
+  rootHex: string;
+  generation: number;
+  allTops: OnionTreeTopCache[];
 }
 
 // ─── CHUNK Round-Presence Symmetry: per-slot classifier ───────────────────
@@ -778,6 +894,15 @@ export class OnionPirWebClient {
   // Database catalog (populated after connect). Used by the UI selector.
   private catalog: DatabaseCatalog | null = null;
 
+  // Strict, session-local trust state. None of these values survives a
+  // disconnect or socket replacement.
+  private strictReady = false;
+  private sessionGeneration = 0;
+  private installedOnionRoots = new Map<number, InstalledOnionRoot>();
+  private verifiedTreeTops = new Map<number, VerifiedTreeTopBinding>();
+  private databaseProofStatuses = new Map<number, DatabaseProofStatus>();
+  private verifiedLayoutDbIds = new Set<number>();
+
   // Test hook: one-shot override of the computed scripthashes for the next
   // queryBatch() call. Consumed on use and then cleared. Used by harnesses
   // that need to drive a query at a specific scripthash without reversing
@@ -802,6 +927,127 @@ export class OnionPirWebClient {
 
   constructor(config: OnionPirClientConfig) {
     this.config = config;
+  }
+
+  private isStrictVerification(): boolean {
+    return this.config.strictVerification === true;
+  }
+
+  private clearSessionTrust(): void {
+    this.strictReady = false;
+    this.installedOnionRoots.clear();
+    this.verifiedTreeTops.clear();
+    this.databaseProofStatuses.clear();
+    this.verifiedLayoutDbIds.clear();
+    this.registeredDbs.clear();
+    this.fheClientId = 0;
+    this.fheSecretKey = null;
+  }
+
+  private layoutPinForDb(dbId: number): OnionQueryLayoutPin | undefined {
+    return this.config.onionQueryLayoutPins?.find((pin) => pin.dbId === dbId);
+  }
+
+  private validateStrictLayoutPins(): void {
+    const catalog = this.catalog;
+    const serverInfo = this.serverInfo;
+    const pins = this.config.onionQueryLayoutPins ?? [];
+    if (!catalog || !serverInfo) {
+      throw new Error('strict OnionPIR layout validation requires server info and catalog');
+    }
+    if (pins.length === 0) {
+      throw new Error('strict OnionPIR requires pinned query layouts');
+    }
+
+    const catalogIds = catalog.databases.map((db) => db.dbId);
+    const pinIds = pins.map((pin) => pin.dbId);
+    const duplicates = pinIds.filter((id, i) => pinIds.indexOf(id) !== i);
+    const missing = catalogIds.filter((id) => !pinIds.includes(id));
+    const unexpected = pinIds.filter((id) => !catalogIds.includes(id));
+    if (duplicates.length || missing.length || unexpected.length) {
+      throw new Error(
+        `strict OnionPIR layout pin coverage failed: duplicates=${[...new Set(duplicates)]}; ` +
+        `missing=${missing}; unexpected=${unexpected}`,
+      );
+    }
+
+    const failures: string[] = [];
+    const check = (dbId: number, field: string, actual: unknown, expected: unknown) => {
+      if (actual !== expected) {
+        failures.push(`db ${dbId} ${field}: expected ${String(expected)}, got ${String(actual)}`);
+      }
+    };
+    const hex64 = (value: bigint) => value.toString(16).padStart(16, '0').toLowerCase();
+
+    for (const pin of pins) {
+      const db = catalog.databases.find((entry) => entry.dbId === pin.dbId);
+      const advertised = this.getOnionPirForDb(pin.dbId);
+      const merkle = this.getOnionPirMerkleForDb(pin.dbId);
+      if (!db || !advertised || !merkle) {
+        failures.push(`db ${pin.dbId}: OnionPIR layout or Merkle metadata unavailable`);
+        continue;
+      }
+
+      check(pin.dbId, 'catalog.index_k', db.indexK, pin.indexK);
+      check(pin.dbId, 'catalog.chunk_k', db.chunkK, pin.chunkK);
+      check(pin.dbId, 'catalog.tag_seed', hex64(db.tagSeed), pin.tagSeedHex);
+      check(pin.dbId, 'catalog.index_master_seed', hex64(db.indexMasterSeed), pin.indexMasterSeedHex);
+      check(pin.dbId, 'catalog.chunk_master_seed', hex64(db.chunkMasterSeed), pin.chunkMasterSeedHex);
+
+      check(pin.dbId, 'onion.total_packed_entries', advertised.total_packed_entries, pin.totalPackedEntries);
+      check(pin.dbId, 'onion.index_bins_per_table', advertised.index_bins_per_table, pin.indexBinsPerTable);
+      check(pin.dbId, 'onion.chunk_bins_per_table', advertised.chunk_bins_per_table, pin.chunkBinsPerTable);
+      check(pin.dbId, 'onion.index_k', advertised.index_k, pin.indexK);
+      check(pin.dbId, 'onion.chunk_k', advertised.chunk_k, pin.chunkK);
+      check(pin.dbId, 'onion.tag_seed', hex64(advertised.tag_seed), pin.tagSeedHex);
+      check(pin.dbId, 'onion.index_slots_per_bin', advertised.index_slots_per_bin, pin.indexSlotsPerBin);
+      check(pin.dbId, 'onion.index_slot_size', advertised.index_slot_size, pin.indexSlotSize);
+
+      check(pin.dbId, 'merkle.arity', merkle.arity, pin.merkleArity);
+      check(pin.dbId, 'merkle.index.k', merkle.index.k, pin.merkleIndexK);
+      check(pin.dbId, 'merkle.data.k', merkle.data.k, pin.merkleDataK);
+      check(pin.dbId, 'merkle.index.num_pt', merkle.index.num_pt, pin.merkleIndexNumPt);
+      check(pin.dbId, 'merkle.data.num_pt', merkle.data.num_pt, pin.merkleDataNumPt);
+
+      const indexEntrySize = this.wasmModule!.paramsInfo(pin.indexBinsPerTable).entrySize;
+      const chunkEntrySize = this.wasmModule!.paramsInfo(pin.chunkBinsPerTable).entrySize;
+      check(pin.dbId, 'local index entry_size', indexEntrySize, pin.onionEntrySize);
+      check(pin.dbId, 'local chunk entry_size', chunkEntrySize, pin.onionEntrySize);
+      check(pin.dbId, 'merkle sibling entry_size', pin.merkleArity * 32, pin.onionEntrySize);
+    }
+    if (failures.length > 0) {
+      throw new Error(`strict OnionPIR query-layout mismatch: ${failures.join('; ')}`);
+    }
+  }
+
+  private catalogToSdkHandle(): any {
+    if (!this.catalog) throw new Error('Database catalog unavailable');
+    const json = {
+      databases: this.catalog.databases.map((db) => ({
+        dbId: db.dbId,
+        dbType: db.dbType,
+        name: db.name,
+        baseHeight: db.baseHeight,
+        height: db.height,
+        indexBins: db.indexBinsPerTable,
+        chunkBins: db.chunkBinsPerTable,
+        indexK: db.indexK,
+        chunkK: db.chunkK,
+        tagSeed: `0x${db.tagSeed.toString(16)}`,
+        dpfNIndex: db.dpfNIndex,
+        dpfNChunk: db.dpfNChunk,
+        hasBucketMerkle: db.hasBucketMerkle,
+        indexMasterSeed: `0x${db.indexMasterSeed.toString(16)}`,
+        chunkMasterSeed: `0x${db.chunkMasterSeed.toString(16)}`,
+        anchorKind: db.anchorKind,
+        anchorHex: db.anchorHex,
+      })),
+    };
+    return requireSdkWasm().WasmDatabaseCatalog.fromJson(json);
+  }
+
+  getDatabaseProofStatus(dbId: number): DatabaseProofStatus | undefined {
+    return this.databaseProofStatuses.get(dbId);
   }
 
   /**
@@ -858,6 +1104,21 @@ export class OnionPirWebClient {
    * the active DB does not expose its own `onionpir` block.
    */
   private updateParamsForActiveDb(): void {
+    if (this.isStrictVerification() && this.verifiedLayoutDbIds.has(this.dbId)) {
+      const pin = this.layoutPinForDb(this.dbId);
+      if (!pin) throw new Error(`strict OnionPIR layout pin missing for dbId=${this.dbId}`);
+      this.indexK = pin.indexK;
+      this.chunkK = pin.chunkK;
+      this.indexBins = pin.indexBinsPerTable;
+      this.chunkBins = pin.chunkBinsPerTable;
+      this.tagSeed = BigInt(`0x${pin.tagSeedHex}`);
+      this.indexMasterSeed = BigInt(`0x${pin.indexMasterSeedHex}`);
+      this.chunkMasterSeed = BigInt(`0x${pin.chunkMasterSeedHex}`);
+      this.totalPacked = pin.totalPackedEntries;
+      this.indexSlotsPerBin = pin.indexSlotsPerBin;
+      this.indexSlotSize = pin.indexSlotSize;
+      return;
+    }
     const opi = this.getOnionPirForDb(this.dbId) ?? this.serverInfo?.onionpir;
     if (!opi) return;
     this.indexK = opi.index_k;
@@ -885,6 +1146,16 @@ export class OnionPirWebClient {
    */
   hasMerkleForDb(dbId: number): boolean {
     const info = this.getOnionPirMerkleForDb(dbId);
+    if (this.isStrictVerification()) {
+      const installed = this.installedOnionRoots.get(dbId);
+      const binding = this.verifiedTreeTops.get(dbId);
+      return !!(
+        info && installed && binding &&
+        installed.generation === this.sessionGeneration &&
+        binding.generation === this.sessionGeneration &&
+        binding.rootHex === installed.onionSuperRootHex
+      );
+    }
     return !!(
       info &&
       info.arity > 0 &&
@@ -896,6 +1167,12 @@ export class OnionPirWebClient {
 
   /** Merkle super-root hex for a specific DB (the pinned trust anchor). */
   getMerkleRootHexForDb(dbId: number): string | undefined {
+    if (this.isStrictVerification()) {
+      const installed = this.installedOnionRoots.get(dbId);
+      return installed?.generation === this.sessionGeneration
+        ? installed.onionSuperRootHex
+        : undefined;
+    }
     const info = this.getOnionPirMerkleForDb(dbId);
     return info && info.super_root ? info.super_root : undefined;
   }
@@ -911,42 +1188,108 @@ export class OnionPirWebClient {
   }
 
   getConnectionState(): ConnectionState { return this.connectionState; }
-  isConnected(): boolean { return this.ws?.isOpen() ?? false; }
+  isConnected(): boolean {
+    const open = this.ws?.isOpen() ?? false;
+    return this.isStrictVerification() ? open && this.strictReady : open;
+  }
 
   // ─── Connection (delegates to shared ws.ts) ───────────────────────────
 
   async connect(): Promise<void> {
+    if (this.ws) this.disconnect();
+    this.sessionGeneration++;
+    const generation = this.sessionGeneration;
+    this.clearSessionTrust();
+    this.catalog = null;
+    this.serverInfo = null;
     this.setState('connecting', 'Loading WASM + connecting...');
 
     // Load WASM module (cached after first load)
     this.wasmModule = await loadWasmModule();
     this.log('WASM module loaded');
 
-    // Connect WebSocket
-    this.ws = new ManagedWebSocket({
+    // Keep the socket identity stable throughout bootstrap. A late close from
+    // an older connection must never clear a replacement session.
+    let socket: ManagedWebSocket;
+    socket = new ManagedWebSocket({
       url: this.config.serverUrl,
       label: 'onionpir',
       onLog: (msg, level) => this.log(msg, level),
       onClose: () => {
+        if (this.ws !== socket) return;
         this.ws = null;
+        this.sessionGeneration++;
+        this.clearSessionTrust();
+        this.catalog = null;
+        this.serverInfo = null;
         this.setState('disconnected');
       },
     });
-    await this.ws.connect();
+    this.ws = socket;
 
-    this.setState('connected', 'Connected');
-    this.log('Connected to server', 'success');
+    try {
+      await socket.connect();
+      if (this.ws !== socket || this.sessionGeneration !== generation) {
+        throw new Error('stale OnionPIR connection bootstrap');
+      }
 
-    // Fetch server info
-    await this.fetchServerInfo();
+      await this.fetchServerInfo();
+      if (this.ws !== socket || this.sessionGeneration !== generation) {
+        throw new Error('stale OnionPIR catalog bootstrap');
+      }
+
+      if (this.isStrictVerification()) {
+        const catalog = this.getCatalog();
+        if (!catalog) throw new Error('strict OnionPIR requires a database catalog');
+        const proofPins = this.config.databaseProofPins ?? [];
+        assertStrictDatabasePinCoverage(
+          catalog.databases.map((db) => db.dbId),
+          proofPins,
+        );
+        this.validateStrictLayoutPins();
+        await verifyInstallAndPreflightDatabaseProofs({
+          client: this,
+          pins: proofPins,
+          onStatus: (dbId, status) => {
+            if (this.sessionGeneration !== generation || this.ws !== socket) return;
+            this.databaseProofStatuses.set(dbId, status);
+            this.config.onDatabaseProof?.(dbId, status);
+          },
+        });
+        if (this.ws !== socket || this.sessionGeneration !== generation) {
+          throw new Error('stale OnionPIR proof bootstrap');
+        }
+        this.strictReady = true;
+        this.updateParamsForActiveDb();
+      }
+
+      this.setState('connected', 'Connected');
+      this.log('Connected to server', 'success');
+    } catch (error) {
+      // Only the bootstrap that still owns the active socket may tear down
+      // session trust. A stale, concurrently replaced bootstrap must not
+      // clear roots or state belonging to its successor.
+      if (this.ws === socket && this.sessionGeneration === generation) {
+        this.ws = null;
+        this.sessionGeneration++;
+        this.clearSessionTrust();
+        this.catalog = null;
+        this.serverInfo = null;
+        this.setState('disconnected', 'Connection failed');
+      }
+      socket.disconnect();
+      throw error;
+    }
   }
 
   disconnect(): void {
-    this.ws?.disconnect();
+    const socket = this.ws;
     this.ws = null;
-    // Reset per-connection FHE registration state — keys live only for the
-    // server connection, so a new connection requires re-registration.
-    this.registeredDbs.clear();
+    this.sessionGeneration++;
+    this.clearSessionTrust();
+    this.catalog = null;
+    this.serverInfo = null;
+    socket?.disconnect();
     this.setState('disconnected', 'Disconnected');
   }
 
@@ -981,11 +1324,124 @@ export class OnionPirWebClient {
     const msg = new Uint8Array(5);
     new DataView(msg.buffer).setUint32(0, 1, true);
     msg[4] = REQ_ANNOUNCE;
-    // sendRaw resolves with the response payload (variant byte first,
-    // outer length already stripped) — exactly the shape
-    // verifyAnnounceResponse expects.
     const resp = await this.sendRaw(msg);
-    return requireSdkWasm().verifyAnnounceResponse(resp);
+    return requireSdkWasm().verifyAnnounceResponse(
+      responsePayloadFromFrame(resp),
+    );
+  }
+
+  /** Fetch and verify one DB proof. This method is deliberately stateless. */
+  async verifyDatabaseProof(
+    dbId: number,
+    expectedParamsHashHex?: string | null,
+    allowedBuilderBinarySha256Hex?: string | null,
+    allowedBuilderGitCommit?: string | null,
+  ): Promise<WasmDatabaseProof> {
+    if (!this.ws?.isOpen()) throw new Error('Not connected');
+    const request = new Uint8Array([2, 0, 0, 0, REQ_GET_DB_PROOF, dbId & 0xff]);
+    const response = await this.sendRaw(request);
+    this.recordRound({
+      kind: 'info',
+      server_id: 0,
+      db_id: dbId,
+      request_bytes: request.length,
+      response_bytes: response.length,
+      items: [],
+    });
+    const catalogHandle = this.catalogToSdkHandle();
+    try {
+      return requireSdkWasm().verifyDatabaseProofResponse(
+        response,
+        catalogHandle,
+        dbId,
+        expectedParamsHashHex,
+        allowedBuilderBinarySha256Hex,
+        allowedBuilderGitCommit,
+      );
+    } finally {
+      catalogHandle.free();
+    }
+  }
+
+  /** Consume a pin-matched proof handle and install its Onion root locally. */
+  installVerifiedDatabaseProof(proof: WasmDatabaseProof): void {
+    try {
+      const pin = this.layoutPinForDb(proof.dbId);
+      const catalogEntry = this.catalog?.databases.find((db) => db.dbId === proof.dbId);
+      if (!pin || !catalogEntry) {
+        throw new Error(`strict OnionPIR install has no layout/catalog entry for db ${proof.dbId}`);
+      }
+      if (proof.onionEntrySize !== pin.onionEntrySize) {
+        throw new Error(
+          `db ${proof.dbId} onion_entry_size mismatch: proof ${proof.onionEntrySize}, ` +
+          `pin ${pin.onionEntrySize}`,
+        );
+      }
+      if (proof.height !== catalogEntry.height || proof.fromHeight !== catalogEntry.baseHeight) {
+        throw new Error(`db ${proof.dbId} proof/catalog height changed during install`);
+      }
+      const root = proof.onionSuperRootHex.toLowerCase();
+      if (!/^[0-9a-f]{64}$/.test(root)) {
+        throw new Error(`db ${proof.dbId} proof has malformed Onion root`);
+      }
+      this.installedOnionRoots.set(proof.dbId, {
+        dbId: proof.dbId,
+        buildKind: proof.buildKind,
+        fromHeight: proof.fromHeight,
+        height: proof.height,
+        onionSuperRootHex: root,
+        onionEntrySize: proof.onionEntrySize,
+        generation: this.sessionGeneration,
+      });
+      this.verifiedTreeTops.delete(proof.dbId);
+      this.verifiedLayoutDbIds.add(proof.dbId);
+    } finally {
+      proof.free();
+    }
+  }
+
+  /** Bind the consolidated Onion tree-tops to the installed proof root. */
+  async preflightDatabase(dbId: number): Promise<void> {
+    const installed = this.installedOnionRoots.get(dbId);
+    const advertised = this.getOnionPirMerkleForDb(dbId);
+    if (!installed || installed.generation !== this.sessionGeneration) {
+      throw new Error(`db ${dbId} has no installed Onion root`);
+    }
+    if (!advertised) throw new Error(`db ${dbId} has no Onion tree-top metadata`);
+
+    const payloadLen = dbId === 0 ? 1 : 2;
+    const request = new Uint8Array(4 + payloadLen);
+    new DataView(request.buffer).setUint32(0, payloadLen, true);
+    request[4] = REQ_ONIONPIR_MERKLE_INDEX_TREE_TOP;
+    if (dbId !== 0) request[5] = dbId;
+    const response = await this.sendRaw(request);
+    this.recordRound({
+      kind: 'merkle_tree_tops',
+      server_id: 0,
+      db_id: dbId,
+      request_bytes: request.length,
+      response_bytes: response.length,
+      items: [],
+    });
+    const payload = responsePayloadFromFrame(
+      response,
+      RESP_ONIONPIR_MERKLE_INDEX_TREE_TOP,
+    );
+    const blob = payload.slice(1);
+    const allTops = parseOnionTreeTopCache(blob);
+    const trustedInfo: OnionPirMerkleInfoJson = {
+      ...advertised,
+      super_root: installed.onionSuperRootHex,
+    };
+    if (!checkTreeTopAnchor(trustedInfo, blob, allTops, (m) => this.log(m, 'error'))) {
+      throw new Error(`db ${dbId} Onion tree-tops do not match the installed root`);
+    }
+    this.verifiedTreeTops.set(dbId, {
+      dbId,
+      rootHex: installed.onionSuperRootHex,
+      generation: this.sessionGeneration,
+      allTops,
+    });
   }
 
   // ─── Server info (delegates to shared server-info.ts) ──────────────────
@@ -1037,8 +1493,11 @@ export class OnionPirWebClient {
       });
       this.log(`Catalog: ${this.catalog.databases.length} database(s)`);
     } catch (e: any) {
-      this.log(`Catalog fetch failed (non-fatal): ${e.message}`, 'info');
       this.catalog = null;
+      if (this.isStrictVerification()) {
+        throw new Error(`strict OnionPIR catalog fetch failed: ${e.message}`);
+      }
+      this.log(`Catalog fetch failed (non-fatal): ${e.message}`, 'info');
     }
   }
 
@@ -1063,6 +1522,21 @@ export class OnionPirWebClient {
     if (!this.wasmModule) throw new Error('WASM not loaded');
 
     const dbId = dbIdOverride ?? this.dbId;
+    if (this.isStrictVerification()) {
+      const installed = this.installedOnionRoots.get(dbId);
+      const binding = this.verifiedTreeTops.get(dbId);
+      if (
+        !this.strictReady ||
+        !installed || installed.generation !== this.sessionGeneration ||
+        !binding || binding.generation !== this.sessionGeneration ||
+        binding.rootHex !== installed.onionSuperRootHex ||
+        !this.verifiedLayoutDbIds.has(dbId)
+      ) {
+        throw new Error(
+          `strict OnionPIR query rejected: db ${dbId} proof/layout/tree-tops are not ready`,
+        );
+      }
+    }
     // Consume the test hook override (if any) — one-shot replacement of the
     // input scripthashes so harnesses can drive queries at known-present
     // delta entries without needing an H160 preimage.
@@ -1156,7 +1630,8 @@ export class OnionPirWebClient {
           response_bytes: ack.length,
           items: [],
         });
-        if (ack[4] !== RESP_KEYS_ACK) throw new Error('Key registration failed');
+        const ackPayload = responsePayloadFromFrame(ack, RESP_KEYS_ACK);
+        if (ackPayload.length !== 1) throw new Error('Key registration response has trailing data');
         this.registeredDbs.add(dbId);
         this.log(`Keys registered for dbId=${dbId}`);
       } else {
@@ -1254,9 +1729,13 @@ export class OnionPirWebClient {
         });
         totalIndexRounds++;
 
-        const respPayload = respRaw.slice(4);
-        if (respPayload[0] !== RESP_ONIONPIR_INDEX_RESULT) throw new Error('Unexpected index response');
-        const { results } = decodeBatchResult(respPayload, 1);
+        const respPayload = responsePayloadFromFrame(respRaw, RESP_ONIONPIR_INDEX_RESULT);
+        const { results } = decodeBatchResult(
+          respPayload,
+          1,
+          totalIndexRounds - 1,
+          queries.length,
+        );
 
         // Decrypt all INDEX_CUCKOO_NUM_HASHES responses per address — even
         // after a match — so the Merkle item count is uniform across
@@ -1500,9 +1979,8 @@ export class OnionPirWebClient {
             items: new Array(this.chunkK).fill(1),
           });
 
-          const respPayload = respRaw.slice(4);
-          if (respPayload[0] !== RESP_ONIONPIR_CHUNK_RESULT) throw new Error('Unexpected chunk response');
-          const { results } = decodeBatchResult(respPayload, 1);
+          const respPayload = responsePayloadFromFrame(respRaw, RESP_ONIONPIR_CHUNK_RESULT);
+          const { results } = decodeBatchResult(respPayload, 1, ri, this.chunkK);
 
           let chunkDecrypted = 0;
           // Post-port (commit 7): unpack the raw plaintext exactly as
@@ -1548,6 +2026,17 @@ export class OnionPirWebClient {
       // OnionPIR Merkle info for this DB — `super_root` (the pinned
       // anchor) is surfaced on each result for display.
       const merkleInfo = this.getOnionPirMerkleForDb(this.dbId);
+      const installedRoot = this.installedOnionRoots.get(this.dbId);
+      const resultMerkleRoot = this.isStrictVerification()
+        ? installedRoot?.onionSuperRootHex
+        : merkleInfo?.super_root;
+      const resultTrustBinding = this.isStrictVerification() && installedRoot
+        ? {
+            verifiedDbId: this.dbId,
+            verifiedOnionRootHex: installedRoot.onionSuperRootHex,
+            verificationGeneration: this.sessionGeneration,
+          }
+        : {};
 
       // Helper: collect the per-group DATA Merkle leaves owned by query
       // `qi` — one per real chunk entry_id (so 0 for not-found / whale).
@@ -1582,12 +2071,13 @@ export class OnionPirWebClient {
             numChunks: 0,
             numRounds: chunkRoundsCount,
             isWhale: true,
-            merkleSuperRoot: merkleInfo?.super_root,
+            merkleSuperRoot: resultMerkleRoot,
             indexBinHash: indexBinHashes[qi] ?? undefined,
             indexBinLeaves: allBinsChecked.get(qi),
             dataBinLeaves: ownedLeaves,
             scriptHash: scriptHashes[qi],
             rawChunkData: new Uint8Array(0),
+            ...resultTrustBinding,
           };
           continue;
         }
@@ -1609,12 +2099,13 @@ export class OnionPirWebClient {
               numChunks: 0,
               numRounds: chunkRoundsCount,
               isWhale: false,
-              merkleSuperRoot: merkleInfo?.super_root,
+              merkleSuperRoot: resultMerkleRoot,
               indexBinHash: binHash,
               indexBinLeaves: allBins,
               dataBinLeaves: ownedLeaves,
               scriptHash: scriptHashes[qi],
               rawChunkData: new Uint8Array(0),
+              ...resultTrustBinding,
             };
           }
           continue;
@@ -1645,7 +2136,7 @@ export class OnionPirWebClient {
           numChunks: ir.numEntries,
           numRounds: chunkRoundsCount,
           isWhale: false,
-          merkleSuperRoot: merkleInfo?.super_root,
+          merkleSuperRoot: resultMerkleRoot,
           indexBinHash: indexBinHashes[qi] ?? undefined,
           // ALL probed cuckoo positions (always INDEX_CUCKOO_NUM_HASHES bins —
           // see CLAUDE.md "Merkle INDEX Item-Count Symmetry"); one per-group
@@ -1658,11 +2149,18 @@ export class OnionPirWebClient {
           // decodeDeltaData in the sync-merge flow. For main DB this is just
           // the same bytes that decodeUtxoData already consumed above.
           rawChunkData: fullData,
+          ...resultTrustBinding,
         };
       }
 
-      const found = results.filter(r => r !== null).length;
-      this.log(`=== Batch complete: ${found}/${N} returned results ===`, 'success');
+      const verifiable = results.filter(r => r !== null).length;
+      const matched = results.filter(
+        r => r !== null && !r.isWhale && r.entries.length > 0,
+      ).length;
+      this.log(
+        `=== Batch complete: ${matched}/${N} matched; ${verifiable}/${N} verifiable results ===`,
+        'success',
+      );
       return results;
 
     } finally {
@@ -1715,8 +2213,43 @@ export class OnionPirWebClient {
     // Per-DB Merkle lookup: falls back to the top-level `onionpir_merkle`
     // when dbId=0 (backward compatible with older servers that only emit
     // main-DB Merkle info at the top level).
-    const merkle = this.getOnionPirMerkleForDb(this.dbId);
-    if (!merkle) throw new Error(`OnionPIR Merkle not available for dbId=${this.dbId}`);
+    const advertisedMerkle = this.getOnionPirMerkleForDb(this.dbId);
+    if (!advertisedMerkle) throw new Error(`OnionPIR Merkle not available for dbId=${this.dbId}`);
+    let merkle = advertisedMerkle;
+    if (this.isStrictVerification()) {
+      const installed = this.installedOnionRoots.get(this.dbId);
+      const binding = this.verifiedTreeTops.get(this.dbId);
+      if (
+        !installed || installed.generation !== this.sessionGeneration ||
+        !binding || binding.generation !== this.sessionGeneration ||
+        binding.rootHex !== installed.onionSuperRootHex
+      ) {
+        throw new Error(`strict OnionPIR Merkle rejected: db ${this.dbId} root binding is stale`);
+      }
+      merkle = { ...advertisedMerkle, super_root: installed.onionSuperRootHex };
+      for (let i = 0; i < results.length; i++) {
+        const result = results[i];
+        if (
+          result.verifiedDbId !== this.dbId ||
+          result.verifiedOnionRootHex !== installed.onionSuperRootHex ||
+          result.verificationGeneration !== this.sessionGeneration
+        ) {
+          throw new Error(`strict OnionPIR result ${i} is not bound to the current DB/root/session`);
+        }
+        if (result.indexBinLeaves?.length !== INDEX_CUCKOO_NUM_HASHES) {
+          throw new Error(
+            `strict OnionPIR result ${i} has ${result.indexBinLeaves?.length ?? 0} INDEX leaves; ` +
+            `expected ${INDEX_CUCKOO_NUM_HASHES}`,
+          );
+        }
+        if ((result.dataBinLeaves?.length ?? 0) !== result.numChunks) {
+          throw new Error(
+            `strict OnionPIR result ${i} has ${result.dataBinLeaves?.length ?? 0} DATA leaves; ` +
+            `expected ${result.numChunks}`,
+          );
+        }
+      }
+    }
     if (!this.fheSecretKey) throw new Error('No FHE keys — call queryBatch() first');
 
     const progress = onProgress || (() => {});
@@ -1751,9 +2284,19 @@ export class OnionPirWebClient {
       }
     }
 
+    // A repeated coordinate may be shared by duplicate queries, but it must
+    // commit to exactly one plaintext hash. First/last-wins would let one copy
+    // influence the result while another copy supplies the proof.
+    assertConsistentOnionMerkleLeaves(leaves);
+
     // Genuinely empty input — nothing to verify, no Merkle traffic.
     // Mirrors the Rust `run_merkle_verification` empty-leaves guard.
-    if (leaves.length === 0) return out;
+    if (leaves.length === 0) {
+      if (this.isStrictVerification() && results.length > 0) {
+        throw new Error('strict OnionPIR results contain no Merkle leaves');
+      }
+      return out;
+    }
 
     // Verify BOTH sub-trees — ALWAYS, even when one has no leaves. An
     // all-not-found / whale batch contributes 0 DATA leaves, but
@@ -1842,55 +2385,53 @@ export class OnionPirWebClient {
     const sibResp = treeName === 'index'
       ? RESP_ONIONPIR_MERKLE_INDEX_SIBLING : RESP_ONIONPIR_MERKLE_DATA_SIBLING;
 
-    // ── 1. Fetch the consolidated 155-tree tree-top blob ───────────────
-    // The whole blob is served on either TREE_TOP opcode; fetching once
-    // per sub-tree mirrors the Rust `verify_sub_tree` (and keeps the
-    // `merkle_tree_tops` round count = 2 — one INDEX, one DATA).
-    progress('Merkle', `Fetching ${treeName} tree-top blob...`);
-    // Wire: [4B len][1B req]([1B db_id] if non-zero, backward compatible).
-    const ttPayloadLen = this.dbId !== 0 ? 2 : 1;
-    const ttReq = new Uint8Array(4 + ttPayloadLen);
-    new DataView(ttReq.buffer).setUint32(0, ttPayloadLen, true);
-    ttReq[4] = treeTopReq;
-    if (this.dbId !== 0) ttReq[5] = this.dbId;
-    const ttRaw = await this.sendRaw(ttReq);
-    // Tree-top fetch is admitted to leak (public Merkle tops). Tagged
-    // `merkle_tree_tops` — matches the Rust `RoundKind::MerkleTreeTops`.
-    this.recordRound({
-      kind: 'merkle_tree_tops',
-      server_id: 0,
-      db_id: this.dbId,
-      request_bytes: ttReq.length,
-      response_bytes: ttRaw.length,
-      items: [],
-    });
-    if (ttRaw.length < 5 || ttRaw[4] !== treeTopResp) {
-      throw new Error(
-        `Unexpected ${treeName} tree-top response: 0x${(ttRaw[4] ?? 0).toString(16)}`,
+    let allTops: OnionTreeTopCache[];
+    if (this.isStrictVerification()) {
+      // Strict sessions reuse only the tree-tops cached by the pre-query
+      // proof-root preflight. Their generation/root binding was checked by
+      // verifyMerkleBatch before reaching this method.
+      const binding = this.verifiedTreeTops.get(this.dbId);
+      if (!binding) throw new Error(`strict OnionPIR tree-tops missing for db ${this.dbId}`);
+      allTops = binding.allTops;
+    } else {
+      // Advisory/back-compat flow: fetch and bind against the advertised root.
+      progress('Merkle', `Fetching ${treeName} tree-top blob...`);
+      const ttPayloadLen = this.dbId !== 0 ? 2 : 1;
+      const ttReq = new Uint8Array(4 + ttPayloadLen);
+      new DataView(ttReq.buffer).setUint32(0, ttPayloadLen, true);
+      ttReq[4] = treeTopReq;
+      if (this.dbId !== 0) ttReq[5] = this.dbId;
+      const ttRaw = await this.sendRaw(ttReq);
+      this.recordRound({
+        kind: 'merkle_tree_tops',
+        server_id: 0,
+        db_id: this.dbId,
+        request_bytes: ttReq.length,
+        response_bytes: ttRaw.length,
+        items: [],
+      });
+      const ttPayload = responsePayloadFromFrame(ttRaw, treeTopResp);
+      const blob = ttPayload.slice(1);
+      allTops = parseOnionTreeTopCache(blob);
+      this.log(
+        `[PIR-AUDIT] OnionPIR Merkle ${treeName} tree-top: ${allTops.length} ` +
+        `trees parsed (arity=${arity})`,
       );
-    }
-    const blob = ttRaw.slice(5);
-    const allTops = parseOnionTreeTopCache(blob);
-    this.log(
-      `[PIR-AUDIT] OnionPIR Merkle ${treeName} tree-top: ${allTops.length} ` +
-      `trees parsed (arity=${arity})`,
-    );
-
-    // ── 2. Bind the blob to the pinned super-root (SOUNDNESS-CRITICAL) ──
-    // A super-root mismatch means the server's whole Merkle commitment
-    // is untrusted (malicious server, or a DB-version skew). Every
-    // probed leaf fails; the sibling rounds would prove nothing against
-    // forged roots, so skip them.
-    if (!checkTreeTopAnchor(info, blob, allTops, (m) => this.log(m, 'error'))) {
-      for (const lf of leaves) out.set(`${lf.pbcGroup}:${lf.bin}`, false);
-      return out;
+      if (!checkTreeTopAnchor(info, blob, allTops, (m) => this.log(m, 'error'))) {
+        for (const lf of leaves) out.set(`${lf.pbcGroup}:${lf.bin}`, false);
+        return out;
+      }
     }
 
     // ── 3. Deduplicate leaves by (pbcGroup, bin) ───────────────────────
     const uniqueMap = new Map<string, { pbcGroup: number; bin: number; hash: Uint8Array }>();
     for (const lf of leaves) {
       const key = `${lf.pbcGroup}:${lf.bin}`;
-      if (!uniqueMap.has(key)) uniqueMap.set(key, lf);
+      const previous = uniqueMap.get(key);
+      if (previous && !bytesEqual(previous.hash, lf.hash)) {
+        throw new Error(`OnionPIR conflicting hashes for ${treeName} Merkle leaf ${key}`);
+      }
+      if (!previous) uniqueMap.set(key, lf);
     }
     const keys = [...uniqueMap.keys()];
     const n = keys.length;
@@ -1985,13 +2526,8 @@ export class OnionPirWebClient {
           response_bytes: respRaw.length,
           items: new Array(k).fill(1),
         });
-        const respPayload = respRaw.slice(4);
-        if (respPayload[0] !== sibResp) {
-          throw new Error(
-            `Unexpected ${treeName} sibling response: 0x${respPayload[0].toString(16)}`,
-          );
-        }
-        const { results: batch } = decodeBatchResult(respPayload, 1);
+        const respPayload = responsePayloadFromFrame(respRaw, sibResp);
+        const { results: batch } = decodeBatchResult(respPayload, 1, 0, k);
 
         // Fold each real group's decrypted sibling row into its leaf.
         for (const [g, item] of passGroupToItem) {

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -103,6 +103,16 @@ interface PirSdkWasm {
    * `pir_sdk_client::announce::parse_announce_response`.
    */
   verifyAnnounceResponse(respPayload: Uint8Array): WasmAnnounceVerification;
+  /** Stateless verification of one complete `[u32 len][RESP_DB_PROOF...]`
+   * frame. This does not install roots or retain session state. */
+  verifyDatabaseProofResponse(
+    responseFrame: Uint8Array,
+    catalog: WasmDatabaseCatalog,
+    expectedDbId: number,
+    expectedParamsHashHex?: string | null,
+    allowedBuilderBinarySha256Hex?: string | null,
+    allowedBuilderGitCommit?: string | null,
+  ): WasmDatabaseProof;
   // ARC (Anonymous Rate-limited Credentials) presentation state. Opaque
   // wrapper over the Rust `arc::PresentationState`; mirrored in TS by
   // `web/src/credential-manager.ts::ArcCredentialManager`. The constructor
@@ -395,6 +405,7 @@ export interface WasmDatabaseProof {
   readonly networkMagicHex: string;
   readonly builderBinarySha256Hex: string;
   readonly builderGitCommit: string;
+  readonly onionEntrySize: number;
   toJson(): any;
 }
 

--- a/web/src/sync-controller.ts
+++ b/web/src/sync-controller.ts
@@ -38,6 +38,16 @@ export interface SyncExecuteHooks<T extends SyncableResult> {
   scriptHashes: Uint8Array[];
   /** Run one step of the plan against the backend and return per-scripthash results. */
   queryStep: (step: SyncStep, stepIdx: number) => Promise<(T | null)[]>;
+  /**
+   * Optional fail-closed verification barrier. It runs immediately after the
+   * step query, while that backend session/key is still current, and before
+   * any result is merged or committed to the cache.
+   */
+  verifyStep?: (
+    step: SyncStep,
+    stepResults: (T | null)[],
+    stepIdx: number,
+  ) => Promise<void>;
   /** Merge a delta step's result onto the current snapshot for one scripthash. */
   mergeStep: (snapshot: T | null, delta: T | null) => T | null;
   /** Optional hook run before each step (e.g. HarmonyPIR hint switch / re-download). */
@@ -192,6 +202,17 @@ export class SyncController<T extends SyncableResult> {
       }
 
       const stepResults = await hooks.queryStep(step, si);
+      if (stepResults.length !== N) {
+        throw new Error(
+          `Sync step ${step.dbId} returned ${stepResults.length} results; expected ${N}`,
+        );
+      }
+
+      // Verification is part of the transaction. A rejection here leaves the
+      // existing snapshot cache and persisted height untouched.
+      if (hooks.verifyStep) {
+        await hooks.verifyStep(step, stepResults, si);
+      }
 
       if (step.dbType === 'full') {
         // Full snapshot replaces merged state entirely.

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -112,6 +112,11 @@ export interface QueryResult {
    * per-group DATA tree; `bin` is the leaf index within it.
    */
   dataBinLeaves?: { hash: Uint8Array; pbcGroup: number; bin: number }[];
+  /** Strict OnionPIR session binding. All three values are immutable for the
+   * query result and must still match when its Merkle proof is checked. */
+  verifiedDbId?: number;
+  verifiedOnionRootHex?: string;
+  verificationGeneration?: number;
 }
 
 // ─── Connection state ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add a stateless Rust/WASM verifier for complete database-proof response frames
- pin and install the Onion root only after full production-pin matching
- pin the v1 standalone Onion query layout, preflight consolidated tree-tops, and bind every result to DB/root/session
- verify found, not-found, whale, and sync-step results before showing a checkmark or committing sync state
- keep the UI compact with a Data integrity YES/NO summary and disconnect after every query

## Security properties

- server-info super_root is diagnostic only in strict mode
- query placement never trusts unpinned standalone Onion layout fields
- truncated, concatenated, wrong-round, wrong-count, stale-session, and conflicting duplicate-leaf inputs fail closed
- this does not claim runtime attestation or an encrypted channel for standalone OnionPIR

## Validation

- pir-sdk-client: 276 unit tests passed; 6 non-network integration tests passed
- pir-sdk-wasm: 73 tests passed
- wasm32 cargo check and wasm-pack build passed
- web: TypeScript and production Vite builds passed; 240 tests passed, 2 optional leakage tests skipped
- live browser smoke against weikeng1: found and not-found results both received automatic Verified marks and each query ended disconnected

## Deployment

Frontend/WASM only. The existing production proof and Onion Merkle protocol is sufficient; no server binary or UKI rebuild is required.