### PR TITLE
Track post-rollout project closeout

### DIFF
--- a/docs/BUILD_REPRODUCIBILITY.md
+++ b/docs/BUILD_REPRODUCIBILITY.md
@@ -7,8 +7,18 @@ the underlying Bitcoin chain.
 
 ## Status
 
-The build pipeline is **byte-deterministic today, but only if every
-operator runs the same release binary**:
+Current status as of 2026-07-24:
+
+- active snapshot and delta builds derive placement and tag seeds from their
+  committed Bitcoin chain anchors;
+- server loading and DPF/Harmony native clients recompute and verify those
+  anchor-derived seeds, while WASM surfaces the same verification result;
+- database proofs and production pins authenticate the block height/hash used
+  by strict clients; and
+- CI runs a small synthetic cross-build determinism test on clean runners.
+
+The original pre-migration baseline was byte-deterministic only when every
+operator ran the same release binary:
 
 - `bitcoind dumptxoutset` is byte-deterministic at a given block hash.
   The UTXO set has a fixed serialization order and Bitcoin Core's
@@ -17,7 +27,7 @@ operator runs the same release binary**:
   no `OsRng`, no `thread_rng`, no `SystemTime` seeding anywhere in
   `build/src/` or `pir-core/src/`. All `Instant::now()` calls are
   timing logs only.
-- All PRG seeds flow from three hardcoded constants in source:
+- All PRG seeds originally flowed from three hardcoded constants in source:
 
   | Constant | Value | Purpose |
   | --- | --- | --- |
@@ -218,26 +228,23 @@ more entropy (e.g., future FHE-layer pre-randomization).
   fabricates a matching anchor+seed pair — that needs the client check
   below.
 
-### Remaining
+### Completion and deferred follow-ups
 
-1. **Client-side verification wiring.** Clients (`pir-sdk-client`,
-   `pir-sdk-wasm`, the standalone TS OnionPIR client) still trust the
-   header seed. They should read the anchor from the v2 header (or the
-   attest response) and `verify_anchor_seeds(&header, domain, tag_domain)`,
-   refusing to query on mismatch. **Trust model (per project owner):**
-   the seed is a deterministic function of the anchor block-header hash,
-   so a client that can *see the block hash used* can recompute the seed
-   and confirm it matches; how the client independently confirms that
-   block hash is left open (Bitcoin light client, baked-in pin,
-   attestation `REPORT_DATA`, or multi-operator quorum — many viable
-   paths). The verifier code is trivial; the anchor-delivery channel is
-   the remaining design choice.
-2. **CI cross-build check.** GitHub Actions workflow that runs
-   `./scripts/build_full.sh <snapshot> <height>` twice on clean
-   checkouts at the same `<height>`, then `sha256sum`-compares the
-   output cuckoo files. Deferred until first multi-operator deployment.
-3. **HarmonyPIR keys not affected** — query-time, client-derived;
-   no build-side seed.
+1. **Client-side verification wiring — complete.** Shared SDK database metadata
+   reconstructs the committed headers and calls `verify_anchor_seeds`; DPF and
+   Harmony clients fail before querying on a mismatch. WASM exposes the same
+   `anchorVerified` result, while strict database-proof and production-pin
+   checks authenticate the displayed block anchors. The browser additionally
+   verifies both delta endpoint inclusion proofs and links their block hashes
+   to mempool.space for independent inspection.
+2. **Cross-build CI — synthetic gate landed; full production build deferred.**
+   `.github/workflows/build-determinism.yml` runs
+   `pir-core/tests/cross_build_determinism.rs` on clean runners and compares
+   serialized outputs. Running the entire multi-hour
+   `scripts/build_full.sh <snapshot> <height>` twice and comparing all large
+   production artifacts remains deferred until the first multi-operator build.
+3. **HarmonyPIR keys are not affected** — they are query-time,
+   client-derived and have no build-side seed.
 
 ## Merkle tables — exempt from chain-derivation (resolved)
 
@@ -257,10 +264,9 @@ The only fixed Merkle seed (`0xBA7C_51B1_… + level`) lived in the
 **legacy N-ary tree Merkle** (`merkle_builder.rs` / `gen_4_build_merkle_dpf`
 / `test_merkle_verify*`), which the active pipeline never built. Those
 builders were **removed** rather than chain-derived. The inert
