### PR TITLE
fix(web): accept proof-v2 production layout

### DIFF
--- a/web/e2e/strict-production.spec.ts
+++ b/web/e2e/strict-production.spec.ts
@@ -34,9 +34,12 @@ async function queryOnce(
   await page.locator(inputSelector).fill(CANARY_ADDRESS);
   await button.click();
   await expect(button).toHaveText('Querying…');
-  await expect(results).toContainText(CANARY_ADDRESS, { timeout: QUERY_TIMEOUT });
   await expect(button).toBeEnabled({ timeout: QUERY_TIMEOUT });
   await expect(button).toHaveText('Query UTXOs');
+  await expect(page.locator('#log')).not.toContainText(
+    /(?:connection failed:|query error:|batch error:)/i,
+  );
+  await expect(results).toContainText(CANARY_ADDRESS);
   return results;
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -1989,8 +1989,21 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 error: 'checking static proof artifacts...',
             });
 
+            const expectedV2Pin = PRODUCTION_ONION_DB_PROOF_V2_PINS.find(pin => pin.dbId === dbInfo.proof.dbId);
+            if (!expectedV2Pin) {
+                const error = `no production v2 pin for db ${dbInfo.proof.dbId}`;
+                renderBitcoinAnchorBadge(idElem, label, {
+                    state: 'unverified',
+                    checks: [],
+                    mismatches: [error],
+                    displayAnchor: dbInfo.proof,
+                });
+                log(`${label}: Bitcoin/MuHash anchor UNVERIFIED — ${error}`, 'error');
+                return;
+            }
+
             const status = await verifyProductionTrustChain({
-                expectedDbPin: DELTA_940611_948454_DB_PROOF_PIN,
+                expectedDbPin: expectedV2Pin,
                 liveDatabaseProof: dbInfo.proof,
                 verifyAmdSignature: true,
             });

