### PR TITLE
Publish database-proof-v2 production runtime pins

### DIFF
--- a/docs/DB_PROOF_V2_PLAN.md
+++ b/docs/DB_PROOF_V2_PLAN.md
@@ -1,16 +1,18 @@
 # Database proof v2: complete OnionPIR layout binding
 
-Status: the producer and consumer capability implementations are merged. The
+Status: the producer and consumer capability implementations are merged, and
+the production server-side dual-serving rollout is complete. The
 [attested-builder producer PR](https://github.com/Bitcoin-PIR/attested-builder/pull/1)
 implements canonical v2 evidence plus existing-artifact re-attestation. The
 [consumer PR #69](https://github.com/Bitcoin-PIR/Bitcoin-PIR/pull/69) implements
 dual-serving, native/WASM verification, typed Onion layout installation, and
-an explicit v2-only native verification method. It intentionally leaves the
-deployed v1 strict call path and temporary per-field layout pins in place so
-the capability PR can merge before production sidecars exist. Production
-activation remains a separate fail-closed cutover. The deployed v1 strict flow
-continues to fail closed against the explicit layout pins until v2 evidence,
-runtime configuration, frontend pins, and deployment all move together.
+an explicit v2-only native verification method. Canonical db 0/db 1 v2 bundles
+have now been independently verified, archived, staged identically, and loaded
+by both production hosts using BitcoinPIR commit
+`81dd96d442d39200fee7e6c97f5c308f38126756`. The deployed v1 strict client path
+and temporary per-field layout pins intentionally remain in place until the
+separate fail-closed client activation PR publishes reviewed v2 pins and moves
+all supported clients together. There is no v2-to-v1 fallback in that cutover.
 
 ## Goal and trust model
 
@@ -142,7 +144,7 @@ It must not be described as a fresh full build.
    OnionPIR, then follow the rollback rules in
    `DATABASE_ROOT_ROTATION_RUNBOOK.md` if any host or proof disagrees.
 
-## Implementation status (2026-07-22)
+## Implementation status (2026-07-24)
 
 - [x] Freeze canonical `BuildParamsV2`, evidence domains, fixed-width encoding,
       and a producer/verifier golden hash vector.
@@ -166,11 +168,14 @@ It must not be described as a fresh full build.
       the existing v1 method during the staged migration.
 - [x] Expose the v2-only stateless verifier and typed layout getters to WASM.
       The production web client deliberately continues to request v1.
-- [ ] Generate v2 evidence and SNP reports for production db 0 and db 1 on the
+- [x] Generate v2 evidence and SNP reports for production db 0 and db 1 on the
       attested builder.
-- [ ] Archive and independently verify the new bundles, then add reviewed
-      production `params_hash_v2`/builder pins.
-- [ ] Configure and deploy `proof_v2_dir` on Hetzner and VPSBG using a runtime
+- [x] Archive and independently verify the new bundles. The reviewed evidence
+      digests and `params_hash_v2` values are recorded in
+      `PHASE3_ROADMAP.md`.
+- [ ] Publish the reviewed production `params_hash_v2`/builder pins in the
+      strict-client activation PR.
+- [x] Configure and deploy `proof_v2_dir` on Hetzner and VPSBG using a runtime
       binary that supports the v2 opcode.
 - [ ] Submit the activation PR: switch strict native/web Onion clients to v2,
       consume only proof-backed layout values, and remove
@@ -181,10 +186,10 @@ It must not be described as a fresh full build.
 The unchecked items are activation gates. Merging the implementation PRs alone
 must not be described as a production v2 rollout.
 
-Before starting the producer PR, inventory the retained files on both hosts
-and record which consistency checks can be reconstructed from final artifacts
-alone. Missing intermediate files can change the cost estimate, but they do
-not justify accepting an uncommitted server-info value.
+The pre-production inventory below determined which consistency checks could
+be reconstructed from final artifacts alone. Missing intermediate files did
+not justify accepting an uncommitted server-info value; the final-serving-image
+re-attestation path was implemented and used instead.
 
 ### Initial artifact inventory (2026-07-20)
 
@@ -214,7 +219,9 @@ proof-bound Onion root.
 The current manifests use an all-zero placeholder hash for the large DPF and
 Onion cuckoo files. The re-attester must therefore verify the actual tables
 against their Merkle roots and proof-bound super-roots; verifying only
-`MANIFEST.toml` is insufficient. VPSBG's corresponding on-disk inventory
-still needs to be recorded before the SEV run; its SSH endpoint was not
-reachable during this read-only inventory, so no claim is made about missing
-files there.
+`MANIFEST.toml` is insufficient. Before the SEV run, the required final-serving
+inputs and both database layouts were confirmed through the measured
+re-attestation workflow on VPSBG. The resulting db 0/db 1 v2 bundles were
+independently verified and then staged byte-identically on VPSBG and Hetzner;
+the production runtime now loads both sidecars while retaining the v1
+compatibility opcode.

--- a/docs/ORAM_LIVE_IMAGE_BINDING_PLAN.md
+++ b/docs/ORAM_LIVE_IMAGE_BINDING_PLAN.md
@@ -34,7 +34,7 @@ the current deployment.
 The final deployment record and reviewed values are in
 [`STRICT_VERIFICATION_PROGRESS.md`](STRICT_VERIFICATION_PROGRESS.md) and
 [`PHASE3_ROADMAP.md`](PHASE3_ROADMAP.md). The archived production UKI is
-`main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi`.
+`main-81dd96d4-db-proof-v2-20260724T112036Z-34b04d1bfc05.efi`.
 
 ## The missing link
 

--- a/docs/PHASE3_ROADMAP.md
+++ b/docs/PHASE3_ROADMAP.md
@@ -30,7 +30,7 @@ to whichever slice you want to start on.
 
 ---
 
-## Current state (as of 2026-07-20, ORAM Tier 3 UKI deployed)
+## Current state (as of 2026-07-24, ORAM + DB-proof-v2 Tier 3 UKI deployed)
 
 ### Production deployment
 
@@ -55,17 +55,17 @@ Launch MEASUREMENT (covers OVMF + Tier 3 UKI bytes — UKI now contains
 the unified_server BINARY itself in initramfs, NOT just a cmdline hash
 pin. So this digest authenticates the literal binary bytes the box is
 running, not "a binary the box claims matches a hash"):
-  a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86
+  d7ae6fb895380b1408b5ba7640a2eaa091754fc6279b62eb96f4bd1eee5532e95bc1df3b1485a06b3f43d648d05d3245
 
 UKI bytes sha256 (built by scripts/build_uki_tier3.sh on VPSBG and archived on Hetzner;
 includes initramfs with unified_server + cloudflared + runit + the
 sev-guest/ccp/tsm_report kernel modules baked in):
-  5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e
+  34b04d1bfc0501c0cc222aff446a55de0a74d4e5218a21a05bf8756f8293b681
 
 unified_server binary sha256 (computed at build time AND attested at
 runtime via /proc/self/exe — the two match because dracut was invoked
 with --nostrip; verifiers pin via --expect-binary on bpir-admin attest):
-  1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37
+  cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e
 
 ARK fingerprint (AMD Turin family root certificate — pinned in
 web/src/attest-pin.ts and used by --expect-ark-fingerprint to anchor
@@ -77,13 +77,24 @@ DB manifest roots (db_id order):
   delta_940611_948454:        c816f067117bca98256ee246c4469591ee8f537b2271d65b38d1536a70887963
 
 Server git rev (per /attest, captured at unified_server build time):
-  66034c8204e19b11b8c0602aa625c2414095deb2
+  81dd96d442d39200fee7e6c97f5c308f38126756
 
 Measured startup script git rev (boot-regeneration path and path-contract fix):
-  7b6cf108da189cc3b693c3f004612dcd90a80a0f
+  81dd96d442d39200fee7e6c97f5c308f38126756
 
 bitcoinpir-oram git rev used by the live binary and oramctl:
   cd2c1a224d640a8149cfdd75ef5a4f2579a84d0b
+
+Database-proof-v2 sidecars served identically by pir1 and pir2
+(`REQ_GET_DB_PROOF_V2 = 0x0c`):
+  db_id=0 build-evidence sha256:
+    e9795887805769525d484824d85d8b3fcda008340c1b2332de7b46a59f055517
+  db_id=0 params_hash_v2:
+    a600f33fa0e644aab533a050eabf9c03882aa00f1b293ddf9d7f4bf7c8142563
+  db_id=1 build-evidence sha256:
+    59bd47d078458490735ea8707db3c10a3473af034f653f4d51275e5e511c0509
+  db_id=1 params_hash_v2:
+    fe6f516696bafaa2226cc1bdc7888c7c69dd263a84817dd0f18cf8027123c45d
 ```
 
 NOTE on the X25519 channel pubkey: it's "long-lived" relative to per-
@@ -97,8 +108,8 @@ Verifiers can cross-check end-to-end with:
 ```bash
 # Static checks: report binding + binary + measurement + ARK chain
 bpir-admin attest wss://weikeng2.bitcoinpir.org \
-    --expect-measurement a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86 \
-    --expect-binary 1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37 \
+    --expect-measurement d7ae6fb895380b1408b5ba7640a2eaa091754fc6279b62eb96f4bd1eee5532e95bc1df3b1485a06b3f43d648d05d3245 \
+    --expect-binary cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e \
     --expect-ark-fingerprint 1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a
 
 # Live encrypted channel + AMD VCEK chain validation
@@ -490,8 +501,8 @@ assume you've reverted to Slice 2 first (see PHASE3_SLICE3_RECOVERY.md).
 
 # Attest VPSBG (verifies SEV-SNP report + binds X25519 channel pubkey)
 ./target/release/bpir-admin attest wss://weikeng2.bitcoinpir.org \
-    --expect-measurement a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86 \
-    --expect-binary 1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37 \
+    --expect-measurement d7ae6fb895380b1408b5ba7640a2eaa091754fc6279b62eb96f4bd1eee5532e95bc1df3b1485a06b3f43d648d05d3245 \
+    --expect-binary cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e \
     --expect-ark-fingerprint 1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a
 
 # End-to-end channel test with ARK-rooted chain validation

--- a/docs/PROJECT_CLOSEOUT_TODO.md
+++ b/docs/PROJECT_CLOSEOUT_TODO.md
@@ -50,25 +50,28 @@ Tracking PRs: `Bitcoin-PIR/attested-builder` #1 and BitcoinPIR #69.
       path, WASM handle, and strict no-fallback behavior.
 - [x] Rebase, rerun all affected Rust/WASM/Web/formal gates, and merge #69 as a
       capability-only change.
-- [ ] Keep the deployed v1 path and explicit Onion layout pins active until v2
-      evidence exists and passes the production activation gates below.
+- [x] Keep the deployed v1 path and explicit Onion layout pins active through
+      the capability merge and server-side dual-serving rollout; move clients
+      only in the separate fail-closed activation PR below.
 
 ## 4. Activate database proof v2 in production
 
 - [x] Inventory Hetzner's retained db 0/db 1 Onion artifacts and implement the
       final-serving-image re-attestation path in `attested-builder` PR #4.
-- [ ] Confirm the same retained paths on VPSBG before booting the re-attestation
+- [x] Confirm the same retained paths on VPSBG before booting the re-attestation
       UKI.
-- [ ] Re-attest both existing layouts and archive canonical v2 evidence, SNP
+- [x] Re-attest both existing layouts and archive canonical v2 evidence, SNP
       reports, inputs, and independent verifier output.
 - [ ] Import the evidence into the proof registry/lock flow before activation.
-- [ ] Stage identical v2 sidecars on Hetzner and VPSBG.
-- [ ] Rebuild and deploy the server binary and Tier 3 UKI required for dual
+- [x] Stage identical v2 sidecars on Hetzner and VPSBG.
+- [x] Rebuild and deploy the server binary and Tier 3 UKI required for dual
       serving; rotate reviewed runtime pins without a fallback window.
+- [x] Verify the db 0/db 1 v2 wire responses and evidence digests on both
+      production hosts.
 - [ ] Switch strict native/WASM/Web clients to v2, remove temporary v1 Onion
       layout pins, and fail closed rather than falling back to v1.
-- [ ] Pass db 0/db 1 verification on both hosts and all strict production
-      browser/native canaries.
+- [ ] Pass all strict production browser/native canaries after the client
+      cutover.
 
 ## 5. Continue repository-boundary migration
 

--- a/docs/STRICT_VERIFICATION_PROGRESS.md
+++ b/docs/STRICT_VERIFICATION_PROGRESS.md
@@ -176,17 +176,27 @@ passed on the full-feature UKI after it reopened state written by the diagnostic
 UKI. Hetzner intentionally remains on the independently pinned 2026-07-20
 binary above.
 
-On 2026-07-24, VPSBG moved to the boot-regeneration UKI built from measured
-startup commit `7b6cf108`. It reuses the unchanged `unified_server` binary from
-BitcoinPIR commit `66034c82` (SHA-256 `1134b8a4...09c37`) and the source-bound
-`oramctl` from bitcoinpir-oram commit `cd2c1a22`. The UKI SHA-256 is
-`5b854888...7b13e` and its live launch MEASUREMENT is
-`a3a8fb0f...04040b86`. Every boot now regenerates both authenticated ORAM
+On 2026-07-24, VPSBG moved to the database-proof-v2 boot-regeneration UKI built
+from BitcoinPIR commit `81dd96d4`. Its `unified_server` SHA-256 is
+`cc4ec24b...5e16b1e`; it uses the source-bound `oramctl` from bitcoinpir-oram
+commit `cd2c1a22`. The UKI SHA-256 is `34b04d1b...93b681` and its live launch
+MEASUREMENT is `d7ae6fb8...5d3245`. Every boot now regenerates both authenticated ORAM
 images from proof-bound inputs in SEV-protected tmpfs, verifies the emitted-page
 Merkle roots and the exact published bulk/trusted-state path contract, and only
 then opens the query server. Fixed-pin AMD attestation, the encrypted channel,
 dummy padded lookups, and known-present padded results for both db_id 0 and
-db_id 1 passed against the live full-feature UKI.
+db_id 1 passed against the live full-feature UKI. The runtime also returned
+strictly framed v2 proof responses for both database IDs; their build-evidence
+SHA-256 values matched the independently verified production bundles
+`e9795887...f055517` and `59bd47d0...1c0509`. After the VPSBG acceptance
+passed, the exact same `cc4ec24b...5e16b1e` binary and sidecars were rolled
+through Hetzner's secondary and primary services. Both loaded db 0/db 1 v2,
+kept `NRestarts=0`, and returned the same evidence digests over the public
+WebSocket endpoint. Hetzner's encrypted channel passed; as expected for that
+host, its binary pin and operator identity are not hardware-backed by SEV. A
+pre-publication browser canary built with the rotated pir1/pir2 pins then passed
+DPF-PIR, HarmonyPIR, OnionPIR, and ORAM TEE queries with automatic result
+verification and per-query teardown.
 
 ## Non-blocking follow-ups
 
@@ -203,12 +213,11 @@ reopen it:
   completely consumed pool-unavailable response may reuse a connection for V1
   fallback. Strict Merkle binding already prevented malformed hints from
   yielding trusted data; this closes the fail-fast and recovery gap.
-- Implement the separately scoped
-  [v2 database-proof migration](DB_PROOF_V2_PLAN.md), which commits the three
-  remaining OnionPIR layout values and replaces the explicit v1 layout pins
-  only after new builder evidence and production sidecars exist. Until then,
-  the production client safely fails closed against the explicit pins in
-  `web/src/attest-pin.ts`.
+- Complete the client-side activation stage of the separately scoped
+  [v2 database-proof migration](DB_PROOF_V2_PLAN.md). Production evidence and
+  dual-serving sidecars now exist on the servers; the remaining cutover must
+  publish reviewed `params_hash_v2` pins, switch strict Onion clients to the
+  v2-only verifier, and remove the temporary v1 layout pins without fallback.
 - Follow [the database/root rotation runbook](DATABASE_ROOT_ROTATION_RUNBOOK.md)
   for every new snapshot or delta generation.
 

--- a/web/public/proofs/oram-source/mainnet_948454.json
+++ b/web/public/proofs/oram-source/mainnet_948454.json
@@ -272,15 +272,15 @@
   },
   "liveDeployment": {
     "status": "strict-source-bound-boot-regeneration-live-on-pir2",
-    "verifiedAtUtc": "2026-07-24T01:52:40Z",
-    "currentPir2RuntimeBitcoinPirCommit": "66034c8204e19b11b8c0602aa625c2414095deb2",
+    "verifiedAtUtc": "2026-07-24T12:03:31Z",
+    "currentPir2RuntimeBitcoinPirCommit": "81dd96d442d39200fee7e6c97f5c308f38126756",
     "currentPir2RuntimeOramCommit": "cd2c1a224d640a8149cfdd75ef5a4f2579a84d0b",
     "strictRebuildOramCommit": "5f366492504d8e853cbd60d25a6adbf021a78746",
-    "pir2UkiSha256": "5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e",
-    "pir2BinarySha256": "1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37",
-    "pir2MeasurementHex": "a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86",
-    "pir2ChannelPubkeyHex": "d5e712c8a718c284d8cfa70a3cd910a04068f566f1ce46a36ef40121c928ae61",
-    "hetznerArchivePath": "/home/pir/uki-archive/tier3/main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi",
-    "note": "The published proof certifies a strict source-bound ORAM rebuild at bitcoinpir-oram commit 5f36649. The live pir2 Tier 3 UKI uses the measured startup script from BitcoinPIR commit 7b6cf108, the unchanged unified_server binary from commit 66034c82, and bitcoinpir-oram commit cd2c1a22. Every boot copies the proof-bound direct inputs into SEV-protected tmpfs, regenerates both authenticated ORAM images with fresh randomness, checks emitted-page Merkle roots before installing trusted state, validates every published bulk and trusted-state path, and only then opens the query server. Live checks passed: bpir-admin attest atomically matched the binary, measurement, and REPORT_DATA while validating ARK-to-ASK-to-VCEK plus the same report signature; channel-test revalidated the AMD chain and encrypted session; padded direct ORAM smoke requests returned known-present results for db_id 0 and db_id 1. The channel pubkey recorded here is observational and changes on process restart; verifiers must obtain it from the fresh attestation response and check REPORT_DATA instead of pinning it."
+    "pir2UkiSha256": "34b04d1bfc0501c0cc222aff446a55de0a74d4e5218a21a05bf8756f8293b681",
+    "pir2BinarySha256": "cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e",
+    "pir2MeasurementHex": "d7ae6fb895380b1408b5ba7640a2eaa091754fc6279b62eb96f4bd1eee5532e95bc1df3b1485a06b3f43d648d05d3245",
+    "pir2ChannelPubkeyHex": "06dfac7d93624a4f75d36aaae4bfcf5abfa6d1715be64bc92f43e6d78fb06608",
+    "hetznerArchivePath": "/home/pir/uki-archive/tier3/main-81dd96d4-db-proof-v2-20260724T112036Z-34b04d1bfc05.efi",
+    "note": "The published proof certifies a strict source-bound ORAM rebuild at bitcoinpir-oram commit 5f36649. The live pir2 Tier 3 UKI uses the measured startup script and unified_server from BitcoinPIR commit 81dd96d4, plus bitcoinpir-oram commit cd2c1a22. It dual-serves the reviewed database-proof-v2 sidecars while retaining v1 compatibility. Every boot copies the proof-bound direct inputs into SEV-protected tmpfs, regenerates both authenticated ORAM images with fresh randomness, checks emitted-page Merkle roots before installing trusted state, validates every published bulk and trusted-state path, and only then opens the query server. Live checks passed: bpir-admin attest atomically matched the binary, measurement, and REPORT_DATA while validating ARK-to-ASK-to-VCEK plus the same report signature; channel-test revalidated the AMD chain and encrypted session; the v2 wire responses matched both reviewed build-evidence digests; padded direct ORAM smoke requests returned known-present results for db_id 0 and db_id 1. The channel pubkey recorded here is observational and changes on process restart; verifiers must obtain it from the fresh attestation response and check REPORT_DATA instead of pinning it."
   }
 }

--- a/web/reproduce.html
+++ b/web/reproduce.html
@@ -482,19 +482,19 @@
                             <table class="pin-table">
                                 <tr>
                                     <td>MEASUREMENT</td>
-                                    <td>a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86</td>
+                                    <td>d7ae6fb895380b1408b5ba7640a2eaa091754fc6279b62eb96f4bd1eee5532e95bc1df3b1485a06b3f43d648d05d3245</td>
                                 </tr>
                                 <tr>
                                     <td>UKI sha256</td>
-                                    <td>5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e</td>
+                                    <td>34b04d1bfc0501c0cc222aff446a55de0a74d4e5218a21a05bf8756f8293b681</td>
                                 </tr>
                                 <tr>
                                     <td>binary sha256</td>
-                                    <td>1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37</td>
+                                    <td>cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e</td>
                                 </tr>
                                 <tr>
                                     <td>server git rev</td>
-                                    <td>66034c8204e19b11b8c0602aa625c2414095deb2</td>
+                                    <td>81dd96d442d39200fee7e6c97f5c308f38126756</td>
                                 </tr>
                                 <tr>
                                     <td>OVMF sha256</td>
@@ -560,7 +560,7 @@
                                 <h3>Get or rebuild the UKI</h3>
                                 <p>
                                     The current operator-archived artifact is
-                                    <code>main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi</code>, the
+                                    <code>main-81dd96d4-db-proof-v2-20260724T112036Z-34b04d1bfc05.efi</code>, the
                                     ORAM-enabled Tier 3 UKI that serves the database
                                     proof sidecar and direct ORAM lookups for db_id 0/1.
                                     It is a large runtime artifact, so this page pins the
@@ -570,11 +570,11 @@
                                     is not a public download URL.
                                 </p>
                                 <p class="meta" style="margin-top: 6px;">
-                                    Verify: <code>sha256sum main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi</code> →
-                                    <code>5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e</code>
+                                    Verify: <code>sha256sum main-81dd96d4-db-proof-v2-20260724T112036Z-34b04d1bfc05.efi</code> →
+                                    <code>34b04d1bfc0501c0cc222aff446a55de0a74d4e5218a21a05bf8756f8293b681</code>
                                 </p>
 <pre><code># Operator-only shortcut: retrieve the exact deployed bytes.
-scp pir-hetzner:/home/pir/uki-archive/tier3/main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi .</code></pre>
+scp pir-hetzner:/home/pir/uki-archive/tier3/main-81dd96d4-db-proof-v2-20260724T112036Z-34b04d1bfc05.efi .</code></pre>
                                 <p class="meta" style="margin-top: 6px;">
                                     Or perform a functional source rebuild. This is not
                                     a byte-identical reproduction of the production artifact:
@@ -584,13 +584,13 @@ scp pir-hetzner:/home/pir/uki-archive/tier3/main-7b6cf108-trusted-path-fix-20260
                                 </p>
 <pre><code>git clone https://github.com/Bitcoin-PIR/Bitcoin-PIR.git BitcoinPIR-runtime-repro
 cd BitcoinPIR-runtime-repro
-git checkout 7b6cf108da189cc3b693c3f004612dcd90a80a0f
+git checkout 81dd96d442d39200fee7e6c97f5c308f38126756
 RUSTFLAGS="--remap-path-prefix=$PWD=/build/repo --remap-path-prefix=$HOME=/build" \
 SOURCE_DATE_EPOCH=0 cargo build --locked --release -p runtime --features cuckoo-oram --bin unified_server
 strip --strip-debug target/release/unified_server
 
 sudo env KERNEL=/boot/vmlinuz-7.0.0-28-generic \
-OUT="$PWD/bpir-tier3-functional-rebuild-7b6cf108.efi" \
+OUT="$PWD/bpir-tier3-functional-rebuild-81dd96d4.efi" \
 BINARY="$PWD/target/release/unified_server" \
 BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
 ./scripts/build_uki_tier3.sh</code></pre>
@@ -615,7 +615,7 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
 	    --vcpus 2 \
 	    --vcpu-sig 0x00B10F10 \
 	    --ovmf OVMF_SEV_MEASUREDBOOT_4M.fd \
-	    --kernel main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi \
+	    --kernel main-81dd96d4-db-proof-v2-20260724T112036Z-34b04d1bfc05.efi \
 	    --guest-features 0x1</code></pre>
                             </li>
 
@@ -623,8 +623,8 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
                                 <h3>Verify the live report and AMD chain</h3>
 	<pre><code>cargo build --locked --release --bin bpir-admin -p bpir-admin
 ./target/release/bpir-admin attest wss://weikeng2.bitcoinpir.org \
-    --expect-measurement a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86 \
-    --expect-binary      1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37 \
+    --expect-measurement d7ae6fb895380b1408b5ba7640a2eaa091754fc6279b62eb96f4bd1eee5532e95bc1df3b1485a06b3f43d648d05d3245 \
+    --expect-binary      cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e \
     --expect-ark-fingerprint 1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a
 ./target/release/bpir-admin channel-test wss://weikeng2.bitcoinpir.org \
     --expect-ark-fingerprint 1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a</code></pre>
@@ -888,18 +888,18 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
                                 This page verifies the strict source-bound rebuild and records
                                 the live pir2 runtime that consumes it. The pinned pir2 runtime
                                 binary commit
-                                <code>66034c8204e19b11b8c0602aa625c2414095deb2</code>
+                                <code>81dd96d442d39200fee7e6c97f5c308f38126756</code>
                                 vendors <code>bitcoinpir-oram</code> at
                                 <code>cd2c1a224d640a8149cfdd75ef5a4f2579a84d0b</code>.
                                 The measured boot-regeneration script comes from
-                                <code>7b6cf108da189cc3b693c3f004612dcd90a80a0f</code>.
+                                <code>81dd96d442d39200fee7e6c97f5c308f38126756</code>.
                             </p>
                             <p>
                                 Live verification on the refreshed measured UKI passed
                                 <code>bpir-admin attest</code>, <code>channel-test</code>, and
                                 padded direct ORAM smoke requests for both db_id 0 and db_id 1.
                                 The UKI bytes are archived on Hetzner at
-                                <code>/home/pir/uki-archive/tier3/main-7b6cf108-trusted-path-fix-20260724T001409Z-5b8548888b5b.efi</code>.
+                                <code>/home/pir/uki-archive/tier3/main-81dd96d4-db-proof-v2-20260724T112036Z-34b04d1bfc05.efi</code>.
                             </p>
                         </div>
                     </section>
@@ -1010,7 +1010,7 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
                             <table class="pin-table">
                                 <tr>
                                     <td>binary sha256</td>
-                                    <td>4cf7d467032d7c7c48147495a0307771fd196dac403a7feb62d6f4f7502045b4</td>
+                                    <td>cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e</td>
                                 </tr>
                             </table>
                         </div>
@@ -1020,7 +1020,7 @@ BPIR_UNIFIED_SERVER_BIN="$PWD/target/release/unified_server" \
                         <h2>Verify pir1</h2>
 	<pre><code>cargo build --release --bin bpir-admin -p bpir-admin
 	./target/release/bpir-admin attest wss://weikeng1.bitcoinpir.org \
-	    --expect-binary 4cf7d467032d7c7c48147495a0307771fd196dac403a7feb62d6f4f7502045b4</code></pre>
+	    --expect-binary cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e</code></pre>
                         <p>
                             You can also check
                             <code>sha256sum /home/pir/BitcoinPIR/target/release/unified_server</code>

--- a/web/src/__tests__/oram-source-proof.test.ts
+++ b/web/src/__tests__/oram-source-proof.test.ts
@@ -44,10 +44,10 @@ describe('ORAM source-binding proof', () => {
       PIR2_TIER3_PIN.measurementHex,
     );
     expect(status.verified?.manifest.liveDeployment.pir2UkiSha256).toBe(
-      '5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e',
+      '34b04d1bfc0501c0cc222aff446a55de0a74d4e5218a21a05bf8756f8293b681',
     );
     expect(status.verified?.manifest.liveDeployment.currentPir2RuntimeBitcoinPirCommit).toBe(
-      '66034c8204e19b11b8c0602aa625c2414095deb2',
+      '81dd96d442d39200fee7e6c97f5c308f38126756',
     );
   });
 

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -132,22 +132,21 @@ export interface ServerAttestPin {
  * binary baked into the initramfs.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // Tier 3 ORAM UKI — 2026-07-24. The measured startup script is from
-  // BitcoinPIR commit 7b6cf108da189cc3b693c3f004612dcd90a80a0f; the unchanged
-  // unified_server binary is from commit
-  // 66034c8204e19b11b8c0602aa625c2414095deb2:
-  // unified_server serves db-proof query traffic and direct ORAM lookup
+  // Tier 3 ORAM + database-proof-v2 UKI — 2026-07-24. The measured startup
+  // script and unified_server binary are both built from BitcoinPIR commit
+  // 81dd96d442d39200fee7e6c97f5c308f38126756. unified_server dual-serves
+  // v1/v2 DB proofs and direct ORAM lookup
   // for db_id 0/1 as pir2 query-only (`--serve-queries`, no hint pool,
   // no OnionPIR) plus `--identity-*` (operator-signed identity,
   // server_id=pir2). MEASUREMENT captured from the live Tier 3 deploy via
   // `bpir-admin attest wss://weikeng2.bitcoinpir.org` after uploading
-  // UKI sha256 `5b8548888b5b5f8eabee5002c263179dd9b2efa8ad135efb1aefe79c3d17b13e`
+  // UKI sha256 `34b04d1bfc0501c0cc222aff446a55de0a74d4e5218a21a05bf8756f8293b681`
   // (SEV-SNP REPORT_DATA binding verified on
   // real hardware).
   measurementHex:
-    'a3a8fb0fb514c44314c96d442088b1646a3fe62f37b118648bcf1ff7d6a3a66039ba80728e5e189847001a9f04040b86',
+    'd7ae6fb895380b1408b5ba7640a2eaa091754fc6279b62eb96f4bd1eee5532e95bc1df3b1485a06b3f43d648d05d3245',
   binarySha256Hex:
-    '1134b8a4c33ffab8c545107983f00c8ef367986e7ea2c2ecd575919102d09c37',
+    'cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e',
   description: 'weikeng2.bitcoinpir.org (VPSBG, SEV-SNP, Tier 3 ORAM UKI)',
 };
 
