### PR TITLE
Fix Tier 3 ORAM trusted-state paths

### DIFF
--- a/docs/PHASE3_ROADMAP.md
+++ b/docs/PHASE3_ROADMAP.md
@@ -44,9 +44,9 @@ to whichever slice you want to start on.
 
 ### Attested values published (operator: weikengchen) — current ORAM Tier 3 baseline
 
-These values match `web/src/attest-pin.ts` and
-`scripts/verify_oram_tier3_deploy.sh`. They were rechecked against the live
-pir2 report on 2026-07-22 with `bpir-admin attest`.
+These values match `web/src/attest-pin.ts`. They were rechecked against the
+live pir2 report on 2026-07-24 with `scripts/verify_oram_tier3_deploy.sh`,
+which requires the operator to provide both expected pins explicitly.
 
 ```
 Server: wss://weikeng2.bitcoinpir.org
@@ -55,17 +55,17 @@ Launch MEASUREMENT (covers OVMF + Tier 3 UKI bytes — UKI now contains
 the unified_server BINARY itself in initramfs, NOT just a cmdline hash
 pin. So this digest authenticates the literal binary bytes the box is
 running, not "a binary the box claims matches a hash"):
-  478fb4acdf0bd505bccfab14f46d7d81e19d782b19480433f7716c27872a003742b0e7ff8f787195533a39514887c3f7
+  a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86
 
-UKI bytes sha256 (built by scripts/build_uki_tier3.sh on pir-hetzner;
+UKI bytes sha256 (built by scripts/build_uki_tier3.sh on VPSBG and archived on Hetzner;
 includes initramfs with unified_server + cloudflared + runit + the
 sev-guest/ccp/tsm_report kernel modules baked in):
-  3d511f88ea065ac564b8838e69d904acd1fd21d63eff1d0a5768e80c1dcaa6ce
+  5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e
 
 unified_server binary sha256 (computed at build time AND attested at
 runtime via /proc/self/exe — the two match because dracut was invoked
 with --nostrip; verifiers pin via --expect-binary on bpir-admin attest):
-  61d74a9ce4f97b3563ce76b5e2b1a0fba0d0e6c8f9934ae95b404ededac5f178
+  1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37
 
 ARK fingerprint (AMD Turin family root certificate — pinned in
 web/src/attest-pin.ts and used by --expect-ark-fingerprint to anchor
@@ -77,7 +77,13 @@ DB manifest roots (db_id order):
   delta_940611_948454:        c816f067117bca98256ee246c4469591ee8f537b2271d65b38d1536a70887963
 
 Server git rev (per /attest, captured at unified_server build time):
-  837108b65374c3c05f876c1d57914e05f106c6a8
+  66034c8204e19b11b8c0602aa625c2414095deb2
+
+Measured startup script git rev (boot-regeneration path and path-contract fix):
+  7b6cf108da189cc3b693c3f004612dcd90a80a0f
+
+bitcoinpir-oram git rev used by the live binary and oramctl:
+  cd2c1a224d640a8149cfdd75ef5a4f2579a84d0b
 ```
 
 NOTE on the X25519 channel pubkey: it's "long-lived" relative to per-