--- a/web/src/__tests__/onion-strict-wire.test.ts
+++ b/web/src/__tests__/onion-strict-wire.test.ts
@@ -109,8 +109,10 @@ describe('strict OnionPIR session lifecycle', () => {
         dbId: 0,
         baseHeight: 0,
         height: 948_454,
-        indexBinsPerTable: 10_273,
-        chunkBinsPerTable: 37_954,
+        // Standard proof-catalog bins are DPF geometry and intentionally
+        // differ from the proof-backed Onion layout below.
+        indexBinsPerTable: 567_558,
+        chunkBinsPerTable: 1_066_928,
         indexK: 75,
         chunkK: 80,
         tagSeed: 1n,
@@ -126,8 +128,10 @@ describe('strict OnionPIR session lifecycle', () => {
         index_k: 75,
         chunk_k: 80,
         tag_seed: 1n,
-        index_master_seed: 2n,
-        chunk_master_seed: 3n,
+        // Optional legacy diagnostic fields may be absent (parsed as 0);
+        // strict query placement still uses the proof-verified catalog seeds.
+        index_master_seed: 0n,
+        chunk_master_seed: 0n,
         index_slots_per_bin: 221,
         index_slot_size: 15,
       },

--- a/web/src/__tests__/trust-chain-proof.test.ts
+++ b/web/src/__tests__/trust-chain-proof.test.ts
@@ -1,7 +1,10 @@
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
-import { DELTA_940611_948454_DB_PROOF_PIN } from '../attest-pin.js';
+import {
+  DELTA_940611_948454_DB_PROOF_PIN,
+  PRODUCTION_ONION_DB_PROOF_V2_PINS,
+} from '../attest-pin.js';
 import {
   DEFAULT_TRUST_CHAIN_MANIFEST_PATH,
   trustChainPinFromManifest,
@@ -90,6 +93,29 @@ describe('database trust-chain proof', () => {
       check.name === 'live DB proof matches manifest anchors and roots'
       && check.state === 'unverified'
     ))).toBe(true);
+  });
+
+  it('bridges the historical trust-chain manifest to a fully pinned v2 proof', async () => {
+    const v2Pin = PRODUCTION_ONION_DB_PROOF_V2_PINS.find(({ dbId }) => dbId === 1);
+    expect(v2Pin).toBeDefined();
+
+    const status = await verifyProductionTrustChain({
+      artifactLoader: publicArtifactLoader,
+      expectedDbPin: v2Pin,
+      liveDatabaseProof: { ...v2Pin! },
+      verifyAmdSignature: false,
+    });
+
+    expect(status.state).toBe('verified');
+    expect(status.mismatches).toEqual([]);
+    expect(status.checks).toContainEqual({
+      name: 'live DB proof matches manifest anchors and roots',
+      state: 'verified',
+    });
+    expect(status.checks).toContainEqual({
+      name: 'live DB proof matches pin',
+      state: 'verified',
+    });
   });
 
   it('reports unverified when the delta from block hash disagrees with its BHTM leaf', async () => {

--- a/web/src/onionpir_client.ts
+++ b/web/src/onionpir_client.ts
@@ -1342,8 +1342,10 @@ export class OnionPirWebClient {
       const check = (field: string, actual: unknown, expected: unknown) => {
         if (actual !== expected) mismatches.push(`${field}: expected ${String(expected)}, got ${String(actual)}`);
       };
-      check('catalog.index_bins', catalogEntry.indexBinsPerTable, indexBinsPerTable);
-      check('catalog.chunk_bins', catalogEntry.chunkBinsPerTable, chunkBinsPerTable);
+      // The standard proof catalog carries the shared DPF table bins. Onion
+      // has separately packed tables, so its bins are bound by the v2 layout
+      // and checked against the Onion query metadata below, not against the
+      // standard catalog's indexBinsPerTable/chunkBinsPerTable.
       check('catalog.index_k', catalogEntry.indexK, indexK);
       check('catalog.chunk_k', catalogEntry.chunkK, chunkK);
       check('onion.total_packed_entries', advertised.total_packed_entries, totalPackedEntries);
@@ -1352,8 +1354,16 @@ export class OnionPirWebClient {
       check('onion.index_k', advertised.index_k, indexK);
       check('onion.chunk_k', advertised.chunk_k, chunkK);
       check('onion.tag_seed', advertised.tag_seed, catalogEntry.tagSeed);
-      check('onion.index_master_seed', advertised.index_master_seed, catalogEntry.indexMasterSeed);
-      check('onion.chunk_master_seed', advertised.chunk_master_seed, catalogEntry.chunkMasterSeed);
+      // Per-DB server-info predates the catalog extension on some production
+      // nodes and reports absent master seeds as 0. Query placement uses the
+      // chain-derived, proof-verified catalog values stored below. If the
+      // diagnostic JSON does publish a seed, require it to agree as well.
+      if (advertised.index_master_seed !== 0n) {
+        check('onion.index_master_seed', advertised.index_master_seed, catalogEntry.indexMasterSeed);
+      }
+      if (advertised.chunk_master_seed !== 0n) {
+        check('onion.chunk_master_seed', advertised.chunk_master_seed, catalogEntry.chunkMasterSeed);
+      }
       check('onion.index_slots_per_bin', advertised.index_slots_per_bin, indexSlotsPerBin);
       check('onion.index_slot_size', advertised.index_slot_size, indexSlotSize);
       check('merkle.arity', merkle.arity, merkleArity);

--- a/web/src/trust-chain-proof.ts
+++ b/web/src/trust-chain-proof.ts
@@ -121,13 +121,12 @@ export async function verifyProductionTrustChain(
     if (options.liveDatabaseProof) {
       const before = mismatches.length;
       const manifestPin = trustChainPinFromManifest(manifest);
-      const dbStatus = verifyDatabaseProofAgainstPin(options.liveDatabaseProof, manifestPin);
-      if (dbStatus.state !== 'verified') {
-        mismatches.push(
-          ...(dbStatus.mismatches ?? [dbStatus.error ?? 'live DB proof did not match manifest'])
-            .map((m) => `live DB proof vs manifest: ${m}`),
-        );
-      }
+      compareTrustChainBinding(
+        options.liveDatabaseProof,
+        manifestPin,
+        'live DB proof vs manifest',
+        mismatches,
+      );
       checks.push(checkFromMismatches('live DB proof matches manifest anchors and roots', mismatches, before));
     }
 
@@ -315,10 +314,7 @@ function compareManifestToDbPin(
   mismatches: string[],
 ): void {
   const pinFromManifest = trustChainPinFromManifest(manifest);
-  const status = verifyDatabaseProofAgainstPin(pinFromManifest, pin);
-  if (status.state !== 'verified') {
-    mismatches.push(...(status.mismatches ?? []).map((m) => `manifest DB pin: ${m}`));
-  }
+  compareTrustChainBinding(pinFromManifest, pin, 'manifest DB pin', mismatches);
   if (manifest.anchor.buildKind === 'delta') {
     if (!pin.fromMuhashHex) {
       mismatches.push('production DB pin is missing delta fromMuhashHex');
@@ -331,6 +327,47 @@ function compareManifestToDbPin(
       );
     }
   }
+}
+
+/**
+ * Bind a current database proof to the historical Bitcoin/MuHash manifest.
+ *
+ * The trust-chain manifest embeds a v1 database proof. A v2 re-attestation of
+ * the same serving images intentionally has a different params hash and
+ * builder identity, because v2 commits the typed Onion layout and image
+ * digests and was produced by a newer builder. Those version-specific fields
+ * are authenticated by `expectedDbPin` below; the cross-version bridge only
+ * compares the Bitcoin endpoints and resulting database roots.
+ */
+function compareTrustChainBinding(
+  actual: DatabaseProofPin | VerifiedDatabaseProof,
+  expected: DatabaseProofPin | VerifiedDatabaseProof,
+  prefix: string,
+  mismatches: string[],
+): void {
+  const compareValue = (field: keyof DatabaseProofPin & keyof VerifiedDatabaseProof) => {
+    if (actual[field] !== expected[field]) {
+      mismatches.push(`${prefix}: ${field}: expected ${String(expected[field])}, got ${String(actual[field])}`);
+    }
+  };
+  const compareHexField = (field: keyof DatabaseProofPin & keyof VerifiedDatabaseProof) => {
+    const actualValue = String(actual[field]).replace(/^0x/i, '').toLowerCase();
+    const expectedValue = String(expected[field]).replace(/^0x/i, '').toLowerCase();
+    if (actualValue !== expectedValue) {
+      mismatches.push(`${prefix}: ${field}: expected ${String(expected[field])}, got ${String(actual[field])}`);
+    }
+  };
+
+  compareValue('dbId');
+  compareValue('buildKind');
+  compareValue('fromHeight');
+  compareValue('height');
+  compareHexField('fromBlockHashHex');
+  compareHexField('blockHashHex');
+  compareHexField('muhashHex');
+  compareHexField('bucketSuperRootHex');
+  compareHexField('onionSuperRootHex');
+  compareHexField('networkMagicHex');
 }
 
 function compareBhtmAttestationToManifest(


### PR DESCRIPTION
## Summary
- distinguish shared DPF catalog geometry from the proof-bound OnionPIR layout
- tolerate absent legacy server-info master-seed diagnostics while retaining proof-verified catalog seeds
- bridge the historical BHTM manifest to v2 proofs through Bitcoin endpoints and database roots, while checking v2-only fields against the production v2 pin
- make production canary connection failures fail quickly and clearly

## Verification
- `npm run build`
- `npm test -- --run` (252 passed, 2 skipped)
- `npm run build-web`
- live production OnionPIR Playwright canary against the local fixed frontend (passed, 1.1m)