-server/protocol/reference-client N-ary load+verify path (opcodes
-`0x31`/`0x32`, the `MappedDatabase.merkle_*` fields) is slated for
-removal in a focused follow-up; it is cleanly separated from the live
-per-bucket path (opcodes `0x33`/`0x34`).
+server/protocol/reference-client N-ary load+verify path has also been removed.
+Opcodes `0x31`/`0x32` remain reserved only so they cannot be reused
+accidentally; the live per-bucket path uses opcodes `0x33`/`0x34`.
 
 **Onion anchor coverage** is complete: `onion_index_meta.bin` +
 `onion_chunk_cuckoo.bin` + `onion_index_all.bin` all embed the anchor,

--- a/docs/ORAM_LIVE_IMAGE_BINDING_PLAN.md
+++ b/docs/ORAM_LIVE_IMAGE_BINDING_PLAN.md
@@ -1,11 +1,14 @@
 # ORAM live-image binding
 
-Status: regenerate-on-boot implementation is tracked by BitcoinPIR PR #70.
-The proof-producing and trusted-state-separation changes landed in
-Bitcoin-PIR/oram PRs #4 and #5. The selected production model discards prior
-mutable ORAM state and rebuilds from proof-bound inputs before listening. This
-document also retains the more complex persistent-lineage design for any future
-node that cannot afford regeneration.
+Status: **production rollout complete as of 2026-07-24**. BitcoinPIR PR #70
+landed the regenerate-on-boot implementation, and PR #71 fixed the final
+trusted-state path contract and published the deployed pins. The
+proof-producing and trusted-state-separation changes landed in Bitcoin-PIR/oram
+PRs #4 and #5. The selected production model discards prior mutable ORAM state
+and rebuilds from proof-bound inputs before listening. This document also
+retains the more complex persistent-lineage design for any future node that
+cannot afford regeneration; that design is not an outstanding requirement for
+the current deployment.
 
 ## Regenerate-on-boot rollout status
 
@@ -21,12 +24,17 @@ node that cannot afford regeneration.
       source/proof mutation tests.
 - [x] Require the frontend trust-chain manifest and production pin to agree on
       `fromMuhashHex`.
-- [ ] Merge the implementation and build the final binaries from the merged
+- [x] Merge the implementation and build the final binaries from the merged
       commit.
-- [ ] Build, archive, upload, and boot the final Tier 3 UKI.
-- [ ] Pass AMD attestation, encrypted-channel, operator-identity, db 0/db 1
+- [x] Build, archive, upload, and boot the final Tier 3 UKI.
+- [x] Pass AMD attestation, encrypted-channel, operator-identity, db 0/db 1
       proof, padded ORAM, and strict browser acceptance gates.
-- [ ] Publish the final binary/UKI/MEASUREMENT pins and deployment record.
+- [x] Publish the final binary/UKI/MEASUREMENT pins and deployment record.
+
+The final deployment record and reviewed values are in
+[`STRICT_VERIFICATION_PROGRESS.md`](STRICT_VERIFICATION_PROGRESS.md) and
+[`PHASE3_ROADMAP.md`](PHASE3_ROADMAP.md). The archived production UKI is
+`main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi`.
 
 ## The missing link
 