@@ -91,8 +97,8 @@ Verifiers can cross-check end-to-end with:
 ```bash
 # Static checks: report binding + binary + measurement + ARK chain
 bpir-admin attest wss://weikeng2.bitcoinpir.org \
-    --expect-measurement 478fb4acdf0bd505bccfab14f46d7d81e19d782b19480433f7716c27872a003742b0e7ff8f787195533a39514887c3f7 \
-    --expect-binary 61d74a9ce4f97b3563ce76b5e2b1a0fba0d0e6c8f9934ae95b404ededac5f178 \
+    --expect-measurement a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86 \
+    --expect-binary 1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37 \
     --expect-ark-fingerprint 1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a
 
 # Live encrypted channel + AMD VCEK chain validation
@@ -484,8 +490,8 @@ assume you've reverted to Slice 2 first (see PHASE3_SLICE3_RECOVERY.md).
 
 # Attest VPSBG (verifies SEV-SNP report + binds X25519 channel pubkey)
 ./target/release/bpir-admin attest wss://weikeng2.bitcoinpir.org \
-    --expect-measurement 478fb4acdf0bd505bccfab14f46d7d81e19d782b19480433f7716c27872a003742b0e7ff8f787195533a39514887c3f7 \
-    --expect-binary 61d74a9ce4f97b3563ce76b5e2b1a0fba0d0e6c8f9934ae95b404ededac5f178 \
+    --expect-measurement a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86 \
+    --expect-binary 1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37 \
     --expect-ark-fingerprint 1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a
 
 # End-to-end channel test with ARK-rooted chain validation

--- a/docs/STRICT_VERIFICATION_PROGRESS.md
+++ b/docs/STRICT_VERIFICATION_PROGRESS.md
@@ -165,6 +165,18 @@ passed on the full-feature UKI after it reopened state written by the diagnostic
 UKI. Hetzner intentionally remains on the independently pinned 2026-07-20
 binary above.
 
+On 2026-07-24, VPSBG moved to the boot-regeneration UKI built from measured
+startup commit `7b6cf108`. It reuses the unchanged `unified_server` binary from
+BitcoinPIR commit `66034c82` (SHA-256 `1134b8a4...09c37`) and the source-bound
+`oramctl` from bitcoinpir-oram commit `cd2c1a22`. The UKI SHA-256 is
+`5b854888...7b13e` and its live launch MEASUREMENT is
+`a3a8fb0f...04040b86`. Every boot now regenerates both authenticated ORAM
+images from proof-bound inputs in SEV-protected tmpfs, verifies the emitted-page
+Merkle roots and the exact published bulk/trusted-state path contract, and only
+then opens the query server. Fixed-pin AMD attestation, the encrypted channel,
+dummy padded lookups, and known-present padded results for both db_id 0 and
+db_id 1 passed against the live full-feature UKI.
+
 ## Non-blocking follow-ups
 
 The strict-root rollout above is closed. The following improvements do not

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -173,6 +173,7 @@ build_direct_oram() {
     expected_from_muhash="$7"
     expected_index_sha="$8"
     expected_chunks_sha="$9"
+    trusted_state_dir="${10}"
     log_file="$ORAM_BUILD_LOG_DIR/${db_label}.build-direct.log"
     seed_hex="$(random_seed_hex)"
 
@@ -194,7 +195,6 @@ build_direct_oram() {
     [ -n "$expected_chunks_sha" ] || fatal "$db_label direct chunks hash pin missing"
 
     trusted_input_dir="$TRUSTED_INPUT_ROOT/$db_label"
-    trusted_state_dir="$TRUSTED_STATE_ROOT/$db_label"
     mkdir -p "$trusted_input_dir" "$trusted_state_dir" \
         || fatal "failed to create trusted tmpfs directories for $db_label"
     : >"$log_file" || fatal "failed to create $log_file"
@@ -285,6 +285,22 @@ build_direct_oram() {
     echo "[unified-server-run] regenerated $db_label direct ORAM; log: $log_file" >&2
 }
 
+verify_direct_oram_publish() {
+    published_dir="$1"
+    trusted_state_dir="$2"
+    db_label="$3"
+    for level in direct-index direct-chunk; do
+        require_file "$published_dir/$level.meta.oram"
+        require_file "$published_dir/$level.payload.oram"
+        require_file "$published_dir/$level.meta.hash.oram"
+        require_file "$published_dir/$level.payload.hash.oram"
+        require_file "$trusted_state_dir/$level.state"
+        require_file "$trusted_state_dir/$level.auth.state"
+        require_file "$trusted_state_dir/$level.metadata"
+    done
+    echo "[unified-server-run] verified published $db_label direct ORAM paths" >&2
+}
+
 [ -x "$ORAMCTL" ] || fatal "$ORAMCTL missing from UKI"
 [ -x "$UNIFIED_SERVER" ] || fatal "$UNIFIED_SERVER missing from UKI"
 require_file "$DELTA_BHTM_FROM_LEAF_PROOF"
@@ -331,12 +347,16 @@ DELTA_ROOT_BUNDLE="$(first_existing_file \
 
 build_direct_oram mainnet-948454 "$MAINNET_SOURCE_DIR" "$ORAM_STAGING_DIR/db0-mainnet-948454" \
     "$MAINNET_DB_EVIDENCE" "$MAINNET_ROOT_BUNDLE" "$MAINNET_EXPECTED_MUHASH" "" \
-    "$MAINNET_EXPECTED_INDEX_SHA256" "$MAINNET_EXPECTED_CHUNKS_SHA256"
+    "$MAINNET_EXPECTED_INDEX_SHA256" "$MAINNET_EXPECTED_CHUNKS_SHA256" \
+    "$ORAM_FULL_TRUSTED_STATE_DIR"
 build_direct_oram delta-940611-948454 "$DELTA_SOURCE_DIR" "$ORAM_STAGING_DIR/db1-delta-940611-948454" \
     "$DELTA_DB_EVIDENCE" "$DELTA_ROOT_BUNDLE" "$DELTA_EXPECTED_MUHASH" "$DELTA_EXPECTED_FROM_MUHASH" \
-    "$DELTA_EXPECTED_INDEX_SHA256" "$DELTA_EXPECTED_CHUNKS_SHA256"
+    "$DELTA_EXPECTED_INDEX_SHA256" "$DELTA_EXPECTED_CHUNKS_SHA256" \
+    "$ORAM_DELTA_TRUSTED_STATE_DIR"
 
 mv "$ORAM_STAGING_DIR" "$ORAM_CURRENT_DIR" || fatal "failed to publish regenerated ORAM image"
+verify_direct_oram_publish "$ORAM_FULL_DIR" "$ORAM_FULL_TRUSTED_STATE_DIR" mainnet-948454
+verify_direct_oram_publish "$ORAM_DELTA_DIR" "$ORAM_DELTA_TRUSTED_STATE_DIR" delta-940611-948454
 safe_remove_runtime_path "$TRUSTED_INPUT_ROOT"
 trap - EXIT
 

--- a/scripts/verify_oram_tier3_deploy.sh
+++ b/scripts/verify_oram_tier3_deploy.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Post-deploy smoke for the ORAM-enabled Tier 3 UKI built from BitcoinPIR
-# commit 837108b6. Run after uploading the UKI in the VPSBG measured-boot
-# portal and waiting for cloudflared to reconnect.
+# Post-deploy smoke for the ORAM-enabled Tier 3 UKI. Run after uploading the
+# candidate UKI in the VPSBG measured-boot portal and waiting for cloudflared
+# to reconnect. EXPECT_MEASUREMENT and EXPECT_BINARY intentionally have no
+# defaults so a stale repository pin cannot silently bless a new deployment.
 
 SERVER=${SERVER:-wss://weikeng2.bitcoinpir.org}
 : "${EXPECT_MEASUREMENT:?set EXPECT_MEASUREMENT to the reviewed live Tier 3 launch measurement}"

--- a/web/public/proofs/oram-source/mainnet_948454.json
+++ b/web/public/proofs/oram-source/mainnet_948454.json
@@ -271,16 +271,16 @@
     }
   },
   "liveDeployment": {
-    "status": "strict-source-bound-live-on-pir2",
-    "verifiedAtUtc": "2026-07-22T11:13:43Z",
-    "currentPir2RuntimeBitcoinPirCommit": "837108b65374c3c05f876c1d57914e05f106c6a8",
-    "currentPir2RuntimeOramCommit": "5f366492504d8e853cbd60d25a6adbf021a78746",
+    "status": "strict-source-bound-boot-regeneration-live-on-pir2",
+    "verifiedAtUtc": "2026-07-24T01:52:40Z",
+    "currentPir2RuntimeBitcoinPirCommit": "66034c8204e19b11b8c0602aa625c2414095deb2",
+    "currentPir2RuntimeOramCommit": "cd2c1a224d640a8149cfdd75ef5a4f2579a84d0b",
     "strictRebuildOramCommit": "5f366492504d8e853cbd60d25a6adbf021a78746",
-    "pir2UkiSha256": "3d511f88ea065ac564b8838e69d904acd1fd21d63eff1d0a5768e80c1dcaa6ce",
-    "pir2BinarySha256": "61d74a9ce4f97b3563ce76b5e2b1a0fba0d0e6c8f9934ae95b404ededac5f178",
-    "pir2MeasurementHex": "478fb4acdf0bd505bccfab14f46d7d81e19d782b19480433f7716c27872a003742b0e7ff8f787195533a39514887c3f7",
-    "pir2ChannelPubkeyHex": "445952e9d5dd7c459f1bc43aca56b3fbdca3593f1a90c8236c67b4ae84c06500",
-    "hetznerArchivePath": "/home/pir/uki-archive/tier3/main-837108b6-20260721T090526Z-3d511f88ea06.efi",
-    "note": "The published proof certifies a strict source-bound ORAM rebuild at bitcoinpir-oram commit 5f36649. The live pir2 Tier 3 UKI now runs BitcoinPIR commit 837108b6, which retains that ORAM revision and serializes each database's complete request and state-commit transaction. Two independent UKI builds were byte-identical. Live checks passed: bpir-admin attest atomically matched the binary, measurement, and REPORT_DATA while validating ARK-to-ASK-to-VCEK plus the same report signature; channel-test revalidated the AMD chain and encrypted session; padded direct ORAM smoke requests completed for db_id 0 and db_id 1."
+    "pir2UkiSha256": "5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e",
+    "pir2BinarySha256": "1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37",
+    "pir2MeasurementHex": "a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86",
+    "pir2ChannelPubkeyHex": "d5e712c8a718c284d8cfa70a3cd910a04068f566f1ce46a36ef40121c928ae61",
+    "hetznerArchivePath": "/home/pir/uki-archive/tier3/main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi",
+    "note": "The published proof certifies a strict source-bound ORAM rebuild at bitcoinpir-oram commit 5f36649. The live pir2 Tier 3 UKI uses the measured startup script from BitcoinPIR commit 7b6cf108, the unchanged unified_server binary from commit 66034c82, and bitcoinpir-oram commit cd2c1a22. Every boot copies the proof-bound direct inputs into SEV-protected tmpfs, regenerates both authenticated ORAM images with fresh randomness, checks emitted-page Merkle roots before installing trusted state, validates every published bulk and trusted-state path, and only then opens the query server. Live checks passed: bpir-admin attest atomically matched the binary, measurement, and REPORT_DATA while validating ARK-to-ASK-to-VCEK plus the same report signature; channel-test revalidated the AMD chain and encrypted session; padded direct ORAM smoke requests returned known-present results for db_id 0 and db_id 1. The channel pubkey recorded here is observational and changes on process restart; verifiers must obtain it from the fresh attestation response and check REPORT_DATA instead of pinning it."
   }
 }

--- a/web/reproduce.html
+++ b/web/reproduce.html
@@ -470,7 +470,7 @@
 
                 <section id="runtime-pins" class="tab-panel" role="tabpanel" aria-labelledby="tab-runtime-pins">
                     <section>
-                        <h2>Frontend-expected runtime pins <span class="badge ok">ORAM UKI — 2026-07-22</span></h2>
+                        <h2>Frontend-expected runtime pins <span class="badge ok">ORAM UKI — 2026-07-24</span></h2>
                         <p>
                             These are the values the browser bundle expects for
                             pir2. They are not a live-status feed. If the app shows
@@ -482,19 +482,19 @@
                             <table class="pin-table">
                                 <tr>
                                     <td>MEASUREMENT</td>
-                                    <td>478fb4acdf0bd505bccfab14f46d7d81e19d782b19480433f7716c27872a003742b0e7ff8f787195533a39514887c3f7</td>
+                                    <td>a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86</td>
                                 </tr>
                                 <tr>
                                     <td>UKI sha256</td>
-                                    <td>3d511f88ea065ac564b8838e69d904acd1fd21d63eff1d0a5768e80c1dcaa6ce</td>
+                                    <td>5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e</td>
                                 </tr>
                                 <tr>
                                     <td>binary sha256</td>
-                                    <td>61d74a9ce4f97b3563ce76b5e2b1a0fba0d0e6c8f9934ae95b404ededac5f178</td>
+                                    <td>1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37</td>
                                 </tr>
                                 <tr>
                                     <td>server git rev</td>
-                                    <td>837108b65374c3c05f876c1d57914e05f106c6a8</td>
+                                    <td>66034c8204e19b11b8c0602aa625c2414095deb2</td>
                                 </tr>
                                 <tr>
                                     <td>OVMF sha256</td>
@@ -560,7 +560,7 @@
                                 <h3>Get or rebuild the UKI</h3>
                                 <p>
                                     The current operator-archived artifact is
-                                    <code>main-837108b6-20260721T090526Z-3d511f88ea06.efi</code>, the
+                                    <code>main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi</code>, the
                                     ORAM-enabled Tier 3 UKI that serves the database
                                     proof sidecar and direct ORAM lookups for db_id 0/1.
                                     It is a large runtime artifact, so this page pins the
@@ -570,11 +570,11 @@
                                     is not a public download URL.
                                 </p>
                                 <p class="meta" style="margin-top: 6px;">
-                                    Verify: <code>sha256sum main-837108b6-20260721T090526Z-3d511f88ea06.efi</code> →
-                                    <code>3d511f88ea065ac564b8838e69d904acd1fd21d63eff1d0a5768e80c1dcaa6ce</code>
+                                    Verify: <code>sha256sum main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi</code> →
+                                    <code>5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e</code>
                                 </p>
 <pre><code># Operator-only shortcut: retrieve the exact deployed bytes.
-scp pir-hetzner:/home/pir/uki-archive/tier3/main-837108b6-20260721T090526Z-3d511f88ea06.efi .</code></pre>
+scp pir-hetzner:/home/pir/uki-archive/tier3/main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi .</code></pre>
                                 <p class="meta" style="margin-top: 6px;">
                                     Or perform a functional source rebuild. This is not
                                     a byte-identical reproduction of the production artifact:
@@ -584,13 +584,13 @@ scp pir-hetzner:/home/pir/uki-archive/tier3/main-837108b6-20260721T090526Z-3d511
                                 </p>
 <pre><code>git clone https://github.com/Bitcoin-PIR/Bitcoin-PIR.git BitcoinPIR-runtime-repro
 cd BitcoinPIR-runtime-repro
-git checkout 837108b65374c3c05f876c1d57914e05f106c6a8
+git checkout 7b6cf108da189cc3b693c3f004612dcd90a80a0f
 RUSTFLAGS="--remap-path-prefix=$PWD=/build/repo --remap-path-prefix=$HOME=/build" \
 SOURCE_DATE_EPOCH=0 cargo build --locked --release -p runtime --features cuckoo-oram --bin unified_server
 strip --strip-debug target/release/unified_server
 
-sudo env KERNEL=/boot/vmlinuz-7.0.0-15-generic \
-OUT="$PWD/bpir-tier3-functional-rebuild-837108b6.efi" \
+sudo env KERNEL=/boot/vmlinuz-7.0.0-28-generic \
+OUT="$PWD/bpir-tier3-functional-rebuild-7b6cf108.efi" \
 BINARY="$PWD/target/release/unified_server" \
 BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
 ./scripts/build_uki_tier3.sh</code></pre>
@@ -615,7 +615,7 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
 	    --vcpus 2 \
 	    --vcpu-sig 0x00B10F10 \
 	    --ovmf OVMF_SEV_MEASUREDBOOT_4M.fd \
-	    --kernel main-837108b6-20260721T090526Z-3d511f88ea06.efi \
+	    --kernel main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi \
 	    --guest-features 0x1</code></pre>
                             </li>
 
@@ -623,8 +623,8 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
                                 <h3>Verify the live report and AMD chain</h3>
 	<pre><code>cargo build --locked --release --bin bpir-admin -p bpir-admin
 ./target/release/bpir-admin attest wss://weikeng2.bitcoinpir.org \
-    --expect-measurement 478fb4acdf0bd505bccfab14f46d7d81e19d782b19480433f7716c27872a003742b0e7ff8f787195533a39514887c3f7 \
-    --expect-binary      61d74a9ce4f97b3563ce76b5e2b1a0fba0d0e6c8f9934ae95b404ededac5f178 \
+    --expect-measurement a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86 \
+    --expect-binary      1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37 \
     --expect-ark-fingerprint 1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a
 ./target/release/bpir-admin channel-test wss://weikeng2.bitcoinpir.org \
     --expect-ark-fingerprint 1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a</code></pre>
@@ -887,17 +887,19 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
                             <p>
                                 This page verifies the strict source-bound rebuild and records
                                 the live pir2 runtime that consumes it. The pinned pir2 runtime
-                                commit
-                                <code>837108b65374c3c05f876c1d57914e05f106c6a8</code>
+                                binary commit
+                                <code>66034c8204e19b11b8c0602aa625c2414095deb2</code>
                                 vendors <code>bitcoinpir-oram</code> at
-                                <code>5f366492504d8e853cbd60d25a6adbf021a78746</code>.
+                                <code>cd2c1a224d640a8149cfdd75ef5a4f2579a84d0b</code>.
+                                The measured boot-regeneration script comes from
+                                <code>7b6cf108da189cc3b693c3f004612dcd90a80a0f</code>.
                             </p>
                             <p>
                                 Live verification on the refreshed measured UKI passed
                                 <code>bpir-admin attest</code>, <code>channel-test</code>, and
                                 padded direct ORAM smoke requests for both db_id 0 and db_id 1.
                                 The UKI bytes are archived on Hetzner at
-                                <code>/home/pir/uki-archive/tier3/main-837108b6-20260721T090526Z-3d511f88ea06.efi</code>.
+                                <code>/home/pir/uki-archive/tier3/main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi</code>.
                             </p>
                         </div>
                     </section>

--- a/web/src/__tests__/oram-source-proof.test.ts
+++ b/web/src/__tests__/oram-source-proof.test.ts
@@ -35,7 +35,7 @@ describe('ORAM source-binding proof', () => {
       '8030603977422561841',
     );
     expect(status.verified?.manifest.liveDeployment.status).toBe(
-      'strict-source-bound-live-on-pir2',
+      'strict-source-bound-boot-regeneration-live-on-pir2',
     );
     expect(status.verified?.manifest.liveDeployment.pir2BinarySha256).toBe(
       PIR2_TIER3_PIN.binarySha256Hex,
@@ -44,10 +44,10 @@ describe('ORAM source-binding proof', () => {
       PIR2_TIER3_PIN.measurementHex,
     );
     expect(status.verified?.manifest.liveDeployment.pir2UkiSha256).toBe(
-      '3d511f88ea065ac564b8838e69d904acd1fd21d63eff1d0a5768e80c1dcaa6ce',
+      '5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e',
     );
     expect(status.verified?.manifest.liveDeployment.currentPir2RuntimeBitcoinPirCommit).toBe(
-      '837108b65374c3c05f876c1d57914e05f106c6a8',
+      '66034c8204e19b11b8c0602aa625c2414095deb2',
     );
   });
 

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -126,26 +126,28 @@ export interface ServerAttestPin {
 }
 
 /**
- * weikeng2.bitcoinpir.org — VPSBG Tier 3 ORAM UKI, pinned 2026-07-22.
- * Built by `scripts/build_uki_tier3.sh` on the Hetzner build host:
- * VPSBG kernel 7.0.0-15 + the ORAM-enabled `unified_server`
+ * weikeng2.bitcoinpir.org — VPSBG Tier 3 ORAM UKI, pinned 2026-07-24.
+ * Built by `scripts/build_uki_tier3.sh` on VPSBG and archived on Hetzner:
+ * VPSBG kernel 7.0.0-28 + the ORAM-enabled `unified_server`
  * binary baked into the initramfs.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // Tier 3 ORAM UKI — 2026-07-22. Built from BitcoinPIR commit
-  // 837108b65374c3c05f876c1d57914e05f106c6a8:
+  // Tier 3 ORAM UKI — 2026-07-24. The measured startup script is from
+  // BitcoinPIR commit 7b6cf108da189cc3b693c3f004612dcd90a80a0f; the unchanged
+  // unified_server binary is from commit
+  // 66034c8204e19b11b8c0602aa625c2414095deb2:
   // unified_server serves db-proof query traffic and direct ORAM lookup
   // for db_id 0/1 as pir2 query-only (`--serve-queries`, no hint pool,
   // no OnionPIR) plus `--identity-*` (operator-signed identity,
   // server_id=pir2). MEASUREMENT captured from the live Tier 3 deploy via
   // `bpir-admin attest wss://weikeng2.bitcoinpir.org` after uploading