@@ -160,13 +159,14 @@ export const PIR2_TIER3_PIN: ServerAttestPin = {
  */
 export const PIR1_PIN: ServerAttestPin = {
   // No measurementHex — Hetzner has no SEV.
-  // Bumped 2026-07-20: pir1 redeployed from BitcoinPIR commit
-  // d126f36adb1ec4da7f23dcfe97a81f7503b6829f with the strict-verification
-  // canary follow-up and durable, non-blocking HarmonyPIR V2 hint pool.
+  // Bumped 2026-07-24: pir1 redeployed from BitcoinPIR commit
+  // 81dd96d442d39200fee7e6c97f5c308f38126756. Both runtime services
+  // dual-serve database proofs v1/v2 while retaining the durable,
+  // non-blocking HarmonyPIR V2 hint pool.
   // Both Hetzner systemd services use this binary. This remains independent
   // from the pir2 Tier 3 UKI measurement pin.
   binarySha256Hex:
-    '4cf7d467032d7c7c48147495a0307771fd196dac403a7feb62d6f4f7502045b4',
+    'cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e',
   description: 'weikeng1.bitcoinpir.org (Hetzner i7-8700, no SEV)',
 };
 


### PR DESCRIPTION
## Summary
- rotate pir1 and pir2 runtime pins to the exact `81dd96d4` dual-serving binary and the new VPSBG Tier 3 UKI measurement
- publish the refreshed ORAM live-deployment record and reproducibility inputs
- record the completed server-side database-proof-v2 rollout while leaving the strict-client v2 cutover explicitly pending

## Production verification
- VPSBG fixed-pin AMD attestation, encrypted channel, padded dummy and known-present ORAM lookups passed for db0/db1
- Hetzner primary and secondary both run binary `cc4ec24b...5e16b1e`, loaded both v2 sidecars, and stayed at `NRestarts=0`
- pir1 and pir2 v2 wire responses matched evidence SHA-256 `e9795887...f055517` and `59bd47d0...1c0509`
- local candidate frontend passed all four production Playwright canaries: DPF, HarmonyPIR, OnionPIR, ORAM TEE

## Tests
- `npm test` (242 passed, 2 skipped)
- `npm run build`
- `npm run build-web`
- `cargo test -p pir-sdk-client db_proof` (13 passed)
- `BPIR_PRODUCTION_CANARY=1 BPIR_WEB_URL=http://127.0.0.1:3001/ npm run test:e2e:strict-production` (4 passed)