### PR TITLE
perf(sdk): pipeline Merkle sibling levels

### DIFF
--- a/crates/sdk/client/src/harmony.rs
+++ b/crates/sdk/client/src/harmony.rs
@@ -37,7 +37,8 @@ use crate::hint_cache;
 use crate::merkle_verify::{
     fetch_tree_tops, verify_bucket_merkle_batch_generic,
     verify_bucket_merkle_batch_parallel, verify_tree_tops_super_root, BucketMerkleItem,
-    BucketMerkleSiblingQuerier, TreeTop, BUCKET_MERKLE_ARITY, BUCKET_MERKLE_SIB_ROW_SIZE,
+    BucketMerkleSiblingQuerier, SiblingLevelPlan, TreeTop, BUCKET_MERKLE_ARITY,
+    BUCKET_MERKLE_SIB_ROW_SIZE,
 };
 use crate::verified_roots::{RootPolicy, VerifiedRootState};
 use crate::transport::PirTransport;
@@ -6547,6 +6548,206 @@ struct HarmonySiblingQuerier<'a> {
     recorded: &'a mut Vec<RoundProfile>,
 }
 
+struct PreparedHarmonySiblingLevel {
+    table_type: u8,
+    level: usize,
+    db_id: u8,
+    targets: Vec<Vec<Option<u32>>>,
+    requests: Vec<Vec<u8>>,
+    request_bytes: Vec<u64>,
+    items_per_group: Vec<Vec<u32>>,
+}
+
+impl HarmonySiblingQuerier<'_> {
+    fn sibling_group_mut(
+        &mut self,
+        table_type: u8,
+        level: usize,
+        group: u8,
+    ) -> PirResult<&mut HarmonyGroup> {
+        match table_type {
+            0 => self.index_sib_groups.get_mut(&(level, group)),
+            1 => self.chunk_sib_groups.get_mut(&(level, group)),
+            other => return Err(PirError::InvalidState(format!(
+                "unknown sibling table_type {}", other
+            ))),
+        }
+        .ok_or_else(|| PirError::InvalidState(format!(
+            "missing sibling group (table={}, level={}, group={})",
+            table_type, level, group
+        )))
+    }
+
+    fn prepare_cross_level(
+        &mut self,
+        table_type: u8,
+        level: usize,
+        passes: &[Vec<Option<u32>>],
+        db_id: u8,
+    ) -> PirResult<PreparedHarmonySiblingLevel> {
+        if passes.is_empty() || passes.len() > 2 {
+            return Err(PirError::InvalidState(format!(
+                "Harmony cross-level pipeline supports one or two passes, got {}",
+                passes.len()
+            )));
+        }
+        let table_k = passes[0].len();
+        if passes.iter().any(|pass| pass.len() != table_k) {
+            return Err(PirError::InvalidState(
+                "Harmony cross-level pipeline received unequal pass widths".into(),
+            ));
+        }
+        let wire_level = match table_type {
+            0 => 10u8.checked_add(level as u8),
+            1 => 20u8.checked_add(level as u8),
+            _ => None,
+        }
+        .ok_or_else(|| PirError::InvalidState(format!(
+            "sibling level {} does not fit in wire byte", level
+        )))?;
+
+        let mut bytes_by_pass: Vec<Vec<Vec<u8>>> = (0..passes.len())
+            .map(|_| Vec::with_capacity(table_k))
+            .collect();
+        for group_idx in 0..table_k {
+            let group_id = group_idx as u8;
+            let group = self.sibling_group_mut(table_type, level, group_id)?;
+            if passes.len() == 2 {
+                if let (Some(target0), Some(target1)) =
+                    (passes[0][group_idx], passes[1][group_idx])
+                {
+                    let (request0, request1) = group
+                        .build_request_pair(target0, target1)
+                        .map_err(|error| PirError::BackendState(format!(
+                            "sib build_request_pair: {:?}", error
+                        )))?
+                        .into_parts();
+                    bytes_by_pass[0].push(request0.into_bytes());
+                    bytes_by_pass[1].push(request1.into_bytes());
+                    continue;
+                }
+            }
+            for (pass_idx, pass) in passes.iter().enumerate() {
+                let bytes = match pass[group_idx] {
+                    Some(target) => group.build_request(target)
+                        .map_err(|error| PirError::BackendState(format!(
+                            "sib build_request: {:?}", error
+                        )))?
+                        .into_bytes(),
+                    None => group.build_synthetic_dummy(),
+                };
+                bytes_by_pass[pass_idx].push(bytes);
+            }
+        }
+
+        let batch_items_by_pass: Vec<Vec<BatchItem>> = bytes_by_pass.iter()
+            .map(|pass| pass.iter().enumerate().map(|(group, bytes)| {
+                Ok(BatchItem {
+                    group_id: group as u8,
+                    indices: bytes_to_u32_vec(bytes)?,
+                })
+            }).collect::<PirResult<Vec<_>>>())
+            .collect::<PirResult<Vec<_>>>()?;
+        let mut requests = Vec::with_capacity(passes.len());
+        for (pass_idx, items) in batch_items_by_pass.iter().enumerate() {
+            let round_id = if passes.len() == 1 {
+                (table_type as u16) * 100 + level as u16
+            } else {
+                (table_type as u16) * 1000 + (level as u16) * 10 + pass_idx as u16
+            };
+            requests.push(encode_batch_query(wire_level, round_id, db_id, items));
+        }
+        Ok(PreparedHarmonySiblingLevel {
+            table_type,
+            level,
+            db_id,
+            targets: passes.to_vec(),
+            request_bytes: requests.iter().map(|request| request.len() as u64).collect(),
+            items_per_group: batch_items_by_pass.iter().map(|items| {
+                items.iter().map(|item| item.indices.len() as u32).collect()
+            }).collect(),
+            requests,
+        })
+    }
+
+    fn finish_cross_level(
+        &mut self,
+        prepared: &PreparedHarmonySiblingLevel,
+        responses: &[Vec<u8>],
+    ) -> PirResult<Vec<Vec<Option<Vec<u8>>>>> {
+        if responses.len() != prepared.targets.len()
+            || responses.iter().any(|response| response.len() < 4)
+        {
+            return Err(PirError::Protocol(format!(
+                "Harmony sibling level {} returned malformed response count",
+                prepared.level
+            )));
+        }
+        let decoded: Vec<_> = responses.iter()
+            .map(|response| decode_batch_response(&response[4..]))
+            .collect::<PirResult<Vec<_>>>()?;
+        let table_k = prepared.targets[0].len();
+        let mut out = vec![vec![None; table_k]; prepared.targets.len()];
+
+        for group_idx in 0..table_k {
+            let group_id = group_idx as u8;
+            let group = self.sibling_group_mut(
+                prepared.table_type,
+                prepared.level,
+                group_id,
+            )?;
+            if prepared.targets.len() == 2
+                && prepared.targets[0][group_idx].is_some()
+                && prepared.targets[1][group_idx].is_some()
+            {
+                let response0 = decoded[0].get(&group_id).ok_or_else(|| {
+                    PirError::Protocol(format!("missing sibling h=0 group {}", group_id))
+                })?;
+                let response1 = decoded[1].get(&group_id).ok_or_else(|| {
+                    PirError::Protocol(format!("missing sibling h=1 group {}", group_id))
+                })?;
+                let (row0, row1) = group.process_response_pair(response0, response1)
+                    .map_err(|error| PirError::BackendState(format!(
+                        "sib process_response_pair: {:?}", error
+                    )))?;
+                if row0.len() != BUCKET_MERKLE_SIB_ROW_SIZE
+                    || row1.len() != BUCKET_MERKLE_SIB_ROW_SIZE
+                {
+                    return Err(PirError::Protocol(
+                        "pipelined sibling pair has wrong row size".into(),
+                    ));
+                }
+                out[0][group_idx] = Some(row0);
+                out[1][group_idx] = Some(row1);
+                continue;
+            }
+            for pass_idx in 0..prepared.targets.len() {
+                if prepared.targets[pass_idx][group_idx].is_none() {
+                    continue;
+                }
+                let response = decoded[pass_idx].get(&group_id).ok_or_else(|| {
+                    PirError::Protocol(format!(
+                        "missing sibling response for pass {}, group {}",
+                        pass_idx, group_id
+                    ))
+                })?;
+                let row = group.process_response(response)
+                    .map_err(|error| PirError::BackendState(format!(
+                        "sib process_response: {:?}", error
+                    )))?;
+                if row.len() != BUCKET_MERKLE_SIB_ROW_SIZE {
+                    return Err(PirError::Protocol(format!(
+                        "sibling row has {} bytes, expected {}",
+                        row.len(), BUCKET_MERKLE_SIB_ROW_SIZE
+                    )));
+                }
+                out[pass_idx][group_idx] = Some(row);
+            }
+        }
+        Ok(out)
+    }
+}
+
 #[async_trait]
 impl BucketMerkleSiblingQuerier for HarmonySiblingQuerier<'_> {
     async fn query_pass(
@@ -7052,6 +7253,78 @@ impl BucketMerkleSiblingQuerier for HarmonySiblingQuerier<'_> {
         }
 
         Ok(vec![out_h0, out_h1])