--- a/docs/PROJECT_CLOSEOUT_TODO.md
+++ b/docs/PROJECT_CLOSEOUT_TODO.md
@@ -1,0 +1,105 @@
+# Project closeout TODO
+
+Status date: 2026-07-24
+
+This file tracks the ordered closeout after the strict-verification and Tier 3
+ORAM regenerate-on-boot rollout. A checked item means the work is merged into
+the authoritative repository and, where applicable, activated and verified in
+production. A draft PR or an implementation on an unmerged branch is not
+complete.
+
+## 0. Reconcile completed rollout documentation
+
+- [x] Record PRs #70 and #71 as merged and the Tier 3 regenerate-on-boot rollout
+      as complete.
+- [x] Mark the final UKI build, archive, upload, boot, acceptance gates, and pin
+      publication complete in `ORAM_LIVE_IMAGE_BINDING_PLAN.md`.
+- [x] Reconcile `BUILD_REPRODUCIBILITY.md` with the landed client-side anchor
+      verification and synthetic cross-build determinism CI.
+- [ ] Merge this documentation reconciliation into `main`.
+
+## 1. Automate browser-only strict production gates
+
+Tracking PR: BitcoinPIR #67.
+
+- [ ] Rebase or merge current `main` into the PR branch.
+- [ ] Review the Playwright assertions for runtime pin, operator identity,
+      encrypted channel, result verification, and per-query disconnect.
+- [ ] Re-run local Web tests and the production browser canary.
+- [ ] Mark the PR ready, merge it, and confirm the scheduled/manual workflow is
+      present on `main`.
+
+## 2. Fail fast on malformed HarmonyPIR V2 streams
+
+Tracking PR: BitcoinPIR #68.
+
+- [ ] Rebase or merge current `main` into the PR branch.
+- [ ] Review duplicate-group, preamble, terminal-metadata, and socket-discard
+      behavior, including regression coverage.
+- [ ] Run the SDK, WASM, Web, and formal-wire-shape gates affected by the diff.
+- [ ] Mark the PR ready and merge it.
+
+## 3. Land database proof v2 capability
+
+Tracking PRs: `Bitcoin-PIR/attested-builder` #1 and BitcoinPIR #69.
+
+- [ ] Review and merge the producer/re-attester implementation in
+      `attested-builder` without treating a recorded verifier result as a trust
+      input.
+- [ ] Review BitcoinPIR #69's v2 parser, typed Onion layout, dual-serving wire
+      path, WASM handle, and strict no-fallback behavior.
+- [ ] Rebase, rerun all affected Rust/WASM/Web/formal gates, and merge #69 as a
+      capability-only change.
+- [ ] Keep the deployed v1 path and explicit Onion layout pins active until v2
+      evidence exists and passes the production activation gates below.
+
+## 4. Activate database proof v2 in production
+
+- [ ] Inventory both hosts' retained db 0/db 1 Onion artifacts.
+- [ ] Re-attest both existing layouts and archive canonical v2 evidence, SNP
+      reports, inputs, and independent verifier output.
+- [ ] Import the evidence into the proof registry/lock flow before activation.
+- [ ] Stage identical v2 sidecars on Hetzner and VPSBG.
+- [ ] Rebuild and deploy the server binary and Tier 3 UKI required for dual
+      serving; rotate reviewed runtime pins without a fallback window.
+- [ ] Switch strict native/WASM/Web clients to v2, remove temporary v1 Onion
+      layout pins, and fail closed rather than falling back to v1.
+- [ ] Pass db 0/db 1 verification on both hosts and all strict production
+      browser/native canaries.
+
+## 5. Continue repository-boundary migration
+
+The initial HarmonyPIR, SDK-directory, and formal-proof milestone is complete in
+PRs #61, #62, and #63. Continue in the order defined by
+`REPOSITORY_BOUNDARIES.md`:
+
+- [ ] Move immutable generated proof bundles into `proof-registry` and add
+      `verification/locks/generated-proofs.json` plus consumer re-verification.
+- [ ] Reconcile the duplicate `rootbundle` implementations.
+- [ ] Move remaining `pdf/` sources into `Bitcoin-PIR/whitepaper` after a
+      reproducible build comparison.
+- [ ] Group remaining in-repository crates/apps/tools in small path-only PRs.
+- [ ] Extract a reusable Web client package while keeping production trust
+      policy in this repository.
+- [ ] Consider standalone explorer/Electrum/development-issuer repositories only
+      after they consume the shared strict client flow.
+- [ ] Handle full builder extraction and `vendor/` replacement last, gated on a
+      byte-identical hermetic offline build.
+
+## 6. Independent non-blocking maintenance
+
+- [ ] Resolve issue #18 by producing empirical DPF/Harmony wire fixtures and
+      evaluating the all-Merkle-levels-parallel optimization.
+- [ ] Review and merge or close outstanding dependency-update PRs separately
+      from the security and proof activation sequence.
+
+## Closeout invariants
+
+- Production activation and capability landing are separate decisions.
+- No v2-to-v1 silent fallback is permitted in strict mode.
+- Any server/UKI change must use an exact merged commit, archived artifact,
+  reviewed binary/UKI/MEASUREMENT pins, and post-deploy attestation/channel/query
+  gates.
+- Any new snapshot or delta follows `DATABASE_ROOT_ROTATION_RUNBOOK.md`.
+- Historical or superseded checklists are not reopened unless current code or
+  production evidence demonstrates an actual gap.


### PR DESCRIPTION
## Summary

- add one ordered closeout tracker for strict verification, database proof v2, production activation, repository boundaries, and maintenance
- mark the Tier 3 regenerate-on-boot rollout and final pin publication complete
- reconcile build reproducibility documentation with landed anchor verification and synthetic determinism CI
- distinguish capability merges from production activation gates

## Why

The implementation and deployment completed in PRs #70 and #71, but the ORAM plan still showed the final rollout steps as open and the reproducibility document still described client anchor verification as missing. The new tracker prevents completed historical items from being confused with the remaining non-blocking work.

## Validation

- `cargo test -p pir-core --test cross_build_determinism -- --nocapture` — 5 passed
- `git diff --check`