-  // UKI sha256 `3d511f88ea065ac564b8838e69d904acd1fd21d63eff1d0a5768e80c1dcaa6ce`
+  // UKI sha256 `5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e`
   // (SEV-SNP REPORT_DATA binding verified on
   // real hardware).
   measurementHex:
-    '478fb4acdf0bd505bccfab14f46d7d81e19d782b19480433f7716c27872a003742b0e7ff8f787195533a39514887c3f7',
+    'a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86',
   binarySha256Hex:
-    '61d74a9ce4f97b3563ce76b5e2b1a0fba0d0e6c8f9934ae95b404ededac5f178',
+    '1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37',
   description: 'weikeng2.bitcoinpir.org (VPSBG, SEV-SNP, Tier 3 ORAM UKI)',
 };
 


### PR DESCRIPTION
## What changed

- pass the exact per-database trusted-state directory into each boot-time ORAM build
- validate the published bulk images, Merkle sidecars, controller state, auth state, and metadata before starting `unified_server`

## Root cause

The boot builder derived `/run/bitcoinpir-oram-state/mainnet-948454`, while the runtime reopened `/run/bitcoinpir-oram-state/db0-mainnet-948454` (and likewise for db1). Both ORAM builds completed, but startup then failed closed with `No such file or directory` while opening db0 metadata.

## Validation

- `sh -n scripts/dracut/97bpir-tier3-init/unified-server-run.sh`
- `git diff --check`
- `cargo test --locked -p runtime --features cuckoo-oram --bin unified_server direct_oram_opens_controller_state_and_metadata_from_trusted_directory -- --nocapture`

The production boot preflight now checks the exact paths that the runtime will reopen.
