### PR TITLE
Add database proof v2 re-attestation UKI mode

### DIFF
--- a/docs/ATTESTED_BUILDER_TIER3_UKI.md
+++ b/docs/ATTESTED_BUILDER_TIER3_UKI.md
@@ -3,8 +3,9 @@
 This runbook is for the temporary VPSBG SEV-SNP builder image. It is separate
 from the production pir2 Tier 3 UKI. The builder UKI has no sshd, no
 cloudflared, and no runit service tree. It boots, mounts `/home/pir/data`, runs
-`pir-attested-builder` once in roots-only mode, writes Merkle roots, the root
-payload, manifests, and SEV-SNP evidence, then powers off. It does not produce a
+one selected attested-builder workflow, writes SEV-SNP evidence, then powers
+off. It supports both a roots-only snapshot build and a v2 re-attestation scan
+of retained production serving images. Neither mode produces a new
 server-loadable BitcoinPIR database.
 
 ## Build the UKI on VPSBG Slice 2
@@ -55,7 +56,44 @@ sudo ATTESTED_BUILDER_REPO=/home/pir/bitcoin-pir/attested-builder \
   ./scripts/build_uki_attested_builder_tier3.sh
 ```
 
-## Provision Runtime Inputs
+## Provision v2 re-attestation inputs
+
+This mode scans db 0 and db 1 in sequence. It validates the retained cuckoo,
+bin-hash, Merkle, preprocessed INDEX/NTT, and sibling images; binds their exact
+hashes into each v2 payload; obtains a new SNP report; and verifies the result
+inside the guest. It does not rebuild either database.
+
+```bash
+sudo mkdir -p /home/pir/data/attested-builder-runs
+sudo tee /home/pir/data/attested-builder/config.env >/dev/null <<'CONFIG'
+MODE=reattest-existing-v2
+RUN_ID=db-proof-v2-948454
+V2_JOB_COUNT=2
+V2_DB0_PREDECESSOR_PROOF_DIR=/home/pir/data/attestations/mainnet_948454_sev_snp
+V2_DB0_ARTIFACT_DIR=/home/pir/data/checkpoints/948454_deterministic
+V2_DB0_OUT_DIR=/home/pir/data/attestations/mainnet_948454_v2_sev_snp
+V2_DB1_PREDECESSOR_PROOF_DIR=/home/pir/data/attestations/delta_940611_948454_sev_snp
+V2_DB1_ARTIFACT_DIR=/home/pir/data/deltas/940611_948454_canonical_20260615
+V2_DB1_OUT_DIR=/home/pir/data/attestations/delta_940611_948454_v2_sev_snp
+CONFIG
+```
+
+All configured paths must be under `/home/pir/data`. Output directories must
+not already exist. Set `V2_JOB_COUNT=1` and use the db0 variables when
+intentionally running or retrying only one database.
+
+Successful outputs are written to the two configured output directories, with
+convenience links at:
+
+```text
+/home/pir/data/attested-builder-runs/v2-db0-latest
+/home/pir/data/attested-builder-runs/v2-db1-latest
+```
+
+Each directory includes `build-evidence.bin`, the SNP report and report data,
+`root-bundle-payload.bin`, `build-evidence.verify.txt`, and `SHA256SUMS`.
+
+## Provision roots-only rebuild inputs
 
 Prepare these while the server is still in Slice 2:
 
@@ -64,6 +102,7 @@ sudo mkdir -p /home/pir/data/attested-builder/inputs
 sudo mkdir -p /home/pir/data/attested-builder-runs
 sudo tee /home/pir/data/attested-builder/config.env >/dev/null <<'CONFIG'
 SNAPSHOT=/home/pir/data/attested-builder/inputs/txoutset_<height>.dat
+MODE=full-build
 EXPECTED_MUHASH=<64-byte-Core-display-muhash>
 NETWORK_MAGIC=f9beb4d9
 ANCHOR_HEIGHT=<height>

--- a/docs/DB_PROOF_V2_PLAN.md
+++ b/docs/DB_PROOF_V2_PLAN.md
@@ -1,7 +1,6 @@
 # Database proof v2: complete OnionPIR layout binding
 
-Status: the producer implementation is merged and the consumer implementation
-is in final review. The
+Status: the producer and consumer capability implementations are merged. The
 [attested-builder producer PR](https://github.com/Bitcoin-PIR/attested-builder/pull/1)
 implements canonical v2 evidence plus existing-artifact re-attestation. The
 [consumer PR #69](https://github.com/Bitcoin-PIR/Bitcoin-PIR/pull/69) implements
@@ -153,6 +152,11 @@ It must not be described as a fresh full build.
       placement, legal cuckoo bins, entry-derived index geometry, and commits
       both the predecessor evidence and SNP-report digests. This re-seals
       existing artifacts without rebuilding the database.
+- [x] Support production's retained final serving images when the raw packed,
+      index-bin, and sibling-row inputs have been deleted. `attested-builder`
+      PR #4 validates their headers/geometry and exact deterministic chunk
+      placements, rebuilds ordered roots from retained leaf hashes, and binds
+      every scanned serving image by SHA-256 in the new v2 payload.
 - [x] Add a distinct `REQ_GET_DB_PROOF_V2` wire request and optional
       `proof_v2_dir`, while preserving v1 serving for old clients.
 - [x] Recompute `params_hash_v2` in Rust/WASM and return a typed verified
@@ -191,10 +195,21 @@ databases under:
 - `/home/pir/data/deltas/940611_948454_canonical_20260615`
 
 Both directories contain `onion_index_meta.bin`,
-`onion_chunk_cuckoo.bin`, the packed/index tables and bin hashes, the Onion
-Merkle roots/siblings/tree-tops, and `MANIFEST.toml`. This is sufficient to
-implement and benchmark the existing-artifact checker without starting a new
-database build.
+`onion_chunk_cuckoo.bin`, the ordered index/data bin hashes, Onion Merkle
+roots/tree-tops, preprocessed sibling databases, `onion_index_all.bin`,
+`onion_shared_ntt.bin`, and `MANIFEST.toml`. They do **not** retain
+`onion_packed_entries.bin`, `onion_index_bins.bin`, or raw sibling-row files.
+The final-serving-image path added in `attested-builder` PR #4 is therefore
+required; the original raw-table-only scanner would not run on production.
+
+A read-only full placement audit on Hetzner confirmed db 0 has 948,640 packed
+entries in 2,845,920 exact deterministic placements and db 1 has 116,030
+entries in 348,090 placements. Every entry appears in exactly its three
+anchor-derived groups and in a legal cuckoo position. The retained preprocessed
+INDEX, NTT, and sibling headers also match the formats now enforced by the
+re-attester. This is sufficient to re-seal the layouts without a database
+rebuild; client-side Merkle verification still binds returned plaintexts to the
+proof-bound Onion root.
 
 The current manifests use an all-zero placeholder hash for the large DPF and
 Onion cuckoo files. The re-attester must therefore verify the actual tables

--- a/docs/PROJECT_CLOSEOUT_TODO.md
+++ b/docs/PROJECT_CLOSEOUT_TODO.md
@@ -48,14 +48,17 @@ Tracking PRs: `Bitcoin-PIR/attested-builder` #1 and BitcoinPIR #69.
       input.
 - [x] Review BitcoinPIR #69's v2 parser, typed Onion layout, dual-serving wire
       path, WASM handle, and strict no-fallback behavior.
-- [ ] Rebase, rerun all affected Rust/WASM/Web/formal gates, and merge #69 as a
+- [x] Rebase, rerun all affected Rust/WASM/Web/formal gates, and merge #69 as a
       capability-only change.
 - [ ] Keep the deployed v1 path and explicit Onion layout pins active until v2
       evidence exists and passes the production activation gates below.
 
 ## 4. Activate database proof v2 in production
 
-- [ ] Inventory both hosts' retained db 0/db 1 Onion artifacts.
+- [x] Inventory Hetzner's retained db 0/db 1 Onion artifacts and implement the
+      final-serving-image re-attestation path in `attested-builder` PR #4.
+- [ ] Confirm the same retained paths on VPSBG before booting the re-attestation
+      UKI.
 - [ ] Re-attest both existing layouts and archive canonical v2 evidence, SNP
       reports, inputs, and independent verifier output.
 - [ ] Import the evidence into the proof registry/lock flow before activation.

--- a/scripts/build_uki_attested_builder_tier3.sh
+++ b/scripts/build_uki_attested_builder_tier3.sh
@@ -247,6 +247,27 @@ echo
 cat <<EOF
 Before booting this UKI, provision runtime inputs on VPSBG Slice 2:
 
+For database-proof v2 re-attestation of the retained production layouts:
+
+  sudo mkdir -p /home/pir/data/attested-builder-runs
+  sudo tee /home/pir/data/attested-builder/config.env >/dev/null <<'CONFIG'
+MODE=reattest-existing-v2
+RUN_ID=db-proof-v2-948454
+V2_JOB_COUNT=2
+V2_DB0_PREDECESSOR_PROOF_DIR=/home/pir/data/attestations/mainnet_948454_sev_snp
+V2_DB0_ARTIFACT_DIR=/home/pir/data/checkpoints/948454_deterministic
+V2_DB0_OUT_DIR=/home/pir/data/attestations/mainnet_948454_v2_sev_snp
+V2_DB1_PREDECESSOR_PROOF_DIR=/home/pir/data/attestations/delta_940611_948454_sev_snp
+V2_DB1_ARTIFACT_DIR=/home/pir/data/deltas/940611_948454_canonical_20260615
+V2_DB1_OUT_DIR=/home/pir/data/attestations/delta_940611_948454_v2_sev_snp
+CONFIG
+
+The v2 mode scans and hashes the retained final serving images; it does not
+rebuild the snapshot or delta. On success, both output directories contain the
+new evidence, SNP report, verifier transcript, and SHA256SUMS.
+
+For a full roots-only snapshot rebuild instead:
+
   sudo mkdir -p /home/pir/data/attested-builder/inputs /home/pir/data/attested-builder-runs
   sudo tee /home/pir/data/attested-builder/config.env >/dev/null <<'CONFIG'
 SNAPSHOT=/home/pir/data/attested-builder/inputs/txoutset_<height>.dat

--- a/scripts/dracut/97bpir-builder-tier3-init/bpir-builder-run.sh
+++ b/scripts/dracut/97bpir-builder-tier3-init/bpir-builder-run.sh
@@ -70,13 +70,128 @@ is_truthy() {
     esac
 }
 
+run_reattest_v2_job() {
+    local job=$1
+    local predecessor_name="V2_DB${job}_PREDECESSOR_PROOF_DIR"
+    local artifact_name="V2_DB${job}_ARTIFACT_DIR"
+    local output_name="V2_DB${job}_OUT_DIR"
+    local predecessor=${!predecessor_name:-}
+    local artifact=${!artifact_name:-}
+    local output=${!output_name:-}
+    local attest_log="$OUT_BASE/v2-db${job}-$RUN_ID.attest.log"
+
+    [[ -n "$predecessor" ]] || fail "$predecessor_name is required"
+    [[ -n "$artifact" ]] || fail "$artifact_name is required"
+    [[ -n "$output" ]] || fail "$output_name is required"
+    require_data_path "$predecessor_name"
+    require_data_path "$artifact_name"
+    require_data_path "$output_name"
+    [[ -d "$predecessor" ]] || fail "$predecessor_name not found: $predecessor"
+    [[ -d "$artifact" ]] || fail "$artifact_name not found: $artifact"
+    [[ ! -e "$output" ]] || fail "$output_name already exists: $output"
+    mkdir -p "$(dirname "$output")"
+
+    echo "[bpir-builder-run] re-attesting v2 db${job}"
+    echo "[bpir-builder-run] predecessor=$predecessor"
+    echo "[bpir-builder-run] artifacts=$artifact"
+    echo "[bpir-builder-run] output=$output"
+    "$BIN" attest-existing-layout \
+        "$predecessor" \
+        "$artifact" \
+        "${BAKED_BUILDER_GIT_COMMIT:-unknown}" \
+        "$BIN" \
+        sev-snp \
+        none \
+        "$ISSUED_AT" \
+        "$output" | tee "$attest_log"
+    mv "$attest_log" "$output/attest-existing-layout.txt"
+
+    "$BIN" emit-sev-snp-quote \
+        "$output/build-evidence.bin" \
+        "$output/build-evidence.sev-snp-report.bin" \
+        "$output/build-evidence.report-data"
+
+    "$BIN" verify-build-evidence \
+        "$output/build-evidence.bin" \
+        --builder-bin "$BIN" \
+        --payload "$output/root-bundle-payload.bin" \
+        --database-manifest "$output/database.manifest.sha256" \
+        --all-artifacts-manifest "$output/all-artifacts.manifest.sha256" \
+        --server-db-manifest "$output/server-db/MANIFEST.toml" \
+        --sev-snp-report "$output/build-evidence.sev-snp-report.bin" \
+        | tee "$output/build-evidence.verify.txt"
+
+    (
+        cd "$output"
+        find . -type f ! -name SHA256SUMS -print \
+            | sort \
+            | while IFS= read -r file; do sha256sum "$file"; done \
+            > SHA256SUMS
+    )
+    ln -sfn "$output" "$OUT_BASE/v2-db${job}-latest"
+    {
+        printf 'db%s_status=ok\n' "$job"
+        printf 'db%s_out_dir=%s\n' "$job" "$output"
+        printf 'db%s_evidence=%s\n' "$job" "$output/build-evidence.bin"
+        printf 'db%s_sev_snp_report=%s\n' "$job" "$output/build-evidence.sev-snp-report.bin"
+    } >> "$STATUS_FILE"
+}
+
+run_reattest_v2() {
+    OUT_BASE=${OUT_BASE:-/home/pir/data/attested-builder-runs}
+    require_data_path OUT_BASE
+    mkdir -p "$OUT_BASE"
+    RUN_ID=${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}
+    [[ "$RUN_ID" =~ ^[A-Za-z0-9._=-]+$ ]] || fail "RUN_ID contains unsafe characters: $RUN_ID"
+    ISSUED_AT=${ISSUED_AT:-$(date -u +%s)}
+    [[ "$ISSUED_AT" =~ ^[0-9]+$ ]] || fail "ISSUED_AT must be an integer"
+    V2_JOB_COUNT=${V2_JOB_COUNT:-2}
+    [[ "$V2_JOB_COUNT" == 1 || "$V2_JOB_COUNT" == 2 ]] ||
+        fail "V2_JOB_COUNT must be 1 or 2"
+
+    STATUS_FILE="$OUT_BASE/builder-tier3-v2-$RUN_ID.status"
+    {
+        printf 'status=running\n'
+        printf 'mode=reattest-existing-v2\n'
+        printf 'run_id=%s\n' "$RUN_ID"
+        printf 'issued_at=%s\n' "$ISSUED_AT"
+        printf 'baked_builder_git_commit=%s\n' "${BAKED_BUILDER_GIT_COMMIT:-unknown}"
+        printf 'baked_builder_bin_sha256=%s\n' "${BAKED_BUILDER_BIN_SHA256:-unknown}"
+        printf 'started_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } > "$STATUS_FILE"
+
+    local status=0
+    trap 'status=$?; if [[ $status -ne 0 ]]; then printf "status=failed\nexit_code=%s\nfinished_at=%s\n" "$status" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$STATUS_FILE"; fi' EXIT
+    local job
+    for ((job = 0; job < V2_JOB_COUNT; job++)); do
+        run_reattest_v2_job "$job"
+    done
+    {
+        printf 'status=ok\n'
+        printf 'exit_code=0\n'
+        printf 'finished_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } >> "$STATUS_FILE"
+    trap - EXIT
+    echo "[bpir-builder-run] v2 re-attestation completed successfully"
+}
+
 [[ -r "$BAKED_ENV" ]] || fail "missing baked metadata: $BAKED_ENV"
 load_kv_file "$BAKED_ENV" \
     "BAKED_BUILDER_REPO BAKED_BUILDER_GIT_COMMIT BAKED_BUILDER_BIN_SHA256"
 
 [[ -r "$CONFIG" ]] || fail "missing runtime config: $CONFIG"
 load_kv_file "$CONFIG" \
-    "SNAPSHOT EXPECTED_MUHASH NETWORK_MAGIC ANCHOR_HEIGHT ANCHOR_HASH CORE_VERSION OUT_BASE OUT_DIR RUN_ID MIN_FREE_KB REFERENCE_DATABASE_MANIFEST REFERENCE_ALL_ARTIFACTS_MANIFEST ONION_ENTRY_SIZE PARTITIONS ISSUED_AT PUSH_BATCH_ENTRIES ORAM_DIRECT_INPUT_DIR KEEP_ORAM_DIRECT_INPUTS"
+    "MODE SNAPSHOT EXPECTED_MUHASH NETWORK_MAGIC ANCHOR_HEIGHT ANCHOR_HASH CORE_VERSION OUT_BASE OUT_DIR RUN_ID MIN_FREE_KB REFERENCE_DATABASE_MANIFEST REFERENCE_ALL_ARTIFACTS_MANIFEST ONION_ENTRY_SIZE PARTITIONS ISSUED_AT PUSH_BATCH_ENTRIES ORAM_DIRECT_INPUT_DIR KEEP_ORAM_DIRECT_INPUTS V2_JOB_COUNT V2_DB0_PREDECESSOR_PROOF_DIR V2_DB0_ARTIFACT_DIR V2_DB0_OUT_DIR V2_DB1_PREDECESSOR_PROOF_DIR V2_DB1_ARTIFACT_DIR V2_DB1_OUT_DIR"
+
+[[ -x "$BIN" ]] || fail "builder binary missing or not executable: $BIN"
+[[ -c /dev/sev-guest ]] || fail "/dev/sev-guest missing"
+
+MODE=${MODE:-full-build}
+if [[ "$MODE" == reattest-existing-v2 ]]; then
+    run_reattest_v2
+    exit 0
+fi
+[[ "$MODE" == full-build ]] || fail "unsupported MODE: $MODE"
 
 require_env SNAPSHOT
 require_env EXPECTED_MUHASH
@@ -92,9 +207,7 @@ require_data_path REFERENCE_ALL_ARTIFACTS_MANIFEST
 [[ "$EXPECTED_MUHASH" =~ ^[0-9a-fA-F]{64}$ ]] || fail "EXPECTED_MUHASH must be 64 hex chars"
 [[ "$NETWORK_MAGIC" =~ ^[0-9a-fA-F]{8}$ ]] || fail "NETWORK_MAGIC must be 8 hex chars"
 [[ "$ANCHOR_HEIGHT" =~ ^[0-9]+$ ]] || fail "ANCHOR_HEIGHT must be an integer"
-[[ -x "$BIN" ]] || fail "builder binary missing or not executable: $BIN"
 [[ -x "$PIPELINE" ]] || fail "pipeline script missing or not executable: $PIPELINE"
-[[ -c /dev/sev-guest ]] || fail "/dev/sev-guest missing"
 
 OUT_BASE=${OUT_BASE:-/home/pir/data/attested-builder-runs}
 require_data_path OUT_BASE


### PR DESCRIPTION
## Summary
- add a fail-closed Tier 3 UKI mode that re-attests retained db0/db1 layouts sequentially without rebuilding them
- emit a new SNP report, verify each bundle in-guest, write SHA256SUMS, and preserve per-database outputs/status
- document the exact production paths and correct the retained-artifact inventory

## Verification
- bash -n on both changed shell scripts
- git diff --check
- attested-builder PR #4 workspace tests: 77 passed
- read-only Hetzner header and full deterministic placement audits for db0/db1