### PR TITLE
ci: follow protocol crate layout in web jobs

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build pir-sdk-wasm
         run: |
           cp Cargo.toml Cargo.toml.bak
-          printf '[workspace]\nresolver = "2"\nmembers = ["pir-core", "crates/sdk/core", "crates/sdk/wasm"]\n' > Cargo.toml
+          printf '[workspace]\nresolver = "2"\nmembers = ["crates/protocol/core", "crates/sdk/core", "crates/sdk/wasm"]\n' > Cargo.toml
           wasm-pack build crates/sdk/wasm --target web --out-dir pkg
           mv Cargo.toml.bak Cargo.toml
 

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Build pir-sdk-wasm (wasm32 target validation)
         run: |
           cp Cargo.toml Cargo.toml.bak
-          printf '[workspace]\nresolver = "2"\nmembers = ["pir-core", "crates/sdk/core", "crates/sdk/wasm"]\n' > Cargo.toml
+          printf '[workspace]\nresolver = "2"\nmembers = ["crates/protocol/core", "crates/sdk/core", "crates/sdk/wasm"]\n' > Cargo.toml
           wasm-pack build crates/sdk/wasm --target web --out-dir pkg
           mv Cargo.toml.bak Cargo.toml
 


### PR DESCRIPTION
## Root cause

PR #85 moved pir-core to crates/protocol/core, but the accelerated Web and deployment jobs still generated a temporary Cargo workspace with the old pir-core path. Because repository checks are not configured as required, #85 merged before the failing check completed.

## Fix

Update both temporary workspace definitions to use crates/protocol/core.

## Verification

- wasm-pack build crates/sdk/wasm --target web --out-dir pkg
- web: npm ci
- web: npm test -- --run (258 passed, 2 skipped)
- web: npm run build
- git diff --check

This PR only repairs CI/deployment build metadata; it does not change runtime behavior.