### PR TITLE
Activate database proof v2 for strict OnionPIR

### DIFF
--- a/.github/workflows/generated-proof-lock.yml
+++ b/.github/workflows/generated-proof-lock.yml
@@ -1,0 +1,46 @@
+name: Generated proof consumer lock
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pir-db-attest/**'
+      - 'verification/locks/generated-proofs.json'
+      - 'verification/scripts/verify_generated_proofs.py'
+      - '.github/workflows/generated-proof-lock.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pir-db-attest/**'
+      - 'verification/locks/generated-proofs.json'
+      - 'verification/scripts/verify_generated_proofs.py'
+      - '.github/workflows/generated-proof-lock.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Registry integrity + independent proof replay
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout BitcoinPIR
+        uses: actions/checkout@v7
+
+      - name: Checkout locked proof registry commit
+        uses: actions/checkout@v7
+        with:
+          repository: Bitcoin-PIR/proof-registry
+          ref: 4e19b0bc675715c88e5c11364ac9e0236c2cb359
+          path: proof-registry
+
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install --profile minimal
+
+      - name: Validate registry lock and replay both proof directories
+        run: >-
+          python3 verification/scripts/verify_generated_proofs.py
+          --registry-root proof-registry

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -39,6 +39,7 @@ on:
       - 'crates/sdk/wasm/**'
       - 'crates/sdk/client/**'
       - 'web/**'
+      - 'verification/locks/generated-proofs.json'
       - '.github/workflows/web-build.yml'
   pull_request:
     branches: [main]
@@ -48,6 +49,7 @@ on:
       - 'crates/sdk/wasm/**'
       - 'crates/sdk/client/**'
       - 'web/**'
+      - 'verification/locks/generated-proofs.json'
       - '.github/workflows/web-build.yml'
   workflow_dispatch:
 

--- a/crates/sdk/client/tests/integration_test.rs
+++ b/crates/sdk/client/tests/integration_test.rs
@@ -145,6 +145,45 @@ const PRODUCTION_DATABASE_PINS: [ProductionDatabasePin; 2] = [
     },
 ];
 
+/// V2 is activated only for strict OnionPIR. DPF/Harmony keep the v1 opcode
+/// during the compatibility window, so their production pins above remain
+/// intentionally unchanged.
+fn production_onion_v2_pin(mut pin: ProductionDatabasePin) -> ProductionDatabasePin {
+    pin.params_hash_hex = match pin.db_id {
+        0 => "a600f33fa0e644aab533a050eabf9c03882aa00f1b293ddf9d7f4bf7c8142563",
+        1 => "fe6f516696bafaa2226cc1bdc7888c7c69dd263a84817dd0f18cf8027123c45d",
+        id => panic!("no production OnionPIR v2 pin for db {id}"),
+    };
+    pin.builder_binary_sha256_hex =
+        "1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c";
+    pin.builder_git_commit = "d49a199e290ccbb05b6481c5ba691cb516aa76bb";
+    pin
+}
+
+fn assert_matches_production_onion_v2_layout(
+    roots: &VerifiedDatabaseRoots,
+    pin: ProductionDatabasePin,
+) {
+    let layout = roots
+        .onion_layout_v2
+        .unwrap_or_else(|| panic!("db {} strict OnionPIR proof fell back to v1", pin.db_id));
+    let (total_packed, index_bins, chunk_bins) = match pin.db_id {
+        0 => (948_640, 10_273, 37_954),
+        1 => (116_030, 965, 4_792),
+        id => panic!("no production OnionPIR v2 layout for db {id}"),
+    };
+    assert_eq!(layout.total_packed_entries, total_packed);
+    assert_eq!(layout.index_bins_per_table, index_bins);
+    assert_eq!(layout.chunk_bins_per_table, chunk_bins);
+    assert_eq!(layout.entry_size, 3_328);
+    assert_eq!(layout.index_slots_per_bin, 221);
+    assert_eq!(layout.index_slot_size, 15);
+    assert_eq!(layout.index_k, 75);
+    assert_eq!(layout.chunk_k, 80);
+    assert_eq!(layout.merkle_arity, 104);
+    assert_eq!(layout.merkle_hash_bytes, 32);
+}
+
 /// The ordinary ignored integration suite still runs on pull requests and
 /// pushes. The heavier strict production canaries are enabled explicitly by
 /// the scheduled/manual workflow steps, avoiding duplicate live queries.
@@ -954,8 +993,9 @@ mod onion_tests {
         assert_missing_verified_root(missing_root, "OnionPIR", 0);
 
         for pin in PRODUCTION_DATABASE_PINS[..1].iter().copied() {
+            let pin = production_onion_v2_pin(pin);
             let roots = client
-                .verify_database_proof(pin.db_id, &production_proof_policy(pin))
+                .verify_database_proof_v2(pin.db_id, &production_proof_policy(pin))
                 .await
                 .unwrap_or_else(|error| {
                     panic!(
@@ -964,6 +1004,7 @@ mod onion_tests {
                     )
                 });
             assert_matches_production_pin(&roots, pin);
+            assert_matches_production_onion_v2_layout(&roots, pin);
             client
                 .install_verified_database_roots(roots)
                 .unwrap_or_else(|error| {
@@ -981,8 +1022,9 @@ mod onion_tests {
         assert_missing_verified_root(missing_delta_root, "OnionPIR", 1);
 
         for pin in PRODUCTION_DATABASE_PINS[1..].iter().copied() {
+            let pin = production_onion_v2_pin(pin);
             let roots = client
-                .verify_database_proof(pin.db_id, &production_proof_policy(pin))
+                .verify_database_proof_v2(pin.db_id, &production_proof_policy(pin))
                 .await
                 .unwrap_or_else(|error| {
                     panic!(
@@ -991,6 +1033,7 @@ mod onion_tests {
                     )
                 });
             assert_matches_production_pin(&roots, pin);
+            assert_matches_production_onion_v2_layout(&roots, pin);
             client
                 .install_verified_database_roots(roots)
                 .unwrap_or_else(|error| {

--- a/docs/DB_PROOF_V2_PLAN.md
+++ b/docs/DB_PROOF_V2_PLAN.md
@@ -173,7 +173,7 @@ It must not be described as a fresh full build.
 - [x] Archive and independently verify the new bundles. The reviewed evidence
       digests and `params_hash_v2` values are recorded in
       `PHASE3_ROADMAP.md`.
-- [ ] Publish the reviewed production `params_hash_v2`/builder pins in the
+- [x] Publish the reviewed production `params_hash_v2`/builder pins in the
       strict-client activation PR.
 - [x] Configure and deploy `proof_v2_dir` on Hetzner and VPSBG using a runtime
       binary that supports the v2 opcode.

--- a/docs/PROJECT_CLOSEOUT_TODO.md
+++ b/docs/PROJECT_CLOSEOUT_TODO.md
@@ -62,7 +62,9 @@ Tracking PRs: `Bitcoin-PIR/attested-builder` #1 and BitcoinPIR #69.
       UKI.
 - [x] Re-attest both existing layouts and archive canonical v2 evidence, SNP
       reports, inputs, and independent verifier output.
-- [ ] Import the evidence into the proof registry/lock flow before activation.
+- [x] Import the evidence into the proof registry and pin the merged registry
+      commit, verification records, deployment records, and replayed proof
+      fields in the consumer lock before activation.
 - [x] Stage identical v2 sidecars on Hetzner and VPSBG.
 - [x] Rebuild and deploy the server binary and Tier 3 UKI required for dual
       serving; rotate reviewed runtime pins without a fallback window.
@@ -79,7 +81,7 @@ The initial HarmonyPIR, SDK-directory, and formal-proof milestone is complete in
 PRs #61, #62, and #63. Continue in the order defined by
 `REPOSITORY_BOUNDARIES.md`:
 
-- [ ] Move immutable generated proof bundles into `proof-registry` and add
+- [x] Move immutable generated proof bundles into `proof-registry` and add
       `verification/locks/generated-proofs.json` plus consumer re-verification.
 - [ ] Reconcile the duplicate `rootbundle` implementations.
 - [ ] Move remaining `pdf/` sources into `Bitcoin-PIR/whitepaper` after a

--- a/pir-db-attest/src/bin/verify-proof-directory.rs
+++ b/pir-db-attest/src/bin/verify-proof-directory.rs
@@ -1,0 +1,55 @@
+use std::env;
+use std::path::PathBuf;
+
+use pir_db_attest::{build_kind_label, display_hash_hex, hex32, ProofDirectory};
+
+fn main() {
+    let mut args = env::args_os().skip(1);
+    let path = PathBuf::from(args.next().unwrap_or_else(|| {
+        eprintln!("usage: verify-proof-directory <artifact-directory>");
+        std::process::exit(2);
+    }));
+    if args.next().is_some() {
+        eprintln!("usage: verify-proof-directory <artifact-directory>");
+        std::process::exit(2);
+    }
+
+    let verified = ProofDirectory::load_and_verify(&path).unwrap_or_else(|error| {
+        eprintln!("proof directory verification failed: {error}");
+        std::process::exit(1);
+    });
+    let evidence = verified.evidence;
+    let layout = evidence.onion_layout_v2.unwrap_or_else(|| {
+        eprintln!("proof directory verification failed: v2 Onion layout is missing");
+        std::process::exit(1);
+    });
+
+    println!("proofVersion={}", evidence.version);
+    println!("buildKind={}", build_kind_label(evidence.build_kind));
+    println!("fromHeight={}", evidence.from_anchor.height);
+    println!(
+        "fromBlockHashHex={}",
+        display_hash_hex(&evidence.from_anchor.block_hash)
+    );
+    println!("height={}", evidence.anchor.height);
+    println!(
+        "blockHashHex={}",
+        display_hash_hex(&evidence.anchor.block_hash)
+    );
+    println!("muhashHex={}", display_hash_hex(&evidence.utxo_muhash));
+    println!("bucketSuperRootHex={}", hex32(&evidence.bucket_super_root));
+    println!("onionSuperRootHex={}", hex32(&evidence.onion_super_root));
+    println!("paramsHashHex={}", hex32(&evidence.params_hash));
+    println!("networkMagicHex={}", hex::encode(evidence.network_magic));
+    println!(
+        "builderBinarySha256Hex={}",
+        hex32(&evidence.builder_binary_sha256)
+    );
+    println!("builderGitCommit={}", evidence.builder_git_commit);
+    println!("onionEntrySize={}", evidence.onion_entry_size);
+    println!("onionTotalPackedEntries={}", layout.total_packed_entries);
+    println!("onionIndexBinsPerTable={}", layout.index_bins_per_table);
+    println!("onionChunkBinsPerTable={}", layout.chunk_bins_per_table);
+    println!("onionIndexSlotsPerBin={}", layout.index_slots_per_bin);
+    println!("onionIndexSlotSize={}", layout.index_slot_size);
+}

--- a/verification/locks/generated-proofs.json
+++ b/verification/locks/generated-proofs.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "registry": {
+    "repository": "https://github.com/Bitcoin-PIR/proof-registry",
+    "commit": "4e19b0bc675715c88e5c11364ac9e0236c2cb359"
+  },
+  "verificationProfile": "bitcoinpir/database-proof-v2/reattest-existing",
+  "acceptedVerifier": {
+    "repository": "https://github.com/Bitcoin-PIR/attested-builder",
+    "commit": "d49a199e290ccbb05b6481c5ba691cb516aa76bb",
+    "tool": "pir-attested-builder verify-build-evidence",
+    "toolSha256": "9a8ed087487de16757865470a2ffbceff02ab5dac69cd54fcf4dd49fc2a8d092"
+  },
+  "bundles": [
+    {
+      "dbId": 0,
+      "manifestSha256": "895d15ec8b9d62c20e2ece98481144b2b0de0d390d150046bfbc46205ea7488f",
+      "verificationRecordSha256": "0e5f718fc742bb6110e7b3c5380c87949a5ff3ef8f12628be025b430e0d5842d",
+      "deploymentRecordSha256": "97e9684ac320d6df9e5523649adb74dc0d46740206e2355426de8ee96a722a9c",
+      "proofFields": {
+        "proofVersion": 2,
+        "buildKind": "snapshot",
+        "fromHeight": 0,
+        "fromBlockHashHex": "0000000000000000000000000000000000000000000000000000000000000000",
+        "height": 948454,
+        "blockHashHex": "00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4",
+        "muhashHex": "cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee",
+        "bucketSuperRootHex": "45def9b3c191cd28e630dae51f32d3e2f85f4d8ccf38c0712a23136967f2ec0b",
+        "onionSuperRootHex": "e83efa5730c47b94e8e6af09b1cb76a9e006634645fd39c939bd7b8ea554f8b4",
+        "paramsHashHex": "a600f33fa0e644aab533a050eabf9c03882aa00f1b293ddf9d7f4bf7c8142563",
+        "networkMagicHex": "f9beb4d9",
+        "builderBinarySha256Hex": "1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c",
+        "builderGitCommit": "d49a199e290ccbb05b6481c5ba691cb516aa76bb",
+        "onionEntrySize": 3328,
+        "onionTotalPackedEntries": 948640,
+        "onionIndexBinsPerTable": 10273,
+        "onionChunkBinsPerTable": 37954,
+        "onionIndexSlotsPerBin": 221,
+        "onionIndexSlotSize": 15
+      }
+    },
+    {
+      "dbId": 1,
+      "manifestSha256": "7d235d1abfa96a208d28f0ac1d189af19c3856fb21871d7b51410ee858d921aa",
+      "verificationRecordSha256": "86ad8e2d5578f277255e918f918bd71c16157d436e9f236079139e7efee61ad0",
+      "deploymentRecordSha256": "2ec2a7439b0e6c3c7d21a82aba580474f7a5217b7616f737a93d05223abc6025",
+      "proofFields": {
+        "proofVersion": 2,
+        "buildKind": "delta",
+        "fromHeight": 940611,
+        "fromBlockHashHex": "000000000000000000002c41243b3d74d135942031ef15f547bca1ce8f85eb99",
+        "height": 948454,
+        "blockHashHex": "00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4",
+        "muhashHex": "cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee",
+        "bucketSuperRootHex": "e2ba2eee6788424309a95f771893d5401cc8e3ceec6188dc2708900e211a910a",
+        "onionSuperRootHex": "f86baa3966a61cdcd70d8c0ad9bed233f591806eb351db2ae35ac0192a3fe997",
+        "paramsHashHex": "fe6f516696bafaa2226cc1bdc7888c7c69dd263a84817dd0f18cf8027123c45d",
+        "networkMagicHex": "f9beb4d9",
+        "builderBinarySha256Hex": "1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c",
+        "builderGitCommit": "d49a199e290ccbb05b6481c5ba691cb516aa76bb",
+        "onionEntrySize": 3328,
+        "onionTotalPackedEntries": 116030,
+        "onionIndexBinsPerTable": 965,
+        "onionChunkBinsPerTable": 4792,
+        "onionIndexSlotsPerBin": 221,
+        "onionIndexSlotSize": 15
+      }
+    }
+  ]
+}

--- a/verification/scripts/verify_generated_proofs.py
+++ b/verification/scripts/verify_generated_proofs.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Verify the production database-proof-v2 consumer lock.
+
+The registry records are useful audit evidence, but are not themselves a
+trust decision. This checker pins an exact registry commit, validates the
+content-addressed records, then replays the proof-directory verifier from the
+current BitcoinPIR source and compares every frontend pin field.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_LOCK = ROOT / "verification/locks/generated-proofs.json"
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+PROOF_FIELDS = {
+    "proofVersion",
+    "buildKind",
+    "fromHeight",
+    "fromBlockHashHex",
+    "height",
+    "blockHashHex",
+    "muhashHex",
+    "bucketSuperRootHex",
+    "onionSuperRootHex",
+    "paramsHashHex",
+    "networkMagicHex",
+    "builderBinarySha256Hex",
+    "builderGitCommit",
+    "onionEntrySize",
+    "onionTotalPackedEntries",
+    "onionIndexBinsPerTable",
+    "onionChunkBinsPerTable",
+    "onionIndexSlotsPerBin",
+    "onionIndexSlotSize",
+}
+
+
+def fail(message: str) -> None:
+    print(f"generated proof lock check failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key {key}")
+        result[key] = value
+    return result
+
+
+def load_json(path: Path, label: str) -> tuple[dict[str, Any], bytes]:
+    try:
+        raw = path.read_bytes()
+        value = json.loads(raw, object_pairs_hook=reject_duplicates)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as error:
+        fail(f"cannot load {label} at {path}: {error}")
+    if not isinstance(value, dict):
+        fail(f"{label} must be an object")
+    return value, raw
+
+
+def exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
+    if set(value) != expected:
+        fail(
+            f"{label} keys differ: missing={sorted(expected - set(value))}, "
+            f"unexpected={sorted(set(value) - expected)}"
+        )
+
+
+def digest(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def require_hex(value: Any, pattern: re.Pattern[str], label: str) -> str:
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        fail(f"{label} is not a canonical digest/commit")
+    return value
+
+
+def run(command: list[str], cwd: Path, label: str) -> str:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if result.returncode != 0:
+        fail(f"{label} failed:\n{result.stdout}{result.stderr}")
+    return result.stdout.strip()
+
+
+def record_path(registry: Path, kind: str, sha: str) -> Path:
+    if kind == "deployment":
+        return registry / "deployments" / "production" / "sha256" / f"{sha}.json"
+    fail(f"unknown record kind {kind}")
+
+
+def verify_bundle(
+    registry: Path,
+    bundle: dict[str, Any],
+    profile: str,
+    accepted_verifier: dict[str, Any],
+    verifier_binary: Path,
+) -> None:
+    exact_keys(
+        bundle,
+        {"dbId", "manifestSha256", "verificationRecordSha256", "deploymentRecordSha256", "proofFields"},
+        "lock bundle",
+    )
+    db_id = bundle["dbId"]
+    if type(db_id) is not int or db_id < 0 or db_id > 255:
+        fail("lock bundle dbId must be a byte")
+    manifest_sha = require_hex(bundle["manifestSha256"], HEX64, f"db {db_id} manifestSha256")
+    verification_sha = require_hex(
+        bundle["verificationRecordSha256"], HEX64, f"db {db_id} verificationRecordSha256"
+    )
+    deployment_sha = require_hex(
+        bundle["deploymentRecordSha256"], HEX64, f"db {db_id} deploymentRecordSha256"
+    )
+    proof_fields = bundle["proofFields"]
+    if not isinstance(proof_fields, dict):
+        fail(f"db {db_id} proofFields must be an object")
+    exact_keys(proof_fields, PROOF_FIELDS, f"db {db_id} proofFields")
+
+    bundle_dir = registry / "bundles" / "sha256" / manifest_sha[:2] / manifest_sha
+    manifest, manifest_raw = load_json(bundle_dir / "manifest.json", f"db {db_id} manifest")
+    if digest(manifest_raw) != manifest_sha:
+        fail(f"db {db_id} manifest content hash drifted")
+    subject = manifest.get("subject", {})
+    identifiers = subject.get("identifiers", {}) if isinstance(subject, dict) else {}
+    claims = manifest.get("claims", {})
+    if not isinstance(identifiers, dict) or not isinstance(claims, dict):
+        fail(f"db {db_id} manifest subject/claims are malformed")
+    manifest_expectations = {
+        "dbId": db_id,
+        "buildKind": proof_fields["buildKind"],
+        "fromHeight": proof_fields["fromHeight"],
+        "height": proof_fields["height"],
+        "blockHash": proof_fields["blockHashHex"],
+    }
+    if proof_fields["buildKind"] == "delta":
+        manifest_expectations["fromBlockHash"] = proof_fields["fromBlockHashHex"]
+    for key, expected in manifest_expectations.items():
+        if identifiers.get(key) != expected:
+            fail(f"db {db_id} manifest identifier {key} does not match the lock")
+    claim_expectations = {
+        "evidenceVersion": proof_fields["proofVersion"],
+        "builderBinarySha256": proof_fields["builderBinarySha256Hex"],
+        "paramsHashV2": proof_fields["paramsHashHex"],
+        "muhash": proof_fields["muhashHex"],
+        "bucketSuperRoot": proof_fields["bucketSuperRootHex"],
+        "onionSuperRoot": proof_fields["onionSuperRootHex"],
+        "onionTotalPackedEntries": proof_fields["onionTotalPackedEntries"],
+        "onionIndexBinsPerTable": proof_fields["onionIndexBinsPerTable"],
+        "onionChunkBinsPerTable": proof_fields["onionChunkBinsPerTable"],
+    }
+    for key, expected in claim_expectations.items():
+        if claims.get(key) != expected:
+            fail(f"db {db_id} manifest claim {key} does not match the lock")
+
+    verifier_commit = accepted_verifier["commit"]
+    verification_path = (
+        registry / "verifications" / "sha256" / manifest_sha / verifier_commit / f"{verification_sha}.json"
+    )
+    verification, verification_raw = load_json(verification_path, f"db {db_id} verification record")
+    if digest(verification_raw) != verification_sha:
+        fail(f"db {db_id} verification record content hash drifted")
+    if verification.get("bundleManifestSha256") != manifest_sha:
+        fail(f"db {db_id} verification record points to another bundle")
+    if verification.get("verificationProfile") != profile:
+        fail(f"db {db_id} verification profile drifted")
+    if verification.get("verifier") != accepted_verifier:
+        fail(f"db {db_id} accepted verifier tuple drifted")
+    checks = verification.get("checks")
+    if verification.get("overallOutcome") != "pass" or not isinstance(checks, list) or not checks:
+        fail(f"db {db_id} verification record is not a non-empty pass")
+    if any(
+        not isinstance(check, dict)
+        or check.get("required") is not True
+        or check.get("outcome") != "pass"
+        or check.get("exitCode") != 0
+        for check in checks
+    ):
+        fail(f"db {db_id} verification record contains a non-passing required check")
+
+    deployment_path = record_path(registry, "deployment", deployment_sha)
+    deployment, deployment_raw = load_json(deployment_path, f"db {db_id} deployment record")
+    if digest(deployment_raw) != deployment_sha:
+        fail(f"db {db_id} deployment record content hash drifted")
+    if deployment.get("environment") != "production":
+        fail(f"db {db_id} deployment is not production")
+    if deployment.get("bundleManifestSha256") != manifest_sha:
+        fail(f"db {db_id} deployment points to another bundle")
+    if deployment.get("verificationRecordSha256") != verification_sha:
+        fail(f"db {db_id} deployment points to another verification")
+
+    revocations = registry / "revocations" / "sha256" / manifest_sha
+    if revocations.exists() and any(revocations.glob("*.json")):
+        fail(f"db {db_id} locked bundle has a revocation record")
+
+    output = run([str(verifier_binary), str(bundle_dir / "artifacts")], ROOT, f"db {db_id} proof replay")
+    replayed: dict[str, str] = {}
+    for line in output.splitlines():
+        key, separator, value = line.partition("=")
+        if not separator or key in replayed:
+            fail(f"db {db_id} proof replay returned malformed output")
+        replayed[key] = value
+    if set(replayed) != PROOF_FIELDS:
+        fail(f"db {db_id} proof replay field set drifted")
+    for key, expected in proof_fields.items():
+        if replayed[key] != str(expected):
+            fail(f"db {db_id} replayed {key}: expected {expected}, got {replayed[key]}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--lock", type=Path, default=DEFAULT_LOCK)
+    parser.add_argument("--registry-root", type=Path, required=True)
+    args = parser.parse_args()
+
+    lock, _ = load_json(args.lock.resolve(), "generated proof lock")
+    exact_keys(lock, {"schemaVersion", "registry", "verificationProfile", "acceptedVerifier", "bundles"}, "lock")
+    if lock["schemaVersion"] != 1:
+        fail("unsupported lock schemaVersion")
+    registry_config = lock["registry"]
+    accepted_verifier = lock["acceptedVerifier"]
+    bundles = lock["bundles"]
+    if not isinstance(registry_config, dict) or not isinstance(accepted_verifier, dict):
+        fail("registry and acceptedVerifier must be objects")
+    exact_keys(registry_config, {"repository", "commit"}, "registry lock")
+    exact_keys(accepted_verifier, {"repository", "commit", "tool", "toolSha256"}, "acceptedVerifier")
+    registry_commit = require_hex(registry_config["commit"], HEX40, "registry commit")
+    require_hex(accepted_verifier["commit"], HEX40, "accepted verifier commit")
+    require_hex(accepted_verifier["toolSha256"], HEX64, "accepted verifier toolSha256")
+    if registry_config["repository"] != "https://github.com/Bitcoin-PIR/proof-registry":
+        fail("unexpected registry repository")
+    if not isinstance(bundles, list) or [item.get("dbId") for item in bundles if isinstance(item, dict)] != [0, 1]:
+        fail("lock must contain exactly the sorted production database IDs 0 and 1")
+
+    registry = args.registry_root.resolve()
+    actual_commit = run(["git", "rev-parse", "HEAD"], registry, "registry commit lookup")
+    if actual_commit != registry_commit:
+        fail(f"registry checkout is {actual_commit}, lock requires {registry_commit}")
+    run([sys.executable, "tools/validate_registry.py", "--root", "."], registry, "registry integrity validator")
+
+    run(["cargo", "build", "--quiet", "-p", "pir-db-attest", "--bin", "verify-proof-directory"], ROOT, "proof replay verifier build")
+    verifier_binary = ROOT / "target" / "debug" / "verify-proof-directory"
+    for bundle in bundles:
+        if not isinstance(bundle, dict):
+            fail("lock bundles must be objects")
+        verify_bundle(
+            registry,
+            bundle,
+            lock["verificationProfile"],
+            accepted_verifier,
+            verifier_binary,
+        )
+    print(f"generated proof lock verified: registry={registry_commit}, bundles=2")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/index.html
+++ b/web/index.html
@@ -1567,7 +1567,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
     </section>
 
     <script type="module">
-        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, PRODUCTION_ONION_QUERY_LAYOUT_PINS, DELTA_940611_948454_DB_PROOF_PIN, MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN, databaseProofAnchorLabel, databaseProofAnchorPoints, mempoolSpaceBlockUrl, verifyProductionTrustChain, verifyOramSourceProof } from './src/index.ts';
+        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, PRODUCTION_ONION_DB_PROOF_V2_PINS, DELTA_940611_948454_DB_PROOF_PIN, MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN, databaseProofAnchorLabel, databaseProofAnchorPoints, mempoolSpaceBlockUrl, verifyProductionTrustChain, verifyOramSourceProof } from './src/index.ts';
         // Initialize SDK WASM (optional - falls back to TS if unavailable)
         initSdkWasm().then(ok => {
             if (ok) console.log('[PIR] SDK WASM loaded');
@@ -3465,8 +3465,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 candidate = new OnionPirWebClient({
                     serverUrl,
                     strictVerification: true,
-                    databaseProofPins: PRODUCTION_DB_PROOF_PINS,
-                    onionQueryLayoutPins: PRODUCTION_ONION_QUERY_LAYOUT_PINS,
+                    databaseProofPins: PRODUCTION_ONION_DB_PROOF_V2_PINS,
                     onConnectionStateChange: (state, message) => {
                         log(`OnionPIR: ${state}${message ? ' - ' + message : ''}`,
                             state === 'connected' ? 'success' : state === 'disconnected' ? 'error' : 'info');

--- a/web/src/__tests__/onion-strict-wire.test.ts
+++ b/web/src/__tests__/onion-strict-wire.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   assertConsistentOnionMerkleLeaves,
+  databaseProofV2Request,
   decodeBatchResult,
   OnionPirWebClient,
   responsePayloadFromFrame,
 } from '../onionpir_client.js';
-import { PRODUCTION_ONION_QUERY_LAYOUT_PINS } from '../attest-pin.js';
 
 function frame(payload: number[]): Uint8Array {
   const out = new Uint8Array(4 + payload.length);
@@ -15,6 +15,12 @@ function frame(payload: number[]): Uint8Array {
 }
 
 describe('strict OnionPIR wire parsing', () => {
+  it('uses only the v2 database-proof opcode and rejects invalid DB IDs', () => {
+    expect([...databaseProofV2Request(1)]).toEqual([2, 0, 0, 0, 0x0c, 1]);
+    expect(() => databaseProofV2Request(-1)).toThrow('must be a byte');
+    expect(() => databaseProofV2Request(256)).toThrow('must be a byte');
+  });
+
   it('accepts exactly one complete length-prefixed response', () => {
     expect([...responsePayloadFromFrame(frame([0x50, 0xaa]), 0x50)])
       .toEqual([0x50, 0xaa]);
@@ -94,12 +100,43 @@ describe('strict OnionPIR session lifecycle', () => {
     const client = new OnionPirWebClient({
       serverUrl: 'wss://example.invalid',
       strictVerification: true,
-      onionQueryLayoutPins: PRODUCTION_ONION_QUERY_LAYOUT_PINS,
     });
     const internal = client as any;
     internal.sessionGeneration = 7;
+    internal.wasmModule = { paramsInfo: () => ({ entrySize: 3_328 }) };
     internal.catalog = {
-      databases: [{ dbId: 0, baseHeight: 0, height: 948_454 }],
+      databases: [{
+        dbId: 0,
+        baseHeight: 0,
+        height: 948_454,
+        indexBinsPerTable: 10_273,
+        chunkBinsPerTable: 37_954,
+        indexK: 75,
+        chunkK: 80,
+        tagSeed: 1n,
+        indexMasterSeed: 2n,
+        chunkMasterSeed: 3n,
+      }],
+    };
+    internal.serverInfo = {
+      onionpir: {
+        total_packed_entries: 948_640,
+        index_bins_per_table: 10_273,
+        chunk_bins_per_table: 37_954,
+        index_k: 75,
+        chunk_k: 80,
+        tag_seed: 1n,
+        index_master_seed: 2n,
+        chunk_master_seed: 3n,
+        index_slots_per_bin: 221,
+        index_slot_size: 15,
+      },
+      onionpir_merkle: {
+        arity: 104,
+        super_root: 'ab'.repeat(32),
+        index: { k: 75, num_pt: 99 },
+        data: { k: 80, num_pt: 365 },
+      },
     };
 
     client.installVerifiedDatabaseProof({
@@ -109,6 +146,12 @@ describe('strict OnionPIR session lifecycle', () => {
       height: 948_454,
       onionSuperRootHex: 'ab'.repeat(32),
       onionEntrySize: 3_328,
+      proofVersion: 2,
+      onionTotalPackedEntries: 948_640,
+      onionIndexBinsPerTable: 10_273,
+      onionChunkBinsPerTable: 37_954,
+      onionIndexSlotsPerBin: 221,
+      onionIndexSlotSize: 15,
       free,
     } as any);
 

--- a/web/src/__tests__/proof-registry-lock.test.ts
+++ b/web/src/__tests__/proof-registry-lock.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { PRODUCTION_ONION_DB_PROOF_V2_PINS } from '../attest-pin.js';
+
+interface GeneratedProofLock {
+  registry: { commit: string };
+  bundles: Array<{ dbId: number; proofFields: Record<string, unknown> }>;
+}
+
+const lock = JSON.parse(
+  readFileSync(
+    new URL('../../../verification/locks/generated-proofs.json', import.meta.url),
+    'utf8',
+  ),
+) as GeneratedProofLock;
+
+describe('generated proof registry lock', () => {
+  it('pins an immutable registry commit and exactly matches the Onion v2 frontend pins', () => {
+    expect(lock.registry.commit).toMatch(/^[0-9a-f]{40}$/);
+    expect(lock.bundles.map((bundle) => bundle.dbId)).toEqual([0, 1]);
+    expect(PRODUCTION_ONION_DB_PROOF_V2_PINS).toHaveLength(lock.bundles.length);
+
+    for (const bundle of lock.bundles) {
+      const pin = PRODUCTION_ONION_DB_PROOF_V2_PINS.find(({ dbId }) => dbId === bundle.dbId);
+      expect(pin).toBeDefined();
+      for (const [field, expected] of Object.entries(bundle.proofFields)) {
+        expect((pin as unknown as Record<string, unknown>)[field], `db ${bundle.dbId} ${field}`)
+          .toBe(expected);
+      }
+    }
+  });
+});

--- a/web/src/__tests__/strict-verification.test.ts
+++ b/web/src/__tests__/strict-verification.test.ts
@@ -25,6 +25,13 @@ const PIN: DatabaseProofPin = {
   networkMagicHex: 'f9beb4d9',
   builderBinarySha256Hex: '77'.repeat(32),
   builderGitCommit: 'deadbeef',
+  onionEntrySize: 3_328,
+  proofVersion: 2,
+  onionTotalPackedEntries: 1_000,
+  onionIndexBinsPerTable: 100,
+  onionChunkBinsPerTable: 200,
+  onionIndexSlotsPerBin: 221,
+  onionIndexSlotSize: 15,
 };
 
 type TrackedProof = WasmDatabaseProof & { freeMock: ReturnType<typeof vi.fn> };
@@ -46,6 +53,12 @@ function proofHandle(pin: DatabaseProofPin, overrides: Partial<WasmDatabaseProof
     builderBinarySha256Hex: pin.builderBinarySha256Hex,
     builderGitCommit: pin.builderGitCommit,
     onionEntrySize: pin.onionEntrySize ?? 3_328,
+    proofVersion: pin.proofVersion,
+    onionTotalPackedEntries: pin.onionTotalPackedEntries,
+    onionIndexBinsPerTable: pin.onionIndexBinsPerTable,
+    onionChunkBinsPerTable: pin.onionChunkBinsPerTable,
+    onionIndexSlotsPerBin: pin.onionIndexSlotsPerBin,
+    onionIndexSlotSize: pin.onionIndexSlotSize,
     toJson: () => ({}),
     free: freeMock,
     freeMock,
@@ -177,6 +190,13 @@ describe('strict database proof flow', () => {
     ['networkMagicHex', '0b110907'],
     ['builderBinarySha256Hex', 'aa'.repeat(32)],
     ['builderGitCommit', 'badc0de'],
+    ['onionEntrySize', 1_024],
+    ['proofVersion', 1],
+    ['onionTotalPackedEntries', 999],
+    ['onionIndexBinsPerTable', 99],
+    ['onionChunkBinsPerTable', 199],
+    ['onionIndexSlotsPerBin', 220],
+    ['onionIndexSlotSize', 14],
   ] as const)('rejects a mismatch in production-pin field %s', async (field, value) => {
     const handle = proofHandle(PIN, { [field]: value });
     const client: StrictDatabaseProofClient = {

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -243,74 +243,56 @@ export const PRODUCTION_DB_PROOF_PINS: DatabaseProofPin[] = [
   DELTA_940611_948454_DB_PROOF_PIN,
 ];
 
-/**
- * Query-layout values needed by the standalone OnionPIR client.
- *
- * The v1 database proof authenticates the Onion super-root and the packed
- * plaintext entry size, but its `index_bins_per_table` /
- * `chunk_bins_per_table` fields describe the shared DPF tables rather than
- * the separately packed OnionPIR tables.  Until a v2 proof commits the full
- * Onion layout, production must pin this remaining query shape explicitly.
- * A server-info response is only accepted when every field below matches.
- */
-export interface OnionQueryLayoutPin {
-  dbId: number;
-  totalPackedEntries: number;
-  indexBinsPerTable: number;
-  chunkBinsPerTable: number;
-  indexK: number;
-  chunkK: number;
-  tagSeedHex: string;
-  indexMasterSeedHex: string;
-  chunkMasterSeedHex: string;
-  indexSlotsPerBin: number;
-  indexSlotSize: number;
-  onionEntrySize: number;
-  merkleArity: number;
-  merkleIndexK: number;
-  merkleDataK: number;
-  merkleIndexNumPt: number;
-  merkleDataNumPt: number;
-}
-
-export const PRODUCTION_ONION_QUERY_LAYOUT_PINS: OnionQueryLayoutPin[] = [
+/** Strict OnionPIR pins for the v2-only proof opcode. Unlike the v1 pins
+ * above (retained for DPF/Harmony compatibility), these bind the complete
+ * typed Onion query layout and replace the temporary per-field layout pins. */
+export const PRODUCTION_ONION_DB_PROOF_V2_PINS: DatabaseProofPin[] = [
   {
     dbId: 0,
-    totalPackedEntries: 948_640,
-    indexBinsPerTable: 10_273,
-    chunkBinsPerTable: 37_954,
-    indexK: 75,
-    chunkK: 80,
-    tagSeedHex: 'f0b13554de8352f6',
-    indexMasterSeedHex: 'c97f21d6d9364b72',
-    chunkMasterSeedHex: '367867dd7bc05649',
-    indexSlotsPerBin: 221,
-    indexSlotSize: 15,
+    buildKind: 'snapshot',
+    fromHeight: 0,
+    height: 948454,
+    fromBlockHashHex: MAINNET_948454_DB_PROOF_PIN.fromBlockHashHex,
+    blockHashHex: MAINNET_948454_DB_PROOF_PIN.blockHashHex,
+    muhashHex: MAINNET_948454_DB_PROOF_PIN.muhashHex,
+    bucketSuperRootHex: MAINNET_948454_DB_PROOF_PIN.bucketSuperRootHex,
+    onionSuperRootHex: MAINNET_948454_DB_PROOF_PIN.onionSuperRootHex,
+    paramsHashHex: 'a600f33fa0e644aab533a050eabf9c03882aa00f1b293ddf9d7f4bf7c8142563',
+    networkMagicHex: 'f9beb4d9',
+    builderBinarySha256Hex: '1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c',
+    builderGitCommit: 'd49a199e290ccbb05b6481c5ba691cb516aa76bb',
     onionEntrySize: 3_328,
-    merkleArity: 104,
-    merkleIndexK: 75,
-    merkleDataK: 80,
-    merkleIndexNumPt: 99,
-    merkleDataNumPt: 365,
+    proofVersion: 2,
+    onionTotalPackedEntries: 948_640,
+    onionIndexBinsPerTable: 10_273,
+    onionChunkBinsPerTable: 37_954,
+    onionIndexSlotsPerBin: 221,
+    onionIndexSlotSize: 15,
+    description: 'mainnet_948454 database proof v2 with complete OnionPIR layout binding',
   },
   {
     dbId: 1,
-    totalPackedEntries: 116_030,
-    indexBinsPerTable: 965,
-    chunkBinsPerTable: 4_792,
-    indexK: 75,
-    chunkK: 80,
-    tagSeedHex: 'ffa0120f182d4a0d',
-    indexMasterSeedHex: '1c353b0854eab60f',
-    chunkMasterSeedHex: '1545e02440952c73',
-    indexSlotsPerBin: 221,
-    indexSlotSize: 15,
+    buildKind: 'delta',
+    fromHeight: 940611,
+    height: 948454,
+    fromBlockHashHex: DELTA_940611_948454_DB_PROOF_PIN.fromBlockHashHex,
+    fromMuhashHex: DELTA_940611_948454_DB_PROOF_PIN.fromMuhashHex,
+    blockHashHex: DELTA_940611_948454_DB_PROOF_PIN.blockHashHex,
+    muhashHex: DELTA_940611_948454_DB_PROOF_PIN.muhashHex,
+    bucketSuperRootHex: DELTA_940611_948454_DB_PROOF_PIN.bucketSuperRootHex,
+    onionSuperRootHex: DELTA_940611_948454_DB_PROOF_PIN.onionSuperRootHex,
+    paramsHashHex: 'fe6f516696bafaa2226cc1bdc7888c7c69dd263a84817dd0f18cf8027123c45d',
+    networkMagicHex: 'f9beb4d9',
+    builderBinarySha256Hex: '1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c',
+    builderGitCommit: 'd49a199e290ccbb05b6481c5ba691cb516aa76bb',
     onionEntrySize: 3_328,
-    merkleArity: 104,
-    merkleIndexK: 75,
-    merkleDataK: 80,
-    merkleIndexNumPt: 10,
-    merkleDataNumPt: 47,
+    proofVersion: 2,
+    onionTotalPackedEntries: 116_030,
+    onionIndexBinsPerTable: 965,
+    onionChunkBinsPerTable: 4_792,
+    onionIndexSlotsPerBin: 221,
+    onionIndexSlotSize: 15,
+    description: 'delta_940611_948454 database proof v2 with complete OnionPIR layout binding',
   },
 ];
 

--- a/web/src/db-proof.ts
+++ b/web/src/db-proof.ts
@@ -43,6 +43,14 @@ export interface DatabaseProofPin {
   /** Present in current attested-builder evidence; optional for older/static
    * manifest-derived pins that predate this field. */
   onionEntrySize?: number;
+  /** V2-only fields. When present, every typed Onion layout value exposed by
+   * the verified WASM proof must match before the handle can be installed. */
+  proofVersion?: number;
+  onionTotalPackedEntries?: number;
+  onionIndexBinsPerTable?: number;
+  onionChunkBinsPerTable?: number;
+  onionIndexSlotsPerBin?: number;
+  onionIndexSlotSize?: number;
   description?: string;
 }
 
@@ -119,6 +127,12 @@ export function verifyDatabaseProofAgainstPin(
   cmp('builderBinarySha256Hex', true);
   cmp('builderGitCommit');
   if (pin.onionEntrySize !== undefined) cmp('onionEntrySize');
+  if (pin.proofVersion !== undefined) cmp('proofVersion');
+  if (pin.onionTotalPackedEntries !== undefined) cmp('onionTotalPackedEntries');
+  if (pin.onionIndexBinsPerTable !== undefined) cmp('onionIndexBinsPerTable');
+  if (pin.onionChunkBinsPerTable !== undefined) cmp('onionChunkBinsPerTable');
+  if (pin.onionIndexSlotsPerBin !== undefined) cmp('onionIndexSlotsPerBin');
+  if (pin.onionIndexSlotSize !== undefined) cmp('onionIndexSlotSize');
 
   return {
     state: mismatches.length === 0 ? 'verified' : 'unverified',

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -130,8 +130,7 @@ export {
   PIR1_PIN,
   PIR2_TIER3_PIN,
   PRODUCTION_DB_PROOF_PINS,
-  PRODUCTION_ONION_QUERY_LAYOUT_PINS,
-  type OnionQueryLayoutPin,
+  PRODUCTION_ONION_DB_PROOF_V2_PINS,
   type ServerAttestPin,
 } from './attest-pin.js';
 

--- a/web/src/onionpir_client.ts
+++ b/web/src/onionpir_client.ts
@@ -41,7 +41,6 @@ import {
 
 import type { UtxoEntry, QueryResult, ConnectionState } from './types.js';
 import type { DatabaseProofPin, DatabaseProofStatus } from './db-proof.js';
-import type { OnionQueryLayoutPin } from './attest-pin.js';
 import type {
   DatabaseCatalog,
   OnionPirMerkleInfoJson,
@@ -76,7 +75,16 @@ const MASK64 = 0xFFFFFFFFFFFFFFFFn;
 
 // Operator-signed identity (shared across all backends; 0x07).
 const REQ_ANNOUNCE              = 0x07;
-const REQ_GET_DB_PROOF          = 0x0A;
+const REQ_GET_DB_PROOF_V2       = 0x0C;
+
+/** Exact v2-only request frame. Kept as a pure helper so no-fallback wire
+ * behavior is covered without a live socket. */
+export function databaseProofV2Request(dbId: number): Uint8Array {
+  if (!Number.isInteger(dbId) || dbId < 0 || dbId > 0xff) {
+    throw new Error(`database proof v2 db id must be a byte, got ${dbId}`);
+  }
+  return new Uint8Array([2, 0, 0, 0, REQ_GET_DB_PROOF_V2, dbId]);
+}
 
 // NOTE: moved from 0x30-0x32 to 0x50-0x52 to avoid collision with
 // REQ_MERKLE_SIBLING_BATCH (0x31) and REQ_MERKLE_TREE_TOP (0x32).
@@ -700,7 +708,6 @@ export interface OnionPirClientConfig {
   /** Production enables this fail-closed proof/root gate. */
   strictVerification?: boolean;
   databaseProofPins?: readonly DatabaseProofPin[];
-  onionQueryLayoutPins?: readonly OnionQueryLayoutPin[];
   onDatabaseProof?: (dbId: number, status: DatabaseProofStatus) => void;
   onConnectionStateChange?: (state: ConnectionState, message?: string) => void;
   onLog?: (message: string, level: 'info' | 'success' | 'error') => void;
@@ -713,6 +720,19 @@ interface InstalledOnionRoot {
   height: number;
   onionSuperRootHex: string;
   onionEntrySize: number;
+  totalPackedEntries: number;
+  indexBinsPerTable: number;
+  chunkBinsPerTable: number;
+  indexK: number;
+  chunkK: number;
+  tagSeed: bigint;
+  indexMasterSeed: bigint;
+  chunkMasterSeed: bigint;
+  indexSlotsPerBin: number;
+  indexSlotSize: number;
+  merkleArity: number;
+  merkleIndexNumPt: number;
+  merkleDataNumPt: number;
   generation: number;
 }
 
@@ -901,7 +921,6 @@ export class OnionPirWebClient {
   private installedOnionRoots = new Map<number, InstalledOnionRoot>();
   private verifiedTreeTops = new Map<number, VerifiedTreeTopBinding>();
   private databaseProofStatuses = new Map<number, DatabaseProofStatus>();
-  private verifiedLayoutDbIds = new Set<number>();
 
   // Test hook: one-shot override of the computed scripthashes for the next
   // queryBatch() call. Consumed on use and then cleared. Used by harnesses
@@ -938,86 +957,9 @@ export class OnionPirWebClient {
     this.installedOnionRoots.clear();
     this.verifiedTreeTops.clear();
     this.databaseProofStatuses.clear();
-    this.verifiedLayoutDbIds.clear();
     this.registeredDbs.clear();
     this.fheClientId = 0;
     this.fheSecretKey = null;
-  }
-
-  private layoutPinForDb(dbId: number): OnionQueryLayoutPin | undefined {
-    return this.config.onionQueryLayoutPins?.find((pin) => pin.dbId === dbId);
-  }
-
-  private validateStrictLayoutPins(): void {
-    const catalog = this.catalog;
-    const serverInfo = this.serverInfo;
-    const pins = this.config.onionQueryLayoutPins ?? [];
-    if (!catalog || !serverInfo) {
-      throw new Error('strict OnionPIR layout validation requires server info and catalog');
-    }
-    if (pins.length === 0) {
-      throw new Error('strict OnionPIR requires pinned query layouts');
-    }
-
-    const catalogIds = catalog.databases.map((db) => db.dbId);
-    const pinIds = pins.map((pin) => pin.dbId);
-    const duplicates = pinIds.filter((id, i) => pinIds.indexOf(id) !== i);
-    const missing = catalogIds.filter((id) => !pinIds.includes(id));
-    const unexpected = pinIds.filter((id) => !catalogIds.includes(id));
-    if (duplicates.length || missing.length || unexpected.length) {
-      throw new Error(
-        `strict OnionPIR layout pin coverage failed: duplicates=${[...new Set(duplicates)]}; ` +
-        `missing=${missing}; unexpected=${unexpected}`,
-      );
-    }
-
-    const failures: string[] = [];
-    const check = (dbId: number, field: string, actual: unknown, expected: unknown) => {
-      if (actual !== expected) {
-        failures.push(`db ${dbId} ${field}: expected ${String(expected)}, got ${String(actual)}`);
-      }
-    };
-    const hex64 = (value: bigint) => value.toString(16).padStart(16, '0').toLowerCase();
-
-    for (const pin of pins) {
-      const db = catalog.databases.find((entry) => entry.dbId === pin.dbId);
-      const advertised = this.getOnionPirForDb(pin.dbId);
-      const merkle = this.getOnionPirMerkleForDb(pin.dbId);
-      if (!db || !advertised || !merkle) {
-        failures.push(`db ${pin.dbId}: OnionPIR layout or Merkle metadata unavailable`);
-        continue;
-      }
-
-      check(pin.dbId, 'catalog.index_k', db.indexK, pin.indexK);
-      check(pin.dbId, 'catalog.chunk_k', db.chunkK, pin.chunkK);
-      check(pin.dbId, 'catalog.tag_seed', hex64(db.tagSeed), pin.tagSeedHex);
-      check(pin.dbId, 'catalog.index_master_seed', hex64(db.indexMasterSeed), pin.indexMasterSeedHex);
-      check(pin.dbId, 'catalog.chunk_master_seed', hex64(db.chunkMasterSeed), pin.chunkMasterSeedHex);
-
-      check(pin.dbId, 'onion.total_packed_entries', advertised.total_packed_entries, pin.totalPackedEntries);
-      check(pin.dbId, 'onion.index_bins_per_table', advertised.index_bins_per_table, pin.indexBinsPerTable);
-      check(pin.dbId, 'onion.chunk_bins_per_table', advertised.chunk_bins_per_table, pin.chunkBinsPerTable);
-      check(pin.dbId, 'onion.index_k', advertised.index_k, pin.indexK);
-      check(pin.dbId, 'onion.chunk_k', advertised.chunk_k, pin.chunkK);
-      check(pin.dbId, 'onion.tag_seed', hex64(advertised.tag_seed), pin.tagSeedHex);
-      check(pin.dbId, 'onion.index_slots_per_bin', advertised.index_slots_per_bin, pin.indexSlotsPerBin);
-      check(pin.dbId, 'onion.index_slot_size', advertised.index_slot_size, pin.indexSlotSize);
-
-      check(pin.dbId, 'merkle.arity', merkle.arity, pin.merkleArity);
-      check(pin.dbId, 'merkle.index.k', merkle.index.k, pin.merkleIndexK);
-      check(pin.dbId, 'merkle.data.k', merkle.data.k, pin.merkleDataK);
-      check(pin.dbId, 'merkle.index.num_pt', merkle.index.num_pt, pin.merkleIndexNumPt);
-      check(pin.dbId, 'merkle.data.num_pt', merkle.data.num_pt, pin.merkleDataNumPt);
-
-      const indexEntrySize = this.wasmModule!.paramsInfo(pin.indexBinsPerTable).entrySize;
-      const chunkEntrySize = this.wasmModule!.paramsInfo(pin.chunkBinsPerTable).entrySize;
-      check(pin.dbId, 'local index entry_size', indexEntrySize, pin.onionEntrySize);
-      check(pin.dbId, 'local chunk entry_size', chunkEntrySize, pin.onionEntrySize);
-      check(pin.dbId, 'merkle sibling entry_size', pin.merkleArity * 32, pin.onionEntrySize);
-    }
-    if (failures.length > 0) {
-      throw new Error(`strict OnionPIR query-layout mismatch: ${failures.join('; ')}`);
-    }
   }
 
   private catalogToSdkHandle(): any {
@@ -1104,19 +1046,19 @@ export class OnionPirWebClient {
    * the active DB does not expose its own `onionpir` block.
    */
   private updateParamsForActiveDb(): void {
-    if (this.isStrictVerification() && this.verifiedLayoutDbIds.has(this.dbId)) {
-      const pin = this.layoutPinForDb(this.dbId);
-      if (!pin) throw new Error(`strict OnionPIR layout pin missing for dbId=${this.dbId}`);
-      this.indexK = pin.indexK;
-      this.chunkK = pin.chunkK;
-      this.indexBins = pin.indexBinsPerTable;
-      this.chunkBins = pin.chunkBinsPerTable;
-      this.tagSeed = BigInt(`0x${pin.tagSeedHex}`);
-      this.indexMasterSeed = BigInt(`0x${pin.indexMasterSeedHex}`);
-      this.chunkMasterSeed = BigInt(`0x${pin.chunkMasterSeedHex}`);
-      this.totalPacked = pin.totalPackedEntries;
-      this.indexSlotsPerBin = pin.indexSlotsPerBin;
-      this.indexSlotSize = pin.indexSlotSize;
+    if (this.isStrictVerification()) {
+      const installed = this.installedOnionRoots.get(this.dbId);
+      if (!installed || installed.generation !== this.sessionGeneration) return;
+      this.indexK = installed.indexK;
+      this.chunkK = installed.chunkK;
+      this.indexBins = installed.indexBinsPerTable;
+      this.chunkBins = installed.chunkBinsPerTable;
+      this.tagSeed = installed.tagSeed;
+      this.indexMasterSeed = installed.indexMasterSeed;
+      this.chunkMasterSeed = installed.chunkMasterSeed;
+      this.totalPacked = installed.totalPackedEntries;
+      this.indexSlotsPerBin = installed.indexSlotsPerBin;
+      this.indexSlotSize = installed.indexSlotSize;
       return;
     }
     const opi = this.getOnionPirForDb(this.dbId) ?? this.serverInfo?.onionpir;
@@ -1246,7 +1188,6 @@ export class OnionPirWebClient {
           catalog.databases.map((db) => db.dbId),
           proofPins,
         );
-        this.validateStrictLayoutPins();
         await verifyInstallAndPreflightDatabaseProofs({
           client: this,
           pins: proofPins,
@@ -1330,7 +1271,7 @@ export class OnionPirWebClient {
     );
   }
 
-  /** Fetch and verify one DB proof. This method is deliberately stateless. */
+  /** Fetch and verify one v2 DB proof. Strict OnionPIR never falls back to v1. */
   async verifyDatabaseProof(
     dbId: number,
     expectedParamsHashHex?: string | null,
@@ -1338,7 +1279,7 @@ export class OnionPirWebClient {
     allowedBuilderGitCommit?: string | null,
   ): Promise<WasmDatabaseProof> {
     if (!this.ws?.isOpen()) throw new Error('Not connected');
-    const request = new Uint8Array([2, 0, 0, 0, REQ_GET_DB_PROOF, dbId & 0xff]);
+    const request = databaseProofV2Request(dbId);
     const response = await this.sendRaw(request);
     this.recordRound({
       kind: 'info',
@@ -1350,7 +1291,7 @@ export class OnionPirWebClient {
     });
     const catalogHandle = this.catalogToSdkHandle();
     try {
-      return requireSdkWasm().verifyDatabaseProofResponse(
+      return requireSdkWasm().verifyDatabaseProofV2Response(
         response,
         catalogHandle,
         dbId,
@@ -1363,22 +1304,68 @@ export class OnionPirWebClient {
     }
   }
 
-  /** Consume a pin-matched proof handle and install its Onion root locally. */
+  /** Consume a pin-matched v2 proof and install its root + typed layout. */
   installVerifiedDatabaseProof(proof: WasmDatabaseProof): void {
     try {
-      const pin = this.layoutPinForDb(proof.dbId);
       const catalogEntry = this.catalog?.databases.find((db) => db.dbId === proof.dbId);
-      if (!pin || !catalogEntry) {
-        throw new Error(`strict OnionPIR install has no layout/catalog entry for db ${proof.dbId}`);
+      const advertised = this.getOnionPirForDb(proof.dbId);
+      const merkle = this.getOnionPirMerkleForDb(proof.dbId);
+      if (!catalogEntry || !advertised || !merkle) {
+        throw new Error(`strict OnionPIR install has no catalog/query/Merkle entry for db ${proof.dbId}`);
       }
-      if (proof.onionEntrySize !== pin.onionEntrySize) {
-        throw new Error(
-          `db ${proof.dbId} onion_entry_size mismatch: proof ${proof.onionEntrySize}, ` +
-          `pin ${pin.onionEntrySize}`,
-        );
+      const typed = {
+        totalPackedEntries: proof.onionTotalPackedEntries,
+        indexBinsPerTable: proof.onionIndexBinsPerTable,
+        chunkBinsPerTable: proof.onionChunkBinsPerTable,
+        indexSlotsPerBin: proof.onionIndexSlotsPerBin,
+        indexSlotSize: proof.onionIndexSlotSize,
+      };
+      if (proof.proofVersion !== 2 || Object.values(typed).some(
+        (value) => !Number.isInteger(value) || (value ?? 0) <= 0,
+      )) {
+        throw new Error(`db ${proof.dbId} proof is missing a valid v2 Onion layout`);
       }
       if (proof.height !== catalogEntry.height || proof.fromHeight !== catalogEntry.baseHeight) {
         throw new Error(`db ${proof.dbId} proof/catalog height changed during install`);
+      }
+      const totalPackedEntries = typed.totalPackedEntries!;
+      const indexBinsPerTable = typed.indexBinsPerTable!;
+      const chunkBinsPerTable = typed.chunkBinsPerTable!;
+      const indexSlotsPerBin = typed.indexSlotsPerBin!;
+      const indexSlotSize = typed.indexSlotSize!;
+      const indexK = 75;
+      const chunkK = 80;
+      const merkleArity = proof.onionEntrySize / 32;
+      const merkleIndexNumPt = Math.ceil(indexBinsPerTable / merkleArity);
+      const merkleDataNumPt = Math.ceil(chunkBinsPerTable / merkleArity);
+      const mismatches: string[] = [];
+      const check = (field: string, actual: unknown, expected: unknown) => {
+        if (actual !== expected) mismatches.push(`${field}: expected ${String(expected)}, got ${String(actual)}`);
+      };
+      check('catalog.index_bins', catalogEntry.indexBinsPerTable, indexBinsPerTable);
+      check('catalog.chunk_bins', catalogEntry.chunkBinsPerTable, chunkBinsPerTable);
+      check('catalog.index_k', catalogEntry.indexK, indexK);
+      check('catalog.chunk_k', catalogEntry.chunkK, chunkK);
+      check('onion.total_packed_entries', advertised.total_packed_entries, totalPackedEntries);
+      check('onion.index_bins', advertised.index_bins_per_table, indexBinsPerTable);
+      check('onion.chunk_bins', advertised.chunk_bins_per_table, chunkBinsPerTable);
+      check('onion.index_k', advertised.index_k, indexK);
+      check('onion.chunk_k', advertised.chunk_k, chunkK);
+      check('onion.tag_seed', advertised.tag_seed, catalogEntry.tagSeed);
+      check('onion.index_master_seed', advertised.index_master_seed, catalogEntry.indexMasterSeed);
+      check('onion.chunk_master_seed', advertised.chunk_master_seed, catalogEntry.chunkMasterSeed);
+      check('onion.index_slots_per_bin', advertised.index_slots_per_bin, indexSlotsPerBin);
+      check('onion.index_slot_size', advertised.index_slot_size, indexSlotSize);
+      check('merkle.arity', merkle.arity, merkleArity);
+      check('merkle.index.k', merkle.index.k, indexK);
+      check('merkle.data.k', merkle.data.k, chunkK);
+      check('merkle.index.num_pt', merkle.index.num_pt, merkleIndexNumPt);
+      check('merkle.data.num_pt', merkle.data.num_pt, merkleDataNumPt);
+      check('local index entry_size', this.wasmModule!.paramsInfo(indexBinsPerTable).entrySize, proof.onionEntrySize);
+      check('local chunk entry_size', this.wasmModule!.paramsInfo(chunkBinsPerTable).entrySize, proof.onionEntrySize);
+      check('Merkle sibling entry_size', merkleArity * 32, proof.onionEntrySize);
+      if (mismatches.length > 0) {
+        throw new Error(`db ${proof.dbId} proof-v2 query-layout mismatch: ${mismatches.join('; ')}`);
       }
       const root = proof.onionSuperRootHex.toLowerCase();
       if (!/^[0-9a-f]{64}$/.test(root)) {
@@ -1391,10 +1378,22 @@ export class OnionPirWebClient {
         height: proof.height,
         onionSuperRootHex: root,
         onionEntrySize: proof.onionEntrySize,
+        totalPackedEntries,
+        indexBinsPerTable,
+        chunkBinsPerTable,
+        indexK,
+        chunkK,
+        tagSeed: catalogEntry.tagSeed,
+        indexMasterSeed: catalogEntry.indexMasterSeed,
+        chunkMasterSeed: catalogEntry.chunkMasterSeed,
+        indexSlotsPerBin,
+        indexSlotSize,
+        merkleArity,
+        merkleIndexNumPt,
+        merkleDataNumPt,
         generation: this.sessionGeneration,
       });
       this.verifiedTreeTops.delete(proof.dbId);
-      this.verifiedLayoutDbIds.add(proof.dbId);
     } finally {
       proof.free();
     }
@@ -1529,8 +1528,7 @@ export class OnionPirWebClient {
         !this.strictReady ||
         !installed || installed.generation !== this.sessionGeneration ||
         !binding || binding.generation !== this.sessionGeneration ||
-        binding.rootHex !== installed.onionSuperRootHex ||
-        !this.verifiedLayoutDbIds.has(dbId)
+        binding.rootHex !== installed.onionSuperRootHex
       ) {
         throw new Error(
           `strict OnionPIR query rejected: db ${dbId} proof/layout/tree-tops are not ready`,


### PR DESCRIPTION
## Summary

- lock production database-proof-v2 evidence to proof-registry commit `4e19b0bc675715c88e5c11364ac9e0236c2cb359`
- independently replay both proof directories in CI and compare every strict frontend pin field
- switch strict native and standalone Web OnionPIR to `REQ_GET_DB_PROOF_V2` with no v1 fallback
- install query geometry only from the verified v2 proof handle plus the chain-bound catalog
- remove `PRODUCTION_ONION_QUERY_LAYOUT_PINS`

DPF and HarmonyPIR intentionally keep their v1 proof opcode during the compatibility window.

## Verification

- `python3 verification/scripts/verify_generated_proofs.py --registry-root /Users/cusgadmin/bitcoin-pir/proof-registry`
- `npm run build`
- `npm test -- --run` (250 passed, 2 skipped)
- `cargo test -p pir-db-attest`
- `cargo test -p pir-sdk-client db_proof --lib` (13 passed)
- `cargo test -p pir-sdk-client --test integration_test --no-run --features onion`
- production native strict OnionPIR canary: db0/db1 v2 proof, preflight, fresh/delta queries, Merkle verification, disconnect cleanup (passed in 110s)

## Rollout

Merge only after all required CI checks pass. The merge deploys the Web client; then run the four-backend production browser canary before marking the v2 activation checklist complete.