+    }
+
+    async fn query_levels(
+        &mut self,
+        table_type: u8,
+        levels: &[SiblingLevelPlan],
+        db_id: u8,
+    ) -> PirResult<Vec<Vec<Vec<Option<Vec<u8>>>>>> {
+        if levels.iter().any(|level| level.passes.len() > 2) {
+            let mut out = Vec::with_capacity(levels.len());
+            for level in levels {
+                out.push(self.query_passes(
+                    table_type,
+                    level.level,
+                    level.level_bins_per_table,
+                    &level.passes,
+                    db_id,
+                ).await?);
+            }
+            return Ok(out);
+        }
+
+        // State is disjoint across (level, group_id). Same-level collisions
+        // still use HarmonyGroup's atomic pair API in prepare_cross_level.
+        let mut prepared = Vec::with_capacity(levels.len());
+        for level in levels {
+            prepared.push(self.prepare_cross_level(
+                table_type,
+                level.level,
+                &level.passes,
+                db_id,
+            )?);
+        }
+        for level in &mut prepared {
+            for request in &mut level.requests {
+                self.query_conn.send(std::mem::take(request)).await?;
+            }
+        }
+        // One ordered recv stream: concurrent recv on a single WebSocket would
+        // lose the protocol's implicit request/response correlation.
+        let mut responses = Vec::with_capacity(prepared.len());
+        for level in &prepared {
+            let mut level_responses = Vec::with_capacity(level.requests.len());
+            for _ in &level.requests {
+                level_responses.push(self.query_conn.recv().await?);
+            }
+            responses.push(level_responses);
+        }
+
+        // Record all drained rounds before proof decoding, so malformed
+        // evidence cannot truncate the observed leakage profile.
+        for (level, level_responses) in prepared.iter().zip(&responses) {
+            let kind = match level.table_type {
+                1 => RoundKind::ChunkMerkleSiblings { level: level.level as u8 },
+                _ => RoundKind::IndexMerkleSiblings { level: level.level as u8 },
+            };
+            for (pass, response) in level_responses.iter().enumerate() {
+                self.recorded.push(RoundProfile {
+                    kind,
+                    server_id: 0,
+                    db_id: Some(level.db_id),
+                    request_bytes: level.request_bytes[pass],
+                    response_bytes: response.len() as u64,
+                    items: level.items_per_group[pass].clone(),
+                });
+            }
+        }
+        let mut out = Vec::with_capacity(prepared.len());
+        for (level, level_responses) in prepared.iter().zip(&responses) {
+            out.push(self.finish_cross_level(level, level_responses)?);
+        }
+        Ok(out)
     }
 }
 

