### PR TITLE
fix(web): select anchor pin by proof version

### DIFF
--- a/web/e2e/strict-production.spec.ts
+++ b/web/e2e/strict-production.spec.ts
@@ -80,6 +80,7 @@ test('DPF-PIR verifies both servers, the result, and tears down transport', asyn
   await expect(page.locator('#dpfVerification1')).toHaveText('YES');
   await expectVerifiedResult(results);
   await expectTornDown(page, '#connectBtn', '#disconnectBtn');
+  await expectNoFatalLog(page);
   await expectLogContains(
     page,
     'Upgraded to encrypted channel',
@@ -89,7 +90,6 @@ test('DPF-PIR verifies both servers, the result, and tears down transport', asyn
     'Batch complete: 1/1 found',
     'Disconnected',
   );
-  await expectNoFatalLog(page);
 });
 
 test('HarmonyPIR verifies both roles, the result, and preserves no socket', async ({ page }) => {
@@ -101,6 +101,7 @@ test('HarmonyPIR verifies both roles, the result, and preserves no socket', asyn
   await expectVerifiedResult(results);
   await expectTornDown(page, '#hp-connectBtn', '#hp-disconnectBtn');
   await expect(page.locator('#hp-status')).toContainText('Status: Disconnected');
+  await expectNoFatalLog(page);
   await expectLogContains(
     page,
     'HarmonyPIR: upgraded to encrypted channel',
@@ -108,7 +109,6 @@ test('HarmonyPIR verifies both roles, the result, and preserves no socket', asyn
     'HarmonyPIR query: operator-endorsed identity verified (pir2)',
     'HarmonyPIR batch complete: 1/1 found',
   );
-  await expectNoFatalLog(page);
 });
 
 test('OnionPIR passes strict layout/tree-top preflight and verifies the result', async ({ page }) => {
@@ -118,8 +118,8 @@ test('OnionPIR passes strict layout/tree-top preflight and verifies the result',
   await expect(page.locator('#onionVerification')).toHaveText('YES');
   await expectVerifiedResult(results);
   await expectTornDown(page, '#op-connectBtn', '#op-disconnectBtn');
-  await expectLogContains(page, 'OnionPIR batch complete: 1/1 found');
   await expectNoFatalLog(page);
+  await expectLogContains(page, 'OnionPIR batch complete: 1/1 found');
 });
 
 test('ORAM TEE verifies the runtime, completes a lookup, and disconnects', async ({ page }) => {
@@ -129,6 +129,7 @@ test('ORAM TEE verifies the runtime, completes a lookup, and disconnects', async
   await expect(page.locator('#oramVerification')).toHaveText('YES');
   await expectTornDown(page, '#oram-connectBtn', '#oram-disconnectBtn');
   await expect(page.locator('#oram-status')).toContainText('Status: Disconnected');
+  await expectNoFatalLog(page);
   await expectLogContains(
     page,
     'ORAM upgraded to encrypted channel',
@@ -136,5 +137,4 @@ test('ORAM TEE verifies the runtime, completes a lookup, and disconnects', async
     'ORAM batch complete: 1/1 found',
     'ORAM: Disconnected',
   );
-  await expectNoFatalLog(page);
 });

--- a/web/index.html
+++ b/web/index.html
@@ -1989,9 +1989,12 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 error: 'checking static proof artifacts...',
             });
 
-            const expectedV2Pin = PRODUCTION_ONION_DB_PROOF_V2_PINS.find(pin => pin.dbId === dbInfo.proof.dbId);
-            if (!expectedV2Pin) {
-                const error = `no production v2 pin for db ${dbInfo.proof.dbId}`;
+            const expectedPinSet = dbInfo.proof.proofVersion === 2
+                ? PRODUCTION_ONION_DB_PROOF_V2_PINS
+                : PRODUCTION_DB_PROOF_PINS;
+            const expectedPin = expectedPinSet.find(pin => pin.dbId === dbInfo.proof.dbId);
+            if (!expectedPin) {
+                const error = `no production v${dbInfo.proof.proofVersion || 1} pin for db ${dbInfo.proof.dbId}`;
                 renderBitcoinAnchorBadge(idElem, label, {
                     state: 'unverified',
                     checks: [],
@@ -2003,7 +2006,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             }
 
             const status = await verifyProductionTrustChain({
-                expectedDbPin: expectedV2Pin,
+                expectedDbPin: expectedPin,
                 liveDatabaseProof: dbInfo.proof,
                 verifyAmdSignature: true,
             });


### PR DESCRIPTION
## Summary
- compare v1 DPF/Harmony proofs with the v1 production pins and v2 Onion proofs with the v2 pins
- retain the cross-version trust-chain bridge for Bitcoin endpoints and database roots
- fail the production browser canary immediately on fatal verification logs before waiting for success messages

## Verification
- `npm run build`
- `npm test -- --run` (252 passed, 2 skipped)
- `npm run build-web`
- live production DPF Playwright canary against the local fixed frontend (passed, 2.3m)