### PR TITLE
docs: close strict proof-v2 rollout

### DIFF
--- a/docs/DB_PROOF_V2_PLAN.md
+++ b/docs/DB_PROOF_V2_PLAN.md
@@ -1,7 +1,7 @@
 # Database proof v2: complete OnionPIR layout binding
 
-Status: the producer and consumer capability implementations are merged, and
-the production server-side dual-serving rollout is complete. The
+Status: the producer, consumer capability, and fail-closed client activation
+implementations are merged, and the production rollout is complete. The
 [attested-builder producer PR](https://github.com/Bitcoin-PIR/attested-builder/pull/1)
 implements canonical v2 evidence plus existing-artifact re-attestation. The
 [consumer PR #69](https://github.com/Bitcoin-PIR/Bitcoin-PIR/pull/69) implements
@@ -9,10 +9,13 @@ dual-serving, native/WASM verification, typed Onion layout installation, and
 an explicit v2-only native verification method. Canonical db 0/db 1 v2 bundles
 have now been independently verified, archived, staged identically, and loaded
 by both production hosts using BitcoinPIR commit
-`81dd96d442d39200fee7e6c97f5c308f38126756`. The deployed v1 strict client path
-and temporary per-field layout pins intentionally remain in place until the
-separate fail-closed client activation PR publishes reviewed v2 pins and moves
-all supported clients together. There is no v2-to-v1 fallback in that cutover.
+`81dd96d442d39200fee7e6c97f5c308f38126756`. Client activation PR #75 pins the
+reviewed registry commit and v2 fields, switches strict native/WASM/Web Onion
+clients to the v2-only verifier, and removes the temporary per-field layout
+pins. Production fixes #76 and #77 align the proof-backed Onion layout with the
+shared catalog and select the BHTM anchor pin by proof version. Strict Onion
+queries never fall back from v2 to v1; DPF/Harmony retain their explicitly
+pinned v1 compatibility proofs.
 
 ## Goal and trust model
 
@@ -167,7 +170,7 @@ It must not be described as a fresh full build.
       typed installation checks against live catalog/Merkle geometry. Preserve
       the existing v1 method during the staged migration.
 - [x] Expose the v2-only stateless verifier and typed layout getters to WASM.
-      The production web client deliberately continues to request v1.
+      The production Web Onion client now requests only the v2 opcode.
 - [x] Generate v2 evidence and SNP reports for production db 0 and db 1 on the
       attested builder.
 - [x] Archive and independently verify the new bundles. The reviewed evidence
@@ -177,14 +180,20 @@ It must not be described as a fresh full build.
       strict-client activation PR.
 - [x] Configure and deploy `proof_v2_dir` on Hetzner and VPSBG using a runtime
       binary that supports the v2 opcode.
-- [ ] Submit the activation PR: switch strict native/web Onion clients to v2,
+- [x] Submit and merge activation PR #75: switch strict native/web Onion clients to v2,
       consume only proof-backed layout values, and remove
       `PRODUCTION_ONION_QUERY_LAYOUT_PINS` without any fallback.
-- [ ] Publish the activation web client and run strict browser/native canaries
+- [x] Publish the activation web client and run strict browser/native canaries
       against both servers before retiring v1.
 
-The unchecked items are activation gates. Merging the implementation PRs alone
-must not be described as a production v2 rollout.
+The activation gates closed on 2026-07-24. The native production Onion canary
+passed both database IDs, v2 proof installation, tree-top preflight, fresh and
+delta queries, result Merkle verification, and teardown. After fixes #76 and
+#77, browser canary run
+[`30107315509`](https://github.com/Bitcoin-PIR/Bitcoin-PIR/actions/runs/30107315509)
+passed DPF-PIR, HarmonyPIR, OnionPIR, and ORAM TEE against the published site in
+2.3 minutes. The v1 proof opcode remains available only for explicitly pinned
+DPF/Harmony compatibility; strict Onion has no v2-to-v1 fallback.
 
 The pre-production inventory below determined which consistency checks could
 be reconstructed from final artifacts alone. Missing intermediate files did

--- a/docs/PROJECT_CLOSEOUT_TODO.md
+++ b/docs/PROJECT_CLOSEOUT_TODO.md
@@ -70,9 +70,9 @@ Tracking PRs: `Bitcoin-PIR/attested-builder` #1 and BitcoinPIR #69.
       serving; rotate reviewed runtime pins without a fallback window.
 - [x] Verify the db 0/db 1 v2 wire responses and evidence digests on both
       production hosts.
-- [ ] Switch strict native/WASM/Web clients to v2, remove temporary v1 Onion
+- [x] Switch strict native/WASM/Web clients to v2, remove temporary v1 Onion
       layout pins, and fail closed rather than falling back to v1.
-- [ ] Pass all strict production browser/native canaries after the client
+- [x] Pass all strict production browser/native canaries after the client
       cutover.
 
 ## 5. Continue repository-boundary migration

--- a/docs/STRICT_VERIFICATION_PROGRESS.md
+++ b/docs/STRICT_VERIFICATION_PROGRESS.md
@@ -147,8 +147,8 @@ A separate scheduled/manual Playwright canary now covers that boundary against
 HarmonyPIR, OnionPIR, and ORAM TEE, checks the runtime/operator verdicts and
 encrypted-channel path, requires automatic result Merkle verification where
 the protocol exposes it, and confirms that every query tears down its sockets.
-The OnionPIR query also exercises the temporary v1 layout/tree-top preflight;
-that gate remains required until database-proof v2 is activated.
+The OnionPIR query now exercises the v2-only proof verifier, proof-backed typed
+layout installation, and tree-top preflight with no v1 fallback.
 
 The initial live run on 2026-07-22 passed all four backends in 2.1 minutes from
 a fresh Chromium profile. Pull requests only parse and discover the suite; live
@@ -213,11 +213,15 @@ reopen it:
   completely consumed pool-unavailable response may reuse a connection for V1
   fallback. Strict Merkle binding already prevented malformed hints from
   yielding trusted data; this closes the fail-fast and recovery gap.
-- Complete the client-side activation stage of the separately scoped
-  [v2 database-proof migration](DB_PROOF_V2_PLAN.md). Production evidence and
-  dual-serving sidecars now exist on the servers; the remaining cutover must
-  publish reviewed `params_hash_v2` pins, switch strict Onion clients to the
-  v2-only verifier, and remove the temporary v1 layout pins without fallback.
+- [x] Complete the client-side activation stage of the separately scoped
+  [v2 database-proof migration](DB_PROOF_V2_PLAN.md). PR #75 published the
+  reviewed proof-registry lock and `params_hash_v2` pins, moved strict native,
+  WASM, and Web Onion clients to the v2-only verifier, and removed the
+  temporary layout pins. Production fixes #76 and #77 passed the full browser
+  canary in run
+  [`30107315509`](https://github.com/Bitcoin-PIR/Bitcoin-PIR/actions/runs/30107315509):
+  all four backends verified their runtime/pin policy, encrypted channel,
+  query result, and per-query teardown in 2.3 minutes.
 - Follow [the database/root rotation runbook](DATABASE_ROOT_ROTATION_RUNBOOK.md)
   for every new snapshot or delta generation.
 


### PR DESCRIPTION
## Summary
- mark strict native/WASM/Web proof-v2 activation complete
- record activation PR #75 and production fixes #76/#77
- record the successful four-backend production browser canary run 30107315509
- remove stale language that the production Web Onion client still requests v1

## Evidence
- native production Onion v2 canary passed proof install, tree-top preflight, fresh/delta queries, Merkle verification, and teardown
- browser run 30107315509 passed DPF, HarmonyPIR, OnionPIR, and ORAM TEE in 2.3m