--- a/crates/sdk/client/src/merkle_verify.rs
+++ b/crates/sdk/client/src/merkle_verify.rs
@@ -497,6 +497,40 @@ pub trait BucketMerkleSiblingQuerier: Send {
         }
         Ok(out)
     }
+
+    /// Ordered batch spanning every sibling level for one table type.
+    /// Targets depend only on the leaf position, so implementations may send
+    /// all levels before receiving any response. The default keeps the legacy
+    /// sequential-level behaviour.
+    async fn query_levels(
+        &mut self,
+        table_type: u8,
+        levels: &[SiblingLevelPlan],
+        db_id: u8,
+    ) -> PirResult<Vec<Vec<Vec<Option<Vec<u8>>>>>> {
+        let mut out = Vec::with_capacity(levels.len());
+        for level in levels {
+            out.push(
+                self.query_passes(
+                    table_type,
+                    level.level,
+                    level.level_bins_per_table,
+                    &level.passes,
+                    db_id,
+                )
+                .await?,
+            );
+        }
+        Ok(out)
+    }
+}
+
+/// All padded passes required for one Merkle sibling level.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SiblingLevelPlan {
+    pub level: usize,
+    pub level_bins_per_table: u32,
+    pub passes: Vec<Vec<Option<u32>>>,
 }
 
 // ─── DPF sibling querier ────────────────────────────────────────────────────
@@ -520,6 +554,18 @@ pub struct DpfSiblingQuerier<'a> {
     leakage_recorder: Option<Arc<dyn LeakageRecorder>>,
 }
 
+struct PreparedDpfSiblingRound {
+    table_type: u8,
+    level: usize,
+    db_id: u8,
+    pass_targets: Vec<Option<u32>>,
+    request0: Vec<u8>,
+    request1: Vec<u8>,
+    request0_bytes: u64,
+    request1_bytes: u64,
+    items_per_group: Vec<u32>,
+}
+
 impl<'a> DpfSiblingQuerier<'a> {
     pub fn new(
         conn0: &'a mut dyn PirTransport,
@@ -538,6 +584,91 @@ impl<'a> DpfSiblingQuerier<'a> {
     /// structured `RoundProfile`s; passing `None` silences emission.
     pub fn set_leakage_recorder(&mut self, recorder: Option<Arc<dyn LeakageRecorder>>) {
         self.leakage_recorder = recorder;
+    }
+
+    fn prepare_round(
+        &mut self,
+        table_type: u8,
+        level: usize,
+        level_bins_per_table: u32,
+        pass_targets: &[Option<u32>],
+        db_id: u8,
+    ) -> PreparedDpfSiblingRound {
+        let num_groups = level_bins_per_table as u64;
+        let dpf_n = compute_dpf_n(num_groups as usize);
+        let mut s0_keys = Vec::with_capacity(pass_targets.len());
+        let mut s1_keys = Vec::with_capacity(pass_targets.len());
+        for target in pass_targets {
+            let alpha = match *target {
+                Some(target) => target as u64,
+                None if num_groups == 0 => 0,
+                None => self.rng.next_u64() % num_groups,
+            };
+            let (key0, key1) = self.dpf.gen(alpha, dpf_n);
+            s0_keys.push(key0.to_bytes());
+            s1_keys.push(key1.to_bytes());
+        }
+        let round_id = (table_type as u16) * 100 + level as u16;
+        let request0 = encode_sibling_batch(db_id, round_id, &s0_keys);
+        let request1 = encode_sibling_batch(db_id, round_id, &s1_keys);
+        PreparedDpfSiblingRound {
+            table_type,
+            level,
+            db_id,
+            pass_targets: pass_targets.to_vec(),
+            request0_bytes: request0.len() as u64,
+            request1_bytes: request1.len() as u64,
+            items_per_group: s0_keys.iter().map(|_| 1).collect(),
+            request0,
+            request1,
+        }
+    }
+
+    fn finish_round(
+        &self,
+        round: &PreparedDpfSiblingRound,
+        response0: &[u8],
+        response1: &[u8],
+    ) -> PirResult<Vec<Option<Vec<u8>>>> {
+        if let Some(recorder) = &self.leakage_recorder {
+            let kind = match round.table_type {
+                1 => RoundKind::ChunkMerkleSiblings { level: round.level as u8 },
+                _ => RoundKind::IndexMerkleSiblings { level: round.level as u8 },
+            };
+            for (server_id, request_bytes, response_bytes) in [
+                (0, round.request0_bytes, response0.len() as u64),
+                (1, round.request1_bytes, response1.len() as u64),
+            ] {
+                recorder.record_round("dpf", RoundProfile {
+                    kind,
+                    server_id,
+                    db_id: Some(round.db_id),
+                    request_bytes,
+                    response_bytes,
+                    items: round.items_per_group.clone(),
+                });
+            }
+        }
+        if response0.len() < 4 || response1.len() < 4 {
+            return Err(PirError::Protocol("sibling response missing length prefix".into()));
+        }
+        let rows0 = decode_sibling_batch(&response0[4..])?;
+        let rows1 = decode_sibling_batch(&response1[4..])?;
+        let mut out = vec![None; round.pass_targets.len()];
+        for (group, target) in round.pass_targets.iter().enumerate() {
+            if target.is_none()
+                || group >= rows0.len()
+                || group >= rows1.len()
+                || rows0[group].is_empty()
+                || rows1[group].is_empty()
+            {
+                continue;
+            }
+            let mut row = rows0[group][0].clone();
+            xor_into(&mut row, &rows1[group][0]);
+            out[group] = Some(row);
+        }
+        Ok(out)
     }
 }
 
@@ -636,6 +767,55 @@ impl BucketMerkleSiblingQuerier for DpfSiblingQuerier<'_> {
             let mut row = r0[g][0].clone();
             xor_into(&mut row, &r1[g][0]);
             out[g] = Some(row);
+        }
+        Ok(out)
+    }
+
+    async fn query_levels(
+        &mut self,
+        table_type: u8,
+        levels: &[SiblingLevelPlan],
+        db_id: u8,
+    ) -> PirResult<Vec<Vec<Vec<Option<Vec<u8>>>>>> {
+        let mut prepared = Vec::with_capacity(levels.len());
+        for level in levels {
+            let mut rounds = Vec::with_capacity(level.passes.len());
+            for pass in &level.passes {
+                rounds.push(self.prepare_round(
+                    table_type,
+                    level.level,
+                    level.level_bins_per_table,
+                    pass,
+                    db_id,
+                ));
+            }
+            prepared.push(rounds);
+        }
+
+        for rounds in &mut prepared {
+            for round in rounds {
+                self.conn0.send(std::mem::take(&mut round.request0)).await?;
+                self.conn1.send(std::mem::take(&mut round.request1)).await?;
+            }
+        }
+
+        // Drain the entire ordered response wave before decoding evidence.
+        let mut responses = Vec::with_capacity(prepared.len());
+        for rounds in &prepared {
+            let mut level_responses = Vec::with_capacity(rounds.len());
+            for _ in rounds {
+                level_responses.push((self.conn0.recv().await?, self.conn1.recv().await?));
+            }
+            responses.push(level_responses);
+        }
+
+        let mut out = Vec::with_capacity(prepared.len());
+        for (rounds, level_responses) in prepared.iter().zip(&responses) {
+            let mut level_out = Vec::with_capacity(rounds.len());
+            for (round, (response0, response1)) in rounds.iter().zip(level_responses) {
+                level_out.push(self.finish_round(round, response0, response1)?);
+            }
+            out.push(level_out);
         }
         Ok(out)
     }
@@ -1054,26 +1234,12 @@ async fn verify_sibling_levels(
         }
     }
 
-    // For each sibling level, run `max_items_per_group` passes pipelined
-    // through the querier in a single batch. Each pass is itself
-    // K-padded: the querier sends one (real or dummy) sub-request per
-    // group for every slot. Within a level, passes are INDEPENDENT
-    // (different items use different group slots, all sourced from the
-    // SAME pre-pass `node_idx`), so sending all of them back-to-back
-    // on one socket and draining the responses pipelined is identical
-    // to running them sequentially — except N RTTs collapse into
-    // ~one wall-clock RTT.
-    //
-    // The hash-update step that divides `node_idx[i] /= arity` is
-    // deferred until ALL passes at this level return — passes' targets
-    // were already computed off the level-L node_idx before the batch
-    // was issued, so the division would have no effect on this level's
-    // requests but it WOULD invalidate the next level's. We therefore
-    // collect per-pass (item, parent_hash, parent_idx) updates first,
-    // then apply them as a batch after the level completes.
+    // Precompute every level target from the leaf position. Earlier sibling
+    // hashes affect only the local hash walk, never a later query index.
+    let mut level_plans = Vec::with_capacity(level_groups_count.len());
+    let mut level_pass_groups = Vec::with_capacity(level_groups_count.len());
+    let mut planned_node_idx = node_idx.clone();
     for (level, &groups_at_level) in level_groups_count.iter().enumerate() {
-        // Build all pass_targets for this level using the CURRENT
-        // node_idx (level-L view).
         let mut all_passes: Vec<Vec<Option<u32>>> = Vec::with_capacity(max_items_per_group);
         let mut pass_groups: Vec<HashMap<usize, usize>> = Vec::with_capacity(max_items_per_group);
         for pass in 0..max_items_per_group {
@@ -1087,25 +1253,41 @@ async fn verify_sibling_levels(
                 .map(|g| {
                     pass_group_to_item
                         .get(&g)
-                        .map(|&item_idx| node_idx[item_idx] / arity as u32)
+                        .map(|&item_idx| planned_node_idx[item_idx] / arity as u32)
                 })
                 .collect();
             all_passes.push(pass_targets);
             pass_groups.push(pass_group_to_item);
         }
+        level_plans.push(SiblingLevelPlan {
+            level,
+            level_bins_per_table: groups_at_level,
+            passes: all_passes,
+        });
+        level_pass_groups.push(pass_groups);
+        for idx in &mut planned_node_idx {
+            *idx /= arity as u32;
+        }
+    }
 
-        // One pipelined batch over the querier — implementations that
-        // override the default `query_passes` (Harmony today) collapse
-        // these into one wall-clock RTT.
-        let batch_rows = querier
-            .query_passes(table_type, level, groups_at_level, &all_passes, db_id)
-            .await?;
-        if batch_rows.len() != max_items_per_group {
+    // Transport implementations can now send every level in one wave. Decode
+    // and walk locally only after all responses have been drained.
+    let all_level_rows = querier.query_levels(table_type, &level_plans, db_id).await?;
+    if all_level_rows.len() != level_plans.len() {
+        return Err(PirError::Protocol(format!(
+            "Merkle querier returned {} level results, expected {}",
+            all_level_rows.len(), level_plans.len()
+        )));
+    }
+    for (level_idx, batch_rows) in all_level_rows.into_iter().enumerate() {
+        let level = level_plans[level_idx].level;
+        let pass_groups = &level_pass_groups[level_idx];
+        if batch_rows.len() != pass_groups.len() {
             return Err(PirError::Protocol(format!(
                 "Merkle L{}: querier returned {} pass results, expected {}",
                 level,
                 batch_rows.len(),
-                max_items_per_group
+                pass_groups.len()
             )));
         }
 
@@ -1279,6 +1461,17 @@ mod tests {
         calls: usize,
     }
 
+    #[derive(Default)]
+    struct BatchCaptureQuerier {
+        levels: Vec<SiblingLevelPlan>,
+        pass_calls: usize,
+    }
+
+    struct OrderingTransport {
+        id: u8,
+        events: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
     #[async_trait]
     impl BucketMerkleSiblingQuerier for StaticSiblingQuerier {
         async fn query_pass(
@@ -1295,6 +1488,50 @@ mod tests {
                 .map(|target| target.as_ref().and(self.row.clone()))
                 .collect())
         }
+    }
+
+    #[async_trait]
+    impl BucketMerkleSiblingQuerier for BatchCaptureQuerier {
+        async fn query_pass(
+            &mut self,
+            _table_type: u8,
+            _level: usize,
+            _level_bins_per_table: u32,
+            targets: &[Option<u32>],
+            _db_id: u8,
+        ) -> PirResult<Vec<Option<Vec<u8>>>> {
+            self.pass_calls += 1;
+            Ok(vec![None; targets.len()])
+        }
+
+        async fn query_levels(
+            &mut self,
+            _table_type: u8,
+            levels: &[SiblingLevelPlan],
+            _db_id: u8,
+        ) -> PirResult<Vec<Vec<Vec<Option<Vec<u8>>>>>> {
+            self.levels = levels.to_vec();
+            Ok(levels.iter().map(|level| {
+                level.passes.iter().map(|pass| vec![None; pass.len()]).collect()
+            }).collect())
+        }
+    }
+
+    #[async_trait]
+    impl PirTransport for OrderingTransport {
+        async fn send(&mut self, _data: Vec<u8>) -> PirResult<()> {
+            self.events.lock().unwrap().push(format!("s{}", self.id));
+            Ok(())
+        }
+        async fn recv(&mut self) -> PirResult<Vec<u8>> {
+            self.events.lock().unwrap().push(format!("r{}", self.id));
+            Ok(vec![0; 4])
+        }
+        async fn roundtrip(&mut self, _request: &[u8]) -> PirResult<Vec<u8>> {
+            unreachable!("DPF pipeline uses split send/recv")
+        }
+        async fn close(&mut self) -> PirResult<()> { Ok(()) }
+        fn url(&self) -> &str { "mock://ordering" }
     }
 
     async fn verify_one_sibling_row(row: Option<Vec<u8>>) -> (bool, usize) {
@@ -1320,6 +1557,42 @@ mod tests {
                 .await
                 .unwrap();
         (verified[0], querier.calls)
+    }
+
+    #[tokio::test]
+    async fn sibling_targets_for_all_levels_are_batched_before_hash_walk() {
+        let contents: Vec<Vec<u8>> = (0..512u32).map(|i| vec![i as u8; 68]).collect();
+        let leaves: Vec<Hash256> = contents.iter().enumerate()
+            .map(|(i, content)| compute_bin_leaf_hash(i as u32, content)).collect();
+        let tree = MerkleTreeN::build(&leaves, BUCKET_MERKLE_ARITY);
+        let top = TreeTop { cache_from_level: 2, levels: tree.levels[2..].to_vec() };
+        let items = vec![SubItem {
+            pbc_group: 0,
+            bin_index: 73,
+            bin_content: contents[73].clone(),
+        }];
+        let mut querier = BatchCaptureQuerier::default();
+        let verified = verify_sibling_levels(&mut querier, &items, 512, 1, 0, &[top], 0)
+            .await.unwrap();
+        assert_eq!(verified, vec![false]);
+        assert_eq!(querier.pass_calls, 0);
+        assert_eq!(querier.levels[0].passes, vec![vec![Some(9)]]);
+        assert_eq!(querier.levels[1].passes, vec![vec![Some(1)]]);
+    }
+
+    #[tokio::test]
+    async fn dpf_cross_level_pipeline_sends_all_rounds_before_receiving() {
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut conn0 = OrderingTransport { id: 0, events: events.clone() };
+        let mut conn1 = OrderingTransport { id: 1, events: events.clone() };
+        let mut querier = DpfSiblingQuerier::new(&mut conn0, &mut conn1);
+        let levels = vec![
+            SiblingLevelPlan { level: 0, level_bins_per_table: 1024, passes: vec![vec![Some(7)]] },
+            SiblingLevelPlan { level: 1, level_bins_per_table: 128, passes: vec![vec![Some(0)]] },
+        ];
+        assert!(querier.query_levels(0, &levels, 0).await.is_err());
+        assert_eq!(*events.lock().unwrap(),
+            vec!["s0", "s1", "s0", "s1", "r0", "r1", "r0", "r1"]);
     }
 
     /// Build a small per-group Merkle tree, turn it into a `TreeTop` that

--- a/docs/PROJECT_CLOSEOUT_TODO.md
+++ b/docs/PROJECT_CLOSEOUT_TODO.md
@@ -96,9 +96,9 @@ PRs #61, #62, and #63. Continue in the order defined by
 
 ## 6. Independent non-blocking maintenance
 
-- [ ] Resolve issue #18 by producing empirical DPF/Harmony wire fixtures and
-      evaluating the all-Merkle-levels-parallel optimization.
-- [ ] Review and merge or close outstanding dependency-update PRs separately
+- [x] Resolve issue #18 by producing empirical DPF/Harmony wire fixtures and
+      implementing the all-Merkle-levels-parallel optimization.
+- [x] Review and merge or close outstanding dependency-update PRs separately
       from the security and proof activation sequence.
 
 ## Closeout invariants

--- a/docs/WIRE_ROUND_AND_BYTE_INVENTORY.md
+++ b/docs/WIRE_ROUND_AND_BYTE_INVENTORY.md
@@ -49,12 +49,12 @@ total bytes on the wire:
 2. **INDEX/CHUNK Merkle in parallel** —
    [`verify_bucket_merkle_batch_parallel`](../crates/sdk/client/src/merkle_verify.rs:808)
    uses `tokio::try_join!` (native) / `futures::future::try_join` (wasm32).
-
-**Not yet exploited:** sibling fetches *across* Merkle levels are still
-sequential, even though DPF alpha at level L is a pure function of
-`bin_index` (= `bin_index / 8^(L+1)`) and has no hash-chain dependency
-on prior levels. Implementing this would collapse the 12 / 6 / 2
-IndexMerkleSiblings wall-clock count to ~1 wave per server.
+3. **Across-level sibling pipelining** — `query_levels` precomputes every
+   target as `bin_index / 8^(L+1)`, sends all levels in a fixed order, drains
+   all responses in that order, and only then performs the local hash walk.
+   This collapses the DPF/Harmony sibling phase to one transport wave without
+   concurrent receives on a single WebSocket. Total round and byte counts are
+   unchanged.
 
 ---
 
@@ -158,15 +158,10 @@ common relay providers:
   All three protocols fit comfortably per round.
 - Fastly OHTTP Relay: no published limit.
 
-For latency, each OHTTP exchange adds one relay → gateway → target
-RTT versus direct HTTPS. The current fresh-client record counts are
-23 / 23 / 10, before any cross-level client-side parallelization
-optimizations land.
-
-The "all Merkle levels in parallel" refactor (see [§1 wall-clock
-note](#whats-wall-clock-vs-total)) would collapse Merkle wall-clock to
-≈ 1 wave per server without touching the protocol — a 3× per-query
-latency improvement on DPF/Harmony.
+For latency, each OHTTP exchange adds one relay → gateway → target RTT versus
+direct HTTPS. The current fresh-client record counts remain 23 / 23 / 10.
+Cross-level client-side pipelining changes wall-clock scheduling, not the
+leakage-visible number, order, or size of wire records.
 
 ---
 
@@ -185,18 +180,18 @@ Completed on 2026-07-24 with `dpf_leakage_dump.rs`,
 `harmony_leakage_dump.rs`, the two checked-in fixtures, and a Vitest regression
 that pins byte-identical not-found transcripts plus exact round/byte totals.
 
-### 5.2 All-Merkle-levels-in-parallel refactor
+### 5.2 All-Merkle-levels-in-parallel refactor — complete
 
-Replace the `for level in 0..n_levels { … await … }` loop in
-`verify_sibling_levels` with a concurrent issue (Promise.all / try_join_all)
-of all sibling DPF batches across all levels. DPF alpha at level L is
-`bin_index / 8^(L+1)` — pure function of leaf position, no dependency
-on the level-L−1 hash chain. The local hash-walk runs after all
-responses arrive.
+Completed on 2026-07-24 in the native DPF and Harmony sibling queriers.
+`verify_sibling_levels` now constructs all level/pass targets before I/O;
+each backend performs an ordered all-send/all-receive wave and the local hash
+walk begins only after every response is drained. Harmony keeps the atomic
+pair API for two real requests to the same group, and layouts requiring more
+than two same-group passes conservatively retain the serial fallback.
 
-Expected impact: wall-clock Merkle phase collapses from L sequential
-RTTs to 1 parallel wave per server. ~3× latency reduction per query on
-DPF/Harmony. Zero protocol change.
+This is deliberately transport pipelining rather than `try_join_all` over
+`recv`: a single WebSocket's response order is the correlation mechanism.
+There is no protocol or leakage-shape change.
 
 ### 5.3 Documented decisions, not action items
 


### PR DESCRIPTION
## Summary

- precompute every Merkle sibling target across all levels before network I/O
- pipeline DPF and Harmony requests as one ordered send wave followed by one ordered receive wave
- preserve Harmony's same-group pair state and conservatively fall back for layouts with more than two passes
- keep the leakage-visible round order and byte shape identical, then perform the local hash walk after all responses are drained
- mark the two executable actions in #18 complete

Closes #18

## Verification

- cargo check -p pir-sdk-client --lib
- cargo check -p pir-sdk-client --examples
- cargo check --target wasm32-unknown-unknown -p pir-sdk-client --lib
- cargo test -p pir-sdk-client --lib (266 passed)
- cargo test -p pir-sdk-client --features onion --lib (298 passed)
- production DPF leakage dump: both queries 23 rounds / 405,563 B up / 9,570,707 B down; normalized round JSON SHA-256 unchanged
- production Harmony leakage dump: both queries 23 rounds / 2,154,526 B up / 131,221,536 B down; normalized round JSON SHA-256 unchanged

## Safety notes

This does not run concurrent receive futures on one WebSocket. Response order remains the request/response correlation mechanism. All responses are drained before proof decoding, so malformed evidence does not leave stale sibling frames on the connection.