### PR TITLE
Prepare Payment V1 Hetzner services and deployment gates

### DIFF
--- a/.github/workflows/payment-platform.yml
+++ b/.github/workflows/payment-platform.yml
@@ -10,7 +10,9 @@ on:
       - '.cargo/**'
       - 'vendor/**'
       - 'apps/payment-issuer/**'
+      - 'apps/cln-rpc-guard/**'
       - 'apps/rollback-authority/**'
+      - 'apps/directory-relay/**'
       - 'apps/admin/**'
       - 'apps/server/**'
       - 'crates/net/**'
@@ -27,7 +29,14 @@ on:
       - 'crates/security/**'
       - 'crates/trust/**'
       - 'docs/payment/**'
+      - 'deploy/payment-v1/**'
       - 'scripts/fixtures/**'
+      - 'scripts/payment-v1-deployment-template-gate.mjs'
+      - 'scripts/payment-v1-deployment-template-gate.test.mjs'
+      - 'scripts/payment-v1-rendered-artifact-gate.mjs'
+      - 'scripts/payment-v1-rendered-artifact-gate.test.mjs'
+      - 'scripts/payment-v1-linux-runtime-evidence.mjs'
+      - 'scripts/payment-v1-linux-runtime-evidence.test.mjs'
       - 'scripts/payment-v1-local-check.sh'
       - 'scripts/payment-v1-cdk-regtest-e2e.sh'
       - 'scripts/payment-v1-cln-regtest-e2e.sh'
@@ -45,7 +54,9 @@ on:
       - '.cargo/**'
       - 'vendor/**'
       - 'apps/payment-issuer/**'
+      - 'apps/cln-rpc-guard/**'
       - 'apps/rollback-authority/**'
+      - 'apps/directory-relay/**'
       - 'apps/admin/**'
       - 'apps/server/**'
       - 'crates/net/**'
@@ -62,7 +73,14 @@ on:
       - 'crates/security/**'
       - 'crates/trust/**'
       - 'docs/payment/**'
+      - 'deploy/payment-v1/**'
       - 'scripts/fixtures/**'
+      - 'scripts/payment-v1-deployment-template-gate.mjs'
+      - 'scripts/payment-v1-deployment-template-gate.test.mjs'
+      - 'scripts/payment-v1-rendered-artifact-gate.mjs'
+      - 'scripts/payment-v1-rendered-artifact-gate.test.mjs'
+      - 'scripts/payment-v1-linux-runtime-evidence.mjs'
+      - 'scripts/payment-v1-linux-runtime-evidence.test.mjs'
       - 'scripts/payment-v1-local-check.sh'
       - 'scripts/payment-v1-cdk-regtest-e2e.sh'
       - 'scripts/payment-v1-cln-regtest-e2e.sh'
@@ -113,6 +131,8 @@ jobs:
           -p pir-cashu-custody
           -p pir-arc-adapter
           -p pir-directory-nostr
+          -p bitcoinpir-directory-relay
+          -p bitcoinpir-cln-rpc-guard
           -p pir-runtime-core
           -p pir-sdk-client
           -p pir-sdk-wasm
@@ -152,6 +172,8 @@ jobs:
           -p pir-cashu-custody
           -p pir-arc-adapter
           -p pir-directory-nostr
+          -p bitcoinpir-directory-relay
+          -p bitcoinpir-cln-rpc-guard
           -p payment-issuer
           -p rollback-authority
           -p bpir-admin
@@ -215,6 +237,26 @@ jobs:
             exit 1
           fi
           grep -F 'unknown argument: --test-only-service-https-root-pem' "$log_file" >/dev/null
+      - name: Exercise real provider to shared issuer clearing over pinned WebPKI TLS
+        run: |
+          issuer_e2e_target_dir="$PWD/target/payment-issuer-shared-e2e"
+          cargo build --locked --offline \
+            -p payment-issuer \
+            --features test-only-fake-lightning \
+            --bin payment-issuer \
+            --target-dir "$issuer_e2e_target_dir"
+          BITCOINPIR_PAYMENT_ISSUER_BIN="$issuer_e2e_target_dir/debug/payment-issuer" \
+            cargo test --locked --offline \
+              -p runtime \
+              --features shared-issuer-process-e2e \
+              --test payment_v1_shared_issuer_process_e2e \
+              shared_issuer_real_process_tls_e2e -- --exact
+          cargo clippy --locked --offline \
+            -p runtime \
+            --features shared-issuer-process-e2e \
+            --bin unified_server \
+            --test payment_v1_shared_issuer_process_e2e \
+            --no-deps -- -D warnings
       - name: Prove test-only WebPKI roots cannot enter release artifacts
         run: |
           log_file="$(mktemp "${RUNNER_TEMP}/bpir-test-root-release.XXXXXX")"
@@ -241,6 +283,11 @@ jobs:
           grep -F 'test-only-webpki-root must never be compiled into a production release' "$log_file" >/dev/null
           if cargo check --locked --offline --release -p runtime --features standard-cashu-process-e2e >"$log_file" 2>&1; then
             echo "runtime Standard Cashu test-only WebPKI feature unexpectedly compiled in release mode" >&2
+            exit 1
+          fi
+          grep -F 'test-only-webpki-root must never be compiled into a production release' "$log_file" >/dev/null
+          if cargo check --locked --offline --release -p runtime --features shared-issuer-process-e2e >"$log_file" 2>&1; then
+            echo "runtime shared-issuer test-only WebPKI feature unexpectedly compiled in release mode" >&2
             exit 1
           fi
           grep -F 'test-only-webpki-root must never be compiled into a production release' "$log_file" >/dev/null
@@ -355,6 +402,18 @@ jobs:
         run: npm ci
       - name: Enforce manual main-only production Pages deployment
         run: node scripts/payment-v1-pages-deploy-gate.mjs
+      - name: Validate non-activating Payment V1 deployment templates
+        run: |
+          node --check scripts/payment-v1-deployment-template-gate.mjs
+          node --test scripts/payment-v1-deployment-template-gate.test.mjs
+          node scripts/payment-v1-deployment-template-gate.mjs
+          node --check scripts/payment-v1-rendered-artifact-gate.mjs
+          node --check scripts/payment-v1-rendered-artifact-gate.test.mjs
+          node --check scripts/payment-v1-linux-runtime-evidence.mjs
+          node --check scripts/payment-v1-linux-runtime-evidence.test.mjs
+          node --test \
+            scripts/payment-v1-rendered-artifact-gate.test.mjs \
+            scripts/payment-v1-linux-runtime-evidence.test.mjs
       - name: Typecheck the opt-in CDK browser interoperability harness
         working-directory: web
         run: npx --no-install tsc -p tsconfig.payment-cdk-cashu-e2e.json --pretty false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoinpir-cln-rpc-guard"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "pir-lightning-backend",
+ "pir-private-files",
+ "pir-service-protocol",
+ "rustix",
+ "serde",
+ "serde_json",
+ "socket2",
+ "tempfile",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "bitcoinpir-directory-relay"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "futures-util",
+ "hex",
+ "log",
+ "pir-directory-nostr",
+ "pir-private-files",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "toml",
+]
+
+[[package]]
 name = "bitcoinpir-oram"
 version = "0.1.0"
 source = "git+https://github.com/Bitcoin-PIR/oram.git?rev=cd2c1a224d640a8149cfdd75ef5a4f2579a84d0b#cd2c1a224d640a8149cfdd75ef5a4f2579a84d0b"
@@ -2000,6 +2037,7 @@ dependencies = [
  "lightning-invoice",
  "pir-private-files",
  "pir-service-protocol",
+ "rustix",
  "serde",
  "serde_json",
  "sha2",
@@ -2684,6 +2722,8 @@ dependencies = [
  "pir-cashu-client",
  "pir-core",
  "pir-db-attest",
+ "pir-issuer-store",
+ "pir-lightning-backend",
  "pir-payment-crypto",
  "pir-private-files",
  "pir-provider-clearing-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,9 @@ members = [
     "tools/block-reader",
     "apps/dev-issuer",
     "apps/payment-issuer",
+    "apps/cln-rpc-guard",
     "apps/rollback-authority",
+    "apps/directory-relay",
 ]
 exclude = ["electrum_plugin/harmonypir-python", "vendor/bitcoinpir-oram"]
 

--- a/apps/admin/src/keygen.rs
+++ b/apps/admin/src/keygen.rs
@@ -95,7 +95,11 @@ pub(crate) fn write_secret_bytes_unix_with_force(
     let outcome = write_secret_bytes_atomically_unix(path, secret, force)?;
     match outcome {
         SecretWriteOutcomeV1::Durable => return Ok(SecretWriteCompletionV1::Durable),
-        SecretWriteOutcomeV1::CommittedDurabilityUnknown { parent, error } => {
+        SecretWriteOutcomeV1::CommittedDurabilityUnknown {
+            parent,
+            error,
+            lock_release_error,
+        } => {
             eprintln!("secret_write_status=committed_durability_unknown");
             eprintln!(
                 "WARNING: the new secret was atomically committed at {} but directory durability is unknown because syncing {} failed: {}",
@@ -103,6 +107,14 @@ pub(crate) fn write_secret_bytes_unix_with_force(
                 parent.display(),
                 error
             );
+            if let Some(error) = lock_release_error {
+                eprintln!("secret_write_lock_release_status=unknown");
+                eprintln!(
+                    "WARNING: explicit secret-parent lock release also failed for {}: {}",
+                    parent.display(),
+                    error
+                );
+            }
             eprintln!(
                 "WARNING: DO NOT retry --force. Inspect the exact target and preserve the public key/fingerprint this command prints."
             );
@@ -111,6 +123,7 @@ pub(crate) fn write_secret_bytes_unix_with_force(
             parent,
             error,
             durability_error,
+            lock_release_error,
         } => {
             eprintln!("secret_write_status=committed_path_unknown");
             eprintln!(
@@ -121,16 +134,36 @@ pub(crate) fn write_secret_bytes_unix_with_force(
             if let Some(error) = durability_error {
                 eprintln!("WARNING: committed directory durability is also unknown: {error}");
             }
+            if let Some(error) = lock_release_error {
+                eprintln!("secret_write_lock_release_status=unknown");
+                eprintln!(
+                    "WARNING: explicit secret-parent lock release also failed for {}: {}",
+                    parent.display(),
+                    error
+                );
+            }
             eprintln!(
                 "WARNING: DO NOT retry --force. Reconcile the pinned directory inode, exact target, and public identity this command prints."
+            );
+        }
+        SecretWriteOutcomeV1::CommittedLockReleaseUnknown { parent, error } => {
+            eprintln!("secret_write_status=committed_lock_release_unknown");
+            eprintln!("secret_write_lock_release_status=unknown");
+            eprintln!(
+                "WARNING: the new secret was atomically committed and verified, but the explicit lock on {} could not be released: {}",
+                parent.display(),
+                error
+            );
+            eprintln!(
+                "WARNING: DO NOT retry --force. Preserve the public key/fingerprint this command prints; later writers will fail closed while the inherited lock remains."
             );
         }
     }
     Ok(SecretWriteCompletionV1::CommittedAmbiguous)
 }
 
-/// Command-facing completion state. A committed-but-ambiguous write must still
-/// print its public identity, but it must not be reported as ordinary success.
+/// Command-facing completion state. A committed-but-nonordinary write must
+/// still print its public identity, but it must not be reported as success.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SecretWriteCompletionV1 {
     Durable,
@@ -152,7 +185,7 @@ fn require_durable_secret_write(completion: SecretWriteCompletionV1) -> Result<(
     match completion {
         SecretWriteCompletionV1::Durable => Ok(()),
         SecretWriteCompletionV1::CommittedAmbiguous => Err(
-            "secret write committed ambiguously; reconcile the installed path and do not retry"
+            "secret write committed but did not complete ordinarily; reconcile the installed path and do not retry"
                 .to_owned(),
         ),
     }
@@ -165,11 +198,17 @@ enum SecretWriteOutcomeV1 {
     CommittedDurabilityUnknown {
         parent: PathBuf,
         error: String,
+        lock_release_error: Option<String>,
     },
     CommittedPathUnknown {
         parent: PathBuf,
         error: String,
         durability_error: Option<String>,
+        lock_release_error: Option<String>,
+    },
+    CommittedLockReleaseUnknown {
+        parent: PathBuf,
+        error: String,
     },
 }
 
@@ -670,19 +709,117 @@ fn write_secret_bytes_atomically_unix(
     secret: &[u8],
     force: bool,
 ) -> Result<SecretWriteOutcomeV1, String> {
-    use rustix::fs::{
-        self as rustix_fs, AtFlags, FileType, FlockOperation, Mode, OFlags, RenameFlags,
-    };
+    write_secret_bytes_atomically_unix_with_after_lock_hook(path, secret, force, |_| Ok(()))
+}
+
+#[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+struct SecretParentLockGuardV1<'a> {
+    parent: &'a std::fs::File,
+    locked: bool,
+}
+
+#[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+impl<'a> SecretParentLockGuardV1<'a> {
+    fn new(parent: &'a std::fs::File) -> Self {
+        Self {
+            parent,
+            locked: true,
+        }
+    }
+
+    fn release(&mut self) -> Result<(), String> {
+        if !self.locked {
+            return Ok(());
+        }
+        rustix::fs::flock(self.parent, rustix::fs::FlockOperation::Unlock)
+            .map_err(|error| error.to_string())?;
+        self.locked = false;
+        Ok(())
+    }
+}
+
+#[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+impl Drop for SecretParentLockGuardV1<'_> {
+    fn drop(&mut self) {
+        // Explicit unlock is also the unwind/backstop path. Failure retains an
+        // availability denial through an inherited descriptor but never
+        // admits an unsafe concurrent writer.
+        let _ = self.release();
+    }
+}
+
+#[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+fn finish_secret_parent_lock_v1(
+    operation_result: Result<SecretWriteOutcomeV1, String>,
+    unlock_result: Result<(), String>,
+    parent_path: &std::path::Path,
+) -> Result<SecretWriteOutcomeV1, String> {
+    match operation_result {
+        Err(error) => match unlock_result {
+            Ok(()) => Err(error),
+            Err(unlock_error) => Err(format!(
+                "{error}; additionally failed to release secret parent lock: {unlock_error}"
+            )),
+        },
+        Ok(outcome) => match unlock_result {
+            Ok(()) => Ok(outcome),
+            Err(error) => match outcome {
+                SecretWriteOutcomeV1::Durable => {
+                    Ok(SecretWriteOutcomeV1::CommittedLockReleaseUnknown {
+                        parent: parent_path.to_path_buf(),
+                        error,
+                    })
+                }
+                SecretWriteOutcomeV1::CommittedDurabilityUnknown {
+                    parent,
+                    error: durability_error,
+                    ..
+                } => Ok(SecretWriteOutcomeV1::CommittedDurabilityUnknown {
+                    parent,
+                    error: durability_error,
+                    lock_release_error: Some(error),
+                }),
+                SecretWriteOutcomeV1::CommittedPathUnknown {
+                    parent,
+                    error: path_error,
+                    durability_error,
+                    ..
+                } => Ok(SecretWriteOutcomeV1::CommittedPathUnknown {
+                    parent,
+                    error: path_error,
+                    durability_error,
+                    lock_release_error: Some(error),
+                }),
+                already_unknown @ SecretWriteOutcomeV1::CommittedLockReleaseUnknown { .. } => {
+                    Ok(already_unknown)
+                }
+            },
+        },
+    }
+}
+
+#[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+fn perform_secret_write_atomically_unix_locked<F>(
+    parent: &std::fs::File,
+    file_name: &std::ffi::OsStr,
+    parent_path: &std::path::Path,
+    path: &std::path::Path,
+    secret: &[u8],
+    force: bool,
+    after_lock: F,
+) -> Result<SecretWriteOutcomeV1, String>
+where
+    F: FnOnce(&std::fs::File) -> Result<(), String>,
+{
+    use rustix::fs::{self as rustix_fs, AtFlags, FileType, Mode, OFlags, RenameFlags};
     use std::io::Write as _;
 
     let owner_only = Mode::from_bits_truncate(0o600);
-    let (parent, file_name, parent_path) = open_secret_parent_v1(path)?;
-    rustix_fs::flock(&parent, FlockOperation::NonBlockingLockExclusive)
-        .map_err(|error| format!("secret parent {} is busy: {error}", parent_path.display()))?;
+    after_lock(parent)?;
     parent
         .sync_all()
         .map_err(|error| format!("preflight secret parent {}: {error}", parent_path.display()))?;
-    let before = inspect_secret_target_v1(&parent, &file_name, path)?;
+    let before = inspect_secret_target_v1(parent, file_name, path)?;
     if before.is_some() && !force {
         return Err(format!(
             "{} already exists; use --force only after confirming key rotation",
@@ -694,7 +831,7 @@ fn write_secret_bytes_atomically_unix(
     let mut temporary_created = false;
     let result = (|| {
         let fd = rustix_fs::openat(
-            &parent,
+            parent,
             &temporary_name,
             OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::NOFOLLOW | OFlags::CLOEXEC,
             owner_only,
@@ -728,8 +865,8 @@ fn write_secret_bytes_atomically_unix(
         parent
             .sync_all()
             .map_err(|error| format!("sync private rotation temporary: {error}"))?;
-        validate_open_secret_parent_still_named_v1(&parent, &parent_path)?;
-        let current = inspect_secret_target_v1(&parent, &file_name, path)?;
+        validate_open_secret_parent_still_named_v1(parent, parent_path)?;
+        let current = inspect_secret_target_v1(parent, file_name, path)?;
         if current != before {
             return Err(format!(
                 "{} changed before atomic key commit; refusing replacement",
@@ -738,23 +875,23 @@ fn write_secret_bytes_atomically_unix(
         }
         if before.is_none() {
             rustix_fs::renameat_with(
-                &parent,
+                parent,
                 &temporary_name,
-                &parent,
-                &file_name,
+                parent,
+                file_name,
                 RenameFlags::NOREPLACE,
             )
         } else {
-            rustix_fs::renameat(&parent, &temporary_name, &parent, &file_name)
+            rustix_fs::renameat(parent, &temporary_name, parent, file_name)
         }
         .map_err(|error| format!("atomically commit {}: {error}", path.display()))?;
         temporary_created = false;
         let durability_error = parent.sync_all().err().map(|error| error.to_string());
         let mut path_errors = Vec::new();
-        if let Err(error) = validate_open_secret_parent_still_named_v1(&parent, &parent_path) {
+        if let Err(error) = validate_open_secret_parent_still_named_v1(parent, parent_path) {
             path_errors.push(error);
         }
-        match inspect_secret_target_v1(&parent, &file_name, path) {
+        match inspect_secret_target_v1(parent, file_name, path) {
             Ok(Some(installed))
                 if installed.device == committed_snapshot.device
                     && installed.inode == committed_snapshot.inode
@@ -772,14 +909,16 @@ fn write_secret_bytes_atomically_unix(
         }
         if !path_errors.is_empty() {
             Ok(SecretWriteOutcomeV1::CommittedPathUnknown {
-                parent: parent_path.clone(),
+                parent: parent_path.to_path_buf(),
                 error: path_errors.join("; "),
                 durability_error,
+                lock_release_error: None,
             })
         } else if let Some(error) = durability_error {
             Ok(SecretWriteOutcomeV1::CommittedDurabilityUnknown {
-                parent: parent_path.clone(),
+                parent: parent_path.to_path_buf(),
                 error,
+                lock_release_error: None,
             })
         } else {
             Ok(SecretWriteOutcomeV1::Durable)
@@ -791,8 +930,7 @@ fn write_secret_bytes_atomically_unix(
             .err()
             .cloned()
             .unwrap_or_else(|| "private temporary cleanup reached an invalid state".to_owned());
-        let cleanup = rustix_fs::unlinkat(&parent, &temporary_name, AtFlags::empty());
-        if let Err(cleanup_error) = cleanup {
+        if let Err(cleanup_error) = rustix_fs::unlinkat(parent, &temporary_name, AtFlags::empty()) {
             return Err(format!(
                 "{original}; cleanup failed for owner-only temporary {}: {cleanup_error}",
                 parent_path.join(&temporary_name).display()
@@ -805,6 +943,39 @@ fn write_secret_bytes_atomically_unix(
         }
     }
     result
+}
+
+#[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+fn write_secret_bytes_atomically_unix_with_after_lock_hook<F>(
+    path: &std::path::Path,
+    secret: &[u8],
+    force: bool,
+    after_lock: F,
+) -> Result<SecretWriteOutcomeV1, String>
+where
+    F: FnOnce(&std::fs::File) -> Result<(), String>,
+{
+    use rustix::fs::{self as rustix_fs, FlockOperation};
+
+    let (parent, file_name, parent_path) = open_secret_parent_v1(path)?;
+    rustix_fs::flock(&parent, FlockOperation::NonBlockingLockExclusive)
+        .map_err(|error| format!("secret parent {} is busy: {error}", parent_path.display()))?;
+    let mut parent_lock = SecretParentLockGuardV1::new(&parent);
+    let operation_result = perform_secret_write_atomically_unix_locked(
+        &parent,
+        &file_name,
+        &parent_path,
+        path,
+        secret,
+        force,
+        after_lock,
+    );
+    // A concurrently running test or service thread may fork while this
+    // descriptor is open. Explicit unlock releases the shared open-file-
+    // description lock even if a child inherited a duplicate descriptor;
+    // CLOEXEC alone does not close that duplicate until exec succeeds.
+    let unlock_result = parent_lock.release();
+    finish_secret_parent_lock_v1(operation_result, unlock_result, &parent_path)
 }
 
 #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
@@ -1323,6 +1494,102 @@ mod tests {
         write_secret_bytes_unix_with_force(&path, &[0x18_u8; 32], false).unwrap();
         write_secret_bytes_unix_with_force(&path, &[0x81_u8; 32], true).unwrap();
         assert_eq!(std::fs::read(path).unwrap(), vec![0x81_u8; 32]);
+    }
+
+    #[test]
+    fn explicit_unlock_releases_an_inherited_open_file_description() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("inherited-lock.key");
+        let mut inherited_parent = None;
+
+        let first = write_secret_bytes_atomically_unix_with_after_lock_hook(
+            &path,
+            &[0x34_u8; 32],
+            false,
+            |parent| {
+                inherited_parent = Some(
+                    parent
+                        .try_clone()
+                        .map_err(|error| format!("duplicate locked parent: {error}"))?,
+                );
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(first, SecretWriteOutcomeV1::Durable);
+
+        // `try_clone` retains the same open-file-description lock just like a
+        // descriptor inherited across fork. The next independent open would
+        // receive EAGAIN here unless the first writer explicitly used LOCK_UN.
+        assert!(inherited_parent.is_some());
+        write_secret_bytes_unix_with_force(&path, &[0x43_u8; 32], true).unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), vec![0x43_u8; 32]);
+        drop(inherited_parent);
+    }
+
+    #[test]
+    fn unlock_failure_preserves_primary_and_post_commit_outcomes() {
+        let parent = std::path::Path::new("/private/secret-parent");
+        assert_eq!(
+            finish_secret_parent_lock_v1(
+                Err("primary operation failure".to_owned()),
+                Err("unlock failure".to_owned()),
+                parent,
+            ),
+            Err("primary operation failure; additionally failed to release secret parent lock: unlock failure".to_owned())
+        );
+        assert_eq!(
+            finish_secret_parent_lock_v1(
+                Ok(SecretWriteOutcomeV1::Durable),
+                Err("unlock failure".to_owned()),
+                parent,
+            )
+            .unwrap(),
+            SecretWriteOutcomeV1::CommittedLockReleaseUnknown {
+                parent: parent.to_path_buf(),
+                error: "unlock failure".to_owned(),
+            }
+        );
+
+        let durability_unknown = SecretWriteOutcomeV1::CommittedDurabilityUnknown {
+            parent: parent.to_path_buf(),
+            error: "fsync failure".to_owned(),
+            lock_release_error: None,
+        };
+        assert_eq!(
+            finish_secret_parent_lock_v1(
+                Ok(durability_unknown),
+                Err("unlock failure".to_owned()),
+                parent,
+            )
+            .unwrap(),
+            SecretWriteOutcomeV1::CommittedDurabilityUnknown {
+                parent: parent.to_path_buf(),
+                error: "fsync failure".to_owned(),
+                lock_release_error: Some("unlock failure".to_owned()),
+            }
+        );
+
+        let path_unknown = SecretWriteOutcomeV1::CommittedPathUnknown {
+            parent: parent.to_path_buf(),
+            error: "path failure".to_owned(),
+            durability_error: Some("fsync failure".to_owned()),
+            lock_release_error: None,
+        };
+        assert_eq!(
+            finish_secret_parent_lock_v1(
+                Ok(path_unknown),
+                Err("unlock failure".to_owned()),
+                parent,
+            )
+            .unwrap(),
+            SecretWriteOutcomeV1::CommittedPathUnknown {
+                parent: parent.to_path_buf(),
+                error: "path failure".to_owned(),
+                durability_error: Some("fsync failure".to_owned()),
+                lock_release_error: Some("unlock failure".to_owned()),
+            }
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/apps/admin/src/lightning_staging.rs
+++ b/apps/admin/src/lightning_staging.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::fmt;
 use std::fs::File;
-use std::io::Read;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Component, Path, PathBuf};
 use std::process::Stdio;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -140,11 +140,50 @@ struct LightningStagingConfigV1 {
 struct BitcoinConfigV1 {
     daemon: PinnedBinaryV1,
     cli: PinnedBinaryV1,
-    rpc_cookie: ProtectedFileV1,
+    rpc_cookie: CoreRpcCookieConfigV1,
     /// `bitcoin-cli` options only. At least one exact default-Signet selector
     /// is required; positional RPC method names and inline credentials fail.
     cli_args: Vec<String>,
     expected_subversion: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CoreRpcCookieConfigV1 {
+    path: PathBuf,
+    protected_parent: PathBuf,
+    #[serde(default)]
+    access_policy: CoreRpcCookieAccessPolicyV1,
+    #[serde(default)]
+    cross_uid_access: Option<CoreRpcCookieCrossUidAccessV1>,
+    /// Exact bitcoind owner of the final network directory and cookie.
+    expected_uid: u32,
+    /// Exact cookie-only group. In cross-UID mode only CLN and the short-lived
+    /// preflight may receive it; payment issuer and CLN RPC guard must not.
+    expected_gid: u32,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+enum CoreRpcCookieAccessPolicyV1 {
+    /// Backwards-compatible V1 staging layout: preflight and bitcoind share
+    /// one UID, the final directory is exact mode 0700 and the cookie is 0600.
+    #[default]
+    SameUidOwnerOnly,
+    /// Split-UID layout: a short-lived preflight unit traverses an exact
+    /// bitcoind-owner/cookie-group mode-0710 directory and reads a 0640 cookie.
+    CrossUidSharedGroup,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct CoreRpcCookieCrossUidAccessV1 {
+    /// Exact EUID under which the read-only preflight must execute.
+    preflight_expected_uid: u32,
+    /// The broad `protected_parent` is a root-owned deployment boundary, not
+    /// the bitcoind-owned final network directory.
+    protected_parent_expected_uid: u32,
+    protected_parent_expected_gid: u32,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -154,10 +193,42 @@ struct LightningConfigV1 {
     cli: PinnedBinaryV1,
     rpc_socket: PathBuf,
     protected_parent: PathBuf,
+    #[serde(default)]
+    rpc_access_policy: LightningRpcAccessPolicyV1,
+    #[serde(default)]
+    cross_uid_access: Option<LightningCrossUidAccessV1>,
+    /// Exact CLN owner of the final network directory and RPC socket.
     expected_uid: u32,
+    /// Exact metadata GID; in cross-UID mode this is the native CLN RPC group
+    /// the dedicated preflight and method guard hold, never the issuer.
     expected_gid: u32,
     expected_version: String,
     allowed_plugins: Vec<PinnedPluginV1>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+enum LightningRpcAccessPolicyV1 {
+    /// Backwards-compatible V1 staging layout: the preflight process, socket
+    /// parent and socket share one UID; the final parent is exact mode 0700
+    /// and the socket is exact mode 0600.
+    #[default]
+    SameUidOwnerOnly,
+    /// Production split-UID layout: the dedicated preflight traverses a
+    /// CLN-owned mode-0710 network directory through an explicit shared group
+    /// and connects to an exact mode-0660 socket.
+    CrossUidSharedGroup,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct LightningCrossUidAccessV1 {
+    /// Exact EUID under which this preflight must execute.
+    client_expected_uid: u32,
+    /// The broad `protected_parent` is a root-owned deployment boundary, not
+    /// the CLN-owned final network directory.
+    protected_parent_expected_uid: u32,
+    protected_parent_expected_gid: u32,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -187,15 +258,6 @@ struct PinnedPluginV1 {
     name: String,
     protected_parent: PathBuf,
     sha256_hex: String,
-    expected_uid: u32,
-    expected_gid: u32,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct ProtectedFileV1 {
-    path: PathBuf,
-    protected_parent: PathBuf,
     expected_uid: u32,
     expected_gid: u32,
 }
@@ -683,6 +745,7 @@ fn validate_static_config_v1(
         &config.bitcoin.rpc_cookie.protected_parent,
         "config.core-rpc-cookie-parent",
     )?;
+    validate_core_rpc_cookie_access_policy_v1(&config.bitcoin.rpc_cookie)?;
     validate_bitcoin_cli_args_v1(&config.bitcoin.cli_args, &config.bitcoin.rpc_cookie.path)?;
     validate_bounded_label_v1(
         &config.bitcoin.expected_subversion,
@@ -715,9 +778,121 @@ fn validate_static_config_v1(
         &config.lightning.protected_parent,
         "config.lightning-parent",
     )?;
+    validate_lightning_rpc_access_policy_v1(&config.lightning)?;
+    validate_preflight_identity_separation_v1(config)?;
     validate_absolute_utf8_path_v1(&config.backup.receipt, "config.backup-receipt")?;
     validate_absolute_utf8_path_v1(&config.backup.protected_parent, "config.backup-parent")?;
     Ok(ids)
+}
+
+fn validate_core_rpc_cookie_access_policy_v1(
+    config: &CoreRpcCookieConfigV1,
+) -> Result<(), PreflightFailureV1> {
+    let check = "config.core-rpc-cookie-access";
+    match (config.access_policy, &config.cross_uid_access) {
+        (CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly, None) => Ok(()),
+        (CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly, Some(_)) => Err(PreflightFailureV1::new(
+            check,
+            "cross-uid-fields-with-same-uid-policy",
+        )),
+        (CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup, None) => {
+            Err(PreflightFailureV1::new(check, "missing-cross-uid-fields"))
+        }
+        (CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup, Some(cross_uid)) => {
+            if cross_uid.protected_parent_expected_uid != 0
+                || cross_uid.protected_parent_expected_gid != 0
+                || cross_uid.preflight_expected_uid == 0
+                || config.expected_uid == 0
+                || config.expected_gid == 0
+                || cross_uid.preflight_expected_uid == config.expected_uid
+            {
+                return Err(PreflightFailureV1::new(
+                    check,
+                    "invalid-cross-uid-identities",
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
+fn validate_preflight_identity_separation_v1(
+    config: &LightningStagingConfigV1,
+) -> Result<(), PreflightFailureV1> {
+    let check = "config.preflight-identities";
+    let core_preflight_uid = match config.bitcoin.rpc_cookie.access_policy {
+        CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly => config.bitcoin.rpc_cookie.expected_uid,
+        CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup => {
+            config
+                .bitcoin
+                .rpc_cookie
+                .cross_uid_access
+                .as_ref()
+                .ok_or_else(|| PreflightFailureV1::new(check, "missing-core-cross-uid-fields"))?
+                .preflight_expected_uid
+        }
+    };
+    let lightning_preflight_uid = match config.lightning.rpc_access_policy {
+        LightningRpcAccessPolicyV1::SameUidOwnerOnly => config.lightning.expected_uid,
+        LightningRpcAccessPolicyV1::CrossUidSharedGroup => {
+            config
+                .lightning
+                .cross_uid_access
+                .as_ref()
+                .ok_or_else(|| {
+                    PreflightFailureV1::new(check, "missing-lightning-cross-uid-fields")
+                })?
+                .client_expected_uid
+        }
+    };
+    if core_preflight_uid != lightning_preflight_uid {
+        return Err(PreflightFailureV1::new(check, "preflight-uid-conflict"));
+    }
+    if config.bitcoin.rpc_cookie.access_policy == CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup
+        && (config.bitcoin.rpc_cookie.expected_uid == config.lightning.expected_uid
+            || config.bitcoin.rpc_cookie.expected_gid == config.lightning.expected_gid)
+    {
+        return Err(PreflightFailureV1::new(
+            check,
+            "core-and-lightning-identities-not-separated",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_lightning_rpc_access_policy_v1(
+    config: &LightningConfigV1,
+) -> Result<(), PreflightFailureV1> {
+    let check = "config.lightning-rpc-access";
+    match (config.rpc_access_policy, &config.cross_uid_access) {
+        (LightningRpcAccessPolicyV1::SameUidOwnerOnly, None) => Ok(()),
+        (LightningRpcAccessPolicyV1::SameUidOwnerOnly, Some(_)) => Err(PreflightFailureV1::new(
+            check,
+            "cross-uid-fields-with-same-uid-policy",
+        )),
+        (LightningRpcAccessPolicyV1::CrossUidSharedGroup, None) => {
+            Err(PreflightFailureV1::new(check, "missing-cross-uid-fields"))
+        }
+        (LightningRpcAccessPolicyV1::CrossUidSharedGroup, Some(cross_uid)) => {
+            // V1 intentionally supports one unambiguous production shape.
+            // Root owns the broad boundary, a non-root CLN daemon owns the
+            // final directory/socket, and a distinct non-root preflight EUID
+            // reaches it only through the non-root shared group.
+            if cross_uid.protected_parent_expected_uid != 0
+                || cross_uid.protected_parent_expected_gid != 0
+                || cross_uid.client_expected_uid == 0
+                || config.expected_uid == 0
+                || config.expected_gid == 0
+                || cross_uid.client_expected_uid == config.expected_uid
+            {
+                return Err(PreflightFailureV1::new(
+                    check,
+                    "invalid-cross-uid-identities",
+                ));
+            }
+            Ok(())
+        }
+    }
 }
 
 fn normalize_node_id_v1(value: &str) -> Result<String, PreflightFailureV1> {
@@ -917,9 +1092,8 @@ fn read_bounded_regular_file_v1(
         .ok_or_else(|| PreflightFailureV1::new(check, "oversize"))?;
     let capacity =
         usize::try_from(read_limit).map_err(|_| PreflightFailureV1::new(check, "oversize"))?;
-    // This helper also reads the Core RPC cookie. Preallocate the bound once
-    // and scrub it on read, oversize and post-read metadata failure paths so
-    // neither a partial secret nor an old reallocated prefix is abandoned.
+    // Preallocate the bound once and scrub it on read, oversize and post-read
+    // metadata failure paths so no abandoned partial buffer survives an error.
     let mut bytes = Zeroizing::new(Vec::with_capacity(capacity));
     file.by_ref()
         .take(read_limit)
@@ -990,35 +1164,11 @@ fn read_protected_config_at_v1(
     }
 }
 
-fn validate_core_rpc_cookie_v1(config: &ProtectedFileV1) -> Result<(), PreflightFailureV1> {
+fn validate_core_rpc_cookie_v1(config: &CoreRpcCookieConfigV1) -> Result<(), PreflightFailureV1> {
     let check = "core.rpc-cookie";
     #[cfg(unix)]
     {
-        use std::os::unix::fs::{MetadataExt, PermissionsExt};
-        validate_protected_tree_v1(
-            &config.protected_parent,
-            &config.path,
-            config.expected_uid,
-            config.expected_gid,
-            true,
-            check,
-        )?;
-        let metadata = std::fs::symlink_metadata(&config.path)
-            .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
-        let mode = metadata.permissions().mode() & 0o777;
-        if metadata.uid() != config.expected_uid
-            || metadata.gid() != config.expected_gid
-            || mode != 0o600
-            || metadata.len() == 0
-            || metadata.len() > MAX_CORE_COOKIE_BYTES_V1
-        {
-            return Err(PreflightFailureV1::new(check, "unsafe-metadata"));
-        }
-        let bytes = Zeroizing::new(read_bounded_regular_file_v1(
-            &config.path,
-            MAX_CORE_COOKIE_BYTES_V1,
-            check,
-        )?);
+        let bytes = read_validated_core_rpc_cookie_with_hook_v1(config, || Ok(()))?;
         let value = bytes.strip_suffix(b"\n").unwrap_or(bytes.as_slice());
         let valid = value
             .iter()
@@ -1040,6 +1190,380 @@ fn validate_core_rpc_cookie_v1(config: &ProtectedFileV1) -> Result<(), Preflight
         let _ = config;
         Err(PreflightFailureV1::new(check, "unsupported-platform"))
     }
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CoreRpcCookieRuntimeIdentityV1 {
+    effective_uid: u32,
+    effective_gid: u32,
+    supplementary_gids: BTreeSet<u32>,
+}
+
+#[cfg(unix)]
+fn current_core_rpc_cookie_runtime_identity_v1(
+    check: &'static str,
+) -> Result<CoreRpcCookieRuntimeIdentityV1, PreflightFailureV1> {
+    let supplementary_gids = rustix::process::getgroups()
+        .map_err(|_| PreflightFailureV1::new(check, "group-list-unavailable"))?
+        .into_iter()
+        .map(|gid| gid.as_raw())
+        .collect();
+    Ok(CoreRpcCookieRuntimeIdentityV1 {
+        effective_uid: rustix::process::geteuid().as_raw(),
+        effective_gid: rustix::process::getegid().as_raw(),
+        supplementary_gids,
+    })
+}
+
+#[cfg(unix)]
+fn validate_core_rpc_cookie_runtime_identity_v1(
+    config: &CoreRpcCookieConfigV1,
+    runtime: &CoreRpcCookieRuntimeIdentityV1,
+) -> Result<(), PreflightFailureV1> {
+    let check = "core.rpc-cookie";
+    match config.access_policy {
+        CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly => {
+            if runtime.effective_uid != config.expected_uid {
+                return Err(PreflightFailureV1::new(check, "runtime-uid-mismatch"));
+            }
+        }
+        CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup => {
+            let cross_uid = config
+                .cross_uid_access
+                .as_ref()
+                .ok_or_else(|| PreflightFailureV1::new(check, "missing-cross-uid-fields"))?;
+            if runtime.effective_uid != cross_uid.preflight_expected_uid {
+                return Err(PreflightFailureV1::new(check, "runtime-uid-mismatch"));
+            }
+            if runtime.effective_gid != config.expected_gid
+                && !runtime.supplementary_gids.contains(&config.expected_gid)
+            {
+                return Err(PreflightFailureV1::new(check, "shared-group-missing"));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CoreRpcCookieBoundaryKindV1 {
+    Directory,
+    RegularFile,
+    Other,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CoreRpcCookieBoundaryMetadataV1 {
+    kind: CoreRpcCookieBoundaryKindV1,
+    uid: u32,
+    gid: u32,
+    mode: u32,
+    nlink: u64,
+    size: u64,
+}
+
+#[cfg(unix)]
+fn core_rpc_cookie_boundary_metadata_v1(
+    metadata: &std::fs::Metadata,
+) -> CoreRpcCookieBoundaryMetadataV1 {
+    use std::os::unix::fs::MetadataExt;
+    let kind = if metadata.file_type().is_dir() {
+        CoreRpcCookieBoundaryKindV1::Directory
+    } else if metadata.is_file() {
+        CoreRpcCookieBoundaryKindV1::RegularFile
+    } else {
+        CoreRpcCookieBoundaryKindV1::Other
+    };
+    CoreRpcCookieBoundaryMetadataV1 {
+        kind,
+        uid: metadata.uid(),
+        gid: metadata.gid(),
+        mode: metadata.mode() & 0o7777,
+        nlink: metadata.nlink(),
+        size: metadata.len(),
+    }
+}
+
+#[cfg(unix)]
+fn validate_core_rpc_cookie_file_metadata_v1(
+    config: &CoreRpcCookieConfigV1,
+    metadata: CoreRpcCookieBoundaryMetadataV1,
+    check: &'static str,
+) -> Result<(), PreflightFailureV1> {
+    let expected_mode = match config.access_policy {
+        CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly => 0o600,
+        CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup => 0o640,
+    };
+    if metadata.kind != CoreRpcCookieBoundaryKindV1::RegularFile
+        || metadata.uid != config.expected_uid
+        || metadata.gid != config.expected_gid
+        || metadata.mode != expected_mode
+        || metadata.nlink != 1
+        || metadata.size == 0
+        || metadata.size > MAX_CORE_COOKIE_BYTES_V1
+    {
+        return Err(PreflightFailureV1::new(check, "unsafe-metadata"));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_core_rpc_cookie_boundary_metadata_v1(
+    config: &CoreRpcCookieConfigV1,
+    protected_parent: CoreRpcCookieBoundaryMetadataV1,
+    final_parent: CoreRpcCookieBoundaryMetadataV1,
+    cookie: CoreRpcCookieBoundaryMetadataV1,
+    check: &'static str,
+) -> Result<(), PreflightFailureV1> {
+    if config.access_policy == CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup {
+        let cross_uid = config
+            .cross_uid_access
+            .as_ref()
+            .ok_or_else(|| PreflightFailureV1::new(check, "missing-cross-uid-fields"))?;
+        if protected_parent.kind != CoreRpcCookieBoundaryKindV1::Directory
+            || protected_parent.uid != cross_uid.protected_parent_expected_uid
+            || protected_parent.gid != cross_uid.protected_parent_expected_gid
+            || protected_parent.mode != 0o755
+        {
+            return Err(PreflightFailureV1::new(check, "unsafe-protected-parent"));
+        }
+    }
+    let expected_final_mode = match config.access_policy {
+        CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly => 0o700,
+        CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup => 0o710,
+    };
+    if final_parent.kind != CoreRpcCookieBoundaryKindV1::Directory
+        || final_parent.uid != config.expected_uid
+        || final_parent.gid != config.expected_gid
+        || final_parent.mode != expected_final_mode
+    {
+        return Err(PreflightFailureV1::new(check, "unsafe-directory"));
+    }
+    validate_core_rpc_cookie_file_metadata_v1(config, cookie, check)
+}
+
+#[cfg(unix)]
+fn validate_canonical_core_rpc_cookie_layout_v1(
+    config: &CoreRpcCookieConfigV1,
+    check: &'static str,
+) -> Result<PathBuf, PreflightFailureV1> {
+    let final_parent = config
+        .path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| PreflightFailureV1::new(check, "invalid-cookie-layout"))?
+        .to_path_buf();
+    let relative = config
+        .path
+        .strip_prefix(&config.protected_parent)
+        .map_err(|_| PreflightFailureV1::new(check, "outside-protected-parent"))?;
+    let components = relative.components().collect::<Vec<_>>();
+    if components.is_empty()
+        || !components
+            .iter()
+            .all(|component| matches!(component, Component::Normal(_)))
+        || (config.access_policy == CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup
+            && components.len() != 2)
+    {
+        return Err(PreflightFailureV1::new(check, "invalid-cookie-layout"));
+    }
+    for path in [
+        config.protected_parent.as_path(),
+        final_parent.as_path(),
+        config.path.as_path(),
+    ] {
+        let canonical = std::fs::canonicalize(path)
+            .map_err(|_| PreflightFailureV1::new(check, "canonicalize-failed"))?;
+        if canonical != path {
+            return Err(PreflightFailureV1::new(check, "non-canonical-path"));
+        }
+    }
+    Ok(final_parent)
+}
+
+#[cfg(unix)]
+fn validate_same_core_rpc_cookie_entry_v1(
+    before: &std::fs::Metadata,
+    after: &std::fs::Metadata,
+    check: &'static str,
+) -> Result<(), PreflightFailureV1> {
+    use std::os::unix::fs::MetadataExt;
+    validate_same_file_v1(before, after, check)?;
+    if before.nlink() != after.nlink() {
+        return Err(PreflightFailureV1::new(check, "file-changed"));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_core_rpc_cookie_namespace_v1(
+    config: &CoreRpcCookieConfigV1,
+    final_parent: &Path,
+    protected_parent: &std::fs::Metadata,
+    final_parent_metadata: &std::fs::Metadata,
+    cookie: &std::fs::Metadata,
+    check: &'static str,
+) -> Result<(), PreflightFailureV1> {
+    if config.access_policy == CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly {
+        validate_protected_tree_v1(
+            &config.protected_parent,
+            &config.path,
+            config.expected_uid,
+            config.expected_gid,
+            true,
+            check,
+        )?;
+    }
+    validate_core_rpc_cookie_boundary_metadata_v1(
+        config,
+        core_rpc_cookie_boundary_metadata_v1(protected_parent),
+        core_rpc_cookie_boundary_metadata_v1(final_parent_metadata),
+        core_rpc_cookie_boundary_metadata_v1(cookie),
+        check,
+    )?;
+    let shared_gid = match config.access_policy {
+        CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly => None,
+        CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup => Some(config.expected_gid),
+    };
+    let checked_path = pir_private_files::prepare_private_unix_socket_parent_v1(
+        &config.path,
+        config.expected_uid,
+        shared_gid,
+        "Core RPC cookie",
+    )
+    .map_err(|_| PreflightFailureV1::new(check, "unsafe-parent-boundary"))?;
+    if checked_path != config.path || config.path.parent() != Some(final_parent) {
+        return Err(PreflightFailureV1::new(check, "path-changed"));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn read_validated_core_rpc_cookie_with_hook_v1<F>(
+    config: &CoreRpcCookieConfigV1,
+    after_read: F,
+) -> Result<Zeroizing<Vec<u8>>, PreflightFailureV1>
+where
+    F: FnOnce() -> Result<(), PreflightFailureV1>,
+{
+    use rustix::fs::{self as rustix_fs, Mode, OFlags};
+
+    let check = "core.rpc-cookie";
+    validate_core_rpc_cookie_access_policy_v1(config)?;
+    let runtime = current_core_rpc_cookie_runtime_identity_v1(check)?;
+    validate_core_rpc_cookie_runtime_identity_v1(config, &runtime)?;
+    let final_parent = validate_canonical_core_rpc_cookie_layout_v1(config, check)?;
+    let protected_parent_before = std::fs::symlink_metadata(&config.protected_parent)
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    let final_parent_before = std::fs::symlink_metadata(&final_parent)
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    let cookie_named_before = std::fs::symlink_metadata(&config.path)
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    validate_core_rpc_cookie_namespace_v1(
+        config,
+        &final_parent,
+        &protected_parent_before,
+        &final_parent_before,
+        &cookie_named_before,
+        check,
+    )?;
+
+    let fd = rustix_fs::open(
+        &config.path,
+        OFlags::RDONLY | OFlags::NOFOLLOW | OFlags::CLOEXEC | OFlags::NONBLOCK,
+        Mode::empty(),
+    )
+    .map_err(|_| PreflightFailureV1::new(check, "open-failed"))?;
+    let mut file = File::from(fd);
+    let opened_before = file
+        .metadata()
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    validate_same_core_rpc_cookie_entry_v1(&cookie_named_before, &opened_before, check)?;
+    validate_core_rpc_cookie_file_metadata_v1(
+        config,
+        core_rpc_cookie_boundary_metadata_v1(&opened_before),
+        check,
+    )?;
+    pir_private_files::reject_extended_acl_v1(&file, "Core RPC cookie")
+        .map_err(|_| PreflightFailureV1::new(check, "unsafe-cookie-acl"))?;
+
+    let read_limit = MAX_CORE_COOKIE_BYTES_V1 + 1;
+    let mut bytes = Zeroizing::new(Vec::with_capacity(read_limit as usize));
+    file.by_ref()
+        .take(read_limit)
+        .read_to_end(&mut bytes)
+        .map_err(|_| PreflightFailureV1::new(check, "read-failed"))?;
+    if bytes.len() as u64 > MAX_CORE_COOKIE_BYTES_V1 {
+        return Err(PreflightFailureV1::new(check, "oversize"));
+    }
+    if bytes.len() as u64 != opened_before.len() {
+        return Err(PreflightFailureV1::new(check, "size-changed"));
+    }
+
+    after_read()?;
+
+    file.seek(SeekFrom::Start(0))
+        .map_err(|_| PreflightFailureV1::new(check, "seek-failed"))?;
+    let mut confirmed_bytes = Zeroizing::new(Vec::with_capacity(read_limit as usize));
+    file.by_ref()
+        .take(read_limit)
+        .read_to_end(&mut confirmed_bytes)
+        .map_err(|_| PreflightFailureV1::new(check, "read-failed"))?;
+    if confirmed_bytes.len() as u64 > MAX_CORE_COOKIE_BYTES_V1 {
+        return Err(PreflightFailureV1::new(check, "oversize"));
+    }
+    if confirmed_bytes.len() != bytes.len() {
+        return Err(PreflightFailureV1::new(check, "size-changed"));
+    }
+    if confirmed_bytes.as_slice() != bytes.as_slice() {
+        return Err(PreflightFailureV1::new(check, "content-changed"));
+    }
+
+    let opened_after = file
+        .metadata()
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    validate_same_core_rpc_cookie_entry_v1(&opened_before, &opened_after, check)?;
+    validate_core_rpc_cookie_file_metadata_v1(
+        config,
+        core_rpc_cookie_boundary_metadata_v1(&opened_after),
+        check,
+    )?;
+    if bytes.len() as u64 != opened_after.len() {
+        return Err(PreflightFailureV1::new(check, "size-changed"));
+    }
+    pir_private_files::reject_extended_acl_v1(&file, "Core RPC cookie")
+        .map_err(|_| PreflightFailureV1::new(check, "unsafe-cookie-acl"))?;
+
+    let protected_parent_after = std::fs::symlink_metadata(&config.protected_parent)
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    let final_parent_after = std::fs::symlink_metadata(&final_parent)
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    let cookie_named_after = std::fs::symlink_metadata(&config.path)
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    validate_same_core_rpc_cookie_entry_v1(
+        &protected_parent_before,
+        &protected_parent_after,
+        check,
+    )?;
+    validate_same_core_rpc_cookie_entry_v1(&final_parent_before, &final_parent_after, check)?;
+    validate_same_core_rpc_cookie_entry_v1(&cookie_named_before, &cookie_named_after, check)?;
+    validate_same_core_rpc_cookie_entry_v1(&cookie_named_after, &opened_after, check)?;
+    let final_parent_after_path = validate_canonical_core_rpc_cookie_layout_v1(config, check)?;
+    if final_parent_after_path != final_parent {
+        return Err(PreflightFailureV1::new(check, "path-changed"));
+    }
+    validate_core_rpc_cookie_namespace_v1(
+        config,
+        &final_parent,
+        &protected_parent_after,
+        &final_parent_after,
+        &cookie_named_after,
+        check,
+    )?;
+    Ok(bytes)
 }
 
 fn validate_pinned_plugin_v1(plugin: &PinnedPluginV1) -> Result<(), PreflightFailureV1> {
@@ -1163,26 +1687,291 @@ fn validate_same_file_v1(
 
 #[cfg(unix)]
 fn validate_protected_socket_v1(config: &LightningConfigV1) -> Result<(), PreflightFailureV1> {
-    use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
     let check = "filesystem.lightning-rpc";
-    validate_protected_tree_v1(
-        &config.protected_parent,
-        &config.rpc_socket,
-        config.expected_uid,
-        config.expected_gid,
-        false,
+    validate_lightning_rpc_access_policy_v1(config)?;
+    let runtime = current_lightning_runtime_identity_v1(check)?;
+    validate_lightning_runtime_identity_v1(config, &runtime)?;
+
+    let final_parent = validate_canonical_lightning_socket_layout_v1(config, check)?;
+    let protected_parent_before = std::fs::symlink_metadata(&config.protected_parent)
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    let final_parent_before = std::fs::symlink_metadata(&final_parent)
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    let socket_before = std::fs::symlink_metadata(&config.rpc_socket)
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+
+    match config.rpc_access_policy {
+        LightningRpcAccessPolicyV1::SameUidOwnerOnly => {
+            // Preserve the V1 same-owner protected-tree pin while adding the
+            // fd-walked final-parent/ACL and exact-mode checks below.
+            validate_protected_tree_v1(
+                &config.protected_parent,
+                &config.rpc_socket,
+                config.expected_uid,
+                config.expected_gid,
+                false,
+                check,
+            )?;
+        }
+        LightningRpcAccessPolicyV1::CrossUidSharedGroup => {
+            validate_cross_uid_boundary_metadata_v1(
+                config,
+                lightning_boundary_metadata_v1(&protected_parent_before),
+                lightning_boundary_metadata_v1(&final_parent_before),
+                lightning_boundary_metadata_v1(&socket_before),
+                check,
+            )?;
+        }
+    }
+
+    validate_lightning_socket_metadata_v1(
+        config,
+        lightning_boundary_metadata_v1(&socket_before),
         check,
     )?;
-    let metadata = std::fs::symlink_metadata(&config.rpc_socket)
+
+    // This component-by-component O_NOFOLLOW walk checks every ancestor and
+    // the final socket parent, including the platform ACL policy. Same-UID
+    // requires exact 0700; cross-UID requires exact CLN:GID 0710.
+    let shared_gid = match config.rpc_access_policy {
+        LightningRpcAccessPolicyV1::SameUidOwnerOnly => None,
+        LightningRpcAccessPolicyV1::CrossUidSharedGroup => Some(config.expected_gid),
+    };
+    let checked_path = pir_private_files::prepare_private_unix_socket_parent_v1(
+        &config.rpc_socket,
+        config.expected_uid,
+        shared_gid,
+        "Lightning staging RPC socket",
+    )
+    .map_err(|_| PreflightFailureV1::new(check, "unsafe-parent-boundary"))?;
+    if checked_path != config.rpc_socket {
+        return Err(PreflightFailureV1::new(check, "path-changed"));
+    }
+
+    let protected_parent_after = std::fs::symlink_metadata(&config.protected_parent)
         .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
-    let mode = metadata.permissions().mode() & 0o777;
-    if !metadata.file_type().is_socket()
-        || metadata.uid() != config.expected_uid
-        || metadata.gid() != config.expected_gid
-        || mode & 0o077 != 0
-        || mode & 0o600 != 0o600
+    let final_parent_after = std::fs::symlink_metadata(&final_parent)
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    let socket_after = std::fs::symlink_metadata(&config.rpc_socket)
+        .map_err(|_| PreflightFailureV1::new(check, "metadata-unavailable"))?;
+    validate_same_lightning_boundary_entry_v1(
+        &protected_parent_before,
+        &protected_parent_after,
+        check,
+    )?;
+    validate_same_lightning_boundary_entry_v1(&final_parent_before, &final_parent_after, check)?;
+    validate_same_lightning_boundary_entry_v1(&socket_before, &socket_after, check)?;
+
+    match config.rpc_access_policy {
+        LightningRpcAccessPolicyV1::SameUidOwnerOnly => {}
+        LightningRpcAccessPolicyV1::CrossUidSharedGroup => {
+            validate_cross_uid_boundary_metadata_v1(
+                config,
+                lightning_boundary_metadata_v1(&protected_parent_after),
+                lightning_boundary_metadata_v1(&final_parent_after),
+                lightning_boundary_metadata_v1(&socket_after),
+                check,
+            )?;
+        }
+    }
+    validate_lightning_socket_metadata_v1(
+        config,
+        lightning_boundary_metadata_v1(&socket_after),
+        check,
+    )?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct LightningRuntimeIdentityV1 {
+    effective_uid: u32,
+    effective_gid: u32,
+    supplementary_gids: BTreeSet<u32>,
+}
+
+#[cfg(unix)]
+fn current_lightning_runtime_identity_v1(
+    check: &'static str,
+) -> Result<LightningRuntimeIdentityV1, PreflightFailureV1> {
+    let supplementary_gids = rustix::process::getgroups()
+        .map_err(|_| PreflightFailureV1::new(check, "group-list-unavailable"))?
+        .into_iter()
+        .map(|gid| gid.as_raw())
+        .collect();
+    Ok(LightningRuntimeIdentityV1 {
+        effective_uid: rustix::process::geteuid().as_raw(),
+        effective_gid: rustix::process::getegid().as_raw(),
+        supplementary_gids,
+    })
+}
+
+#[cfg(unix)]
+fn validate_lightning_runtime_identity_v1(
+    config: &LightningConfigV1,
+    runtime: &LightningRuntimeIdentityV1,
+) -> Result<(), PreflightFailureV1> {
+    let check = "filesystem.lightning-rpc";
+    match config.rpc_access_policy {
+        LightningRpcAccessPolicyV1::SameUidOwnerOnly => {
+            if runtime.effective_uid != config.expected_uid {
+                return Err(PreflightFailureV1::new(check, "runtime-uid-mismatch"));
+            }
+        }
+        LightningRpcAccessPolicyV1::CrossUidSharedGroup => {
+            let cross_uid = config
+                .cross_uid_access
+                .as_ref()
+                .ok_or_else(|| PreflightFailureV1::new(check, "missing-cross-uid-fields"))?;
+            if runtime.effective_uid != cross_uid.client_expected_uid {
+                return Err(PreflightFailureV1::new(check, "runtime-uid-mismatch"));
+            }
+            if runtime.effective_gid != config.expected_gid
+                && !runtime.supplementary_gids.contains(&config.expected_gid)
+            {
+                return Err(PreflightFailureV1::new(check, "shared-group-missing"));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LightningBoundaryKindV1 {
+    Directory,
+    Socket,
+    Other,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct LightningBoundaryMetadataV1 {
+    kind: LightningBoundaryKindV1,
+    uid: u32,
+    gid: u32,
+    mode: u32,
+    nlink: u64,
+}
+
+#[cfg(unix)]
+fn lightning_boundary_metadata_v1(metadata: &std::fs::Metadata) -> LightningBoundaryMetadataV1 {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+    let kind = if metadata.file_type().is_dir() {
+        LightningBoundaryKindV1::Directory
+    } else if metadata.file_type().is_socket() {
+        LightningBoundaryKindV1::Socket
+    } else {
+        LightningBoundaryKindV1::Other
+    };
+    LightningBoundaryMetadataV1 {
+        kind,
+        uid: metadata.uid(),
+        gid: metadata.gid(),
+        mode: metadata.mode() & 0o7777,
+        nlink: metadata.nlink(),
+    }
+}
+
+#[cfg(unix)]
+fn validate_cross_uid_boundary_metadata_v1(
+    config: &LightningConfigV1,
+    protected_parent: LightningBoundaryMetadataV1,
+    final_parent: LightningBoundaryMetadataV1,
+    socket: LightningBoundaryMetadataV1,
+    check: &'static str,
+) -> Result<(), PreflightFailureV1> {
+    let cross_uid = config
+        .cross_uid_access
+        .as_ref()
+        .ok_or_else(|| PreflightFailureV1::new(check, "missing-cross-uid-fields"))?;
+    if protected_parent.kind != LightningBoundaryKindV1::Directory
+        || protected_parent.uid != cross_uid.protected_parent_expected_uid
+        || protected_parent.gid != cross_uid.protected_parent_expected_gid
+        || protected_parent.mode != 0o755
+    {
+        return Err(PreflightFailureV1::new(check, "unsafe-protected-parent"));
+    }
+    if final_parent.kind != LightningBoundaryKindV1::Directory
+        || final_parent.uid != config.expected_uid
+        || final_parent.gid != config.expected_gid
+        || final_parent.mode != 0o710
+    {
+        return Err(PreflightFailureV1::new(check, "unsafe-directory"));
+    }
+    validate_lightning_socket_metadata_v1(config, socket, check)
+}
+
+#[cfg(unix)]
+fn validate_lightning_socket_metadata_v1(
+    config: &LightningConfigV1,
+    socket: LightningBoundaryMetadataV1,
+    check: &'static str,
+) -> Result<(), PreflightFailureV1> {
+    let expected_mode = match config.rpc_access_policy {
+        LightningRpcAccessPolicyV1::SameUidOwnerOnly => 0o600,
+        LightningRpcAccessPolicyV1::CrossUidSharedGroup => 0o660,
+    };
+    if socket.kind != LightningBoundaryKindV1::Socket
+        || socket.uid != config.expected_uid
+        || socket.gid != config.expected_gid
+        || socket.mode != expected_mode
+        || socket.nlink != 1
     {
         return Err(PreflightFailureV1::new(check, "unsafe-socket"));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_canonical_lightning_socket_layout_v1(
+    config: &LightningConfigV1,
+    check: &'static str,
+) -> Result<PathBuf, PreflightFailureV1> {
+    let final_parent = config
+        .rpc_socket
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| PreflightFailureV1::new(check, "invalid-socket-layout"))?
+        .to_path_buf();
+    if config.rpc_access_policy == LightningRpcAccessPolicyV1::CrossUidSharedGroup {
+        let relative = config
+            .rpc_socket
+            .strip_prefix(&config.protected_parent)
+            .map_err(|_| PreflightFailureV1::new(check, "outside-protected-parent"))?;
+        let components = relative.components().collect::<Vec<_>>();
+        if components.len() != 2
+            || !components
+                .iter()
+                .all(|component| matches!(component, Component::Normal(_)))
+        {
+            return Err(PreflightFailureV1::new(check, "invalid-cross-uid-layout"));
+        }
+    }
+    for path in [
+        config.protected_parent.as_path(),
+        final_parent.as_path(),
+        config.rpc_socket.as_path(),
+    ] {
+        let canonical = std::fs::canonicalize(path)
+            .map_err(|_| PreflightFailureV1::new(check, "canonicalize-failed"))?;
+        if canonical != path {
+            return Err(PreflightFailureV1::new(check, "non-canonical-path"));
+        }
+    }
+    Ok(final_parent)
+}
+
+#[cfg(unix)]
+fn validate_same_lightning_boundary_entry_v1(
+    before: &std::fs::Metadata,
+    after: &std::fs::Metadata,
+    check: &'static str,
+) -> Result<(), PreflightFailureV1> {
+    use std::os::unix::fs::MetadataExt;
+    validate_same_file_v1(before, after, check)?;
+    if before.nlink() != after.nlink() {
+        return Err(PreflightFailureV1::new(check, "file-changed"));
     }
     Ok(())
 }
@@ -2201,9 +2990,11 @@ mod tests {
             bitcoin: BitcoinConfigV1 {
                 daemon: pinned("/opt/bitcoinpir/bin/bitcoind"),
                 cli: pinned("/opt/bitcoinpir/bin/bitcoin-cli"),
-                rpc_cookie: ProtectedFileV1 {
+                rpc_cookie: CoreRpcCookieConfigV1 {
                     path: PathBuf::from("/srv/bitcoin/signet/.cookie"),
                     protected_parent: PathBuf::from("/srv/bitcoin"),
+                    access_policy: CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly,
+                    cross_uid_access: None,
                     expected_uid: 1000,
                     expected_gid: 1000,
                 },
@@ -2223,6 +3014,8 @@ mod tests {
                 cli: pinned("/opt/bitcoinpir/bin/lightning-cli"),
                 rpc_socket: PathBuf::from("/srv/lightning/signet/lightning-rpc"),
                 protected_parent: PathBuf::from("/srv/lightning"),
+                rpc_access_policy: LightningRpcAccessPolicyV1::SameUidOwnerOnly,
+                cross_uid_access: None,
                 expected_uid: 1000,
                 expected_gid: 1000,
                 expected_version: "v26.06.6".to_owned(),
@@ -2242,6 +3035,88 @@ mod tests {
                 max_age_seconds: 3600,
             },
         }
+    }
+
+    fn cross_uid_config(role: StagingRoleV1) -> LightningStagingConfigV1 {
+        let mut value = config(role);
+        value.lightning.rpc_access_policy = LightningRpcAccessPolicyV1::CrossUidSharedGroup;
+        value.lightning.cross_uid_access = Some(LightningCrossUidAccessV1 {
+            client_expected_uid: 1001,
+            protected_parent_expected_uid: 0,
+            protected_parent_expected_gid: 0,
+        });
+        value.lightning.expected_uid = 1000;
+        value.lightning.expected_gid = 1002;
+        value.bitcoin.rpc_cookie.expected_uid = 1001;
+        value.bitcoin.rpc_cookie.expected_gid = 1001;
+        value
+    }
+
+    fn fully_cross_uid_config(role: StagingRoleV1) -> LightningStagingConfigV1 {
+        let mut value = cross_uid_config(role);
+        value.bitcoin.rpc_cookie.access_policy = CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup;
+        value.bitcoin.rpc_cookie.cross_uid_access = Some(CoreRpcCookieCrossUidAccessV1 {
+            preflight_expected_uid: 1001,
+            protected_parent_expected_uid: 0,
+            protected_parent_expected_gid: 0,
+        });
+        value.bitcoin.rpc_cookie.expected_uid = 1003;
+        value.bitcoin.rpc_cookie.expected_gid = 1004;
+        value
+    }
+
+    #[cfg(unix)]
+    fn same_uid_cookie_fixture() -> (tempfile::TempDir, CoreRpcCookieConfigV1, PathBuf) {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let protected_parent = std::fs::canonicalize(directory.path()).unwrap();
+        let metadata = std::fs::metadata(&protected_parent).unwrap();
+        let cookie_path = protected_parent.join(".cookie");
+        let cookie = format!("__cookie__:{}\n", "a".repeat(64));
+        std::fs::write(&cookie_path, cookie.as_bytes()).unwrap();
+        std::fs::set_permissions(&cookie_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let config = CoreRpcCookieConfigV1 {
+            path: cookie_path.clone(),
+            protected_parent,
+            access_policy: CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly,
+            cross_uid_access: None,
+            expected_uid: metadata.uid(),
+            expected_gid: metadata.gid(),
+        };
+        (directory, config, cookie_path)
+    }
+
+    #[cfg(unix)]
+    fn same_uid_socket_fixture() -> (
+        tempfile::TempDir,
+        std::os::unix::net::UnixListener,
+        LightningConfigV1,
+        PathBuf,
+    ) {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        // macOS TMPDIR normally begins with `/var`, which is an alias for
+        // `/private/var`. Feed the validator the required canonical path.
+        let protected_parent = std::fs::canonicalize(directory.path()).unwrap();
+        let final_parent = protected_parent.join("signet");
+        std::fs::create_dir(&final_parent).unwrap();
+        std::fs::set_permissions(&final_parent, std::fs::Permissions::from_mode(0o700)).unwrap();
+        let rpc_socket = final_parent.join("lightning-rpc");
+        let listener = std::os::unix::net::UnixListener::bind(&rpc_socket).unwrap();
+        std::fs::set_permissions(&rpc_socket, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let metadata = std::fs::metadata(&protected_parent).unwrap();
+        let mut lightning = config(StagingRoleV1::Issuer).lightning;
+        lightning.rpc_socket = rpc_socket;
+        lightning.protected_parent = protected_parent;
+        lightning.rpc_access_policy = LightningRpcAccessPolicyV1::SameUidOwnerOnly;
+        lightning.cross_uid_access = None;
+        lightning.expected_uid = metadata.uid();
+        lightning.expected_gid = metadata.gid();
+        (directory, listener, lightning, final_parent)
     }
 
     fn peer(peer_id: &str) -> ClnPeerChannelV1 {
@@ -2581,10 +3456,777 @@ mod tests {
     }
 
     #[test]
+    fn core_rpc_cookie_access_policy_is_explicit_and_fail_closed() {
+        let legacy = config(StagingRoleV1::Issuer);
+        assert_eq!(
+            legacy.bitcoin.rpc_cookie.access_policy,
+            CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly
+        );
+        assert!(validate_static_config_v1(&legacy).is_ok());
+
+        let mut same_with_cross_fields = legacy.clone();
+        same_with_cross_fields.bitcoin.rpc_cookie.cross_uid_access =
+            Some(CoreRpcCookieCrossUidAccessV1 {
+                preflight_expected_uid: 1001,
+                protected_parent_expected_uid: 0,
+                protected_parent_expected_gid: 0,
+            });
+        assert_eq!(
+            validate_static_config_v1(&same_with_cross_fields)
+                .unwrap_err()
+                .reason,
+            "cross-uid-fields-with-same-uid-policy"
+        );
+
+        let mut missing_fields = legacy.clone();
+        missing_fields.bitcoin.rpc_cookie.access_policy =
+            CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup;
+        assert_eq!(
+            validate_static_config_v1(&missing_fields)
+                .unwrap_err()
+                .reason,
+            "missing-cross-uid-fields"
+        );
+
+        let valid_cross_uid = fully_cross_uid_config(StagingRoleV1::Issuer);
+        assert!(validate_static_config_v1(&valid_cross_uid).is_ok());
+        for mutation in 0..5 {
+            let mut invalid = valid_cross_uid.clone();
+            let daemon_uid = invalid.bitcoin.rpc_cookie.expected_uid;
+            match mutation {
+                0 => {
+                    invalid
+                        .bitcoin
+                        .rpc_cookie
+                        .cross_uid_access
+                        .as_mut()
+                        .unwrap()
+                        .preflight_expected_uid = 0
+                }
+                1 => {
+                    invalid
+                        .bitcoin
+                        .rpc_cookie
+                        .cross_uid_access
+                        .as_mut()
+                        .unwrap()
+                        .preflight_expected_uid = daemon_uid
+                }
+                2 => {
+                    invalid
+                        .bitcoin
+                        .rpc_cookie
+                        .cross_uid_access
+                        .as_mut()
+                        .unwrap()
+                        .protected_parent_expected_uid = 1
+                }
+                3 => {
+                    invalid
+                        .bitcoin
+                        .rpc_cookie
+                        .cross_uid_access
+                        .as_mut()
+                        .unwrap()
+                        .protected_parent_expected_gid = 1
+                }
+                4 => invalid.bitcoin.rpc_cookie.expected_gid = 0,
+                _ => unreachable!(),
+            }
+            assert_eq!(
+                validate_static_config_v1(&invalid).unwrap_err().reason,
+                "invalid-cross-uid-identities"
+            );
+        }
+    }
+
+    #[test]
+    fn core_cookie_and_lightning_identities_are_separate_but_share_preflight_euid() {
+        let valid = fully_cross_uid_config(StagingRoleV1::Issuer);
+        assert!(validate_preflight_identity_separation_v1(&valid).is_ok());
+
+        let mut mismatched_preflight = valid.clone();
+        mismatched_preflight
+            .bitcoin
+            .rpc_cookie
+            .cross_uid_access
+            .as_mut()
+            .unwrap()
+            .preflight_expected_uid += 1;
+        assert_eq!(
+            validate_preflight_identity_separation_v1(&mismatched_preflight)
+                .unwrap_err()
+                .reason,
+            "preflight-uid-conflict"
+        );
+
+        let mut shared_daemon_uid = valid.clone();
+        shared_daemon_uid.bitcoin.rpc_cookie.expected_uid =
+            shared_daemon_uid.lightning.expected_uid;
+        assert_eq!(
+            validate_preflight_identity_separation_v1(&shared_daemon_uid)
+                .unwrap_err()
+                .reason,
+            "core-and-lightning-identities-not-separated"
+        );
+
+        let mut shared_long_lived_group = valid;
+        shared_long_lived_group.bitcoin.rpc_cookie.expected_gid =
+            shared_long_lived_group.lightning.expected_gid;
+        assert_eq!(
+            validate_preflight_identity_separation_v1(&shared_long_lived_group)
+                .unwrap_err()
+                .reason,
+            "core-and-lightning-identities-not-separated"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn core_rpc_cookie_runtime_identity_requires_exact_euid_and_cookie_group() {
+        let same_uid = config(StagingRoleV1::Issuer);
+        let mut runtime = CoreRpcCookieRuntimeIdentityV1 {
+            effective_uid: same_uid.bitcoin.rpc_cookie.expected_uid,
+            effective_gid: same_uid.bitcoin.rpc_cookie.expected_gid,
+            supplementary_gids: BTreeSet::new(),
+        };
+        validate_core_rpc_cookie_runtime_identity_v1(&same_uid.bitcoin.rpc_cookie, &runtime)
+            .unwrap();
+        runtime.effective_uid += 1;
+        assert_eq!(
+            validate_core_rpc_cookie_runtime_identity_v1(&same_uid.bitcoin.rpc_cookie, &runtime)
+                .unwrap_err()
+                .reason,
+            "runtime-uid-mismatch"
+        );
+
+        let cross_uid = fully_cross_uid_config(StagingRoleV1::Issuer);
+        let cookie = &cross_uid.bitcoin.rpc_cookie;
+        let preflight_uid = cookie
+            .cross_uid_access
+            .as_ref()
+            .unwrap()
+            .preflight_expected_uid;
+        runtime = CoreRpcCookieRuntimeIdentityV1 {
+            effective_uid: preflight_uid,
+            effective_gid: preflight_uid,
+            supplementary_gids: BTreeSet::from([cookie.expected_gid]),
+        };
+        validate_core_rpc_cookie_runtime_identity_v1(cookie, &runtime).unwrap();
+        runtime.supplementary_gids.clear();
+        assert_eq!(
+            validate_core_rpc_cookie_runtime_identity_v1(cookie, &runtime)
+                .unwrap_err()
+                .reason,
+            "shared-group-missing"
+        );
+        runtime.effective_gid = cookie.expected_gid;
+        validate_core_rpc_cookie_runtime_identity_v1(cookie, &runtime).unwrap();
+        runtime.effective_uid = cookie.expected_uid;
+        assert_eq!(
+            validate_core_rpc_cookie_runtime_identity_v1(cookie, &runtime)
+                .unwrap_err()
+                .reason,
+            "runtime-uid-mismatch"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn core_rpc_cookie_boundary_metadata_requires_exact_split_uid_layout() {
+        let config = fully_cross_uid_config(StagingRoleV1::Issuer);
+        let cookie_config = &config.bitcoin.rpc_cookie;
+        let protected_parent = CoreRpcCookieBoundaryMetadataV1 {
+            kind: CoreRpcCookieBoundaryKindV1::Directory,
+            uid: 0,
+            gid: 0,
+            mode: 0o755,
+            nlink: 2,
+            size: 0,
+        };
+        let final_parent = CoreRpcCookieBoundaryMetadataV1 {
+            kind: CoreRpcCookieBoundaryKindV1::Directory,
+            uid: cookie_config.expected_uid,
+            gid: cookie_config.expected_gid,
+            mode: 0o710,
+            nlink: 2,
+            size: 0,
+        };
+        let cookie = CoreRpcCookieBoundaryMetadataV1 {
+            kind: CoreRpcCookieBoundaryKindV1::RegularFile,
+            uid: cookie_config.expected_uid,
+            gid: cookie_config.expected_gid,
+            mode: 0o640,
+            nlink: 1,
+            size: 76,
+        };
+        validate_core_rpc_cookie_boundary_metadata_v1(
+            cookie_config,
+            protected_parent,
+            final_parent,
+            cookie,
+            "test.core-cookie",
+        )
+        .unwrap();
+
+        let mutations = [
+            (
+                CoreRpcCookieBoundaryMetadataV1 {
+                    uid: 1,
+                    ..protected_parent
+                },
+                final_parent,
+                cookie,
+                "unsafe-protected-parent",
+            ),
+            (
+                CoreRpcCookieBoundaryMetadataV1 {
+                    mode: 0o750,
+                    ..protected_parent
+                },
+                final_parent,
+                cookie,
+                "unsafe-protected-parent",
+            ),
+            (
+                CoreRpcCookieBoundaryMetadataV1 {
+                    gid: 1,
+                    ..protected_parent
+                },
+                final_parent,
+                cookie,
+                "unsafe-protected-parent",
+            ),
+            (
+                protected_parent,
+                CoreRpcCookieBoundaryMetadataV1 {
+                    uid: cookie_config.expected_uid + 1,
+                    ..final_parent
+                },
+                cookie,
+                "unsafe-directory",
+            ),
+            (
+                protected_parent,
+                CoreRpcCookieBoundaryMetadataV1 {
+                    gid: cookie_config.expected_gid + 1,
+                    ..final_parent
+                },
+                cookie,
+                "unsafe-directory",
+            ),
+            (
+                protected_parent,
+                CoreRpcCookieBoundaryMetadataV1 {
+                    mode: 0o711,
+                    ..final_parent
+                },
+                cookie,
+                "unsafe-directory",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                CoreRpcCookieBoundaryMetadataV1 {
+                    mode: 0o600,
+                    ..cookie
+                },
+                "unsafe-metadata",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                CoreRpcCookieBoundaryMetadataV1 {
+                    uid: cookie_config.expected_uid + 1,
+                    ..cookie
+                },
+                "unsafe-metadata",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                CoreRpcCookieBoundaryMetadataV1 {
+                    gid: cookie_config.expected_gid + 1,
+                    ..cookie
+                },
+                "unsafe-metadata",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                CoreRpcCookieBoundaryMetadataV1 { nlink: 2, ..cookie },
+                "unsafe-metadata",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                CoreRpcCookieBoundaryMetadataV1 { size: 0, ..cookie },
+                "unsafe-metadata",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                CoreRpcCookieBoundaryMetadataV1 {
+                    size: MAX_CORE_COOKIE_BYTES_V1 + 1,
+                    ..cookie
+                },
+                "unsafe-metadata",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                CoreRpcCookieBoundaryMetadataV1 {
+                    kind: CoreRpcCookieBoundaryKindV1::Other,
+                    ..cookie
+                },
+                "unsafe-metadata",
+            ),
+        ];
+        for (protected_parent, final_parent, cookie, expected_reason) in mutations {
+            assert_eq!(
+                validate_core_rpc_cookie_boundary_metadata_v1(
+                    cookie_config,
+                    protected_parent,
+                    final_parent,
+                    cookie,
+                    "test.core-cookie",
+                )
+                .unwrap_err()
+                .reason,
+                expected_reason
+            );
+        }
+    }
+
+    #[test]
+    fn lightning_rpc_access_policy_is_explicit_and_unambiguous() {
+        let legacy = config(StagingRoleV1::Issuer);
+        assert_eq!(
+            legacy.lightning.rpc_access_policy,
+            LightningRpcAccessPolicyV1::SameUidOwnerOnly
+        );
+        assert!(validate_static_config_v1(&legacy).is_ok());
+
+        let mut same_with_cross_fields = legacy.clone();
+        same_with_cross_fields.lightning.cross_uid_access = Some(LightningCrossUidAccessV1 {
+            client_expected_uid: 1001,
+            protected_parent_expected_uid: 0,
+            protected_parent_expected_gid: 0,
+        });
+        assert_eq!(
+            validate_static_config_v1(&same_with_cross_fields)
+                .unwrap_err()
+                .reason,
+            "cross-uid-fields-with-same-uid-policy"
+        );
+
+        let mut missing_fields = legacy.clone();
+        missing_fields.lightning.rpc_access_policy =
+            LightningRpcAccessPolicyV1::CrossUidSharedGroup;
+        assert_eq!(
+            validate_static_config_v1(&missing_fields)
+                .unwrap_err()
+                .reason,
+            "missing-cross-uid-fields"
+        );
+
+        let valid_cross_uid = cross_uid_config(StagingRoleV1::Issuer);
+        assert!(validate_static_config_v1(&valid_cross_uid).is_ok());
+
+        for mutation in 0..5 {
+            let mut invalid = valid_cross_uid.clone();
+            let daemon_uid = invalid.lightning.expected_uid;
+            match mutation {
+                0 => {
+                    invalid
+                        .lightning
+                        .cross_uid_access
+                        .as_mut()
+                        .unwrap()
+                        .client_expected_uid = 0
+                }
+                1 => {
+                    invalid
+                        .lightning
+                        .cross_uid_access
+                        .as_mut()
+                        .unwrap()
+                        .client_expected_uid = daemon_uid
+                }
+                2 => {
+                    invalid
+                        .lightning
+                        .cross_uid_access
+                        .as_mut()
+                        .unwrap()
+                        .protected_parent_expected_uid = 1
+                }
+                3 => {
+                    invalid
+                        .lightning
+                        .cross_uid_access
+                        .as_mut()
+                        .unwrap()
+                        .protected_parent_expected_gid = 1
+                }
+                4 => invalid.lightning.expected_gid = 0,
+                _ => unreachable!(),
+            }
+            assert_eq!(
+                validate_static_config_v1(&invalid).unwrap_err().reason,
+                "invalid-cross-uid-identities"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lightning_rpc_runtime_identity_requires_exact_client_and_shared_group() {
+        let same_uid = config(StagingRoleV1::Issuer);
+        let mut runtime = LightningRuntimeIdentityV1 {
+            effective_uid: same_uid.lightning.expected_uid,
+            effective_gid: same_uid.lightning.expected_gid,
+            supplementary_gids: BTreeSet::new(),
+        };
+        validate_lightning_runtime_identity_v1(&same_uid.lightning, &runtime).unwrap();
+        runtime.effective_uid += 1;
+        assert_eq!(
+            validate_lightning_runtime_identity_v1(&same_uid.lightning, &runtime)
+                .unwrap_err()
+                .reason,
+            "runtime-uid-mismatch"
+        );
+
+        let cross_uid = cross_uid_config(StagingRoleV1::Issuer);
+        let cross_fields = cross_uid.lightning.cross_uid_access.as_ref().unwrap();
+        runtime = LightningRuntimeIdentityV1 {
+            effective_uid: cross_fields.client_expected_uid,
+            effective_gid: cross_fields.client_expected_uid,
+            supplementary_gids: BTreeSet::from([cross_uid.lightning.expected_gid]),
+        };
+        validate_lightning_runtime_identity_v1(&cross_uid.lightning, &runtime).unwrap();
+
+        runtime.supplementary_gids.clear();
+        assert_eq!(
+            validate_lightning_runtime_identity_v1(&cross_uid.lightning, &runtime)
+                .unwrap_err()
+                .reason,
+            "shared-group-missing"
+        );
+        runtime.effective_gid = cross_uid.lightning.expected_gid;
+        validate_lightning_runtime_identity_v1(&cross_uid.lightning, &runtime).unwrap();
+        runtime.effective_uid = cross_uid.lightning.expected_uid;
+        assert_eq!(
+            validate_lightning_runtime_identity_v1(&cross_uid.lightning, &runtime)
+                .unwrap_err()
+                .reason,
+            "runtime-uid-mismatch"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cross_uid_boundary_metadata_requires_exact_production_layout() {
+        let config = cross_uid_config(StagingRoleV1::Issuer);
+        let protected_parent = LightningBoundaryMetadataV1 {
+            kind: LightningBoundaryKindV1::Directory,
+            uid: 0,
+            gid: 0,
+            mode: 0o755,
+            nlink: 2,
+        };
+        let final_parent = LightningBoundaryMetadataV1 {
+            kind: LightningBoundaryKindV1::Directory,
+            uid: config.lightning.expected_uid,
+            gid: config.lightning.expected_gid,
+            mode: 0o710,
+            nlink: 2,
+        };
+        let socket = LightningBoundaryMetadataV1 {
+            kind: LightningBoundaryKindV1::Socket,
+            uid: config.lightning.expected_uid,
+            gid: config.lightning.expected_gid,
+            mode: 0o660,
+            nlink: 1,
+        };
+        validate_cross_uid_boundary_metadata_v1(
+            &config.lightning,
+            protected_parent,
+            final_parent,
+            socket,
+            "test.lightning-rpc",
+        )
+        .unwrap();
+
+        let mutations = [
+            (
+                LightningBoundaryMetadataV1 {
+                    uid: 1,
+                    ..protected_parent
+                },
+                final_parent,
+                socket,
+                "unsafe-protected-parent",
+            ),
+            (
+                LightningBoundaryMetadataV1 {
+                    mode: 0o750,
+                    ..protected_parent
+                },
+                final_parent,
+                socket,
+                "unsafe-protected-parent",
+            ),
+            (
+                protected_parent,
+                LightningBoundaryMetadataV1 {
+                    gid: config.lightning.expected_gid + 1,
+                    ..final_parent
+                },
+                socket,
+                "unsafe-directory",
+            ),
+            (
+                protected_parent,
+                LightningBoundaryMetadataV1 {
+                    mode: 0o711,
+                    ..final_parent
+                },
+                socket,
+                "unsafe-directory",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                LightningBoundaryMetadataV1 {
+                    uid: config.lightning.expected_uid + 1,
+                    ..socket
+                },
+                "unsafe-socket",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                LightningBoundaryMetadataV1 {
+                    gid: config.lightning.expected_gid + 1,
+                    ..socket
+                },
+                "unsafe-socket",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                LightningBoundaryMetadataV1 {
+                    mode: 0o600,
+                    ..socket
+                },
+                "unsafe-socket",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                LightningBoundaryMetadataV1 { nlink: 2, ..socket },
+                "unsafe-socket",
+            ),
+            (
+                protected_parent,
+                final_parent,
+                LightningBoundaryMetadataV1 {
+                    kind: LightningBoundaryKindV1::Other,
+                    ..socket
+                },
+                "unsafe-socket",
+            ),
+        ];
+        for (protected_parent, final_parent, socket, expected_reason) in mutations {
+            assert_eq!(
+                validate_cross_uid_boundary_metadata_v1(
+                    &config.lightning,
+                    protected_parent,
+                    final_parent,
+                    socket,
+                    "test.lightning-rpc",
+                )
+                .unwrap_err()
+                .reason,
+                expected_reason
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn same_uid_socket_validation_accepts_legacy_layout_but_requires_exact_modes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_directory, _listener, lightning, final_parent) = same_uid_socket_fixture();
+        validate_protected_socket_v1(&lightning).unwrap();
+
+        std::fs::set_permissions(
+            &lightning.rpc_socket,
+            std::fs::Permissions::from_mode(0o660),
+        )
+        .unwrap();
+        assert_eq!(
+            validate_protected_socket_v1(&lightning).unwrap_err().reason,
+            "unsafe-socket"
+        );
+        std::fs::set_permissions(
+            &lightning.rpc_socket,
+            std::fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+
+        std::fs::set_permissions(&final_parent, std::fs::Permissions::from_mode(0o710)).unwrap();
+        assert_eq!(
+            validate_protected_socket_v1(&lightning).unwrap_err().reason,
+            "unsafe-parent-boundary"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lightning_socket_validation_rejects_symlink_and_parent_metadata_drift() {
+        use std::os::unix::fs::symlink;
+
+        let (_directory, listener, lightning, final_parent) = same_uid_socket_fixture();
+        let parent_before = std::fs::symlink_metadata(&final_parent).unwrap();
+        let nested = final_parent.join("unexpected-child");
+        std::fs::create_dir(&nested).unwrap();
+        let parent_after = std::fs::symlink_metadata(&final_parent).unwrap();
+        assert_eq!(
+            validate_same_lightning_boundary_entry_v1(
+                &parent_before,
+                &parent_after,
+                "test.lightning-rpc",
+            )
+            .unwrap_err()
+            .reason,
+            "file-changed"
+        );
+        std::fs::remove_dir(&nested).unwrap();
+
+        drop(listener);
+        let real_socket = final_parent.join("lightning-rpc.real");
+        std::fs::rename(&lightning.rpc_socket, &real_socket).unwrap();
+        symlink("lightning-rpc.real", &lightning.rpc_socket).unwrap();
+        assert_eq!(
+            validate_protected_socket_v1(&lightning).unwrap_err().reason,
+            "non-canonical-path"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn lightning_socket_validation_rejects_extended_acl_on_final_parent() {
+        let (_directory, _listener, lightning, final_parent) = same_uid_socket_fixture();
+        assert!(std::process::Command::new("chmod")
+            .args(["+a", "everyone allow read"])
+            .arg(&final_parent)
+            .status()
+            .unwrap()
+            .success());
+        assert_eq!(
+            validate_protected_socket_v1(&lightning).unwrap_err().reason,
+            "unsafe-parent-boundary"
+        );
+    }
+
+    #[test]
     fn published_config_template_parses_and_denies_unknown_fields() {
         let template =
             include_str!("../../../docs/payment/LIGHTNING_STAGING_PREFLIGHT.toml.example");
-        assert!(toml::from_str::<LightningStagingConfigV1>(template).is_ok());
+        let parsed = toml::from_str::<LightningStagingConfigV1>(template).unwrap();
+        assert_eq!(
+            parsed.bitcoin.rpc_cookie.access_policy,
+            CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup
+        );
+        assert_eq!(parsed.bitcoin.rpc_cookie.expected_uid, 990);
+        assert_eq!(parsed.bitcoin.rpc_cookie.expected_gid, 994);
+        assert_eq!(
+            parsed
+                .bitcoin
+                .rpc_cookie
+                .cross_uid_access
+                .as_ref()
+                .unwrap()
+                .preflight_expected_uid,
+            992
+        );
+        assert_eq!(
+            parsed.lightning.rpc_access_policy,
+            LightningRpcAccessPolicyV1::CrossUidSharedGroup
+        );
+        assert_eq!(parsed.lightning.expected_uid, 991);
+        assert_eq!(parsed.lightning.expected_gid, 993);
+        assert_eq!(
+            parsed
+                .lightning
+                .cross_uid_access
+                .as_ref()
+                .unwrap()
+                .client_expected_uid,
+            992
+        );
+        let mut legacy_template = String::new();
+        let mut skipping_cross_uid_table = false;
+        for line in template.lines() {
+            if line.trim() == "[lightning.cross_uid_access]" {
+                skipping_cross_uid_table = true;
+                continue;
+            }
+            if skipping_cross_uid_table && line.trim() == "[lightning.daemon]" {
+                skipping_cross_uid_table = false;
+            }
+            if skipping_cross_uid_table || line.trim_start().starts_with("rpc_access_policy =") {
+                continue;
+            }
+            legacy_template.push_str(line);
+            legacy_template.push('\n');
+        }
+        let legacy = toml::from_str::<LightningStagingConfigV1>(&legacy_template).unwrap();
+        assert_eq!(
+            legacy.lightning.rpc_access_policy,
+            LightningRpcAccessPolicyV1::SameUidOwnerOnly
+        );
+        assert!(legacy.lightning.cross_uid_access.is_none());
+
+        let mut core_legacy_template = String::new();
+        let mut skipping_core_cross_uid_table = false;
+        for line in template.lines() {
+            if line.trim() == "[bitcoin.rpc_cookie.cross_uid_access]" {
+                skipping_core_cross_uid_table = true;
+                continue;
+            }
+            if skipping_core_cross_uid_table && line.trim() == "[bitcoin.daemon]" {
+                skipping_core_cross_uid_table = false;
+            }
+            if skipping_core_cross_uid_table || line.trim_start().starts_with("access_policy =") {
+                continue;
+            }
+            core_legacy_template.push_str(line);
+            core_legacy_template.push('\n');
+        }
+        let core_legacy =
+            toml::from_str::<LightningStagingConfigV1>(&core_legacy_template).unwrap();
+        assert_eq!(
+            core_legacy.bitcoin.rpc_cookie.access_policy,
+            CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly
+        );
+        assert!(core_legacy.bitcoin.rpc_cookie.cross_uid_access.is_none());
+
+        let with_unknown_cross_uid_field = template.replace(
+            "client_expected_uid = 992",
+            "client_expected_uid = 992\nunexpected_cross_uid_field = true",
+        );
+        assert!(toml::from_str::<LightningStagingConfigV1>(&with_unknown_cross_uid_field).is_err());
+        let with_unknown_core_cross_uid_field = template.replace(
+            "preflight_expected_uid = 992",
+            "preflight_expected_uid = 992\nunexpected_cookie_cross_uid_field = true",
+        );
+        assert!(
+            toml::from_str::<LightningStagingConfigV1>(&with_unknown_core_cross_uid_field).is_err()
+        );
         let with_unknown_backup_field = format!("{template}\nunexpected = true\n");
         assert!(toml::from_str::<LightningStagingConfigV1>(&with_unknown_backup_field).is_err());
     }
@@ -2624,13 +4266,16 @@ mod tests {
             b"schema_version=1\n"
         );
 
-        let cookie_path = directory.path().join(".cookie");
+        let cookie_parent = std::fs::canonicalize(directory.path()).unwrap();
+        let cookie_path = cookie_parent.join(".cookie");
         let cookie = format!("__cookie__:{}\n", "a".repeat(64));
         std::fs::write(&cookie_path, cookie.as_bytes()).unwrap();
         std::fs::set_permissions(&cookie_path, std::fs::Permissions::from_mode(0o600)).unwrap();
-        let cookie_config = ProtectedFileV1 {
+        let cookie_config = CoreRpcCookieConfigV1 {
             path: cookie_path.clone(),
-            protected_parent: directory.path().to_path_buf(),
+            protected_parent: cookie_parent,
+            access_policy: CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly,
+            cross_uid_access: None,
             expected_uid: metadata.uid(),
             expected_gid: metadata.gid(),
         };
@@ -2666,6 +4311,141 @@ mod tests {
                 .unwrap_err()
                 .reason,
             "unsafe-protected-parent"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn core_rpc_cookie_rejects_hardlinks_symlinks_and_metadata_drift() {
+        use std::io::{Seek, SeekFrom, Write};
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let (_directory, cookie_config, cookie_path) = same_uid_cookie_fixture();
+        validate_core_rpc_cookie_v1(&cookie_config).unwrap();
+
+        std::fs::set_permissions(
+            &cookie_config.protected_parent,
+            std::fs::Permissions::from_mode(0o710),
+        )
+        .unwrap();
+        assert_eq!(
+            validate_core_rpc_cookie_v1(&cookie_config)
+                .unwrap_err()
+                .reason,
+            "unsafe-directory"
+        );
+        std::fs::set_permissions(
+            &cookie_config.protected_parent,
+            std::fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+        validate_core_rpc_cookie_v1(&cookie_config).unwrap();
+
+        let hardlink = cookie_config.protected_parent.join("cookie-hardlink");
+        std::fs::hard_link(&cookie_path, &hardlink).unwrap();
+        assert_eq!(
+            validate_core_rpc_cookie_v1(&cookie_config)
+                .unwrap_err()
+                .reason,
+            "unsafe-metadata"
+        );
+        std::fs::remove_file(&hardlink).unwrap();
+        validate_core_rpc_cookie_v1(&cookie_config).unwrap();
+
+        let real_cookie = cookie_config.protected_parent.join("cookie-real");
+        std::fs::rename(&cookie_path, &real_cookie).unwrap();
+        symlink("cookie-real", &cookie_path).unwrap();
+        assert_eq!(
+            validate_core_rpc_cookie_v1(&cookie_config)
+                .unwrap_err()
+                .reason,
+            "non-canonical-path"
+        );
+        std::fs::remove_file(&cookie_path).unwrap();
+        std::fs::rename(&real_cookie, &cookie_path).unwrap();
+        validate_core_rpc_cookie_v1(&cookie_config).unwrap();
+
+        let error = read_validated_core_rpc_cookie_with_hook_v1(&cookie_config, || {
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&cookie_path)
+                .map_err(|_| PreflightFailureV1::new("test.core-cookie", "open-failed"))?;
+            file.write_all(b"x")
+                .map_err(|_| PreflightFailureV1::new("test.core-cookie", "write-failed"))?;
+            file.sync_all()
+                .map_err(|_| PreflightFailureV1::new("test.core-cookie", "sync-failed"))
+        })
+        .unwrap_err();
+        assert_eq!(error.reason, "size-changed");
+
+        let valid_cookie = format!("__cookie__:{}\n", "b".repeat(64));
+        std::fs::write(&cookie_path, valid_cookie.as_bytes()).unwrap();
+        std::fs::set_permissions(&cookie_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let changed_cookie = format!("__cookie__:{}\n", "c".repeat(64));
+        let error = read_validated_core_rpc_cookie_with_hook_v1(&cookie_config, || {
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&cookie_path)
+                .map_err(|_| PreflightFailureV1::new("test.core-cookie", "open-failed"))?;
+            file.seek(SeekFrom::Start(0))
+                .map_err(|_| PreflightFailureV1::new("test.core-cookie", "seek-failed"))?;
+            file.write_all(changed_cookie.as_bytes())
+                .map_err(|_| PreflightFailureV1::new("test.core-cookie", "write-failed"))?;
+            file.sync_all()
+                .map_err(|_| PreflightFailureV1::new("test.core-cookie", "sync-failed"))
+        })
+        .unwrap_err();
+        assert_eq!(error.reason, "content-changed");
+
+        std::fs::write(&cookie_path, valid_cookie.as_bytes()).unwrap();
+        std::fs::set_permissions(&cookie_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let replaced = cookie_config.protected_parent.join("cookie-replaced");
+        let error = read_validated_core_rpc_cookie_with_hook_v1(&cookie_config, || {
+            std::fs::rename(&cookie_path, &replaced)
+                .map_err(|_| PreflightFailureV1::new("test.core-cookie", "rename-failed"))?;
+            std::fs::write(&cookie_path, valid_cookie.as_bytes())
+                .map_err(|_| PreflightFailureV1::new("test.core-cookie", "write-failed"))?;
+            std::fs::set_permissions(&cookie_path, std::fs::Permissions::from_mode(0o600))
+                .map_err(|_| PreflightFailureV1::new("test.core-cookie", "chmod-failed"))
+        })
+        .unwrap_err();
+        assert_eq!(error.reason, "file-changed");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn core_rpc_cookie_rejects_extended_acl_on_cookie_and_parent() {
+        let (_directory, cookie_config, cookie_path) = same_uid_cookie_fixture();
+        assert!(std::process::Command::new("chmod")
+            .args(["+a", "everyone allow read"])
+            .arg(&cookie_path)
+            .status()
+            .unwrap()
+            .success());
+        assert_eq!(
+            validate_core_rpc_cookie_v1(&cookie_config)
+                .unwrap_err()
+                .reason,
+            "unsafe-cookie-acl"
+        );
+
+        assert!(std::process::Command::new("chmod")
+            .args(["-N"])
+            .arg(&cookie_path)
+            .status()
+            .unwrap()
+            .success());
+        assert!(std::process::Command::new("chmod")
+            .args(["+a", "everyone allow read"])
+            .arg(&cookie_config.protected_parent)
+            .status()
+            .unwrap()
+            .success());
+        assert_eq!(
+            validate_core_rpc_cookie_v1(&cookie_config)
+                .unwrap_err()
+                .reason,
+            "unsafe-parent-boundary"
         );
     }
 

--- a/apps/admin/src/lightning_staging.rs
+++ b/apps/admin/src/lightning_staging.rs
@@ -4151,7 +4151,7 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .preflight_expected_uid,
-            992
+            995
         );
         assert_eq!(
             parsed.lightning.rpc_access_policy,
@@ -4166,7 +4166,7 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .client_expected_uid,
-            992
+            995
         );
         let mut legacy_template = String::new();
         let mut skipping_cross_uid_table = false;
@@ -4216,13 +4216,13 @@ mod tests {
         assert!(core_legacy.bitcoin.rpc_cookie.cross_uid_access.is_none());
 
         let with_unknown_cross_uid_field = template.replace(
-            "client_expected_uid = 992",
-            "client_expected_uid = 992\nunexpected_cross_uid_field = true",
+            "client_expected_uid = 995",
+            "client_expected_uid = 995\nunexpected_cross_uid_field = true",
         );
         assert!(toml::from_str::<LightningStagingConfigV1>(&with_unknown_cross_uid_field).is_err());
         let with_unknown_core_cross_uid_field = template.replace(
-            "preflight_expected_uid = 992",
-            "preflight_expected_uid = 992\nunexpected_cookie_cross_uid_field = true",
+            "preflight_expected_uid = 995",
+            "preflight_expected_uid = 995\nunexpected_cookie_cross_uid_field = true",
         );
         assert!(
             toml::from_str::<LightningStagingConfigV1>(&with_unknown_core_cross_uid_field).is_err()

--- a/apps/admin/src/service_keygen.rs
+++ b/apps/admin/src/service_keygen.rs
@@ -18,7 +18,7 @@ pub enum ServiceKeyRole {
     IssuerRootEd25519,
     /// Short-lived online BOLT11 quote Ed25519 signing key.
     QuoteEd25519,
-    /// Provider-local direct-receipt Ed25519 key.
+    /// Issuer-held direct-receipt Ed25519 signing key; providers pin its public key.
     ReceiptEd25519,
     /// Free anonymous-ticket Ed25519 key.
     AnonymousTicketEd25519,
@@ -36,6 +36,14 @@ pub enum ServiceKeyRole {
     CredentialDerivation,
     /// Issuer deterministic redeem-response derivation key.
     RedeemDerivation,
+    /// Provider-local HMAC key for durable Free/IP quota cohorts.
+    FreeIpHmac,
+    /// Provider-local Standard Cashu swap-recovery AEAD key.
+    CashuRecoveryAead,
+    /// Provider-local Standard Cashu note-custody AEAD key.
+    CashuCustodyAead,
+    /// Provider-local HMAC key for shared-issuer wire idempotency.
+    ProviderSharedIdempotencyHmac,
     /// Experimental ARC draft-01 four-scalar key (128 bytes).
     ArcExperimental,
 }
@@ -83,7 +91,12 @@ pub fn run(args: ServiceKeygenArgs) -> Result<crate::keygen::SecretWriteCompleti
                     .ok()
                     .map(|key| hex::encode(key.public_key().to_encoded_point(true).as_bytes()))
             }
-            ServiceKeyRole::CredentialDerivation | ServiceKeyRole::RedeemDerivation => {
+            ServiceKeyRole::CredentialDerivation
+            | ServiceKeyRole::RedeemDerivation
+            | ServiceKeyRole::FreeIpHmac
+            | ServiceKeyRole::CashuRecoveryAead
+            | ServiceKeyRole::CashuCustodyAead
+            | ServiceKeyRole::ProviderSharedIdempotencyHmac => {
                 (!secret.iter().all(|byte| *byte == 0)).then(|| {
                     let mut hasher = Sha256::new();
                     hasher.update(b"BitcoinPIR/operator-secret-fingerprint/v1");
@@ -110,7 +123,12 @@ pub fn run(args: ServiceKeygenArgs) -> Result<crate::keygen::SecretWriteCompleti
     println!("role={:?}", args.role);
     if matches!(
         args.role,
-        ServiceKeyRole::CredentialDerivation | ServiceKeyRole::RedeemDerivation
+        ServiceKeyRole::CredentialDerivation
+            | ServiceKeyRole::RedeemDerivation
+            | ServiceKeyRole::FreeIpHmac
+            | ServiceKeyRole::CashuRecoveryAead
+            | ServiceKeyRole::CashuCustodyAead
+            | ServiceKeyRole::ProviderSharedIdempotencyHmac
     ) {
         println!("secret_fingerprint={public}");
     } else {
@@ -172,6 +190,10 @@ mod tests {
             ServiceKeyRole::CashuEcash,
             ServiceKeyRole::CredentialDerivation,
             ServiceKeyRole::RedeemDerivation,
+            ServiceKeyRole::FreeIpHmac,
+            ServiceKeyRole::CashuRecoveryAead,
+            ServiceKeyRole::CashuCustodyAead,
+            ServiceKeyRole::ProviderSharedIdempotencyHmac,
             ServiceKeyRole::ArcExperimental,
         ] {
             let directory = private_tempdir().unwrap();
@@ -196,7 +218,12 @@ mod tests {
                 ServiceKeyRole::CashuBat | ServiceKeyRole::CashuEcash => {
                     Secp256k1SecretKey::from_slice(&bytes).unwrap();
                 }
-                ServiceKeyRole::CredentialDerivation | ServiceKeyRole::RedeemDerivation => {
+                ServiceKeyRole::CredentialDerivation
+                | ServiceKeyRole::RedeemDerivation
+                | ServiceKeyRole::FreeIpHmac
+                | ServiceKeyRole::CashuRecoveryAead
+                | ServiceKeyRole::CashuCustodyAead
+                | ServiceKeyRole::ProviderSharedIdempotencyHmac => {
                     assert!(bytes.iter().any(|byte| *byte != 0));
                 }
                 ServiceKeyRole::ArcExperimental => {

--- a/apps/cln-rpc-guard/Cargo.toml
+++ b/apps/cln-rpc-guard/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "bitcoinpir-cln-rpc-guard"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.81"
+publish = false
+description = "Least-privilege Core Lightning JSON-RPC guard for the BitcoinPIR payment issuer"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/Bitcoin-PIR/Bitcoin-PIR"
+
+[[bin]]
+name = "bitcoinpir-cln-rpc-guard"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+pir-lightning-backend = { path = "../../crates/payment/lightning-backend", features = ["cln-rpc-guard"] }
+pir-private-files = { path = "../../crates/security/private-files" }
+pir-service-protocol = { path = "../../crates/protocol/service" }
+rustix = { version = "1", features = ["fs", "process"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["raw_value"] }
+socket2 = "0.6"
+tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "signal", "time", "io-util"] }
+zeroize = "1"
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/apps/cln-rpc-guard/README.md
+++ b/apps/cln-rpc-guard/README.md
@@ -1,0 +1,71 @@
+# BitcoinPIR Core Lightning RPC guard
+
+This process is the only payment-issuer-side principal permitted to reach the
+Core Lightning JSON-RPC socket. It exposes a second Unix socket to exactly one
+configured issuer UID/GID and accepts only the RPC surface used by
+`pir-lightning-backend`:
+
+- `getinfo` with empty parameters;
+- `listinvoices` with one canonical private BitcoinPIR backend label;
+- `invoice` with a bounded amount and expiry, the fixed anonymous description,
+  and privacy-preserving flags.
+
+The guard rejects batch requests, notifications, unknown or duplicate fields,
+extra methods, malformed framing, oversized input, and socket identity changes.
+It reconstructs requests before forwarding them and reconstructs responses
+before returning them. In particular, a CLN `payment_preimage` is never exposed
+to the issuer.
+
+Four explicit root-controlled limits contain a compromised issuer's ability to
+grow CLN's invoice database:
+
+- `--max-invoice-msat` caps every invoice independently of the issuer's signed
+  offer policy;
+- `--max-invoices-per-minute` and `--max-invoice-burst` form a monotonic token
+  bucket for the mutating `invoice` method;
+- `--max-invoices-per-runtime` is a generation deadman. Once consumed, invoice
+  creation stays closed until a trusted operator deliberately restarts the
+  guard.
+
+The binary also rejects configurations above its compiled safety ceilings:
+600 invoice attempts per minute, a burst of 100, or 100,000 invoice attempts
+per process generation. The amount ceiling may not exceed the protocol-wide
+Bitcoin maximum, but production units should pin a materially smaller value
+that matches their signed offer policy. All four arguments must be owned and
+pinned by the service manager; they are not issuer-controlled API parameters.
+
+The runtime counter is intentionally not resettable over the issuer socket and
+the guard never logs labels, hashes, invoices, or response bodies. It is not a
+durable accounting ledger: a host reboot or root-initiated service start creates
+a new generation. The reviewed production unit therefore uses `Restart=no`;
+guard failure also stops the bound issuer and requires an explicit operator
+review/start ceremony. An automatic restart policy would erase this containment
+property. Settlement accounting remains the issuer store's responsibility.
+
+The token bucket and generation deadman apply only to the mutating `invoice`
+method. `getinfo` and `listinvoices` remain constrained by the connection
+deadline and `--max-in-flight`, but do not have a sustained request-rate quota.
+A compromised issuer can therefore still impose bounded concurrent read load
+on CLN even though it cannot grow the invoice database without consuming the
+independent invoice budgets.
+
+The upstream CLN socket remains a custody boundary. In a split-UID deployment,
+it should be owned by the CLN UID and the guard's pinned primary group at mode
+`0660`; its parent is `0710`. The issuer must not be a member of that group. The
+downstream guard directory is owned by the guard UID and issuer GID at mode
+`0710`; the guard creates its socket as `0660` and verifies the connecting
+issuer's kernel peer credentials.
+
+Kernel peer credentials expose only the connection's effective UID/GID, not
+the issuer account's complete supplementary-group list. Provisioning must
+therefore independently verify that the issuer account is not a member of the
+guard/CLN socket group. On Linux the guard rejects POSIX ACLs on the relevant
+directories and sockets. On macOS the parent-directory ACL is checked, but an
+ACL attached directly to an already-existing upstream CLN socket is outside the
+current transport check and must be prohibited by deployment policy.
+
+The binary deliberately refuses root UIDs/GIDs, an upstream owner or group
+shared with the issuer, stale listener paths, and permissive or replaceable
+directories. It does not delete an existing socket automatically after a
+crash; an operator must first establish that the old process is dead and then
+remove the stale path.

--- a/apps/cln-rpc-guard/src/lib.rs
+++ b/apps/cln-rpc-guard/src/lib.rs
@@ -1,0 +1,1277 @@
+//! Closed-world Core Lightning JSON-RPC guard for the BitcoinPIR issuer.
+//!
+//! The issuer gets a separate Unix socket and can neither reach the custody
+//! socket nor select arbitrary CLN methods. Requests and responses are parsed,
+//! validated, and reconstructed rather than blindly proxied.
+
+#![forbid(unsafe_code)]
+
+#[cfg(target_os = "macos")]
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::fs::{self, File};
+use std::future::Future;
+use std::os::fd::OwnedFd;
+use std::os::unix::fs::{FileTypeExt as _, MetadataExt as _};
+use std::os::unix::net::UnixListener as StdUnixListener;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use clap::Parser;
+use pir_lightning_backend::{ClnRpcTransportV1, UnixClnRpcSocketPolicyV1, UnixClnRpcTransportV1};
+use pir_private_files::reject_extended_acl_v1;
+use pir_service_protocol::{
+    MAX_BITCOIN_MSAT_V1, MAX_BOLT11_INVOICE_EXPIRY_SECONDS_V1, MAX_BOLT11_INVOICE_LEN,
+};
+use rustix::fs::{AtFlags, FileType, Mode, OFlags};
+use rustix::process::Gid;
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+use socket2::{Domain, SockAddr, Socket, Type};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::task::JoinSet;
+use tokio::time::{self, Instant};
+use zeroize::Zeroizing;
+
+const MAX_REQUEST_BYTES_V1: usize = 64 * 1024;
+const MAX_RESPONSE_BYTES_V1: usize = 256 * 1024;
+const MAX_IN_FLIGHT_V1: usize = 256;
+const MAX_INVOICES_PER_MINUTE_V1: u32 = 600;
+const MAX_INVOICE_BURST_V1: u32 = 100;
+const MAX_INVOICES_PER_RUNTIME_V1: u64 = 100_000;
+const TOKEN_MINUTE_NANOS_V1: u128 = 60_000_000_000;
+const LISTENER_CHECK_INTERVAL_V1: Duration = Duration::from_secs(1);
+const ANONYMOUS_DESCRIPTION_V1: &str = "BitcoinPIR anonymous service capability v1";
+const BACKEND_LABEL_PREFIX_V1: &str = "bpir-v1-";
+const BACKEND_LABEL_HEX_LEN_V1: usize = 64;
+
+/// Production command-line surface. Numeric identities are explicit so a
+/// renamed local account cannot silently change the authority boundary.
+#[derive(Parser)]
+#[command(name = "bitcoinpir-cln-rpc-guard")]
+pub struct Cli {
+    /// Guard-created socket exposed only to the configured issuer principal.
+    #[arg(long)]
+    listen_socket: PathBuf,
+    /// Core Lightning's real JSON-RPC socket.
+    #[arg(long)]
+    upstream_socket: PathBuf,
+    /// Effective UID the guard process must run as.
+    #[arg(long)]
+    guard_uid: u32,
+    /// Effective primary GID the guard process must run as.
+    #[arg(long)]
+    guard_gid: u32,
+    /// Exact effective UID accepted on the downstream socket.
+    #[arg(long)]
+    issuer_uid: u32,
+    /// Exact effective primary GID accepted on the downstream socket.
+    #[arg(long)]
+    issuer_gid: u32,
+    /// UID that must own the upstream CLN socket.
+    #[arg(long)]
+    upstream_expected_uid: u32,
+    /// Optional exact group for an upstream mode-0660 socket. Omit only when
+    /// the upstream socket is guard-owned and mode 0600.
+    #[arg(long)]
+    upstream_expected_gid: Option<u32>,
+    /// Per-phase wall-clock bound. The upstream transport applies the same
+    /// bound to connect, complete request, and complete response.
+    #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u64).range(1..=30))]
+    timeout_seconds: u64,
+    /// Maximum simultaneous issuer RPCs; excess connections are closed.
+    #[arg(long, default_value_t = 32)]
+    max_in_flight: usize,
+    /// Root-controlled ceiling applied independently of issuer policy.
+    #[arg(long)]
+    max_invoice_msat: u64,
+    /// Sustained mutating invoice attempts admitted per monotonic minute.
+    #[arg(long)]
+    max_invoices_per_minute: u32,
+    /// Initial token count and bucket capacity. Sustained refill is controlled
+    /// by `--max-invoices-per-minute`; this value may not exceed that rate.
+    #[arg(long)]
+    max_invoice_burst: u32,
+    /// Process-generation deadman. Once reached, invoice mutations remain
+    /// closed until a trusted operator deliberately restarts the guard.
+    #[arg(long)]
+    max_invoices_per_runtime: u64,
+}
+
+/// Validated immutable runtime policy. It intentionally has no `Debug`
+/// implementation so socket paths do not enter structured logs by accident.
+pub struct GuardConfig {
+    listen_socket: PathBuf,
+    upstream_socket: PathBuf,
+    guard_uid: u32,
+    guard_gid: u32,
+    issuer_uid: u32,
+    issuer_gid: u32,
+    upstream_expected_uid: u32,
+    upstream_expected_gid: Option<u32>,
+    timeout: Duration,
+    max_in_flight: usize,
+    max_invoice_msat: u64,
+    max_invoices_per_minute: u32,
+    max_invoice_burst: u32,
+    max_invoices_per_runtime: u64,
+}
+
+impl TryFrom<Cli> for GuardConfig {
+    type Error = String;
+
+    fn try_from(value: Cli) -> Result<Self, Self::Error> {
+        for (name, id) in [
+            ("guard UID", value.guard_uid),
+            ("guard GID", value.guard_gid),
+            ("issuer UID", value.issuer_uid),
+            ("issuer GID", value.issuer_gid),
+            ("upstream owner UID", value.upstream_expected_uid),
+        ] {
+            if id == 0 || id == u32::MAX {
+                return Err(format!("{name} must be a non-root concrete identity"));
+            }
+        }
+        if value
+            .upstream_expected_gid
+            .is_some_and(|gid| gid == 0 || gid == u32::MAX)
+        {
+            return Err("upstream group GID must be a non-root concrete identity".to_owned());
+        }
+        if !value.listen_socket.is_absolute() || !value.upstream_socket.is_absolute() {
+            return Err("both Unix socket paths must be absolute".to_owned());
+        }
+        if value.listen_socket == value.upstream_socket {
+            return Err("downstream and upstream sockets must be different paths".to_owned());
+        }
+        if value.guard_uid == value.issuer_uid || value.guard_gid == value.issuer_gid {
+            return Err("guard and issuer must use distinct UID and primary GID values".to_owned());
+        }
+        if value.upstream_expected_uid == value.issuer_uid
+            || value.upstream_expected_gid == Some(value.issuer_gid)
+        {
+            return Err(
+                "issuer identity must not own or group-access the upstream socket".to_owned(),
+            );
+        }
+        if value.upstream_expected_uid != value.guard_uid && value.upstream_expected_gid.is_none() {
+            return Err(
+                "a cross-UID upstream socket requires an explicit guard-only group".to_owned(),
+            );
+        }
+        if value
+            .upstream_expected_gid
+            .is_some_and(|gid| gid != value.guard_gid)
+        {
+            return Err(
+                "the upstream access group must be the pinned guard primary GID".to_owned(),
+            );
+        }
+        if value.timeout_seconds == 0
+            || value.timeout_seconds > 30
+            || value.max_in_flight == 0
+            || value.max_in_flight > MAX_IN_FLIGHT_V1
+        {
+            return Err(
+                "timeout or concurrency limit is outside the fixed safety bound".to_owned(),
+            );
+        }
+        if value.max_invoice_msat == 0 || value.max_invoice_msat > MAX_BITCOIN_MSAT_V1 {
+            return Err("invoice amount ceiling is outside the protocol bound".to_owned());
+        }
+        if value.max_invoices_per_minute == 0
+            || value.max_invoices_per_minute > MAX_INVOICES_PER_MINUTE_V1
+            || value.max_invoice_burst == 0
+            || value.max_invoice_burst > MAX_INVOICE_BURST_V1
+            || value.max_invoice_burst > value.max_invoices_per_minute
+            || value.max_invoices_per_runtime == 0
+            || value.max_invoices_per_runtime > MAX_INVOICES_PER_RUNTIME_V1
+        {
+            return Err("invoice mutation budget is outside the fixed safety bounds".to_owned());
+        }
+        Ok(Self {
+            listen_socket: value.listen_socket,
+            upstream_socket: value.upstream_socket,
+            guard_uid: value.guard_uid,
+            guard_gid: value.guard_gid,
+            issuer_uid: value.issuer_uid,
+            issuer_gid: value.issuer_gid,
+            upstream_expected_uid: value.upstream_expected_uid,
+            upstream_expected_gid: value.upstream_expected_gid,
+            timeout: Duration::from_secs(value.timeout_seconds),
+            max_in_flight: value.max_in_flight,
+            max_invoice_msat: value.max_invoice_msat,
+            max_invoices_per_minute: value.max_invoices_per_minute,
+            max_invoice_burst: value.max_invoice_burst,
+            max_invoices_per_runtime: value.max_invoices_per_runtime,
+        })
+    }
+}
+
+impl GuardConfig {
+    fn validate_runtime_identity(&self) -> Result<(), String> {
+        let euid = rustix::process::geteuid().as_raw();
+        let egid = rustix::process::getegid().as_raw();
+        if euid != self.guard_uid || egid != self.guard_gid {
+            return Err("effective guard UID/GID does not match the pinned policy".to_owned());
+        }
+        let supplementary = rustix::process::getgroups()
+            .map_err(|_| "read guard supplementary groups failed".to_owned())?;
+        let has_group =
+            |gid: u32| egid == gid || supplementary.iter().any(|group| group.as_raw() == gid);
+        if !has_group(self.issuer_gid) {
+            return Err("guard lacks the issuer group needed to publish its socket".to_owned());
+        }
+        if self
+            .upstream_expected_gid
+            .is_some_and(|gid| !has_group(gid))
+        {
+            return Err("guard lacks the group needed to reach the upstream socket".to_owned());
+        }
+        Ok(())
+    }
+}
+
+/// Run until SIGINT or SIGTERM, then stop accepting and drain every bounded
+/// in-flight call before unlinking the exact listener inode.
+pub async fn run(config: GuardConfig) -> Result<(), String> {
+    let shutdown = shutdown_signal();
+    run_with_shutdown(config, shutdown).await
+}
+
+async fn run_with_shutdown<F>(config: GuardConfig, shutdown: F) -> Result<(), String>
+where
+    F: Future<Output = ()>,
+{
+    config.validate_runtime_identity()?;
+    let upstream_policy = UnixClnRpcSocketPolicyV1 {
+        expected_uid: config.upstream_expected_uid,
+        expected_gid: config.upstream_expected_gid,
+    };
+    UnixClnRpcTransportV1::new(
+        config.upstream_socket.clone(),
+        upstream_policy,
+        config.timeout,
+    )
+    .map_err(|_| "upstream CLN socket failed its ownership boundary".to_owned())?;
+    let upstream = Arc::new(ProductionUpstreamV1 {
+        socket_path: config.upstream_socket.clone(),
+        socket_policy: upstream_policy,
+    });
+    let runtime_policy = Arc::new(GuardRuntimePolicyV1 {
+        max_invoice_msat: config.max_invoice_msat,
+        invoice_admission: InvoiceAdmissionV1::new(
+            config.max_invoices_per_minute,
+            config.max_invoice_burst,
+            config.max_invoices_per_runtime,
+            std::time::Instant::now(),
+        )?,
+    });
+    let (listener, listener_guard) = create_listener(&config)?;
+    let semaphore = Arc::new(Semaphore::new(config.max_in_flight));
+    let mut tasks = JoinSet::new();
+    let mut check_interval = time::interval(LISTENER_CHECK_INTERVAL_V1);
+    check_interval.set_missed_tick_behavior(time::MissedTickBehavior::Delay);
+    let shutdown = shutdown;
+    tokio::pin!(shutdown);
+    let fatal = loop {
+        tokio::select! {
+            _ = &mut shutdown => break None,
+            _ = check_interval.tick() => {
+                if listener_guard.validate().is_err() {
+                    break Some("downstream listener path changed at runtime".to_owned());
+                }
+            }
+            accepted = listener.accept() => {
+                let (stream, _) = match accepted {
+                    Ok(value) => value,
+                    Err(_) => break Some("accepting the downstream Unix socket failed".to_owned()),
+                };
+                if listener_guard.validate().is_err() {
+                    drop(stream);
+                    break Some("downstream listener path changed while accepting".to_owned());
+                }
+                let credentials = match stream.peer_cred() {
+                    Ok(credentials) => credentials,
+                    Err(_) => {
+                        drop(stream);
+                        continue;
+                    }
+                };
+                if !peer_identity_allowed(
+                    credentials.uid(),
+                    credentials.gid(),
+                    config.issuer_uid,
+                    config.issuer_gid,
+                ) {
+                    drop(stream);
+                    continue;
+                }
+                let permit = match semaphore.clone().try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        drop(stream);
+                        continue;
+                    }
+                };
+                let upstream = upstream.clone();
+                let runtime_policy = runtime_policy.clone();
+                let timeout = config.timeout;
+                tasks.spawn(async move {
+                    serve_connection(stream, upstream, runtime_policy, permit, timeout).await;
+                });
+            }
+            joined = tasks.join_next(), if !tasks.is_empty() => {
+                let _ = joined;
+            }
+        }
+    };
+    while tasks.join_next().await.is_some() {}
+    drop(listener);
+    drop(listener_guard);
+    match fatal {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+fn peer_identity_allowed(
+    actual_uid: u32,
+    actual_gid: u32,
+    expected_uid: u32,
+    expected_gid: u32,
+) -> bool {
+    actual_uid == expected_uid && actual_gid == expected_gid
+}
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        let terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate());
+        match terminate {
+            Ok(mut terminate) => {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {},
+                    _ = terminate.recv() => {},
+                }
+            }
+            Err(_) => {
+                let _ = tokio::signal::ctrl_c().await;
+            }
+        }
+    }
+}
+
+trait GuardUpstreamV1: Send + Sync + 'static {
+    fn call(&self, request: &[u8], deadline: std::time::Instant) -> Result<Zeroizing<Vec<u8>>, ()>;
+}
+
+struct GuardRuntimePolicyV1 {
+    max_invoice_msat: u64,
+    invoice_admission: InvoiceAdmissionV1,
+}
+
+struct InvoiceAdmissionV1 {
+    per_minute: u32,
+    burst: u32,
+    maximum_per_runtime: u64,
+    state: Mutex<InvoiceAdmissionStateV1>,
+}
+
+struct InvoiceAdmissionStateV1 {
+    token_units: u128,
+    admitted: u64,
+    updated_at: std::time::Instant,
+}
+
+impl InvoiceAdmissionV1 {
+    fn new(
+        per_minute: u32,
+        burst: u32,
+        maximum_per_runtime: u64,
+        now: std::time::Instant,
+    ) -> Result<Self, String> {
+        if per_minute == 0
+            || per_minute > MAX_INVOICES_PER_MINUTE_V1
+            || burst == 0
+            || burst > MAX_INVOICE_BURST_V1
+            || burst > per_minute
+            || maximum_per_runtime == 0
+            || maximum_per_runtime > MAX_INVOICES_PER_RUNTIME_V1
+        {
+            return Err("invoice admission policy is outside its fixed bound".to_owned());
+        }
+        Ok(Self {
+            per_minute,
+            burst,
+            maximum_per_runtime,
+            state: Mutex::new(InvoiceAdmissionStateV1 {
+                token_units: u128::from(burst) * TOKEN_MINUTE_NANOS_V1,
+                admitted: 0,
+                updated_at: now,
+            }),
+        })
+    }
+
+    fn try_admit(&self) -> bool {
+        self.try_admit_at(std::time::Instant::now())
+    }
+
+    fn try_admit_at(&self, now: std::time::Instant) -> bool {
+        let Ok(mut state) = self.state.lock() else {
+            return false;
+        };
+        let Some(elapsed) = now.checked_duration_since(state.updated_at) else {
+            return false;
+        };
+        let Some(refill) = elapsed.as_nanos().checked_mul(u128::from(self.per_minute)) else {
+            return false;
+        };
+        let capacity = u128::from(self.burst) * TOKEN_MINUTE_NANOS_V1;
+        state.token_units = state.token_units.saturating_add(refill).min(capacity);
+        state.updated_at = now;
+        if state.admitted >= self.maximum_per_runtime || state.token_units < TOKEN_MINUTE_NANOS_V1 {
+            return false;
+        }
+        state.token_units -= TOKEN_MINUTE_NANOS_V1;
+        state.admitted += 1;
+        true
+    }
+}
+
+struct ProductionUpstreamV1 {
+    socket_path: PathBuf,
+    socket_policy: UnixClnRpcSocketPolicyV1,
+}
+
+impl GuardUpstreamV1 for ProductionUpstreamV1 {
+    fn call(&self, request: &[u8], deadline: std::time::Instant) -> Result<Zeroizing<Vec<u8>>, ()> {
+        let remaining = deadline
+            .checked_duration_since(std::time::Instant::now())
+            .filter(|remaining| !remaining.is_zero() && *remaining <= Duration::from_secs(30))
+            .ok_or(())?;
+        let transport =
+            UnixClnRpcTransportV1::new(self.socket_path.clone(), self.socket_policy, remaining)
+                .map_err(|_| ())?;
+        transport
+            .call(request)
+            .map(|response| response.copy_for_local_guard())
+            .map_err(|_| ())
+    }
+}
+
+async fn serve_connection<U>(
+    mut stream: UnixStream,
+    upstream: Arc<U>,
+    runtime_policy: Arc<GuardRuntimePolicyV1>,
+    permit: OwnedSemaphorePermit,
+    timeout: Duration,
+) where
+    U: GuardUpstreamV1,
+{
+    let deadline = Instant::now() + timeout;
+    let frame = match time::timeout_at(deadline, read_request_frame(&mut stream)).await {
+        Ok(Ok(frame)) => frame,
+        _ => return,
+    };
+    let validated = match validate_request(&frame, runtime_policy.max_invoice_msat) {
+        Ok(validated) => validated,
+        Err(()) => return,
+    };
+    if matches!(validated.method, AllowedMethodV1::Invoice)
+        && !runtime_policy.invoice_admission.try_admit()
+    {
+        return;
+    }
+    let method = validated.method;
+    let expected_label = validated.expected_label;
+    let canonical = validated.canonical;
+    let blocking_deadline = deadline.into_std();
+    let mut called = tokio::task::spawn_blocking(move || {
+        // Keep the concurrency permit in the blocking closure. Timing out the
+        // client task detaches (rather than cancels) spawn_blocking work, so
+        // releasing this permit early would permit unbounded queued RPCs.
+        let _permit = permit;
+        let raw = upstream.call(&canonical, blocking_deadline)?;
+        sanitize_response(
+            method,
+            expected_label.as_ref().map(|label| label.as_str()),
+            &raw,
+        )
+    });
+    let response = match time::timeout_at(deadline, &mut called).await {
+        Ok(Ok(Ok(response))) => response,
+        _ => return,
+    };
+    let written = time::timeout_at(deadline, async {
+        stream.write_all(&response).await?;
+        stream.write_all(b"\n\n").await?;
+        stream.shutdown().await
+    })
+    .await;
+    let _ = written;
+}
+
+async fn read_request_frame(stream: &mut UnixStream) -> Result<Zeroizing<Vec<u8>>, ()> {
+    let mut frame = Zeroizing::new(Vec::with_capacity(MAX_REQUEST_BYTES_V1 + 3));
+    let mut chunk = Zeroizing::new([0_u8; 4096]);
+    loop {
+        let remaining = (MAX_REQUEST_BYTES_V1 + 3).saturating_sub(frame.len());
+        if remaining == 0 {
+            return Err(());
+        }
+        let read_bound = remaining.min(chunk.len());
+        let read = stream
+            .read(&mut chunk[..read_bound])
+            .await
+            .map_err(|_| ())?;
+        if read == 0 {
+            return Err(());
+        }
+        frame.extend_from_slice(&chunk[..read]);
+        if let Some(index) = frame.windows(2).position(|window| window == b"\n\n") {
+            if index == 0 || index > MAX_REQUEST_BYTES_V1 || index + 2 != frame.len() {
+                return Err(());
+            }
+            frame.truncate(index);
+            return Ok(frame);
+        }
+        if frame.len() > MAX_REQUEST_BYTES_V1 + 2 {
+            return Err(());
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum AllowedMethodV1 {
+    GetInfo,
+    ListInvoices,
+    Invoice,
+}
+
+struct ValidatedRequestV1 {
+    method: AllowedMethodV1,
+    expected_label: Option<Zeroizing<String>>,
+    canonical: Zeroizing<Vec<u8>>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RequestEnvelopeV1<'a> {
+    #[serde(borrow)]
+    jsonrpc: &'a str,
+    id: u8,
+    #[serde(borrow)]
+    method: &'a str,
+    #[serde(borrow)]
+    params: &'a RawValue,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct EmptyParamsV1 {}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ListInvoicesParamsV1<'a> {
+    #[serde(borrow)]
+    label: &'a str,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct InvoiceParamsV1<'a> {
+    amount_msat: u64,
+    #[serde(borrow)]
+    label: &'a str,
+    #[serde(borrow)]
+    description: &'a str,
+    expiry: u32,
+    exposeprivatechannels: bool,
+    deschashonly: bool,
+}
+
+#[derive(Serialize)]
+struct CanonicalRequestV1<'a, P> {
+    jsonrpc: &'static str,
+    id: u8,
+    method: &'static str,
+    params: &'a P,
+}
+
+fn validate_request(bytes: &[u8], max_invoice_msat: u64) -> Result<ValidatedRequestV1, ()> {
+    if max_invoice_msat == 0 || max_invoice_msat > MAX_BITCOIN_MSAT_V1 {
+        return Err(());
+    }
+    let envelope: RequestEnvelopeV1<'_> = serde_json::from_slice(bytes).map_err(|_| ())?;
+    if envelope.jsonrpc != "2.0" || envelope.id != 1 {
+        return Err(());
+    }
+    match envelope.method {
+        "getinfo" => {
+            let params: EmptyParamsV1 =
+                serde_json::from_str(envelope.params.get()).map_err(|_| ())?;
+            Ok(ValidatedRequestV1 {
+                method: AllowedMethodV1::GetInfo,
+                expected_label: None,
+                canonical: encode_request("getinfo", &params)?,
+            })
+        }
+        "listinvoices" => {
+            let params: ListInvoicesParamsV1<'_> =
+                serde_json::from_str(envelope.params.get()).map_err(|_| ())?;
+            if !is_canonical_label(params.label) {
+                return Err(());
+            }
+            Ok(ValidatedRequestV1 {
+                method: AllowedMethodV1::ListInvoices,
+                expected_label: Some(Zeroizing::new(params.label.to_owned())),
+                canonical: encode_request("listinvoices", &params)?,
+            })
+        }
+        "invoice" => {
+            let params: InvoiceParamsV1<'_> =
+                serde_json::from_str(envelope.params.get()).map_err(|_| ())?;
+            if params.amount_msat == 0
+                || params.amount_msat > max_invoice_msat
+                || !is_canonical_label(params.label)
+                || params.description != ANONYMOUS_DESCRIPTION_V1
+                || params.expiry == 0
+                || params.expiry > MAX_BOLT11_INVOICE_EXPIRY_SECONDS_V1
+                || params.exposeprivatechannels
+                || !params.deschashonly
+            {
+                return Err(());
+            }
+            Ok(ValidatedRequestV1 {
+                method: AllowedMethodV1::Invoice,
+                expected_label: Some(Zeroizing::new(params.label.to_owned())),
+                canonical: encode_request("invoice", &params)?,
+            })
+        }
+        _ => Err(()),
+    }
+}
+
+fn encode_request<P: Serialize>(
+    method: &'static str,
+    params: &P,
+) -> Result<Zeroizing<Vec<u8>>, ()> {
+    let mut encoded = Zeroizing::new(Vec::with_capacity(MAX_REQUEST_BYTES_V1 + 2));
+    serde_json::to_writer(
+        &mut *encoded,
+        &CanonicalRequestV1 {
+            jsonrpc: "2.0",
+            id: 1,
+            method,
+            params,
+        },
+    )
+    .map_err(|_| ())?;
+    if encoded.is_empty() || encoded.len() > MAX_REQUEST_BYTES_V1 {
+        return Err(());
+    }
+    encoded.extend_from_slice(b"\n\n");
+    Ok(encoded)
+}
+
+fn is_canonical_label(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix(BACKEND_LABEL_PREFIX_V1) else {
+        return false;
+    };
+    hex.len() == BACKEND_LABEL_HEX_LEN_V1
+        && hex
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ResponseEnvelopeV1<'a> {
+    #[serde(borrow)]
+    jsonrpc: &'a str,
+    id: u8,
+    #[serde(borrow)]
+    result: Option<&'a RawValue>,
+    #[serde(borrow)]
+    error: Option<&'a RawValue>,
+}
+
+#[derive(Deserialize)]
+struct RemoteErrorV1 {
+    code: i64,
+}
+
+#[derive(Serialize)]
+struct SanitizedErrorV1 {
+    code: i64,
+}
+
+#[derive(Serialize)]
+struct SuccessEnvelopeV1<'a, T> {
+    jsonrpc: &'static str,
+    id: u8,
+    result: &'a T,
+}
+
+#[derive(Serialize)]
+struct ErrorEnvelopeV1 {
+    jsonrpc: &'static str,
+    id: u8,
+    error: SanitizedErrorV1,
+}
+
+#[derive(Deserialize, Serialize)]
+struct GetInfoResultV1<'a> {
+    #[serde(borrow)]
+    id: &'a str,
+    #[serde(borrow)]
+    network: &'a str,
+}
+
+#[derive(Deserialize, Serialize)]
+struct InvoiceResultV1<'a> {
+    #[serde(borrow)]
+    bolt11: &'a str,
+    #[serde(borrow)]
+    payment_hash: &'a str,
+    expires_at: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ListInvoicesResultV1<'a> {
+    #[serde(borrow)]
+    invoices: Vec<ListedInvoiceV1<'a>>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ListedInvoiceV1<'a> {
+    #[serde(borrow)]
+    label: &'a str,
+    #[serde(borrow)]
+    payment_hash: &'a str,
+    #[serde(borrow)]
+    status: &'a str,
+    expires_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(borrow)]
+    bolt11: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(borrow)]
+    amount_msat: Option<ClnMsatV1<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(borrow)]
+    amount_received_msat: Option<ClnMsatV1<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    paid_at: Option<u64>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(untagged)]
+enum ClnMsatV1<'a> {
+    Integer(u64),
+    Text(#[serde(borrow)] &'a str),
+}
+
+impl ClnMsatV1<'_> {
+    fn value(&self) -> Option<u64> {
+        match self {
+            Self::Integer(value) => Some(*value),
+            Self::Text(value) => value
+                .strip_suffix("msat")
+                .filter(|digits| {
+                    !digits.is_empty()
+                        && digits.bytes().all(|byte| byte.is_ascii_digit())
+                        && (*digits == "0" || !digits.starts_with('0'))
+                })
+                .and_then(|digits| digits.parse().ok()),
+        }
+    }
+}
+
+fn sanitize_response(
+    method: AllowedMethodV1,
+    expected_label: Option<&str>,
+    bytes: &[u8],
+) -> Result<Zeroizing<Vec<u8>>, ()> {
+    if bytes.is_empty() || bytes.len() > MAX_RESPONSE_BYTES_V1 {
+        return Err(());
+    }
+    let envelope: ResponseEnvelopeV1<'_> = serde_json::from_slice(bytes).map_err(|_| ())?;
+    if envelope.jsonrpc != "2.0" || envelope.id != 1 {
+        return Err(());
+    }
+    match (envelope.result, envelope.error) {
+        (Some(result), None) => match method {
+            AllowedMethodV1::GetInfo => {
+                let result: GetInfoResultV1<'_> =
+                    serde_json::from_str(result.get()).map_err(|_| ())?;
+                if !is_lower_hex(result.id, 66)
+                    || !matches!(result.network, "bitcoin" | "testnet" | "signet" | "regtest")
+                {
+                    return Err(());
+                }
+                encode_response(&SuccessEnvelopeV1 {
+                    jsonrpc: "2.0",
+                    id: 1,
+                    result: &result,
+                })
+            }
+            AllowedMethodV1::Invoice => {
+                let result: InvoiceResultV1<'_> =
+                    serde_json::from_str(result.get()).map_err(|_| ())?;
+                if result.bolt11.is_empty()
+                    || result.bolt11.len() > MAX_BOLT11_INVOICE_LEN
+                    || !result
+                        .bolt11
+                        .bytes()
+                        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+                    || !is_lower_hex(result.payment_hash, 64)
+                    || result.expires_at == 0
+                {
+                    return Err(());
+                }
+                encode_response(&SuccessEnvelopeV1 {
+                    jsonrpc: "2.0",
+                    id: 1,
+                    result: &result,
+                })
+            }
+            AllowedMethodV1::ListInvoices => {
+                let result: ListInvoicesResultV1<'_> =
+                    serde_json::from_str(result.get()).map_err(|_| ())?;
+                if result.invoices.len() > 1 {
+                    return Err(());
+                }
+                if let Some(invoice) = result.invoices.first() {
+                    validate_listed_invoice(invoice, expected_label.ok_or(())?)?;
+                }
+                encode_response(&SuccessEnvelopeV1 {
+                    jsonrpc: "2.0",
+                    id: 1,
+                    result: &result,
+                })
+            }
+        },
+        (None, Some(error)) => {
+            let error: RemoteErrorV1 = serde_json::from_str(error.get()).map_err(|_| ())?;
+            encode_response(&ErrorEnvelopeV1 {
+                jsonrpc: "2.0",
+                id: 1,
+                error: SanitizedErrorV1 { code: error.code },
+            })
+        }
+        _ => Err(()),
+    }
+}
+
+fn validate_listed_invoice(invoice: &ListedInvoiceV1<'_>, expected_label: &str) -> Result<(), ()> {
+    let amount = invoice.amount_msat.as_ref().and_then(ClnMsatV1::value);
+    let received = invoice
+        .amount_received_msat
+        .as_ref()
+        .and_then(ClnMsatV1::value);
+    if invoice.label != expected_label
+        || !is_canonical_label(invoice.label)
+        || !is_lower_hex(invoice.payment_hash, 64)
+        || invoice.expires_at == 0
+        || match invoice.bolt11 {
+            Some(bolt11) => {
+                bolt11.is_empty()
+                    || bolt11.len() > MAX_BOLT11_INVOICE_LEN
+                    || !bolt11
+                        .bytes()
+                        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+            }
+            None => true,
+        }
+        || match amount {
+            Some(amount) => amount == 0 || amount > MAX_BITCOIN_MSAT_V1,
+            None => true,
+        }
+        || received.is_some_and(|received| received > MAX_BITCOIN_MSAT_V1)
+    {
+        return Err(());
+    }
+    match invoice.status {
+        "paid"
+            if invoice.paid_at.is_some_and(|paid_at| paid_at != 0)
+                && received.is_some_and(|value| value != 0) =>
+        {
+            Ok(())
+        }
+        "unpaid" | "expired" if invoice.paid_at.is_none() => Ok(()),
+        _ => Err(()),
+    }
+}
+
+fn is_lower_hex(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn encode_response<T: Serialize>(value: &T) -> Result<Zeroizing<Vec<u8>>, ()> {
+    let mut encoded = Zeroizing::new(Vec::with_capacity(MAX_RESPONSE_BYTES_V1));
+    serde_json::to_writer(&mut *encoded, value).map_err(|_| ())?;
+    if encoded.is_empty() || encoded.len() > MAX_RESPONSE_BYTES_V1 {
+        return Err(());
+    }
+    Ok(encoded)
+}
+
+struct ListenerTargetV1 {
+    parent: File,
+    file_name: OsString,
+    path: PathBuf,
+    parent_device: u64,
+    parent_inode: u64,
+}
+
+#[derive(Clone, Copy)]
+struct SocketIdentityV1 {
+    device: u64,
+    inode: u64,
+}
+
+struct ListenerGuardV1 {
+    target: ListenerTargetV1,
+    identity: SocketIdentityV1,
+    guard_uid: u32,
+    issuer_gid: u32,
+}
+
+impl ListenerGuardV1 {
+    fn validate(&self) -> Result<(), ()> {
+        let parent = rustix::fs::fstat(&self.target.parent).map_err(|_| ())?;
+        if parent.st_dev as u64 != self.target.parent_device
+            || parent.st_ino != self.target.parent_inode
+            || !FileType::from_raw_mode(parent.st_mode).is_dir()
+            || parent.st_uid != self.guard_uid
+            || parent.st_gid != self.issuer_gid
+            || parent.st_mode & 0o7777 != 0o710
+        {
+            return Err(());
+        }
+        let pinned = rustix::fs::statat(
+            &self.target.parent,
+            &self.target.file_name,
+            AtFlags::SYMLINK_NOFOLLOW,
+        )
+        .map_err(|_| ())?;
+        if !socket_stat_matches(&pinned, self.identity, self.guard_uid, self.issuer_gid) {
+            return Err(());
+        }
+        let named = fs::symlink_metadata(&self.target.path).map_err(|_| ())?;
+        if !named.file_type().is_socket()
+            || named.dev() != self.identity.device
+            || named.ino() != self.identity.inode
+            || named.uid() != self.guard_uid
+            || named.gid() != self.issuer_gid
+            || named.nlink() != 1
+            || named.mode() & 0o7777 != 0o660
+        {
+            return Err(());
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ListenerGuardV1 {
+    fn drop(&mut self) {
+        let Ok(stat) = rustix::fs::statat(
+            &self.target.parent,
+            &self.target.file_name,
+            AtFlags::SYMLINK_NOFOLLOW,
+        ) else {
+            return;
+        };
+        if FileType::from_raw_mode(stat.st_mode).is_socket()
+            && stat.st_dev as u64 == self.identity.device
+            && stat.st_ino == self.identity.inode
+            && stat.st_uid == self.guard_uid
+            && stat.st_nlink == 1
+        {
+            let _ = rustix::fs::unlinkat(
+                &self.target.parent,
+                &self.target.file_name,
+                AtFlags::empty(),
+            );
+        }
+    }
+}
+
+fn create_listener(config: &GuardConfig) -> Result<(UnixListener, ListenerGuardV1), String> {
+    let target = open_listener_target(&config.listen_socket, config.guard_uid, config.issuer_gid)?;
+    match rustix::fs::statat(&target.parent, &target.file_name, AtFlags::SYMLINK_NOFOLLOW) {
+        Err(rustix::io::Errno::NOENT) => {}
+        Ok(_) => return Err("downstream socket path already exists".to_owned()),
+        Err(_) => return Err("inspect downstream socket path failed".to_owned()),
+    }
+    let socket = Socket::new(Domain::UNIX, Type::STREAM, None)
+        .map_err(|_| "create downstream Unix socket failed".to_owned())?;
+    let address = SockAddr::unix(&target.path)
+        .map_err(|_| "downstream Unix socket path is invalid".to_owned())?;
+    socket
+        .bind(&address)
+        .map_err(|_| "bind downstream Unix socket failed".to_owned())?;
+    let provisional =
+        rustix::fs::statat(&target.parent, &target.file_name, AtFlags::SYMLINK_NOFOLLOW)
+            .map_err(|_| "inspect newly bound downstream socket failed".to_owned())?;
+    if !FileType::from_raw_mode(provisional.st_mode).is_socket()
+        || provisional.st_uid != config.guard_uid
+        || provisional.st_nlink != 1
+    {
+        let _ = rustix::fs::unlinkat(&target.parent, &target.file_name, AtFlags::empty());
+        return Err("new downstream socket has an unexpected identity".to_owned());
+    }
+    let identity = SocketIdentityV1 {
+        device: provisional.st_dev as u64,
+        inode: provisional.st_ino,
+    };
+    let guard = ListenerGuardV1 {
+        target,
+        identity,
+        guard_uid: config.guard_uid,
+        issuer_gid: config.issuer_gid,
+    };
+    rustix::fs::chownat(
+        &guard.target.parent,
+        &guard.target.file_name,
+        None,
+        Some(Gid::from_raw_unchecked(config.issuer_gid)),
+        AtFlags::SYMLINK_NOFOLLOW,
+    )
+    .map_err(|_| "assign issuer group to downstream socket failed".to_owned())?;
+    rustix::fs::chmodat(
+        &guard.target.parent,
+        &guard.target.file_name,
+        Mode::from_bits_truncate(0o660),
+        AtFlags::empty(),
+    )
+    .map_err(|_| "set downstream socket permissions failed".to_owned())?;
+    reject_new_listener_acl(&guard.target.path)?;
+    guard
+        .validate()
+        .map_err(|_| "new downstream socket failed final validation".to_owned())?;
+    let backlog = i32::try_from(config.max_in_flight.saturating_mul(2))
+        .unwrap_or(i32::MAX)
+        .max(1);
+    socket
+        .listen(backlog)
+        .map_err(|_| "listen on downstream Unix socket failed".to_owned())?;
+    socket
+        .set_nonblocking(true)
+        .map_err(|_| "set downstream Unix socket nonblocking failed".to_owned())?;
+    let owned = OwnedFd::from(socket);
+    let standard = StdUnixListener::from(owned);
+    let listener = UnixListener::from_std(standard)
+        .map_err(|_| "register downstream Unix socket with runtime failed".to_owned())?;
+    guard
+        .validate()
+        .map_err(|_| "downstream socket changed during activation".to_owned())?;
+    Ok((listener, guard))
+}
+
+fn socket_stat_matches(
+    stat: &rustix::fs::Stat,
+    identity: SocketIdentityV1,
+    uid: u32,
+    gid: u32,
+) -> bool {
+    FileType::from_raw_mode(stat.st_mode).is_socket()
+        && stat.st_dev as u64 == identity.device
+        && stat.st_ino == identity.inode
+        && stat.st_uid == uid
+        && stat.st_gid == gid
+        && stat.st_nlink == 1
+        && stat.st_mode & 0o7777 == 0o660
+}
+
+fn open_listener_target(
+    path: &Path,
+    guard_uid: u32,
+    issuer_gid: u32,
+) -> Result<ListenerTargetV1, String> {
+    let file_name = path
+        .file_name()
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| "downstream socket must name a file".to_owned())?
+        .to_os_string();
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| "downstream socket must have an absolute parent".to_owned())?;
+    if !parent.is_absolute() {
+        return Err("downstream socket path must be absolute".to_owned());
+    }
+    let parent = normalize_macos_system_root_alias(parent)?;
+    let flags = OFlags::RDONLY | OFlags::DIRECTORY | OFlags::NOFOLLOW | OFlags::CLOEXEC;
+    let root = rustix::fs::open("/", flags, Mode::empty())
+        .map_err(|_| "open filesystem root for downstream socket failed".to_owned())?;
+    let mut current = File::from(root);
+    validate_listener_ancestor(&current, Path::new("/"), guard_uid)?;
+    let components: Vec<_> = parent.components().collect();
+    let normal_count = components
+        .iter()
+        .filter(|component| matches!(component, Component::Normal(_)))
+        .count();
+    if normal_count == 0 {
+        return Err("downstream socket parent must not be filesystem root".to_owned());
+    }
+    let mut opened_path = PathBuf::from("/");
+    let mut normal_index = 0usize;
+    for component in components {
+        let name = match component {
+            Component::RootDir | Component::CurDir => continue,
+            Component::Normal(name) => name,
+            Component::ParentDir | Component::Prefix(_) => {
+                return Err("downstream socket path contains an unsupported component".to_owned())
+            }
+        };
+        normal_index += 1;
+        let next = rustix::fs::openat(&current, name, flags, Mode::empty()).map_err(|_| {
+            "open downstream socket parent without following symlinks failed".to_owned()
+        })?;
+        current = File::from(next);
+        opened_path.push(name);
+        if normal_index == normal_count {
+            validate_listener_parent(&current, &opened_path, guard_uid, issuer_gid)?;
+        } else {
+            validate_listener_ancestor(&current, &opened_path, guard_uid)?;
+        }
+    }
+    let stat = rustix::fs::fstat(&current)
+        .map_err(|_| "inspect downstream socket parent failed".to_owned())?;
+    Ok(ListenerTargetV1 {
+        parent: current,
+        file_name: file_name.clone(),
+        path: opened_path.join(file_name),
+        parent_device: stat.st_dev as u64,
+        parent_inode: stat.st_ino,
+    })
+}
+
+fn validate_listener_ancestor(file: &File, path: &Path, guard_uid: u32) -> Result<(), String> {
+    let stat = rustix::fs::fstat(file)
+        .map_err(|_| "inspect downstream socket ancestor failed".to_owned())?;
+    let mode = stat.st_mode & 0o7777;
+    let sticky_root = stat.st_uid == 0 && mode & 0o1000 != 0 && mode & 0o022 != 0;
+    if !FileType::from_raw_mode(stat.st_mode).is_dir()
+        || (stat.st_uid != 0 && stat.st_uid != guard_uid)
+        || (mode & 0o022 != 0 && !sticky_root)
+    {
+        return Err(format!(
+            "downstream socket ancestor is writable or untrusted: {}",
+            path.display()
+        ));
+    }
+    reject_listener_directory_acl(file, "downstream socket ancestor")
+}
+
+fn validate_listener_parent(
+    file: &File,
+    path: &Path,
+    guard_uid: u32,
+    issuer_gid: u32,
+) -> Result<(), String> {
+    let stat = rustix::fs::fstat(file)
+        .map_err(|_| "inspect downstream socket final parent failed".to_owned())?;
+    if !FileType::from_raw_mode(stat.st_mode).is_dir()
+        || stat.st_uid != guard_uid
+        || stat.st_gid != issuer_gid
+        || stat.st_mode & 0o7777 != 0o710
+    {
+        return Err(format!(
+            "downstream socket parent must be guard-owned, issuer-grouped, and mode 0710: {}",
+            path.display()
+        ));
+    }
+    reject_listener_directory_acl(file, "downstream socket final parent")
+}
+
+fn reject_listener_directory_acl(file: &File, description: &str) -> Result<(), String> {
+    reject_extended_acl_v1(file, description)?;
+    #[cfg(target_os = "linux")]
+    {
+        let mut attributes = Vec::<u8>::with_capacity(4096);
+        rustix::fs::flistxattr(file, rustix::buffer::spare_capacity(&mut attributes))
+            .map_err(|_| format!("inspect Linux ACL attributes on {description} failed"))?;
+        if attributes
+            .split(|byte| *byte == 0)
+            .any(|name| name == b"system.posix_acl_access" || name == b"system.posix_acl_default")
+        {
+            return Err(format!("{description} must not carry a POSIX ACL"));
+        }
+    }
+    Ok(())
+}
+
+fn reject_new_listener_acl(path: &Path) -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        let mut attributes = Vec::<u8>::with_capacity(4096);
+        rustix::fs::llistxattr(path, rustix::buffer::spare_capacity(&mut attributes))
+            .map_err(|_| "inspect Linux ACL attributes on downstream socket failed".to_owned())?;
+        if attributes
+            .split(|byte| *byte == 0)
+            .any(|name| name == b"system.posix_acl_access" || name == b"system.posix_acl_default")
+        {
+            return Err("downstream socket must not carry a POSIX ACL".to_owned());
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = path;
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn normalize_macos_system_root_alias(path: &Path) -> Result<PathBuf, String> {
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let mut components = path.components();
+    if components.next() != Some(Component::RootDir) {
+        return Ok(path.to_path_buf());
+    }
+    let Some(Component::Normal(first)) = components.next() else {
+        return Ok(path.to_path_buf());
+    };
+    let expected = if first == OsStr::new("var") {
+        Path::new("private/var")
+    } else if first == OsStr::new("tmp") {
+        Path::new("private/tmp")
+    } else if first == OsStr::new("etc") {
+        Path::new("private/etc")
+    } else {
+        return Ok(path.to_path_buf());
+    };
+    let alias = Path::new("/").join(first);
+    let metadata = fs::symlink_metadata(&alias)
+        .map_err(|_| "inspect fixed macOS filesystem alias failed".to_owned())?;
+    let actual =
+        fs::read_link(&alias).map_err(|_| "read fixed macOS filesystem alias failed".to_owned())?;
+    if !metadata.file_type().is_symlink()
+        || metadata.uid() != 0
+        || metadata.nlink() != 1
+        || actual.as_os_str().as_bytes() != expected.as_os_str().as_bytes()
+    {
+        return Err("fixed macOS filesystem alias is not byte-exact".to_owned());
+    }
+    let mut normalized = PathBuf::from("/").join(expected);
+    for component in components {
+        normalized.push(component.as_os_str());
+    }
+    Ok(normalized)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn normalize_macos_system_root_alias(path: &Path) -> Result<PathBuf, String> {
+    Ok(path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/cln-rpc-guard/src/lib.rs
+++ b/apps/cln-rpc-guard/src/lib.rs
@@ -948,7 +948,7 @@ struct ListenerGuardV1 {
 impl ListenerGuardV1 {
     fn validate(&self) -> Result<(), ()> {
         let parent = rustix::fs::fstat(&self.target.parent).map_err(|_| ())?;
-        if parent.st_dev as u64 != self.target.parent_device
+        if parent.st_dev != self.target.parent_device
             || parent.st_ino != self.target.parent_inode
             || !FileType::from_raw_mode(parent.st_mode).is_dir()
             || parent.st_uid != self.guard_uid
@@ -991,7 +991,7 @@ impl Drop for ListenerGuardV1 {
             return;
         };
         if FileType::from_raw_mode(stat.st_mode).is_socket()
-            && stat.st_dev as u64 == self.identity.device
+            && stat.st_dev == self.identity.device
             && stat.st_ino == self.identity.inode
             && stat.st_uid == self.guard_uid
             && stat.st_nlink == 1
@@ -1030,7 +1030,7 @@ fn create_listener(config: &GuardConfig) -> Result<(UnixListener, ListenerGuardV
         return Err("new downstream socket has an unexpected identity".to_owned());
     }
     let identity = SocketIdentityV1 {
-        device: provisional.st_dev as u64,
+        device: provisional.st_dev,
         inode: provisional.st_ino,
     };
     let guard = ListenerGuardV1 {
@@ -1084,7 +1084,7 @@ fn socket_stat_matches(
     gid: u32,
 ) -> bool {
     FileType::from_raw_mode(stat.st_mode).is_socket()
-        && stat.st_dev as u64 == identity.device
+        && stat.st_dev == identity.device
         && stat.st_ino == identity.inode
         && stat.st_uid == uid
         && stat.st_gid == gid
@@ -1151,7 +1151,7 @@ fn open_listener_target(
         parent: current,
         file_name: file_name.clone(),
         path: opened_path.join(file_name),
-        parent_device: stat.st_dev as u64,
+        parent_device: stat.st_dev,
         parent_inode: stat.st_ino,
     })
 }

--- a/apps/cln-rpc-guard/src/main.rs
+++ b/apps/cln-rpc-guard/src/main.rs
@@ -1,0 +1,27 @@
+use clap::Parser;
+
+use bitcoinpir_cln_rpc_guard::{run, Cli, GuardConfig};
+
+fn main() {
+    let config = match GuardConfig::try_from(Cli::parse()) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("bitcoinpir-cln-rpc-guard: {error}");
+            std::process::exit(2);
+        }
+    };
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(_) => {
+            eprintln!("bitcoinpir-cln-rpc-guard: initialize async runtime failed");
+            std::process::exit(1);
+        }
+    };
+    if let Err(error) = runtime.block_on(run(config)) {
+        eprintln!("bitcoinpir-cln-rpc-guard: {error}");
+        std::process::exit(1);
+    }
+}

--- a/apps/cln-rpc-guard/src/tests.rs
+++ b/apps/cln-rpc-guard/src/tests.rs
@@ -1,0 +1,623 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt as _;
+use std::os::unix::net::UnixListener as StdUnixListener;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use super::*;
+
+const PAYEE: &str = "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const HASH: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn label() -> String {
+    format!("bpir-v1-{}", "ab".repeat(32))
+}
+
+fn valid_request(method: &str, params: &str) -> String {
+    format!(r#"{{"jsonrpc":"2.0","id":1,"method":"{method}","params":{params}}}"#)
+}
+
+fn valid_invoice_request() -> String {
+    valid_request(
+        "invoice",
+        &format!(
+            r#"{{"amount_msat":44000,"label":"{}","description":"{}","expiry":600,"exposeprivatechannels":false,"deschashonly":true}}"#,
+            label(),
+            ANONYMOUS_DESCRIPTION_V1
+        ),
+    )
+}
+
+#[derive(Default)]
+struct ScriptedUpstreamV1 {
+    requests: Mutex<Vec<Vec<u8>>>,
+    response: Mutex<Option<Result<Vec<u8>, ()>>>,
+}
+
+impl ScriptedUpstreamV1 {
+    fn with_response(response: impl Into<Vec<u8>>) -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+            response: Mutex::new(Some(Ok(response.into()))),
+        }
+    }
+
+    fn failing() -> Self {
+        Self {
+            requests: Mutex::new(Vec::new()),
+            response: Mutex::new(Some(Err(()))),
+        }
+    }
+}
+
+impl GuardUpstreamV1 for ScriptedUpstreamV1 {
+    fn call(&self, request: &[u8], deadline: std::time::Instant) -> Result<Zeroizing<Vec<u8>>, ()> {
+        if std::time::Instant::now() >= deadline {
+            return Err(());
+        }
+        self.requests.lock().unwrap().push(request.to_vec());
+        self.response
+            .lock()
+            .unwrap()
+            .take()
+            .unwrap_or(Err(()))
+            .map(Zeroizing::new)
+    }
+}
+
+async fn invoke(request: &[u8], upstream: Arc<ScriptedUpstreamV1>) -> Vec<u8> {
+    invoke_with_policy(request, upstream, test_runtime_policy()).await
+}
+
+async fn invoke_with_policy(
+    request: &[u8],
+    upstream: Arc<ScriptedUpstreamV1>,
+    runtime_policy: Arc<GuardRuntimePolicyV1>,
+) -> Vec<u8> {
+    let (mut client, server) = UnixStream::pair().unwrap();
+    let permit = Arc::new(Semaphore::new(1)).acquire_owned().await.unwrap();
+    let task = tokio::spawn(async move {
+        serve_connection(
+            server,
+            upstream,
+            runtime_policy,
+            permit,
+            Duration::from_millis(250),
+        )
+        .await;
+    });
+    client.write_all(request).await.unwrap();
+    client.shutdown().await.unwrap();
+    let mut output = Vec::new();
+    client.read_to_end(&mut output).await.unwrap();
+    task.await.unwrap();
+    output
+}
+
+fn test_runtime_policy() -> Arc<GuardRuntimePolicyV1> {
+    Arc::new(GuardRuntimePolicyV1 {
+        max_invoice_msat: 100_000_000,
+        invoice_admission: InvoiceAdmissionV1::new(100, 100, 10_000, std::time::Instant::now())
+            .unwrap(),
+    })
+}
+
+fn validate_test_request(bytes: &[u8]) -> Result<ValidatedRequestV1, ()> {
+    validate_request(bytes, 100_000_000)
+}
+
+#[test]
+fn request_surface_is_closed_world_and_reencoded() {
+    let getinfo = validate_test_request(valid_request("getinfo", "{}").as_bytes()).unwrap();
+    assert!(matches!(getinfo.method, AllowedMethodV1::GetInfo));
+    assert_eq!(
+        getinfo.canonical.as_slice(),
+        br#"{"jsonrpc":"2.0","id":1,"method":"getinfo","params":{}}
+
+"#
+    );
+
+    let list = validate_test_request(
+        valid_request("listinvoices", &format!(r#"{{"label":"{}"}}"#, label())).as_bytes(),
+    )
+    .unwrap();
+    assert!(matches!(list.method, AllowedMethodV1::ListInvoices));
+    assert_eq!(
+        list.expected_label.as_ref().map(|label| label.as_str()),
+        Some(label().as_str())
+    );
+
+    let invoice = validate_test_request(valid_invoice_request().as_bytes()).unwrap();
+    assert!(matches!(invoice.method, AllowedMethodV1::Invoice));
+    assert_eq!(
+        invoice.expected_label.as_ref().map(|label| label.as_str()),
+        Some(label().as_str())
+    );
+}
+
+#[test]
+fn batch_notification_unknown_duplicate_and_smuggled_fields_fail_closed() {
+    let cases = [
+        r#"[{"jsonrpc":"2.0","id":1,"method":"getinfo","params":{}}]"#.to_owned(),
+        r#"{"jsonrpc":"2.0","method":"getinfo","params":{}}"#.to_owned(),
+        r#"{"jsonrpc":"2.0","id":1,"id":1,"method":"getinfo","params":{}}"#.to_owned(),
+        r#"{"jsonrpc":"2.0","id":1,"method":"getinfo","method":"getinfo","params":{}}"#.to_owned(),
+        r#"{"jsonrpc":"2.0","id":1,"method":"getinfo","params":{},"extra":1}"#.to_owned(),
+        valid_request("getinfo", r#"{"extra":1}"#),
+        valid_request("getinfo", r#"{"extra":1,"extra":1}"#),
+        valid_request("pay", "{}"),
+        r#"{"jsonrpc":"2.0","id":null,"method":"getinfo","params":{}}"#.to_owned(),
+        r#"{"jsonrpc":"2.0","id":1,"method":"getinfo","params":{}} {}"#.to_owned(),
+    ];
+    for case in cases {
+        assert!(
+            validate_test_request(case.as_bytes()).is_err(),
+            "accepted {case}"
+        );
+    }
+}
+
+#[test]
+fn invoice_amount_label_expiry_description_and_flags_are_bounded() {
+    let good = valid_invoice_request();
+    let cases = [
+        good.replace("44000", "0"),
+        good.replace("44000", &(MAX_BITCOIN_MSAT_V1 + 1).to_string()),
+        good.replace(&label(), "bpir-v1-deadbeef"),
+        good.replace("\"expiry\":600", "\"expiry\":0"),
+        good.replace(
+            "\"expiry\":600",
+            &format!("\"expiry\":{}", MAX_BOLT11_INVOICE_EXPIRY_SECONDS_V1 + 1),
+        ),
+        good.replace(ANONYMOUS_DESCRIPTION_V1, "query address 1abc"),
+        good.replace(
+            "\"exposeprivatechannels\":false",
+            "\"exposeprivatechannels\":true",
+        ),
+        good.replace("\"deschashonly\":true", "\"deschashonly\":false"),
+        good.replace(
+            "\"deschashonly\":true",
+            "\"deschashonly\":true,\"preimage\":\"00\"",
+        ),
+        good.replace(
+            "\"amount_msat\":44000",
+            "\"amount_msat\":44000,\"amount_msat\":44000",
+        ),
+        good.replace(
+            &format!("\"label\":\"{}\"", label()),
+            &format!("\"label\":\"{}\",\"label\":\"{}\"", label(), label()),
+        ),
+    ];
+    for case in cases {
+        assert!(
+            validate_test_request(case.as_bytes()).is_err(),
+            "accepted {case}"
+        );
+    }
+    assert!(validate_request(good.as_bytes(), 43_999).is_err());
+    assert!(validate_request(good.as_bytes(), 44_000).is_ok());
+}
+
+#[test]
+fn invoice_rate_burst_runtime_cap_and_concurrency_are_atomic() {
+    let started = std::time::Instant::now();
+    let admission = InvoiceAdmissionV1::new(2, 2, 3, started).unwrap();
+    assert!(admission.try_admit_at(started));
+    assert!(admission.try_admit_at(started));
+    assert!(!admission.try_admit_at(started));
+    assert!(admission.try_admit_at(started + Duration::from_secs(30)));
+    assert!(!admission.try_admit_at(started + Duration::from_secs(60)));
+
+    let concurrent = Arc::new(InvoiceAdmissionV1::new(100, 100, 5, started).unwrap());
+    let admitted = Arc::new(AtomicUsize::new(0));
+    std::thread::scope(|scope| {
+        for _ in 0..32 {
+            let concurrent = concurrent.clone();
+            let admitted = admitted.clone();
+            scope.spawn(move || {
+                if concurrent.try_admit_at(started) {
+                    admitted.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+        }
+    });
+    assert_eq!(admitted.load(Ordering::SeqCst), 5);
+}
+
+#[tokio::test]
+async fn exhausted_invoice_budget_and_amount_ceiling_never_reach_cln() {
+    let response = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"result":{{"bolt11":"lnbc1abc","payment_hash":"{HASH}","expires_at":1700000600}}}}"#
+    );
+    let upstream = Arc::new(ScriptedUpstreamV1::with_response(response));
+    let policy = Arc::new(GuardRuntimePolicyV1 {
+        max_invoice_msat: 44_000,
+        invoice_admission: InvoiceAdmissionV1::new(1, 1, 1, std::time::Instant::now()).unwrap(),
+    });
+    let framed = format!("{}\n\n", valid_invoice_request());
+    assert!(
+        !invoke_with_policy(framed.as_bytes(), upstream.clone(), policy.clone())
+            .await
+            .is_empty()
+    );
+    assert!(
+        invoke_with_policy(framed.as_bytes(), upstream.clone(), policy)
+            .await
+            .is_empty()
+    );
+    assert_eq!(upstream.requests.lock().unwrap().len(), 1);
+
+    let over_ceiling = Arc::new(GuardRuntimePolicyV1 {
+        max_invoice_msat: 43_999,
+        invoice_admission: InvoiceAdmissionV1::new(1, 1, 1, std::time::Instant::now()).unwrap(),
+    });
+    assert!(
+        invoke_with_policy(framed.as_bytes(), upstream.clone(), over_ceiling)
+            .await
+            .is_empty()
+    );
+    assert_eq!(upstream.requests.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn valid_request_reaches_upstream_and_secret_response_fields_are_removed() {
+    let response = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"result":{{"invoices":[{{"label":"{}","payment_hash":"{}","status":"paid","expires_at":1700000600,"bolt11":"lnbc1abc","amount_msat":"44000msat","amount_received_msat":"44001msat","paid_at":1700000010,"payment_preimage":"{}","description":"sensitive"}}],"warning":"ignored"}}}}"#,
+        label(),
+        HASH,
+        "cc".repeat(32)
+    );
+    let upstream = Arc::new(ScriptedUpstreamV1::with_response(response));
+    let framed = format!(
+        "{}\n\n",
+        valid_request("listinvoices", &format!(r#"{{"label":"{}"}}"#, label()))
+    );
+    let output = invoke(framed.as_bytes(), upstream.clone()).await;
+    assert!(output.ends_with(b"\n\n"));
+    assert!(!output
+        .windows(b"payment_preimage".len())
+        .any(|part| part == b"payment_preimage"));
+    assert!(!output
+        .windows(b"sensitive".len())
+        .any(|part| part == b"sensitive"));
+    let request = upstream.requests.lock().unwrap()[0].clone();
+    assert!(request.ends_with(b"\n\n"));
+    let parsed: serde_json::Value = serde_json::from_slice(&request[..request.len() - 2]).unwrap();
+    assert_eq!(parsed["method"], "listinvoices");
+    assert_eq!(parsed["params"]["label"], label());
+}
+
+#[tokio::test]
+async fn remote_error_is_reduced_to_code_and_preserves_duplicate_label_recovery() {
+    let upstream = Arc::new(ScriptedUpstreamV1::with_response(
+        br#"{"jsonrpc":"2.0","id":1,"error":{"code":900,"message":"duplicate label bpir-v1-secret","data":{"payment_preimage":"secret"}}}"#
+            .to_vec(),
+    ));
+    let framed = format!("{}\n\n", valid_invoice_request());
+    let output = invoke(framed.as_bytes(), upstream).await;
+    assert_eq!(
+        output,
+        br#"{"jsonrpc":"2.0","id":1,"error":{"code":900}}
+
+"#
+    );
+}
+
+#[tokio::test]
+async fn invalid_request_and_upstream_failure_return_no_forged_response() {
+    let forbidden = Arc::new(ScriptedUpstreamV1::with_response(Vec::new()));
+    let output = invoke(
+        br#"{"jsonrpc":"2.0","id":1,"method":"withdraw","params":{}}
+
+"#,
+        forbidden.clone(),
+    )
+    .await;
+    assert!(output.is_empty());
+    assert!(forbidden.requests.lock().unwrap().is_empty());
+
+    let failing = Arc::new(ScriptedUpstreamV1::failing());
+    let output = invoke(
+        format!("{}\n\n", valid_request("getinfo", "{}")).as_bytes(),
+        failing.clone(),
+    )
+    .await;
+    assert!(output.is_empty());
+    assert_eq!(failing.requests.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn response_identity_label_hash_status_and_shape_fail_closed() {
+    let list = |label: &str, extra: &str| {
+        format!(
+            r#"{{"jsonrpc":"2.0","id":1,"result":{{"invoices":[{{"label":"{label}","payment_hash":"{HASH}","status":"unpaid","expires_at":1700000600,"bolt11":"lnbc1abc","amount_msat":"44000msat"}}]{extra}}}}}"#
+        )
+    };
+    assert!(sanitize_response(
+        AllowedMethodV1::ListInvoices,
+        Some(&label()),
+        list(&label(), "").as_bytes()
+    )
+    .is_ok());
+    for response in [
+        list("bpir-v1-deadbeef", ""),
+        list(&label(), r#", "invoices": []"#),
+        list(&label(), r#", "unexpected": 1"#).replace(HASH, &HASH.to_uppercase()),
+        r#"{"jsonrpc":"2.0","id":2,"result":{"invoices":[]}}"#.to_owned(),
+        r#"{"jsonrpc":"2.0","id":1,"result":{"invoices":[]},"error":{"code":1}}"#.to_owned(),
+    ] {
+        assert!(sanitize_response(
+            AllowedMethodV1::ListInvoices,
+            Some(&label()),
+            response.as_bytes()
+        )
+        .is_err());
+    }
+}
+
+#[test]
+fn getinfo_and_invoice_responses_are_bounded_and_reconstructed() {
+    let getinfo = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"result":{{"id":"{PAYEE}","network":"signet","version":"v24","fees_collected_msat":"secret"}}}}"#
+    );
+    let sanitized = sanitize_response(AllowedMethodV1::GetInfo, None, getinfo.as_bytes()).unwrap();
+    assert_eq!(
+        sanitized.as_slice(),
+        format!(r#"{{"jsonrpc":"2.0","id":1,"result":{{"id":"{PAYEE}","network":"signet"}}}}"#)
+            .as_bytes()
+    );
+
+    let invoice = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"result":{{"bolt11":"lnbc1abc","payment_hash":"{HASH}","expires_at":1700000600,"payment_secret":"{}","warning":"ignored"}}}}"#,
+        "cc".repeat(32)
+    );
+    let sanitized =
+        sanitize_response(AllowedMethodV1::Invoice, Some(&label()), invoice.as_bytes()).unwrap();
+    let text = std::str::from_utf8(&sanitized).unwrap();
+    assert!(!text.contains("payment_secret"));
+    assert!(!text.contains("warning"));
+    assert!(text.contains("lnbc1abc"));
+
+    let duplicate = getinfo.replace(
+        &format!(r#""id":"{PAYEE}""#),
+        &format!(r#""id":"{PAYEE}","id":"{PAYEE}""#),
+    );
+    assert!(sanitize_response(AllowedMethodV1::GetInfo, None, duplicate.as_bytes()).is_err());
+}
+
+#[test]
+fn peer_identity_and_nonblocking_capacity_are_exact() {
+    assert!(peer_identity_allowed(1001, 1002, 1001, 1002));
+    assert!(!peer_identity_allowed(1001, 1003, 1001, 1002));
+    assert!(!peer_identity_allowed(1004, 1002, 1001, 1002));
+
+    let semaphore = Arc::new(Semaphore::new(1));
+    let permit = semaphore.clone().try_acquire_owned().unwrap();
+    assert!(semaphore.clone().try_acquire_owned().is_err());
+    drop(permit);
+    assert!(semaphore.try_acquire_owned().is_ok());
+}
+
+struct DelayedUpstreamV1 {
+    calls: AtomicUsize,
+    delay: Duration,
+}
+
+impl GuardUpstreamV1 for DelayedUpstreamV1 {
+    fn call(
+        &self,
+        _request: &[u8],
+        _deadline: std::time::Instant,
+    ) -> Result<Zeroizing<Vec<u8>>, ()> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        std::thread::sleep(self.delay);
+        Err(())
+    }
+}
+
+#[tokio::test]
+async fn absolute_deadline_closes_client_but_retains_permit_until_blocking_call_finishes() {
+    let upstream = Arc::new(DelayedUpstreamV1 {
+        calls: AtomicUsize::new(0),
+        delay: Duration::from_millis(150),
+    });
+    let semaphore = Arc::new(Semaphore::new(1));
+    let permit = semaphore.clone().acquire_owned().await.unwrap();
+    let runtime_policy = test_runtime_policy();
+    let (mut client, server) = UnixStream::pair().unwrap();
+    let upstream_for_task = upstream.clone();
+    let task = tokio::spawn(async move {
+        serve_connection(
+            server,
+            upstream_for_task,
+            runtime_policy,
+            permit,
+            Duration::from_millis(40),
+        )
+        .await;
+    });
+    client
+        .write_all(format!("{}\n\n", valid_request("getinfo", "{}")).as_bytes())
+        .await
+        .unwrap();
+    client.shutdown().await.unwrap();
+    let mut output = Vec::new();
+    client.read_to_end(&mut output).await.unwrap();
+    task.await.unwrap();
+    assert!(output.is_empty());
+    assert_eq!(upstream.calls.load(Ordering::SeqCst), 1);
+    assert!(semaphore.clone().try_acquire_owned().is_err());
+    time::sleep(Duration::from_millis(140)).await;
+    assert!(semaphore.try_acquire_owned().is_ok());
+}
+
+#[tokio::test]
+async fn framing_rejects_suffix_oversize_and_timeout_without_calling_upstream() {
+    let upstream = Arc::new(ScriptedUpstreamV1::with_response(Vec::new()));
+    let suffix = format!("{}\n\n{{}}", valid_request("getinfo", "{}"));
+    assert!(invoke(suffix.as_bytes(), upstream.clone()).await.is_empty());
+
+    let mut oversize = vec![b' '; MAX_REQUEST_BYTES_V1 + 1];
+    oversize.extend_from_slice(b"\n\n");
+    assert!(invoke(&oversize, upstream.clone()).await.is_empty());
+    assert!(upstream.requests.lock().unwrap().is_empty());
+
+    let (mut client, server) = UnixStream::pair().unwrap();
+    let permit = Arc::new(Semaphore::new(1)).acquire_owned().await.unwrap();
+    let runtime_policy = test_runtime_policy();
+    let upstream_for_task = upstream.clone();
+    let task = tokio::spawn(async move {
+        serve_connection(
+            server,
+            upstream_for_task,
+            runtime_policy,
+            permit,
+            Duration::from_millis(30),
+        )
+        .await;
+    });
+    client.write_all(b"{").await.unwrap();
+    time::sleep(Duration::from_millis(60)).await;
+    let mut output = Vec::new();
+    client.read_to_end(&mut output).await.unwrap();
+    task.await.unwrap();
+    assert!(output.is_empty());
+    assert!(upstream.requests.lock().unwrap().is_empty());
+}
+
+fn current_ids() -> (u32, u32) {
+    (
+        rustix::process::geteuid().as_raw(),
+        rustix::process::getegid().as_raw(),
+    )
+}
+
+fn listener_config(path: PathBuf) -> GuardConfig {
+    let (uid, gid) = current_ids();
+    GuardConfig {
+        listen_socket: path.clone(),
+        upstream_socket: path.with_file_name("upstream-rpc"),
+        guard_uid: uid,
+        guard_gid: gid.wrapping_add(1),
+        issuer_uid: uid.wrapping_add(1),
+        issuer_gid: gid,
+        upstream_expected_uid: uid,
+        upstream_expected_gid: None,
+        timeout: Duration::from_secs(1),
+        max_in_flight: 2,
+        max_invoice_msat: 100_000_000,
+        max_invoices_per_minute: 10,
+        max_invoice_burst: 2,
+        max_invoices_per_runtime: 100,
+    }
+}
+
+#[tokio::test]
+async fn listener_path_is_hardened_and_replacement_is_detected_without_unlinking_attacker() {
+    let directory = tempfile::tempdir().unwrap();
+    fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o710)).unwrap();
+    let config = listener_config(directory.path().join("issuer-rpc"));
+    let (listener, guard) = create_listener(&config).unwrap();
+    guard.validate().unwrap();
+    let metadata = fs::symlink_metadata(&guard.target.path).unwrap();
+    assert!(metadata.file_type().is_socket());
+    assert_eq!(metadata.mode() & 0o7777, 0o660);
+    assert_eq!(metadata.nlink(), 1);
+
+    fs::remove_file(&guard.target.path).unwrap();
+    let attacker = StdUnixListener::bind(&guard.target.path).unwrap();
+    fs::set_permissions(&guard.target.path, fs::Permissions::from_mode(0o660)).unwrap();
+    assert!(guard.validate().is_err());
+    drop(listener);
+    drop(guard);
+    assert!(fs::symlink_metadata(config.listen_socket).is_ok());
+    drop(attacker);
+}
+
+#[tokio::test]
+async fn stale_listener_and_symlink_parent_fail_before_binding() {
+    let directory = tempfile::tempdir().unwrap();
+    fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o710)).unwrap();
+    let stale_path = directory.path().join("issuer-rpc");
+    fs::write(&stale_path, b"stale").unwrap();
+    let config = listener_config(stale_path);
+    assert!(create_listener(&config).is_err());
+
+    let outer = tempfile::tempdir().unwrap();
+    let real = outer.path().join("real");
+    fs::create_dir(&real).unwrap();
+    fs::set_permissions(&real, fs::Permissions::from_mode(0o710)).unwrap();
+    let alias = outer.path().join("alias");
+    std::os::unix::fs::symlink(&real, &alias).unwrap();
+    let config = listener_config(alias.join("issuer-rpc"));
+    assert!(create_listener(&config).is_err());
+}
+
+#[test]
+fn configuration_forbids_root_shared_identity_and_direct_issuer_upstream_access() {
+    let base = || Cli {
+        listen_socket: PathBuf::from("/run/bitcoinpir-cln-guard/issuer-rpc"),
+        upstream_socket: PathBuf::from("/run/lightning/signet/lightning-rpc"),
+        guard_uid: 1001,
+        guard_gid: 1002,
+        issuer_uid: 1003,
+        issuer_gid: 1004,
+        upstream_expected_uid: 1005,
+        upstream_expected_gid: Some(1002),
+        timeout_seconds: 10,
+        max_in_flight: 32,
+        max_invoice_msat: 100_000_000,
+        max_invoices_per_minute: 60,
+        max_invoice_burst: 10,
+        max_invoices_per_runtime: 10_000,
+    };
+    assert!(GuardConfig::try_from(base()).is_ok());
+
+    let mut root = base();
+    root.guard_uid = 0;
+    assert!(GuardConfig::try_from(root).is_err());
+    let mut shared = base();
+    shared.issuer_uid = shared.guard_uid;
+    assert!(GuardConfig::try_from(shared).is_err());
+    let mut direct_owner = base();
+    direct_owner.upstream_expected_uid = direct_owner.issuer_uid;
+    assert!(GuardConfig::try_from(direct_owner).is_err());
+    let mut direct_group = base();
+    direct_group.upstream_expected_gid = Some(direct_group.issuer_gid);
+    assert!(GuardConfig::try_from(direct_group).is_err());
+    let mut unpinned_group = base();
+    unpinned_group.upstream_expected_gid = Some(1006);
+    assert!(GuardConfig::try_from(unpinned_group).is_err());
+    let mut no_cross_uid_group = base();
+    no_cross_uid_group.upstream_expected_gid = None;
+    assert!(GuardConfig::try_from(no_cross_uid_group).is_err());
+    let mut zero_amount = base();
+    zero_amount.max_invoice_msat = 0;
+    assert!(GuardConfig::try_from(zero_amount).is_err());
+    let mut excessive_amount = base();
+    excessive_amount.max_invoice_msat = MAX_BITCOIN_MSAT_V1 + 1;
+    assert!(GuardConfig::try_from(excessive_amount).is_err());
+    let mut zero_rate = base();
+    zero_rate.max_invoices_per_minute = 0;
+    assert!(GuardConfig::try_from(zero_rate).is_err());
+    let mut excessive_rate = base();
+    excessive_rate.max_invoices_per_minute = MAX_INVOICES_PER_MINUTE_V1 + 1;
+    assert!(GuardConfig::try_from(excessive_rate).is_err());
+    let mut zero_burst = base();
+    zero_burst.max_invoice_burst = 0;
+    assert!(GuardConfig::try_from(zero_burst).is_err());
+    let mut excessive_burst = base();
+    excessive_burst.max_invoice_burst = MAX_INVOICE_BURST_V1 + 1;
+    assert!(GuardConfig::try_from(excessive_burst).is_err());
+    let mut burst_over_rate = base();
+    burst_over_rate.max_invoice_burst = burst_over_rate.max_invoices_per_minute + 1;
+    assert!(GuardConfig::try_from(burst_over_rate).is_err());
+    let mut zero_runtime = base();
+    zero_runtime.max_invoices_per_runtime = 0;
+    assert!(GuardConfig::try_from(zero_runtime).is_err());
+    let mut excessive_runtime = base();
+    excessive_runtime.max_invoices_per_runtime = MAX_INVOICES_PER_RUNTIME_V1 + 1;
+    assert!(GuardConfig::try_from(excessive_runtime).is_err());
+}

--- a/apps/directory-relay/Cargo.toml
+++ b/apps/directory-relay/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "bitcoinpir-directory-relay"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.81"
+publish = false
+description = "Minimal BitcoinPIR directory-profile NIP-01 relay"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/Bitcoin-PIR/Bitcoin-PIR"
+
+[[bin]]
+name = "bitcoinpir-directory-relay"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+futures-util = "0.3"
+hex = "0.4"
+log = "0.4"
+env_logger = "0.11"
+pir-directory-nostr = { path = "../../crates/directory/nostr" }
+pir-private-files = { path = "../../crates/security/private-files" }
+rusqlite = { version = "=0.39.0", default-features = false, features = ["bundled"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["raw_value"] }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "signal", "time"] }
+tokio-tungstenite = "0.26"
+toml = "0.8"
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints.rust]
+unsafe_code = "forbid"

--- a/apps/directory-relay/src/lib.rs
+++ b/apps/directory-relay/src/lib.rs
@@ -1,0 +1,214 @@
+//! BitcoinPIR directory-profile relay.
+//!
+//! This is intentionally not a generic Nostr relay. It implements only the
+//! bounded NIP-01 subset used to publish and snapshot BitcoinPIR's signed
+//! service directory.
+
+#![forbid(unsafe_code)]
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use clap::Parser;
+use pir_private_files::{read_private_file_bounded_v1, PrivateFileModeV1};
+use serde::Deserialize;
+
+pub mod server;
+pub mod store;
+pub mod wire;
+
+#[derive(Clone, Debug, Parser)]
+#[command(name = "bitcoinpir-directory-relay")]
+#[command(about = "Minimal loopback-only BitcoinPIR directory-profile relay")]
+#[command(version)]
+pub struct Cli {
+    /// Exact owner-only v1 TOML configuration. No CLI override path exists.
+    #[arg(long)]
+    pub config: PathBuf,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RelayFileConfig {
+    profile: String,
+    listen: SocketAddr,
+    database: PathBuf,
+    directory_pubkey_hex: String,
+    max_connections: usize,
+    max_in_flight_operations: usize,
+    max_operations_per_second: u32,
+    max_egress_bytes_per_second: u64,
+    max_egress_bytes_per_connection: u64,
+    max_archive_events: u64,
+    max_archive_bytes: u64,
+    handshake_timeout_seconds: u64,
+    idle_timeout_seconds: u64,
+    connection_timeout_seconds: u64,
+    operation_timeout_seconds: u64,
+    egress_timeout_seconds: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct RelayConfig {
+    pub listen: SocketAddr,
+    pub database: PathBuf,
+    pub directory_pubkey: [u8; 32],
+    pub max_connections: usize,
+    pub max_in_flight_operations: usize,
+    pub max_operations_per_second: u32,
+    pub max_egress_bytes_per_second: u64,
+    pub max_egress_bytes_per_connection: u64,
+    pub max_archive_events: u64,
+    pub max_archive_bytes: u64,
+    pub handshake_timeout: Duration,
+    pub idle_timeout: Duration,
+    pub connection_timeout: Duration,
+    pub operation_timeout: Duration,
+    pub egress_timeout: Duration,
+}
+
+impl TryFrom<Cli> for RelayConfig {
+    type Error = String;
+
+    fn try_from(cli: Cli) -> Result<Self, Self::Error> {
+        if !cli.config.is_absolute() {
+            return Err("directory relay configuration path must be absolute".to_owned());
+        }
+        let bytes = read_private_file_bounded_v1(
+            &cli.config,
+            16 * 1024,
+            PrivateFileModeV1::ReadOnlyOrReadWrite,
+            "directory relay configuration",
+        )?;
+        let text = std::str::from_utf8(&bytes)
+            .map_err(|_| "directory relay configuration is not UTF-8".to_owned())?;
+        let file: RelayFileConfig = toml::from_str(text)
+            .map_err(|_| "directory relay configuration is invalid".to_owned())?;
+        if file.profile != "bitcoinpir-directory-relay-v1" {
+            return Err("directory relay configuration profile is unsupported".to_owned());
+        }
+        if !file.listen.ip().is_loopback() {
+            return Err("directory relay must bind to a numeric loopback address".to_owned());
+        }
+        if !file.database.is_absolute() {
+            return Err("directory relay database path must be absolute".to_owned());
+        }
+        let directory_pubkey = decode_public_key(&file.directory_pubkey_hex)?;
+        if file.max_connections == 0
+            || file.max_connections > 4_096
+            || file.max_in_flight_operations == 0
+            || file.max_in_flight_operations > 256
+            || file.max_operations_per_second == 0
+            || file.max_operations_per_second > 1_000_000
+            || file.max_egress_bytes_per_second < 1024 * 1024
+            || file.max_egress_bytes_per_second > 1024 * 1024 * 1024
+            || file.max_egress_bytes_per_connection < 2 * 1024 * 1024
+            || file.max_egress_bytes_per_connection > 8 * 1024 * 1024 * 1024
+            || file.max_archive_events < 16_400
+            || file.max_archive_events > 10_000_000
+            || file.max_archive_bytes < 16 * 1024 * 1024
+            || file.max_archive_bytes > 1024 * 1024 * 1024 * 1024
+        {
+            return Err(
+                "directory relay concurrency/rate limits are outside safe bounds".to_owned(),
+            );
+        }
+        for (label, value, maximum) in [
+            ("handshake timeout", file.handshake_timeout_seconds, 60),
+            ("idle timeout", file.idle_timeout_seconds, 600),
+            ("connection timeout", file.connection_timeout_seconds, 3_600),
+            ("operation timeout", file.operation_timeout_seconds, 120),
+            ("egress timeout", file.egress_timeout_seconds, 120),
+        ] {
+            if value == 0 || value > maximum {
+                return Err(format!("{label} must be in 1..={maximum} seconds"));
+            }
+        }
+        Ok(Self {
+            listen: file.listen,
+            database: file.database,
+            directory_pubkey,
+            max_connections: file.max_connections,
+            max_in_flight_operations: file.max_in_flight_operations,
+            max_operations_per_second: file.max_operations_per_second,
+            max_egress_bytes_per_second: file.max_egress_bytes_per_second,
+            max_egress_bytes_per_connection: file.max_egress_bytes_per_connection,
+            max_archive_events: file.max_archive_events,
+            max_archive_bytes: file.max_archive_bytes,
+            handshake_timeout: Duration::from_secs(file.handshake_timeout_seconds),
+            idle_timeout: Duration::from_secs(file.idle_timeout_seconds),
+            connection_timeout: Duration::from_secs(file.connection_timeout_seconds),
+            operation_timeout: Duration::from_secs(file.operation_timeout_seconds),
+            egress_timeout: Duration::from_secs(file.egress_timeout_seconds),
+        })
+    }
+}
+
+fn decode_public_key(value: &str) -> Result<[u8; 32], String> {
+    if value.len() != 64
+        || !value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+    {
+        return Err("directory public key must be exact lowercase 32-byte hex".to_owned());
+    }
+    let bytes = hex::decode(value).map_err(|_| "directory public key is invalid hex".to_owned())?;
+    let key: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| "directory public key has the wrong length".to_owned())?;
+    if key.iter().all(|byte| *byte == 0) {
+        return Err("directory public key cannot be all zero".to_owned());
+    }
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn configuration_is_loopback_only_and_key_strict() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let path = directory.path().join("relay.toml");
+        let render = |listen: &str, key: &str| {
+            format!(
+                r#"
+profile = "bitcoinpir-directory-relay-v1"
+listen = "{listen}"
+database = "/tmp/bitcoinpir-directory-test.sqlite"
+directory_pubkey_hex = "{key}"
+max_connections = 1
+max_in_flight_operations = 1
+max_operations_per_second = 1
+max_egress_bytes_per_second = 1048576
+max_egress_bytes_per_connection = 2097152
+max_archive_events = 16400
+max_archive_bytes = 16777216
+handshake_timeout_seconds = 1
+idle_timeout_seconds = 1
+connection_timeout_seconds = 1
+operation_timeout_seconds = 1
+egress_timeout_seconds = 1
+"#
+            )
+        };
+        fs::write(&path, render("127.0.0.1:8080", &"01".repeat(32))).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(RelayConfig::try_from(Cli {
+            config: path.clone()
+        })
+        .is_ok());
+        fs::write(&path, render("0.0.0.0:8080", &"01".repeat(32))).unwrap();
+        assert!(RelayConfig::try_from(Cli {
+            config: path.clone()
+        })
+        .is_err());
+        fs::write(&path, render("127.0.0.1:8080", &"AA".repeat(32))).unwrap();
+        assert!(RelayConfig::try_from(Cli { config: path }).is_err());
+    }
+}

--- a/apps/directory-relay/src/main.rs
+++ b/apps/directory-relay/src/main.rs
@@ -1,0 +1,55 @@
+use clap::Parser;
+use log::LevelFilter;
+
+use bitcoinpir_directory_relay::{server, Cli, RelayConfig};
+
+#[tokio::main]
+async fn main() {
+    init_logger();
+    let result = match RelayConfig::try_from(Cli::parse()) {
+        Ok(config) => server::run(config).await,
+        Err(error) => Err(error),
+    };
+    if let Err(error) = result {
+        eprintln!("bitcoinpir-directory-relay: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn init_logger() {
+    let mut builder = env_logger::Builder::from_default_env();
+    silence_frame_logging(&mut builder);
+    builder.init();
+}
+
+fn silence_frame_logging(builder: &mut env_logger::Builder) {
+    // tungstenite trace records include complete frame payloads. Directory
+    // requests and signed events must stay out of logs even under RUST_LOG=trace.
+    builder.filter_module("tungstenite", LevelFilter::Off);
+    builder.filter_module("tokio_tungstenite", LevelFilter::Off);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use log::{Log, Metadata};
+
+    #[test]
+    fn dependency_frame_targets_remain_silent_at_trace() {
+        let mut builder = env_logger::Builder::new();
+        builder.filter_level(LevelFilter::Trace);
+        builder.filter_module("tungstenite", LevelFilter::Trace);
+        builder.filter_module("tokio_tungstenite", LevelFilter::Trace);
+        silence_frame_logging(&mut builder);
+        let logger = builder.build();
+        let metadata = |target: &'static str| {
+            Metadata::builder()
+                .level(log::Level::Trace)
+                .target(target)
+                .build()
+        };
+        assert!(!logger.enabled(&metadata("tungstenite::protocol")));
+        assert!(!logger.enabled(&metadata("tokio_tungstenite::handshake")));
+        assert!(logger.enabled(&metadata("bitcoinpir_directory_relay")));
+    }
+}

--- a/apps/directory-relay/src/server.rs
+++ b/apps/directory-relay/src/server.rs
@@ -1,0 +1,1307 @@
+//! Loopback WebSocket transport with bounded snapshot-only semantics.
+
+use std::collections::BTreeSet;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use futures_util::{SinkExt, StreamExt};
+use rusqlite::InterruptHandle;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{watch, OwnedSemaphorePermit, Semaphore};
+use tokio::task::{JoinHandle, JoinSet};
+use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::store::{DirectoryStore, IngestDisposition, SnapshotPlan, StoreLimits};
+use crate::wire::{
+    best_effort_event_id, best_effort_subscription_id, closed_message, eose_message, event_message,
+    ok_message, ok_message_hex, parse_client_message, ClientMessage, RequestFilter, ValidatedEvent,
+    MAX_EVENT_MESSAGE_BYTES, MAX_READBACK_IDS, MAX_SUBSCRIPTION_ID_BYTES, MAX_WIRE_MESSAGE_BYTES,
+};
+use crate::RelayConfig;
+
+const MAX_MESSAGES_PER_CONNECTION: usize = 16 * 1_024 + 64;
+const MAX_WORK_UNITS_PER_CONNECTION: u32 = 256;
+const READBACK_IDS_PER_WORK_UNIT: usize = 8;
+const MAX_OUTBOUND_EVENT_BYTES: u64 =
+    (MAX_EVENT_MESSAGE_BYTES + 2 * MAX_SUBSCRIPTION_ID_BYTES + 32) as u64;
+/// Wire-level upper bound for one worst-case legal bounded ID readback.
+pub const MAX_LEGAL_READBACK_EGRESS_BYTES: u64 =
+    MAX_READBACK_IDS as u64 * MAX_OUTBOUND_EVENT_BYTES + MAX_WIRE_MESSAGE_BYTES as u64;
+
+struct ServerState {
+    store: Arc<Mutex<DirectoryStore>>,
+    directory_pubkey: [u8; 32],
+    operation_slots: Arc<Semaphore>,
+    operation_timeout: Duration,
+    egress_timeout: Duration,
+    max_egress_bytes_per_connection: u64,
+    rate_gate: RateGate,
+    egress_rate_gate: ByteRateGate,
+}
+
+struct RateGate {
+    limit: u32,
+    state: Mutex<RateWindow>,
+}
+
+struct RateWindow {
+    started: Instant,
+    count: u32,
+}
+
+struct ByteRateGate {
+    limit: u64,
+    state: Mutex<ByteRateWindow>,
+}
+
+struct ByteRateWindow {
+    started: Instant,
+    bytes: u64,
+}
+
+struct ConnectionEgressBudget {
+    remaining: u64,
+}
+
+struct ConnectionWorkBudget {
+    remaining: u32,
+}
+
+enum IngestOperationError {
+    NotStarted,
+    OutcomeUnavailable,
+}
+
+impl RateGate {
+    fn new(limit: u32) -> Self {
+        Self {
+            limit,
+            state: Mutex::new(RateWindow {
+                started: Instant::now(),
+                count: 0,
+            }),
+        }
+    }
+
+    fn admit(&self, cost: u32) -> bool {
+        if cost == 0 {
+            return true;
+        }
+        let Ok(mut state) = self.state.lock() else {
+            return false;
+        };
+        if state.started.elapsed() >= Duration::from_secs(1) {
+            state.started = Instant::now();
+            state.count = 0;
+        }
+        let Some(next) = state.count.checked_add(cost) else {
+            return false;
+        };
+        if next > self.limit {
+            return false;
+        }
+        state.count = next;
+        true
+    }
+}
+
+impl ByteRateGate {
+    fn new(limit: u64) -> Self {
+        Self {
+            limit,
+            state: Mutex::new(ByteRateWindow {
+                started: Instant::now(),
+                bytes: 0,
+            }),
+        }
+    }
+
+    async fn wait_for_capacity(&self, bytes: u64) -> Result<(), String> {
+        if bytes > self.limit {
+            return Err("single egress frame exceeds the configured byte rate".to_owned());
+        }
+        loop {
+            let delay = {
+                let mut state = self
+                    .state
+                    .lock()
+                    .map_err(|_| "directory egress byte limiter poisoned".to_owned())?;
+                let elapsed = state.started.elapsed();
+                if elapsed >= Duration::from_secs(1) {
+                    state.started = Instant::now();
+                    state.bytes = 0;
+                }
+                if state.bytes.saturating_add(bytes) <= self.limit {
+                    state.bytes += bytes;
+                    None
+                } else {
+                    Some(Duration::from_secs(1).saturating_sub(elapsed))
+                }
+            };
+            let Some(delay) = delay else {
+                return Ok(());
+            };
+            tokio::time::sleep(delay.max(Duration::from_millis(1))).await;
+        }
+    }
+}
+
+impl ConnectionEgressBudget {
+    fn new(limit: u64) -> Self {
+        Self { remaining: limit }
+    }
+
+    fn reserve(&mut self, bytes: usize) -> Result<(), String> {
+        let bytes = u64::try_from(bytes).map_err(|_| "egress byte count overflow".to_owned())?;
+        self.remaining = self
+            .remaining
+            .checked_sub(bytes)
+            .ok_or_else(|| "connection egress byte budget exhausted".to_owned())?;
+        Ok(())
+    }
+}
+
+impl ConnectionWorkBudget {
+    fn new(limit: u32) -> Self {
+        Self { remaining: limit }
+    }
+
+    fn reserve(&mut self, cost: u32) -> Result<(), String> {
+        self.remaining = self
+            .remaining
+            .checked_sub(cost)
+            .ok_or_else(|| "connection work budget exhausted".to_owned())?;
+        Ok(())
+    }
+}
+
+fn request_work_units(filter: &RequestFilter) -> u32 {
+    match filter {
+        RequestFilter::Catalog { .. } => 1,
+        RequestFilter::Ids(ids) => {
+            let units = ids.len().div_ceil(READBACK_IDS_PER_WORK_UNIT);
+            u32::try_from(units).unwrap_or(u32::MAX).max(1)
+        }
+    }
+}
+
+pub struct RelayHandle {
+    local_addr: SocketAddr,
+    shutdown: watch::Sender<bool>,
+    store_interrupt: Arc<InterruptHandle>,
+    task: JoinHandle<Result<(), String>>,
+}
+
+impl RelayHandle {
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub async fn shutdown(self) -> Result<(), String> {
+        let _ = self.shutdown.send(true);
+        // sqlite3_interrupt is safe across threads. It makes a current long
+        // query/transaction return instead of leaving shutdown to wait on an
+        // invisible spawn_blocking worker. A write either returns its durable
+        // outcome or the connection closes without an acknowledgement.
+        self.store_interrupt.interrupt();
+        self.task
+            .await
+            .map_err(|error| format!("directory relay task failed: {error}"))?
+    }
+}
+
+pub async fn run(config: RelayConfig) -> Result<(), String> {
+    let handle = start(config).await?;
+    log::info!("BitcoinPIR directory-profile relay ready on loopback; limits are active");
+    wait_for_shutdown_signal().await?;
+    handle.shutdown().await
+}
+
+pub async fn start(config: RelayConfig) -> Result<RelayHandle, String> {
+    if !config.listen.ip().is_loopback() {
+        return Err("directory relay refused a non-loopback bind".to_owned());
+    }
+    let now = now_unix()?;
+    let path = config.database.clone();
+    let key = config.directory_pubkey;
+    let limits = StoreLimits {
+        max_archive_events: config.max_archive_events,
+        max_archive_bytes: config.max_archive_bytes,
+    };
+    let store = tokio::task::spawn_blocking(move || {
+        DirectoryStore::open_or_create(&path, key, limits, now)
+    })
+    .await
+    .map_err(|error| format!("directory relay startup worker failed: {error}"))??;
+    let store_interrupt = Arc::new(store.interrupt_handle());
+    let listener = TcpListener::bind(config.listen)
+        .await
+        .map_err(|error| format!("bind directory relay loopback socket failed: {error}"))?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(|error| format!("read directory relay socket address failed: {error}"))?;
+    if !local_addr.ip().is_loopback() {
+        return Err("bound directory relay socket is not loopback".to_owned());
+    }
+    let state = Arc::new(ServerState {
+        store: Arc::new(Mutex::new(store)),
+        directory_pubkey: config.directory_pubkey,
+        operation_slots: Arc::new(Semaphore::new(config.max_in_flight_operations)),
+        operation_timeout: config.operation_timeout,
+        egress_timeout: config.egress_timeout,
+        max_egress_bytes_per_connection: config.max_egress_bytes_per_connection,
+        rate_gate: RateGate::new(config.max_operations_per_second),
+        egress_rate_gate: ByteRateGate::new(config.max_egress_bytes_per_second),
+    });
+    let connection_slots = Arc::new(Semaphore::new(config.max_connections));
+    let (shutdown, shutdown_rx) = watch::channel(false);
+    let task = tokio::spawn(serve(
+        listener,
+        state,
+        connection_slots,
+        config.handshake_timeout,
+        config.idle_timeout,
+        config.connection_timeout,
+        shutdown_rx,
+    ));
+    Ok(RelayHandle {
+        local_addr,
+        shutdown,
+        store_interrupt,
+        task,
+    })
+}
+
+async fn serve(
+    listener: TcpListener,
+    state: Arc<ServerState>,
+    connection_slots: Arc<Semaphore>,
+    handshake_timeout: Duration,
+    idle_timeout: Duration,
+    connection_timeout: Duration,
+    mut shutdown: watch::Receiver<bool>,
+) -> Result<(), String> {
+    let mut connections = JoinSet::new();
+    loop {
+        tokio::select! {
+            changed = shutdown.changed() => {
+                if changed.is_err() || *shutdown.borrow() {
+                    break;
+                }
+            }
+            completed = connections.join_next(), if !connections.is_empty() => {
+                if completed.is_some_and(|result| result.is_err()) {
+                    log::warn!("directory_relay_connection_task_failed");
+                }
+            }
+            accepted = listener.accept() => {
+                let (stream, peer) = accepted
+                    .map_err(|error| format!("accept directory relay connection failed: {error}"))?;
+                if !peer.ip().is_loopback() {
+                    log::warn!("directory_relay_non_loopback_peer_rejected");
+                    drop(stream);
+                    continue;
+                }
+                let Ok(permit) = connection_slots.clone().try_acquire_owned() else {
+                    log::warn!("directory_relay_connection_capacity_rejected");
+                    drop(stream);
+                    continue;
+                };
+                let state = state.clone();
+                let connection_shutdown = shutdown.clone();
+                connections.spawn(async move {
+                    if handle_connection(
+                        stream,
+                        state,
+                        permit,
+                        handshake_timeout,
+                        idle_timeout,
+                        connection_timeout,
+                        connection_shutdown,
+                    )
+                    .await
+                    .is_err()
+                    {
+                        log::warn!("directory_relay_connection_failed");
+                    }
+                });
+            }
+        }
+    }
+    // Stop accepting first, signal is already visible to every connection,
+    // then drain them. Started SQLite operations are not detached or cancelled.
+    while let Some(result) = connections.join_next().await {
+        if result.is_err() {
+            log::warn!("directory_relay_connection_task_failed");
+        }
+    }
+    Ok(())
+}
+
+async fn handle_connection(
+    stream: TcpStream,
+    state: Arc<ServerState>,
+    _connection_permit: OwnedSemaphorePermit,
+    handshake_timeout: Duration,
+    idle_timeout: Duration,
+    connection_timeout: Duration,
+    mut shutdown: watch::Receiver<bool>,
+) -> Result<(), String> {
+    let connection_deadline = Instant::now() + connection_timeout;
+    let websocket_config = WebSocketConfig::default()
+        .max_message_size(Some(MAX_WIRE_MESSAGE_BYTES))
+        .max_frame_size(Some(MAX_WIRE_MESSAGE_BYTES))
+        .max_write_buffer_size(MAX_WIRE_MESSAGE_BYTES * 2);
+    let mut websocket = tokio::time::timeout(
+        handshake_timeout,
+        tokio_tungstenite::accept_async_with_config(stream, Some(websocket_config)),
+    )
+    .await
+    .map_err(|_| "WebSocket handshake timeout".to_owned())?
+    .map_err(|_| "WebSocket handshake rejected".to_owned())?;
+
+    let mut subscriptions = BTreeSet::new();
+    let mut egress_budget = ConnectionEgressBudget::new(state.max_egress_bytes_per_connection);
+    let mut work_budget = ConnectionWorkBudget::new(MAX_WORK_UNITS_PER_CONNECTION);
+    let mut message_count = 0usize;
+    loop {
+        let remaining = connection_deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| "WebSocket connection lifetime exceeded".to_owned())?;
+        let receive_timeout = idle_timeout.min(remaining);
+        let next = tokio::select! {
+            changed = shutdown.changed() => {
+                if changed.is_err() || *shutdown.borrow() {
+                    return Ok(());
+                }
+                continue;
+            }
+            next = tokio::time::timeout(receive_timeout, websocket.next()) => {
+                next.map_err(|_| "WebSocket idle or connection timeout".to_owned())?
+            }
+        };
+        let Some(message) = next else {
+            return Ok(());
+        };
+        let message = message.map_err(|_| "WebSocket receive failed".to_owned())?;
+        let Message::Text(text) = message else {
+            if matches!(message, Message::Close(_)) {
+                return Ok(());
+            }
+            // No binary protocol, live heartbeat, AUTH, NOTICE, or active Pong path.
+            return Err("non-text WebSocket message rejected".to_owned());
+        };
+        message_count += 1;
+        if message_count > MAX_MESSAGES_PER_CONNECTION {
+            return Err("connection message bound exceeded".to_owned());
+        }
+        let bytes = text.as_str().as_bytes();
+        work_budget.reserve(1)?;
+        if !state.rate_gate.admit(1) {
+            // A syntactically recognizable EVENT may be a retry whose durable
+            // positive OK was lost. Without consulting the archive, a negative
+            // ACK would contradict that committed state. Close without any ACK
+            // and let the publisher retry idempotently on a fresh connection.
+            if best_effort_event_id(bytes).is_some() {
+                return Err("EVENT rate-limited without acknowledgement".to_owned());
+            }
+            if !send_bounded_rejection(
+                &mut websocket,
+                bytes,
+                "rate-limited: coarse relay limit",
+                &state,
+                &mut egress_budget,
+            )
+            .await?
+            {
+                return Err("rate-limited message had no safe rejection envelope".to_owned());
+            }
+            continue;
+        }
+        let now = now_unix()?;
+        let message = match parse_client_message(bytes, &state.directory_pubkey, now) {
+            Ok(message) => message,
+            Err(_) => {
+                if !send_bounded_rejection(
+                    &mut websocket,
+                    bytes,
+                    "invalid: outside relay profile",
+                    &state,
+                    &mut egress_budget,
+                )
+                .await?
+                {
+                    return Err("invalid message had no safe rejection envelope".to_owned());
+                }
+                continue;
+            }
+        };
+        match message {
+            ClientMessage::Event(event) => {
+                let event_id = *event.event.id();
+                let response = match ingest_operation(state.clone(), event, now).await {
+                    Ok(IngestDisposition::Saved) => {
+                        ok_message(&event_id, true, "saved: durable commit complete")
+                    }
+                    Ok(IngestDisposition::Duplicate) => ok_message(
+                        &event_id,
+                        true,
+                        "duplicate: durable archive already contains event",
+                    ),
+                    Ok(IngestDisposition::ReplacedByNewer) => ok_message(
+                        &event_id,
+                        false,
+                        "replaced: newer addressable event retained",
+                    ),
+                    Ok(IngestDisposition::ShardCapacityExceeded) => {
+                        ok_message(&event_id, false, "blocked: shard capacity exceeded")
+                    }
+                    Ok(IngestDisposition::ArchiveCapacityExceeded) => ok_message(
+                        &event_id,
+                        false,
+                        "blocked: immutable archive capacity exceeded",
+                    ),
+                    Ok(IngestDisposition::InvalidCurrentEvent) => ok_message(
+                        &event_id,
+                        false,
+                        "invalid: event is not current directory profile",
+                    ),
+                    Err(IngestOperationError::NotStarted) => {
+                        log::warn!("directory_relay_event_store_failed");
+                        return Err("EVENT operation did not start; no acknowledgement".to_owned());
+                    }
+                    Err(IngestOperationError::OutcomeUnavailable) => {
+                        // A started SQLite transaction may have committed even if its
+                        // final outcome could not be returned. Never emit a negative
+                        // acknowledgement that could race a late durable commit.
+                        log::warn!("directory_relay_event_outcome_unavailable");
+                        return Err("EVENT durable outcome unavailable".to_owned());
+                    }
+                };
+                send_text(&mut websocket, response, &state, &mut egress_budget).await?;
+            }
+            ClientMessage::Req {
+                subscription_id,
+                filter,
+            } => {
+                let additional_work = request_work_units(&filter).saturating_sub(1);
+                if work_budget.reserve(additional_work).is_err()
+                    || !state.rate_gate.admit(additional_work)
+                {
+                    let closed = closed_message(&subscription_id, "rate-limited: bounded REQ work");
+                    send_text(&mut websocket, closed, &state, &mut egress_budget).await?;
+                    continue;
+                }
+                if !subscriptions.insert(subscription_id.clone()) {
+                    let closed =
+                        closed_message(&subscription_id, "duplicate: subscription id in use");
+                    send_text(&mut websocket, closed, &state, &mut egress_budget).await?;
+                    continue;
+                }
+                let snapshot = match freeze_snapshot_operation(state.clone(), filter).await {
+                    Ok(snapshot) => snapshot,
+                    Err(_) => {
+                        log::warn!("directory_relay_snapshot_failed");
+                        let closed =
+                            closed_message(&subscription_id, "error: bounded snapshot unavailable");
+                        send_text(&mut websocket, closed, &state, &mut egress_budget).await?;
+                        continue;
+                    }
+                };
+                send_snapshot(
+                    &mut websocket,
+                    &subscription_id,
+                    snapshot,
+                    state.clone(),
+                    &mut egress_budget,
+                )
+                .await?;
+            }
+            ClientMessage::Close { subscription_id } => {
+                subscriptions.remove(&subscription_id);
+            }
+        }
+    }
+}
+
+async fn ingest_operation(
+    state: Arc<ServerState>,
+    event: ValidatedEvent,
+    received_at: u64,
+) -> Result<IngestDisposition, IngestOperationError> {
+    let permit = acquire_operation_permit(&state)
+        .await
+        .map_err(|_| IngestOperationError::NotStarted)?;
+    let store = state.store.clone();
+    let task = tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        let mut store = store
+            .lock()
+            .map_err(|_| "directory store lock poisoned".to_owned())?;
+        store.ingest(&event, received_at)
+    });
+    // Do not apply an acknowledgement timeout after the mutating operation has
+    // started. Dropping a spawn_blocking JoinHandle does not cancel SQLite and
+    // could otherwise produce OK=false followed by a late COMMIT.
+    task.await
+        .map_err(|_| IngestOperationError::OutcomeUnavailable)?
+        .map_err(|_| IngestOperationError::OutcomeUnavailable)
+}
+
+async fn freeze_snapshot_operation(
+    state: Arc<ServerState>,
+    filter: RequestFilter,
+) -> Result<SnapshotPlan, String> {
+    let permit = acquire_operation_permit(&state).await?;
+    let store = state.store.clone();
+    let task = tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        let store = store
+            .lock()
+            .map_err(|_| "directory store lock poisoned".to_owned())?;
+        store.freeze_snapshot(&filter)
+    });
+    // Once a SQLite read starts, await its bounded result. Dropping a
+    // spawn_blocking handle on timeout would not cancel the worker and could
+    // leave it holding the single store mutex invisibly.
+    task.await
+        .map_err(|_| "directory snapshot worker failed".to_owned())?
+}
+
+async fn load_snapshot_page_operation(
+    state: Arc<ServerState>,
+    ids: Vec<[u8; 32]>,
+) -> Result<Vec<Vec<u8>>, String> {
+    let permit = acquire_operation_permit(&state).await?;
+    let store = state.store.clone();
+    let task = tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        let store = store
+            .lock()
+            .map_err(|_| "directory store lock poisoned".to_owned())?;
+        store.load_snapshot_page(&ids)
+    });
+    task.await
+        .map_err(|_| "directory snapshot page worker failed".to_owned())?
+}
+
+async fn acquire_operation_permit(state: &ServerState) -> Result<OwnedSemaphorePermit, String> {
+    tokio::time::timeout(
+        state.operation_timeout,
+        state.operation_slots.clone().acquire_owned(),
+    )
+    .await
+    .map_err(|_| "directory operation queue timeout".to_owned())?
+    .map_err(|_| "directory operation limiter closed".to_owned())
+}
+
+async fn send_snapshot<S>(
+    websocket: &mut tokio_tungstenite::WebSocketStream<S>,
+    subscription_id: &str,
+    snapshot: SnapshotPlan,
+    state: Arc<ServerState>,
+    egress_budget: &mut ConnectionEgressBudget,
+) -> Result<(), String>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let subscription_bytes = serde_json::to_string(subscription_id)
+        .map_err(|_| "serialize subscription id failed".to_owned())?
+        .len();
+    let per_event_envelope = u64::try_from(subscription_bytes + 11)
+        .map_err(|_| "snapshot envelope byte count overflow".to_owned())?;
+    let event_count = u64::try_from(snapshot.event_ids.len())
+        .map_err(|_| "snapshot event count overflow".to_owned())?;
+    let response_bytes = snapshot
+        .event_json_bytes
+        .checked_add(
+            per_event_envelope
+                .checked_mul(event_count)
+                .ok_or_else(|| "snapshot envelope byte count overflow".to_owned())?,
+        )
+        .and_then(|bytes| bytes.checked_add(eose_message(subscription_id).len() as u64))
+        .ok_or_else(|| "snapshot response byte count overflow".to_owned())?;
+    // Reserve the exact complete response before the first EVENT. A request
+    // that exceeds the cumulative budget closes without leaking a prefix.
+    egress_budget.reserve(
+        usize::try_from(response_bytes)
+            .map_err(|_| "snapshot response exceeds platform byte range".to_owned())?,
+    )?;
+    for ids in snapshot.event_ids.chunks(8) {
+        let events = load_snapshot_page_operation(state.clone(), ids.to_vec()).await?;
+        if events.len() != ids.len() {
+            return Err("frozen snapshot page is incomplete".to_owned());
+        }
+        for event in events {
+            let message = event_message(subscription_id, &event)?;
+            send_text_reserved(websocket, message, &state).await?;
+        }
+    }
+    send_text_reserved(websocket, eose_message(subscription_id), &state).await
+}
+
+async fn send_text<S>(
+    websocket: &mut tokio_tungstenite::WebSocketStream<S>,
+    text: String,
+    state: &ServerState,
+    egress_budget: &mut ConnectionEgressBudget,
+) -> Result<(), String>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    egress_budget.reserve(text.len())?;
+    send_text_reserved(websocket, text, state).await
+}
+
+async fn send_text_reserved<S>(
+    websocket: &mut tokio_tungstenite::WebSocketStream<S>,
+    text: String,
+    state: &ServerState,
+) -> Result<(), String>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let bytes = u64::try_from(text.len()).map_err(|_| "egress byte count overflow".to_owned())?;
+    tokio::time::timeout(state.egress_timeout, async {
+        state.egress_rate_gate.wait_for_capacity(bytes).await?;
+        websocket
+            .send(Message::Text(text.into()))
+            .await
+            .map_err(|_| "WebSocket egress failed".to_owned())
+    })
+    .await
+    .map_err(|_| "WebSocket egress timeout".to_owned())?
+}
+
+async fn send_bounded_rejection<S>(
+    websocket: &mut tokio_tungstenite::WebSocketStream<S>,
+    bytes: &[u8],
+    reason: &str,
+    state: &ServerState,
+    egress_budget: &mut ConnectionEgressBudget,
+) -> Result<bool, String>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let response = if let Some(event_id) = best_effort_event_id(bytes) {
+        Some(ok_message_hex(&event_id, false, reason))
+    } else {
+        best_effort_subscription_id(bytes).map(|id| closed_message(&id, reason))
+    };
+    if let Some(response) = response {
+        send_text(websocket, response, state, egress_budget).await?;
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn now_unix() -> Result<u64, String> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| "system clock is before Unix epoch".to_owned())
+        .map(|duration| duration.as_secs())
+}
+
+#[cfg(unix)]
+async fn wait_for_shutdown_signal() -> Result<(), String> {
+    let mut terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .map_err(|error| format!("install SIGTERM handler failed: {error}"))?;
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => result.map_err(|error| format!("wait for Ctrl-C failed: {error}")),
+        _ = terminate.recv() => Ok(()),
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown_signal() -> Result<(), String> {
+    tokio::signal::ctrl_c()
+        .await
+        .map_err(|error| format!("wait for Ctrl-C failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    use pir_directory_nostr::{
+        catalog_req_json_v1, DirectoryEntryV1, DirectoryHealthClassV1, DirectoryHealthV1,
+        DirectoryPublisherKeyV1, NostrEventV1,
+    };
+    use serde::Serialize;
+    use serde_json::Value;
+    use tokio_tungstenite::tungstenite::protocol::frame::{
+        coding::{Data as FrameData, OpCode},
+        Frame,
+    };
+    use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+
+    use crate::wire::{MAX_READBACK_IDS, MAX_WIRE_MESSAGE_BYTES};
+
+    type TestClient = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+    #[derive(Serialize)]
+    struct IdFilter {
+        ids: Vec<String>,
+    }
+
+    fn test_config(database: std::path::PathBuf, key: [u8; 32]) -> RelayConfig {
+        RelayConfig {
+            listen: "127.0.0.1:0".parse().unwrap(),
+            database,
+            directory_pubkey: key,
+            max_connections: 32,
+            max_in_flight_operations: 4,
+            max_operations_per_second: 1_000_000,
+            max_egress_bytes_per_second: 1024 * 1024 * 1024,
+            max_egress_bytes_per_connection: 64 * 1024 * 1024,
+            max_archive_events: 20_000,
+            max_archive_bytes: 64 * 1024 * 1024,
+            handshake_timeout: Duration::from_secs(5),
+            idle_timeout: Duration::from_secs(10),
+            connection_timeout: Duration::from_secs(60),
+            operation_timeout: Duration::from_secs(10),
+            egress_timeout: Duration::from_secs(5),
+        }
+    }
+
+    fn signed_entry(
+        publisher: &DirectoryPublisherKeyV1,
+        provider: [u8; 32],
+        sequence: u64,
+        created_at: u64,
+        now: u64,
+        randomness: u8,
+    ) -> NostrEventV1 {
+        let entry = DirectoryEntryV1::new_tombstone(
+            provider,
+            sequence,
+            now + 3_600,
+            DirectoryHealthV1 {
+                class: DirectoryHealthClassV1::Unknown,
+                observed_bucket: now - (now % 300),
+            },
+            now,
+        )
+        .unwrap();
+        publisher
+            .sign_entry_event(&entry, created_at, &[randomness; 32])
+            .unwrap()
+    }
+
+    async fn connect(handle: &RelayHandle) -> TestClient {
+        connect_async(format!("ws://{}", handle.local_addr()))
+            .await
+            .unwrap()
+            .0
+    }
+
+    async fn receive_text(client: &mut TestClient) -> String {
+        let message = tokio::time::timeout(Duration::from_secs(10), client.next())
+            .await
+            .expect("relay response timeout")
+            .expect("relay closed before response")
+            .expect("relay WebSocket error");
+        match message {
+            Message::Text(text) => text.to_string(),
+            other => panic!("unexpected relay message: {other:?}"),
+        }
+    }
+
+    async fn publish(client: &mut TestClient, event: &NostrEventV1) -> (bool, String) {
+        let message = String::from_utf8(event.to_event_message_json_bytes().unwrap()).unwrap();
+        client.send(Message::Text(message.into())).await.unwrap();
+        let response: Value = serde_json::from_str(&receive_text(client).await).unwrap();
+        assert_eq!(response[0], "OK");
+        assert_eq!(response[1], hex::encode(event.id()));
+        (
+            response[2].as_bool().unwrap(),
+            response[3].as_str().unwrap().to_owned(),
+        )
+    }
+
+    async fn receive_catalog(
+        client: &mut TestClient,
+        request: &str,
+        subscription_id: &str,
+    ) -> Vec<String> {
+        client
+            .send(Message::Text(request.to_owned().into()))
+            .await
+            .unwrap();
+        let mut ids = Vec::new();
+        loop {
+            let response: Value = serde_json::from_str(&receive_text(client).await).unwrap();
+            match response[0].as_str().unwrap() {
+                "EVENT" => {
+                    assert_eq!(response[1], subscription_id);
+                    ids.push(response[2]["id"].as_str().unwrap().to_owned());
+                }
+                "EOSE" => {
+                    assert_eq!(response[1], subscription_id);
+                    return ids;
+                }
+                other => panic!("unexpected catalog response {other}"),
+            }
+        }
+    }
+
+    async fn expect_connection_failure(client: &mut TestClient) {
+        let outcome = tokio::time::timeout(Duration::from_secs(5), client.next())
+            .await
+            .expect("connection did not fail closed");
+        assert!(matches!(
+            outcome,
+            None | Some(Err(_)) | Some(Ok(Message::Close(_)))
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn websocket_profile_is_durable_paged_and_fail_closed() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let database = directory.path().join("relay.sqlite");
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([61; 32]).unwrap();
+        let config = test_config(database.clone(), *publisher.public_key());
+        let handle = start(config.clone()).await.unwrap();
+        let now = now_unix().unwrap();
+        let provider = [0x21; 32];
+        let first = signed_entry(&publisher, provider, 1, now - 3, now, 1);
+        let second = signed_entry(&publisher, provider, 2, now - 2, now, 2);
+        let older = signed_entry(&publisher, provider, 1, now - 4, now, 3);
+
+        let mut client = connect(&handle).await;
+        assert!(publish(&mut client, &first).await.0);
+        assert!(publish(&mut client, &second).await.0);
+        let (accepted, reason) = publish(&mut client, &older).await;
+        assert!(!accepted);
+        assert!(reason.starts_with("replaced:"));
+        let (accepted, reason) = publish(&mut client, &first).await;
+        assert!(accepted);
+        assert!(reason.starts_with("duplicate:"));
+
+        let mut stored = vec![*first.id(), *second.id()];
+        let mut expected_catalog = vec![hex::encode(second.id())];
+        for offset in 0_u8..9 {
+            let mut extra_provider = [0_u8; 32];
+            extra_provider[0] = 0x22 + offset;
+            extra_provider[31] = offset;
+            let event = signed_entry(&publisher, extra_provider, 1, now - 1, now, 10 + offset);
+            assert!(publish(&mut client, &event).await.0);
+            stored.push(*event.id());
+            expected_catalog.push(hex::encode(event.id()));
+        }
+
+        let catalog_request =
+            String::from_utf8(catalog_req_json_v1(publisher.public_key(), 2).unwrap()).unwrap();
+        let catalog = receive_catalog(
+            &mut client,
+            &catalog_request,
+            "bitcoinpir-directory-v1-shard-2",
+        )
+        .await;
+        assert_eq!(catalog, expected_catalog);
+
+        client
+            .send(Message::Text(catalog_request.clone().into()))
+            .await
+            .unwrap();
+        let duplicate_subscription: Value =
+            serde_json::from_str(&receive_text(&mut client).await).unwrap();
+        assert_eq!(duplicate_subscription[0], "CLOSED");
+        client
+            .send(Message::Text(
+                serde_json::to_string(&("CLOSE", "bitcoinpir-directory-v1-shard-2"))
+                    .unwrap()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+
+        stored.reverse();
+        let mut requested = stored.clone();
+        let mut requested_set = requested.iter().copied().collect::<BTreeSet<_>>();
+        let mut next = 0u64;
+        while requested.len() < MAX_READBACK_IDS {
+            let mut id = [0xee; 32];
+            id[24..].copy_from_slice(&next.to_be_bytes());
+            next += 1;
+            if requested_set.insert(id) {
+                requested.push(id);
+            }
+        }
+        let readback_request = serde_json::to_string(&(
+            "REQ",
+            "paged-readback",
+            IdFilter {
+                ids: requested.iter().map(hex::encode).collect(),
+            },
+        ))
+        .unwrap();
+        assert!(readback_request.len() < MAX_WIRE_MESSAGE_BYTES);
+        let readback = receive_catalog(&mut client, &readback_request, "paged-readback").await;
+        assert_eq!(
+            readback,
+            stored.iter().map(hex::encode).collect::<Vec<_>>(),
+            "readback crosses the internal eight-event page and preserves request order"
+        );
+
+        // Simulate a committed EVENT whose positive OK is lost with the socket.
+        let lost_ack_event = signed_entry(&publisher, [0x2f; 32], 1, now - 1, now, 31);
+        let mut lost_ack_client = connect(&handle).await;
+        lost_ack_client
+            .send(Message::Text(
+                String::from_utf8(lost_ack_event.to_event_message_json_bytes().unwrap())
+                    .unwrap()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        drop(lost_ack_client);
+        let mut commit_probe = connect(&handle).await;
+        tokio::time::timeout(Duration::from_secs(5), async {
+            for attempt in 0u64.. {
+                let subscription_id = format!("commit-barrier-{attempt}");
+                let request = serde_json::to_string(&(
+                    "REQ",
+                    &subscription_id,
+                    IdFilter {
+                        ids: vec![hex::encode(lost_ack_event.id())],
+                    },
+                ))
+                .unwrap();
+                let ids = receive_catalog(&mut commit_probe, &request, &subscription_id).await;
+                if ids == [hex::encode(lost_ack_event.id())] {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("lost-ACK event never crossed the durable readback barrier");
+        commit_probe.send(Message::Close(None)).await.unwrap();
+        let mut retry_client = connect(&handle).await;
+        let (accepted, reason) = publish(&mut retry_client, &lost_ack_event).await;
+        assert!(accepted);
+        assert!(reason.starts_with("duplicate:"));
+        retry_client.send(Message::Close(None)).await.unwrap();
+
+        client.send(Message::Close(None)).await.unwrap();
+        drop(client);
+        handle.shutdown().await.unwrap();
+
+        // A positive OK survived restart and all address heads are still deterministic.
+        let restarted = start(config.clone()).await.unwrap();
+        let mut after_restart = connect(&restarted).await;
+        let catalog = receive_catalog(
+            &mut after_restart,
+            &catalog_request,
+            "bitcoinpir-directory-v1-shard-2",
+        )
+        .await;
+        let mut expected_after_restart = expected_catalog;
+        expected_after_restart.push(hex::encode(lost_ack_event.id()));
+        expected_after_restart.sort();
+        let mut actual_sorted = catalog;
+        actual_sorted.sort();
+        assert_eq!(actual_sorted, expected_after_restart);
+        after_restart.send(Message::Close(None)).await.unwrap();
+
+        let mut malformed = connect(&restarted).await;
+        malformed
+            .send(Message::Text(
+                r#"["REQ","bad",{"ids":[]}]"#.to_owned().into(),
+            ))
+            .await
+            .unwrap();
+        let response: Value = serde_json::from_str(&receive_text(&mut malformed).await).unwrap();
+        assert_eq!(response[0], "CLOSED");
+        malformed.send(Message::Close(None)).await.unwrap();
+
+        let mut unknown = connect(&restarted).await;
+        unknown
+            .send(Message::Text(r#"["AUTH",{}]"#.to_owned().into()))
+            .await
+            .unwrap();
+        expect_connection_failure(&mut unknown).await;
+
+        let mut binary = connect(&restarted).await;
+        binary
+            .send(Message::Binary(vec![1, 2, 3].into()))
+            .await
+            .unwrap();
+        expect_connection_failure(&mut binary).await;
+
+        let mut oversized = connect(&restarted).await;
+        let oversized_message = format!(
+            "[\"REQ\",\"oversized\",{{\"padding\":\"{}\"}}]",
+            "x".repeat(MAX_WIRE_MESSAGE_BYTES)
+        );
+        assert!(oversized_message.len() > MAX_WIRE_MESSAGE_BYTES);
+        if oversized
+            .send(Message::Text(oversized_message.into()))
+            .await
+            .is_ok()
+        {
+            expect_connection_failure(&mut oversized).await;
+        }
+
+        let mut fragmented = connect(&restarted).await;
+        fragmented
+            .send(Message::Frame(Frame::message(
+                vec![b'x'; MAX_WIRE_MESSAGE_BYTES / 2 + 1],
+                OpCode::Data(FrameData::Text),
+                false,
+            )))
+            .await
+            .unwrap();
+        if fragmented
+            .send(Message::Frame(Frame::message(
+                vec![b'x'; MAX_WIRE_MESSAGE_BYTES / 2 + 1],
+                OpCode::Data(FrameData::Continue),
+                true,
+            )))
+            .await
+            .is_ok()
+        {
+            expect_connection_failure(&mut fragmented).await;
+        }
+
+        restarted.shutdown().await.unwrap();
+
+        // The complete response is budgeted before its first EVENT. A cap that
+        // cannot fit the catalog therefore closes without leaking a prefix.
+        let mut low_budget_config = config;
+        low_budget_config.max_egress_bytes_per_connection = 256;
+        let low_budget = start(low_budget_config).await.unwrap();
+        let mut capped = connect(&low_budget).await;
+        capped
+            .send(Message::Text(catalog_request.into()))
+            .await
+            .unwrap();
+        expect_connection_failure(&mut capped).await;
+        low_budget.shutdown().await.unwrap();
+    }
+
+    #[test]
+    fn legal_readback_wire_maximum_and_connection_budget_are_bounded() {
+        assert_eq!(
+            MAX_LEGAL_READBACK_EGRESS_BYTES,
+            MAX_READBACK_IDS as u64 * MAX_OUTBOUND_EVENT_BYTES + MAX_WIRE_MESSAGE_BYTES as u64
+        );
+        let mut budget = ConnectionEgressBudget::new(10);
+        assert!(budget.reserve(11).is_err());
+        assert_eq!(budget.remaining, 10, "failed reservation is atomic");
+        budget.reserve(10).unwrap();
+        assert_eq!(budget.remaining, 0);
+
+        let mut work = ConnectionWorkBudget::new(8);
+        work.reserve(8).unwrap();
+        assert_eq!(work.remaining, 0);
+        assert!(work.reserve(1).is_err());
+        assert_eq!(work.remaining, 0, "failed work reservation is atomic");
+
+        assert_eq!(request_work_units(&RequestFilter::Ids(vec![[0; 32]; 1])), 1);
+        assert_eq!(request_work_units(&RequestFilter::Ids(vec![[0; 32]; 8])), 1);
+        assert_eq!(request_work_units(&RequestFilter::Ids(vec![[0; 32]; 9])), 2);
+        assert_eq!(
+            request_work_units(&RequestFilter::Ids(vec![[0; 32]; MAX_READBACK_IDS])),
+            8,
+        );
+
+        let gate = RateGate::new(8);
+        assert!(gate.admit(1));
+        assert!(!gate.admit(8), "weighted admission must be atomic");
+        assert!(gate.admit(7));
+        assert!(!gate.admit(1));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn rate_limited_durable_duplicate_gets_no_negative_ack_and_retries_positive() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([62; 32]).unwrap();
+        let mut config = test_config(
+            directory.path().join("rate.sqlite"),
+            *publisher.public_key(),
+        );
+        config.max_operations_per_second = 1;
+        let handle = start(config).await.unwrap();
+        let now = now_unix().unwrap();
+        let event = signed_entry(&publisher, [0x31; 32], 1, now - 1, now, 1);
+
+        let mut first = connect(&handle).await;
+        assert!(publish(&mut first, &event).await.0);
+        first.send(Message::Close(None)).await.unwrap();
+
+        let wire = String::from_utf8(event.to_event_message_json_bytes().unwrap()).unwrap();
+        let mut limited = connect(&handle).await;
+        limited
+            .send(Message::Text(wire.clone().into()))
+            .await
+            .unwrap();
+        expect_connection_failure(&mut limited).await;
+
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                let mut retry = connect(&handle).await;
+                retry
+                    .send(Message::Text(wire.clone().into()))
+                    .await
+                    .unwrap();
+                match tokio::time::timeout(Duration::from_secs(1), retry.next()).await {
+                    Ok(Some(Ok(Message::Text(response)))) => {
+                        let response: Value = serde_json::from_str(response.as_str()).unwrap();
+                        assert_eq!(response[0], "OK");
+                        assert_eq!(
+                            response[2], true,
+                            "durable duplicate cannot become negative"
+                        );
+                        assert!(response[3].as_str().unwrap().starts_with("duplicate:"));
+                        break;
+                    }
+                    Ok(None | Some(Err(_)) | Some(Ok(Message::Close(_)))) => {}
+                    Ok(Some(Ok(other))) => panic!("unexpected retry response: {other:?}"),
+                    Err(_) => panic!("rate-limited EVENT connection did not fail closed"),
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("rate window never admitted an idempotent duplicate retry");
+        handle.shutdown().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn id_readback_rate_is_weighted_by_eight_id_pages() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([63; 32]).unwrap();
+
+        let ids = (0u8..9)
+            .map(|suffix| {
+                let mut id = [0x42; 32];
+                id[31] = suffix;
+                hex::encode(id)
+            })
+            .collect::<Vec<_>>();
+        let mut config = test_config(
+            directory.path().join("weighted.sqlite"),
+            *publisher.public_key(),
+        );
+        config.max_operations_per_second = 1;
+        let handle = start(config).await.unwrap();
+        let mut client = connect(&handle).await;
+        let request =
+            serde_json::to_string(&("REQ", "weighted-readback", IdFilter { ids: ids.clone() }))
+                .unwrap();
+        client.send(Message::Text(request.into())).await.unwrap();
+        let response: Value = serde_json::from_str(&receive_text(&mut client).await).unwrap();
+        assert_eq!(response[0], "CLOSED");
+        assert_eq!(response[1], "weighted-readback");
+        assert!(response[2].as_str().unwrap().starts_with("rate-limited:"));
+        handle.shutdown().await.unwrap();
+
+        let mut config = test_config(
+            directory.path().join("one-unit.sqlite"),
+            *publisher.public_key(),
+        );
+        config.max_operations_per_second = 1;
+        let handle = start(config).await.unwrap();
+        let mut client = connect(&handle).await;
+        let request = serde_json::to_string(&(
+            "REQ",
+            "one-unit-readback",
+            IdFilter {
+                ids: ids[..8].to_vec(),
+            },
+        ))
+        .unwrap();
+        let response = receive_catalog(&mut client, &request, "one-unit-readback").await;
+        assert!(response.is_empty());
+        handle.shutdown().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_equal_timestamp_replacement_and_shutdown_are_deterministic() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([63; 32]).unwrap();
+        let config = test_config(
+            directory.path().join("concurrent.sqlite"),
+            *publisher.public_key(),
+        );
+        let handle = start(config).await.unwrap();
+        let now = now_unix().unwrap();
+        let events = (1u8..=8)
+            .map(|randomness| {
+                signed_entry(
+                    &publisher,
+                    [0x71; 32],
+                    u64::from(randomness),
+                    now - 1,
+                    now,
+                    randomness,
+                )
+            })
+            .collect::<Vec<_>>();
+        let unique_ids = events
+            .iter()
+            .map(|event| *event.id())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(unique_ids.len(), events.len());
+        let expected = events.iter().map(|event| *event.id()).min().unwrap();
+
+        let mut clients = Vec::new();
+        for _ in &events {
+            clients.push(connect(&handle).await);
+        }
+        let tasks = clients
+            .into_iter()
+            .zip(events)
+            .map(|(mut client, event)| {
+                tokio::spawn(async move {
+                    let outcome = publish(&mut client, &event).await;
+                    let _ = client.send(Message::Close(None)).await;
+                    outcome
+                })
+            })
+            .collect::<Vec<_>>();
+        for task in tasks {
+            let _ = task.await.unwrap();
+        }
+
+        let request =
+            String::from_utf8(catalog_req_json_v1(publisher.public_key(), 7).unwrap()).unwrap();
+        let mut reader = connect(&handle).await;
+        assert_eq!(
+            receive_catalog(&mut reader, &request, "bitcoinpir-directory-v1-shard-7").await,
+            vec![hex::encode(expected)]
+        );
+
+        tokio::time::timeout(Duration::from_secs(2), handle.shutdown())
+            .await
+            .expect("shutdown did not drain an idle open connection")
+            .unwrap();
+        expect_connection_failure(&mut reader).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn absolute_connection_timeout_closes_idle_socket() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([64; 32]).unwrap();
+        let mut config = test_config(
+            directory.path().join("timeout.sqlite"),
+            *publisher.public_key(),
+        );
+        config.connection_timeout = Duration::from_millis(50);
+        let handle = start(config).await.unwrap();
+        let mut client = connect(&handle).await;
+        expect_connection_failure(&mut client).await;
+        handle.shutdown().await.unwrap();
+    }
+}

--- a/apps/directory-relay/src/server.rs
+++ b/apps/directory-relay/src/server.rs
@@ -441,7 +441,7 @@ async fn handle_connection(
         match message {
             ClientMessage::Event(event) => {
                 let event_id = *event.event.id();
-                let response = match ingest_operation(state.clone(), event, now).await {
+                let response = match ingest_operation(state.clone(), *event, now).await {
                     Ok(IngestDisposition::Saved) => {
                         ok_message(&event_id, true, "saved: durable commit complete")
                     }

--- a/apps/directory-relay/src/store.rs
+++ b/apps/directory-relay/src/store.rs
@@ -1,0 +1,1383 @@
+//! Owner-only SQLite archive and addressable-head store.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use pir_directory_nostr::{
+    nip01_addressable_replacement_order_v1, NostrEventV1, BITCOINPIR_DIRECTORY_KIND_V1,
+    DIRECTORY_SHARD_COUNT_V1,
+};
+use pir_private_files::{
+    checked_existing_private_file_v1, create_new_private_file_v1, sync_private_file_and_parent_v1,
+    PrivateFileIdentityV1, PrivateFileModeV1,
+};
+use rusqlite::{
+    params, params_from_iter, Connection, InterruptHandle, OpenFlags, OptionalExtension,
+    Transaction, TransactionBehavior,
+};
+
+use crate::wire::{
+    validate_current_event_profile, validate_event_json, DirectoryEventProfile, RequestFilter,
+    ValidatedEvent, MAX_CATALOG_EVENTS_PER_SHARD, MAX_DIRECTORY_ENTRIES_PER_SHARD,
+    MAX_SNAPSHOT_PAGE_BYTES,
+};
+
+const APPLICATION_ID: i64 = 0x4250_4452; // "BPDR"
+const SCHEMA_VERSION: i64 = 1;
+const PROFILE_NAME: &str = "bitcoinpir-directory-profile-v1";
+const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
+const SCHEMA: &str = r#"
+CREATE TABLE metadata (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    profile TEXT NOT NULL,
+    directory_pubkey BLOB NOT NULL CHECK (length(directory_pubkey) = 32),
+    max_archive_events INTEGER NOT NULL CHECK (max_archive_events > 0),
+    max_archive_bytes INTEGER NOT NULL CHECK (max_archive_bytes > 0),
+    archive_event_count INTEGER NOT NULL CHECK (archive_event_count >= 0),
+    archive_bytes INTEGER NOT NULL CHECK (archive_bytes >= 0),
+    created_at INTEGER NOT NULL CHECK (created_at > 0)
+) STRICT;
+CREATE TABLE events (
+    event_id BLOB PRIMARY KEY CHECK (length(event_id) = 32),
+    pubkey BLOB NOT NULL CHECK (length(pubkey) = 32),
+    kind INTEGER NOT NULL CHECK (kind = 30078),
+    created_at INTEGER NOT NULL CHECK (created_at > 0),
+    d_tag TEXT NOT NULL CHECK (length(d_tag) BETWEEN 1 AND 255),
+    s_tag TEXT NOT NULL CHECK (length(s_tag) BETWEEN 1 AND 128),
+    shard INTEGER NOT NULL CHECK (shard BETWEEN 0 AND 15),
+    profile INTEGER NOT NULL CHECK (profile IN (1, 2)),
+    event_json BLOB NOT NULL CHECK (length(event_json) BETWEEN 1 AND 262144),
+    received_at INTEGER NOT NULL CHECK (received_at > 0)
+) STRICT;
+CREATE TABLE address_heads (
+    pubkey BLOB NOT NULL CHECK (length(pubkey) = 32),
+    kind INTEGER NOT NULL CHECK (kind = 30078),
+    d_tag TEXT NOT NULL CHECK (length(d_tag) BETWEEN 1 AND 255),
+    event_id BLOB NOT NULL UNIQUE CHECK (length(event_id) = 32),
+    PRIMARY KEY (pubkey, kind, d_tag),
+    FOREIGN KEY (event_id) REFERENCES events(event_id) ON DELETE RESTRICT
+) STRICT;
+CREATE INDEX events_shard_order ON events(shard, d_tag, event_id);
+CREATE INDEX events_coordinate_order ON events(pubkey, kind, d_tag, created_at, event_id);
+"#;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum IngestDisposition {
+    Saved,
+    Duplicate,
+    ReplacedByNewer,
+    ShardCapacityExceeded,
+    ArchiveCapacityExceeded,
+    InvalidCurrentEvent,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StoreLimits {
+    pub max_archive_events: u64,
+    pub max_archive_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SnapshotPlan {
+    pub event_ids: Vec<[u8; 32]>,
+    pub event_json_bytes: u64,
+}
+
+pub struct DirectoryStore {
+    connection: Connection,
+    path: PathBuf,
+    sidecars: SidecarSnapshot,
+    pinned_directory_pubkey: [u8; 32],
+    limits: StoreLimits,
+}
+
+impl DirectoryStore {
+    pub fn open_or_create(
+        path: &Path,
+        pinned_directory_pubkey: [u8; 32],
+        limits: StoreLimits,
+        now_unix: u64,
+    ) -> Result<Self, String> {
+        if !path.is_absolute() {
+            return Err("directory relay database path must be absolute".to_owned());
+        }
+        if pinned_directory_pubkey.iter().all(|byte| *byte == 0)
+            || now_unix == 0
+            || limits.max_archive_events == 0
+            || limits.max_archive_bytes == 0
+            || limits.max_archive_events > i64::MAX as u64
+            || limits.max_archive_bytes > i64::MAX as u64
+        {
+            return Err("directory relay key/time configuration is invalid".to_owned());
+        }
+        let create = match fs::symlink_metadata(path) {
+            Ok(_) => false,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
+            Err(error) => return Err(format!("inspect directory relay database failed: {error}")),
+        };
+        if create {
+            let file = create_new_private_file_v1(path, "directory relay SQLite database")?;
+            file.sync_all()
+                .map_err(|error| format!("sync new directory relay database failed: {error}"))?;
+            drop(file);
+        }
+        let checked_before = checked_existing_private_file_v1(
+            path,
+            PrivateFileModeV1::ReadWrite,
+            "directory relay SQLite database",
+        )?;
+        // The private-file walker returns the component-by-component checked
+        // path, including macOS' normalized `/private/var` root alias. Opening
+        // the caller spelling (normally `/var/...` for tempfile on macOS)
+        // with SQLITE_OPEN_NOFOLLOW would correctly reject that ancestor
+        // symlink. Reuse the already checked spelling so SQLite and every
+        // sidecar check refer to the same namespace without weakening
+        // NOFOLLOW.
+        let checked_path = checked_before.path().to_path_buf();
+        let sidecars_before = inspect_sidecars_at_path(&checked_path)?;
+
+        let flags = OpenFlags::SQLITE_OPEN_READ_WRITE
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_NOFOLLOW;
+        let connection = Connection::open_with_flags(&checked_path, flags)
+            .map_err(|error| format!("open directory relay SQLite database failed: {error}"))?;
+        configure_connection(&connection)?;
+        if create {
+            initialize_schema(&connection, &pinned_directory_pubkey, limits, now_unix)?;
+            sync_private_file_and_parent_v1(&checked_path, "directory relay SQLite database")?;
+        }
+        let checked_after = checked_existing_private_file_v1(
+            &checked_path,
+            PrivateFileModeV1::ReadWrite,
+            "directory relay SQLite database",
+        )?;
+        if checked_after.identity() != checked_before.identity() {
+            return Err("directory relay SQLite file changed while it was opened".to_owned());
+        }
+        let sidecars_after = inspect_sidecars_at_path(&checked_path)?;
+        validate_sidecar_open_transition(&sidecars_before, &sidecars_after)?;
+
+        let store = Self {
+            connection,
+            path: checked_path,
+            sidecars: sidecars_after,
+            pinned_directory_pubkey,
+            limits,
+        };
+        store.full_startup_validation()?;
+        store.validate_sidecars()?;
+        Ok(store)
+    }
+
+    pub fn interrupt_handle(&self) -> InterruptHandle {
+        self.connection.get_interrupt_handle()
+    }
+
+    pub fn ingest(
+        &mut self,
+        event: &ValidatedEvent,
+        received_at: u64,
+    ) -> Result<IngestDisposition, String> {
+        self.ingest_with_commit(event, received_at, |transaction| {
+            transaction.commit().map_err(|error| error.to_string())
+        })
+    }
+
+    fn ingest_with_commit<F>(
+        &mut self,
+        event: &ValidatedEvent,
+        received_at: u64,
+        commit: F,
+    ) -> Result<IngestDisposition, String>
+    where
+        F: FnOnce(Transaction<'_>) -> Result<(), String>,
+    {
+        self.validate_sidecars()?;
+        let transaction = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| format!("begin EVENT transaction failed: {error}"))?;
+
+        let existing: Option<Vec<u8>> = transaction
+            .query_row(
+                "SELECT event_json FROM events WHERE event_id = ?1",
+                params![event.event.id().as_slice()],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|error| format!("query duplicate EVENT failed: {error}"))?;
+        if let Some(existing) = existing {
+            if existing != event.canonical_json {
+                return Err("stored EVENT id maps to different bytes".to_owned());
+            }
+            commit(transaction)
+                .map_err(|error| format!("commit duplicate EVENT failed: {error}"))?;
+            return Ok(IngestDisposition::Duplicate);
+        }
+
+        if received_at == 0 || event.event.created_at() > received_at {
+            commit(transaction)
+                .map_err(|error| format!("commit invalid EVENT time decision failed: {error}"))?;
+            return Ok(IngestDisposition::InvalidCurrentEvent);
+        }
+        let created_at = i64::try_from(event.event.created_at())
+            .map_err(|_| "EVENT timestamp exceeds SQLite range".to_owned())?;
+        let received_at = i64::try_from(received_at)
+            .map_err(|_| "receive timestamp exceeds SQLite range".to_owned())?;
+
+        if validate_current_event_profile(event, &self.pinned_directory_pubkey, received_at as u64)
+            .is_err()
+        {
+            commit(transaction)
+                .map_err(|error| format!("commit invalid EVENT decision failed: {error}"))?;
+            return Ok(IngestDisposition::InvalidCurrentEvent);
+        }
+
+        let current_json: Option<Vec<u8>> = transaction
+            .query_row(
+                "SELECT e.event_json FROM address_heads h JOIN events e USING (event_id) \
+                 WHERE h.pubkey = ?1 AND h.kind = ?2 AND h.d_tag = ?3",
+                params![
+                    event.event.pubkey().as_slice(),
+                    i64::from(event.event.kind()),
+                    &event.d_tag
+                ],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|error| format!("query address head failed: {error}"))?;
+        let replacing = current_json.is_some();
+        if let Some(current_json) = current_json {
+            let current = validate_event_json(
+                &current_json,
+                &self.pinned_directory_pubkey,
+                event.event.created_at().max(1),
+            )
+            .or_else(|_| {
+                let parsed = NostrEventV1::parse_json(&current_json)
+                    .map_err(|error| format!("stored address head is invalid: {error}"))?;
+                validate_event_json(
+                    &current_json,
+                    &self.pinned_directory_pubkey,
+                    parsed.created_at(),
+                )
+            })?;
+            if nip01_addressable_replacement_order_v1(&event.event, &current.event)
+                .map_err(|error| format!("compare addressable EVENT failed: {error}"))?
+                != Ordering::Greater
+            {
+                commit(transaction)
+                    .map_err(|error| format!("commit replaced EVENT decision failed: {error}"))?;
+                return Ok(IngestDisposition::ReplacedByNewer);
+            }
+        }
+
+        if !replacing {
+            let head_count: i64 = transaction
+                .query_row(
+                    "SELECT COUNT(*) FROM address_heads h JOIN events e USING (event_id) \
+                     WHERE e.shard = ?1 AND e.profile = ?2",
+                    params![i64::from(event.shard), profile_code(event.profile)],
+                    |row| row.get(0),
+                )
+                .map_err(|error| format!("count shard heads failed: {error}"))?;
+            let capacity = match event.profile {
+                DirectoryEventProfile::Entry => MAX_DIRECTORY_ENTRIES_PER_SHARD,
+                DirectoryEventProfile::Checkpoint => 1,
+            };
+            if head_count >= capacity as i64 {
+                commit(transaction)
+                    .map_err(|error| format!("commit shard-capacity decision failed: {error}"))?;
+                return Ok(IngestDisposition::ShardCapacityExceeded);
+            }
+        }
+
+        let (archive_count, archive_bytes): (i64, i64) = transaction
+            .query_row(
+                "SELECT archive_event_count, archive_bytes FROM metadata WHERE singleton = 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .map_err(|error| format!("read archive capacity failed: {error}"))?;
+        let candidate_bytes = i64::try_from(event.canonical_json.len())
+            .map_err(|_| "EVENT length exceeds SQLite range".to_owned())?;
+        if archive_count >= self.limits.max_archive_events as i64
+            || archive_bytes
+                .checked_add(candidate_bytes)
+                .map_or(true, |total| total > self.limits.max_archive_bytes as i64)
+        {
+            commit(transaction)
+                .map_err(|error| format!("commit archive-capacity decision failed: {error}"))?;
+            return Ok(IngestDisposition::ArchiveCapacityExceeded);
+        }
+
+        transaction
+            .execute(
+                "INSERT INTO events \
+                 (event_id, pubkey, kind, created_at, d_tag, s_tag, shard, profile, event_json, received_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                params![
+                    event.event.id().as_slice(),
+                    event.event.pubkey().as_slice(),
+                    i64::from(event.event.kind()),
+                    created_at,
+                    &event.d_tag,
+                    &event.s_tag,
+                    i64::from(event.shard),
+                    profile_code(event.profile),
+                    &event.canonical_json,
+                    received_at,
+                ],
+            )
+            .map_err(|error| format!("archive EVENT failed: {error}"))?;
+        transaction
+            .execute(
+                "UPDATE metadata SET archive_event_count = archive_event_count + 1, \
+                 archive_bytes = archive_bytes + ?1 WHERE singleton = 1",
+                params![candidate_bytes],
+            )
+            .map_err(|error| format!("advance archive capacity counters failed: {error}"))?;
+        transaction
+            .execute(
+                "INSERT INTO address_heads (pubkey, kind, d_tag, event_id) VALUES (?1, ?2, ?3, ?4) \
+                 ON CONFLICT(pubkey, kind, d_tag) DO UPDATE SET event_id = excluded.event_id",
+                params![
+                    event.event.pubkey().as_slice(),
+                    i64::from(event.event.kind()),
+                    &event.d_tag,
+                    event.event.id().as_slice(),
+                ],
+            )
+            .map_err(|error| format!("advance address head failed: {error}"))?;
+        commit(transaction).map_err(|error| format!("commit EVENT failed: {error}"))?;
+        self.validate_sidecars()?;
+        Ok(IngestDisposition::Saved)
+    }
+
+    pub fn freeze_snapshot(&self, filter: &RequestFilter) -> Result<SnapshotPlan, String> {
+        self.validate_sidecars()?;
+        let result = match filter {
+            RequestFilter::Catalog { shard } => self.catalog_snapshot_ids(*shard),
+            RequestFilter::Ids(ids) => self.readback_snapshot_ids(ids),
+        };
+        self.validate_sidecars()?;
+        result
+    }
+
+    fn catalog_snapshot_ids(&self, shard: u8) -> Result<SnapshotPlan, String> {
+        if shard >= DIRECTORY_SHARD_COUNT_V1 {
+            return Err("catalog shard is invalid".to_owned());
+        }
+        let mut statement = self
+            .connection
+            .prepare(
+                "SELECT e.event_id, length(e.event_json) FROM address_heads h JOIN events e USING (event_id) \
+                 WHERE e.pubkey = ?1 AND e.kind = ?2 AND e.shard = ?3 \
+                 ORDER BY e.d_tag ASC, e.event_id ASC",
+            )
+            .map_err(|error| format!("prepare catalog snapshot failed: {error}"))?;
+        let mut rows = statement
+            .query(params![
+                self.pinned_directory_pubkey.as_slice(),
+                i64::from(BITCOINPIR_DIRECTORY_KIND_V1),
+                i64::from(shard)
+            ])
+            .map_err(|error| format!("query catalog snapshot failed: {error}"))?;
+        let mut event_ids = Vec::new();
+        let mut event_json_bytes = 0u64;
+        while let Some(row) = rows
+            .next()
+            .map_err(|error| format!("read catalog snapshot failed: {error}"))?
+        {
+            let event_id: Vec<u8> = row
+                .get(0)
+                .map_err(|error| format!("decode catalog snapshot failed: {error}"))?;
+            let event_bytes: i64 = row
+                .get(1)
+                .map_err(|error| format!("decode catalog event length failed: {error}"))?;
+            let event_bytes = u64::try_from(event_bytes)
+                .map_err(|_| "catalog snapshot contains an invalid event length".to_owned())?;
+            event_json_bytes = event_json_bytes
+                .checked_add(event_bytes)
+                .ok_or_else(|| "catalog snapshot byte count overflow".to_owned())?;
+            event_ids.push(
+                event_id
+                    .try_into()
+                    .map_err(|_| "catalog snapshot contains an invalid event id".to_owned())?,
+            );
+        }
+        if event_ids.len() > MAX_CATALOG_EVENTS_PER_SHARD {
+            return Err("catalog shard exceeds the protocol event bound".to_owned());
+        }
+        Ok(SnapshotPlan {
+            event_ids,
+            event_json_bytes,
+        })
+    }
+
+    fn readback_snapshot_ids(&self, ids: &[[u8; 32]]) -> Result<SnapshotPlan, String> {
+        if ids.is_empty() {
+            return Err("ID readback snapshot cannot be empty".to_owned());
+        }
+        let placeholders = std::iter::repeat("?")
+            .take(ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut statement = self
+            .connection
+            .prepare(&format!(
+                "SELECT event_id, length(event_json) FROM events WHERE event_id IN ({placeholders})"
+            ))
+            .map_err(|error| format!("prepare ID readback failed: {error}"))?;
+        let rows = statement
+            .query_map(
+                params_from_iter(ids.iter().map(|id| id.as_slice())),
+                |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .map_err(|error| format!("query ID readback failed: {error}"))?;
+        let mut lengths = HashMap::with_capacity(ids.len());
+        for row in rows {
+            let (event_id, event_bytes) =
+                row.map_err(|error| format!("decode ID readback failed: {error}"))?;
+            let event_id: [u8; 32] = event_id
+                .try_into()
+                .map_err(|_| "ID readback returned an invalid event id".to_owned())?;
+            let event_bytes = u64::try_from(event_bytes)
+                .map_err(|_| "readback event length is invalid".to_owned())?;
+            if lengths.insert(event_id, event_bytes).is_some() {
+                return Err("ID readback returned a duplicate event id".to_owned());
+            }
+        }
+
+        let mut found = Vec::with_capacity(lengths.len());
+        let mut event_json_bytes = 0u64;
+        for id in ids {
+            if let Some(event_bytes) = lengths.remove(id) {
+                event_json_bytes = event_json_bytes
+                    .checked_add(event_bytes)
+                    .ok_or_else(|| "readback snapshot byte count overflow".to_owned())?;
+                found.push(*id);
+            }
+        }
+        Ok(SnapshotPlan {
+            event_ids: found,
+            event_json_bytes,
+        })
+    }
+
+    pub fn load_snapshot_page(&self, ids: &[[u8; 32]]) -> Result<Vec<Vec<u8>>, String> {
+        self.validate_sidecars()?;
+        if ids.is_empty() || ids.len() > 8 {
+            return Err("snapshot page must contain 1..=8 immutable event ids".to_owned());
+        }
+        let mut statement = self
+            .connection
+            .prepare("SELECT event_json FROM events WHERE event_id = ?1")
+            .map_err(|error| format!("prepare snapshot page failed: {error}"))?;
+        let mut events = Vec::with_capacity(ids.len());
+        let mut bytes = 0usize;
+        for id in ids {
+            let event: Vec<u8> = statement
+                .query_row(params![id.as_slice()], |row| row.get(0))
+                .map_err(|error| format!("frozen snapshot EVENT disappeared: {error}"))?;
+            reserve_snapshot_event(&mut bytes, &event)?;
+            events.push(event);
+        }
+        self.validate_sidecars()?;
+        Ok(events)
+    }
+
+    fn full_startup_validation(&self) -> Result<(), String> {
+        validate_pragmas_and_schema(&self.connection)?;
+        let integrity_rows = {
+            let mut statement = self
+                .connection
+                .prepare("PRAGMA integrity_check")
+                .map_err(|error| format!("prepare integrity_check failed: {error}"))?;
+            let rows = statement
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(|error| format!("run integrity_check failed: {error}"))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| format!("read integrity_check failed: {error}"))?;
+            rows
+        };
+        if integrity_rows.as_slice() != ["ok"] {
+            return Err(format!(
+                "directory relay SQLite integrity_check failed: {}",
+                integrity_rows.join("; ")
+            ));
+        }
+        let foreign_violation: Option<i64> = self
+            .connection
+            .query_row(
+                "SELECT 1 FROM pragma_foreign_key_check LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|error| format!("run foreign_key_check failed: {error}"))?;
+        if foreign_violation.is_some() {
+            return Err("directory relay SQLite foreign_key_check failed".to_owned());
+        }
+        let metadata: Vec<(String, Vec<u8>, i64, i64, i64, i64)> = {
+            let mut statement = self
+                .connection
+                .prepare(
+                    "SELECT profile, directory_pubkey, max_archive_events, max_archive_bytes, \
+                     archive_event_count, archive_bytes \
+                     FROM metadata WHERE singleton = 1",
+                )
+                .map_err(|error| format!("prepare metadata validation failed: {error}"))?;
+            let rows = statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
+                })
+                .map_err(|error| format!("query metadata failed: {error}"))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| format!("read metadata failed: {error}"))?;
+            rows
+        };
+        if metadata.len() != 1
+            || metadata[0].0 != PROFILE_NAME
+            || metadata[0].1.as_slice() != self.pinned_directory_pubkey
+            || metadata[0].2 != self.limits.max_archive_events as i64
+            || metadata[0].3 != self.limits.max_archive_bytes as i64
+        {
+            return Err(
+                "directory relay profile/key metadata does not match configuration".to_owned(),
+            );
+        }
+
+        let mut winners = BTreeMap::<(Vec<u8>, u16, String), WinnerRecord>::new();
+        let mut archive_count = 0u64;
+        let mut archive_bytes = 0u64;
+        {
+            let mut statement = self
+                .connection
+                .prepare(
+                    "SELECT event_id, pubkey, kind, created_at, d_tag, s_tag, shard, profile, \
+                     event_json, received_at FROM events ORDER BY event_id",
+                )
+                .map_err(|error| format!("prepare archive validation failed: {error}"))?;
+            let mut rows = statement
+                .query([])
+                .map_err(|error| format!("query archive validation failed: {error}"))?;
+            while let Some(row) = rows
+                .next()
+                .map_err(|error| format!("read archive validation failed: {error}"))?
+            {
+                archive_count = archive_count
+                    .checked_add(1)
+                    .ok_or_else(|| "archive event count overflow".to_owned())?;
+                if archive_count > self.limits.max_archive_events {
+                    return Err("stored archive exceeds configured event capacity".to_owned());
+                }
+                let event_id: Vec<u8> = row
+                    .get(0)
+                    .map_err(|error| format!("decode archive event id failed: {error}"))?;
+                let pubkey: Vec<u8> = row
+                    .get(1)
+                    .map_err(|error| format!("decode archive pubkey failed: {error}"))?;
+                let kind: i64 = row
+                    .get(2)
+                    .map_err(|error| format!("decode archive kind failed: {error}"))?;
+                let created_at: i64 = row
+                    .get(3)
+                    .map_err(|error| format!("decode archive timestamp failed: {error}"))?;
+                let d_tag: String = row
+                    .get(4)
+                    .map_err(|error| format!("decode archive d tag failed: {error}"))?;
+                let s_tag: String = row
+                    .get(5)
+                    .map_err(|error| format!("decode archive s tag failed: {error}"))?;
+                let shard: i64 = row
+                    .get(6)
+                    .map_err(|error| format!("decode archive shard failed: {error}"))?;
+                let profile: i64 = row
+                    .get(7)
+                    .map_err(|error| format!("decode archive profile failed: {error}"))?;
+                let event_json: Vec<u8> = row
+                    .get(8)
+                    .map_err(|error| format!("decode archive event failed: {error}"))?;
+                let received_at: i64 = row
+                    .get(9)
+                    .map_err(|error| format!("decode archive receive time failed: {error}"))?;
+                archive_bytes = archive_bytes
+                    .checked_add(event_json.len() as u64)
+                    .ok_or_else(|| "archive byte count overflow".to_owned())?;
+                if archive_bytes > self.limits.max_archive_bytes {
+                    return Err("stored archive exceeds configured byte capacity".to_owned());
+                }
+
+                let parsed = NostrEventV1::parse_json(&event_json)
+                    .map_err(|error| format!("stored EVENT parse failed: {error}"))?;
+                let validated = validate_event_json(
+                    &event_json,
+                    &self.pinned_directory_pubkey,
+                    parsed.created_at(),
+                )?;
+                validate_current_event_profile(
+                    &validated,
+                    &self.pinned_directory_pubkey,
+                    parsed.created_at(),
+                )?;
+                if event_id.as_slice() != validated.event.id()
+                    || pubkey.as_slice() != validated.event.pubkey()
+                    || u16::try_from(kind).ok() != Some(validated.event.kind())
+                    || u64::try_from(created_at).ok() != Some(validated.event.created_at())
+                    || d_tag != validated.d_tag
+                    || s_tag != validated.s_tag
+                    || u8::try_from(shard).ok() != Some(validated.shard)
+                    || profile != profile_code(validated.profile)
+                    || received_at < created_at
+                {
+                    return Err("stored EVENT columns disagree with the signed event".to_owned());
+                }
+                let event_id: [u8; 32] = event_id
+                    .try_into()
+                    .map_err(|_| "stored EVENT id has the wrong length".to_owned())?;
+                let coordinate = (
+                    validated.event.pubkey().to_vec(),
+                    validated.event.kind(),
+                    validated.d_tag,
+                );
+                let candidate = WinnerRecord {
+                    event_id,
+                    created_at: validated.event.created_at(),
+                    shard: validated.shard,
+                    profile: validated.profile,
+                };
+                if let Some(current) = winners.get_mut(&coordinate) {
+                    if candidate.created_at > current.created_at
+                        || (candidate.created_at == current.created_at
+                            && candidate.event_id < current.event_id)
+                    {
+                        *current = candidate;
+                    }
+                } else {
+                    if winners.len()
+                        >= DIRECTORY_SHARD_COUNT_V1 as usize * MAX_CATALOG_EVENTS_PER_SHARD
+                    {
+                        return Err("archive contains too many addressable coordinates".to_owned());
+                    }
+                    winners.insert(coordinate, candidate);
+                }
+            }
+        }
+        if metadata[0].4 != archive_count as i64 || metadata[0].5 != archive_bytes as i64 {
+            return Err("archive capacity counters disagree with immutable rows".to_owned());
+        }
+
+        let mut entry_counts = [0usize; DIRECTORY_SHARD_COUNT_V1 as usize];
+        let mut checkpoint_counts = [0usize; DIRECTORY_SHARD_COUNT_V1 as usize];
+        let mut head_count = 0usize;
+        {
+            let mut statement = self
+                .connection
+                .prepare(
+                    "SELECT pubkey, kind, d_tag, event_id FROM address_heads \
+                     ORDER BY pubkey, kind, d_tag",
+                )
+                .map_err(|error| format!("prepare head validation failed: {error}"))?;
+            let mut rows = statement
+                .query([])
+                .map_err(|error| format!("query head validation failed: {error}"))?;
+            while let Some(row) = rows
+                .next()
+                .map_err(|error| format!("read head validation failed: {error}"))?
+            {
+                head_count += 1;
+                if head_count > DIRECTORY_SHARD_COUNT_V1 as usize * MAX_CATALOG_EVENTS_PER_SHARD {
+                    return Err("address head set exceeds the protocol bound".to_owned());
+                }
+                let pubkey: Vec<u8> = row
+                    .get(0)
+                    .map_err(|error| format!("decode head pubkey failed: {error}"))?;
+                let kind: i64 = row
+                    .get(1)
+                    .map_err(|error| format!("decode head kind failed: {error}"))?;
+                let d_tag: String = row
+                    .get(2)
+                    .map_err(|error| format!("decode head d tag failed: {error}"))?;
+                let event_id: Vec<u8> = row
+                    .get(3)
+                    .map_err(|error| format!("decode head event id failed: {error}"))?;
+                let coordinate = (
+                    pubkey,
+                    u16::try_from(kind).map_err(|_| "address head kind is invalid".to_owned())?,
+                    d_tag,
+                );
+                let winner = winners
+                    .remove(&coordinate)
+                    .ok_or_else(|| "address head has no matching archive coordinate".to_owned())?;
+                if event_id.as_slice() != winner.event_id {
+                    return Err("address head is not the winning archived EVENT".to_owned());
+                }
+                match winner.profile {
+                    DirectoryEventProfile::Entry => entry_counts[usize::from(winner.shard)] += 1,
+                    DirectoryEventProfile::Checkpoint => {
+                        checkpoint_counts[usize::from(winner.shard)] += 1
+                    }
+                }
+            }
+        }
+        if !winners.is_empty() {
+            return Err("address head set does not cover every archived coordinate".to_owned());
+        }
+        if entry_counts
+            .iter()
+            .any(|count| *count > MAX_DIRECTORY_ENTRIES_PER_SHARD)
+            || checkpoint_counts.iter().any(|count| *count > 1)
+        {
+            return Err("stored catalog shard exceeds the protocol bound".to_owned());
+        }
+        Ok(())
+    }
+
+    fn validate_sidecars(&self) -> Result<(), String> {
+        let current = inspect_sidecars_at_path(&self.path)?;
+        if current != self.sidecars {
+            return Err("directory relay SQLite sidecar identity changed while open".to_owned());
+        }
+        Ok(())
+    }
+}
+
+struct WinnerRecord {
+    event_id: [u8; 32],
+    created_at: u64,
+    shard: u8,
+    profile: DirectoryEventProfile,
+}
+
+fn configure_connection(connection: &Connection) -> Result<(), String> {
+    let journal: String = connection
+        .query_row("PRAGMA journal_mode = WAL", [], |row| row.get(0))
+        .map_err(|error| format!("enable SQLite WAL failed: {error}"))?;
+    if !journal.eq_ignore_ascii_case("wal") {
+        return Err("directory relay SQLite did not enter WAL mode".to_owned());
+    }
+    connection
+        .pragma_update(None, "synchronous", "FULL")
+        .and_then(|_| connection.pragma_update(None, "foreign_keys", true))
+        .and_then(|_| connection.pragma_update(None, "trusted_schema", false))
+        .and_then(|_| connection.pragma_update(None, "temp_store", "MEMORY"))
+        .and_then(|_| connection.busy_timeout(BUSY_TIMEOUT))
+        .map_err(|error| format!("configure directory relay SQLite failed: {error}"))?;
+    Ok(())
+}
+
+fn initialize_schema(
+    connection: &Connection,
+    directory_pubkey: &[u8; 32],
+    limits: StoreLimits,
+    now_unix: u64,
+) -> Result<(), String> {
+    connection
+        .execute_batch(&format!(
+            "BEGIN IMMEDIATE; PRAGMA application_id = {APPLICATION_ID}; \
+             PRAGMA user_version = {SCHEMA_VERSION}; {SCHEMA}"
+        ))
+        .map_err(|error| format!("create directory relay schema failed: {error}"))?;
+    connection
+        .execute(
+            "INSERT INTO metadata \
+             (singleton, profile, directory_pubkey, max_archive_events, max_archive_bytes, \
+              archive_event_count, archive_bytes, created_at) \
+             VALUES (1, ?1, ?2, ?3, ?4, 0, 0, ?5)",
+            params![
+                PROFILE_NAME,
+                directory_pubkey.as_slice(),
+                i64::try_from(limits.max_archive_events)
+                    .map_err(|_| "archive event limit exceeds SQLite range")?,
+                i64::try_from(limits.max_archive_bytes)
+                    .map_err(|_| "archive byte limit exceeds SQLite range")?,
+                i64::try_from(now_unix).map_err(|_| "metadata time exceeds SQLite range")?,
+            ],
+        )
+        .map_err(|error| format!("write directory relay metadata failed: {error}"))?;
+    connection
+        .execute_batch("COMMIT")
+        .map_err(|error| format!("commit directory relay schema failed: {error}"))?;
+    Ok(())
+}
+
+fn validate_pragmas_and_schema(connection: &Connection) -> Result<(), String> {
+    let application_id: i64 = connection
+        .query_row("PRAGMA application_id", [], |row| row.get(0))
+        .map_err(|error| format!("read application_id failed: {error}"))?;
+    let user_version: i64 = connection
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(|error| format!("read user_version failed: {error}"))?;
+    let synchronous: i64 = connection
+        .query_row("PRAGMA synchronous", [], |row| row.get(0))
+        .map_err(|error| format!("read synchronous failed: {error}"))?;
+    let foreign_keys: i64 = connection
+        .query_row("PRAGMA foreign_keys", [], |row| row.get(0))
+        .map_err(|error| format!("read foreign_keys failed: {error}"))?;
+    let trusted_schema: i64 = connection
+        .query_row("PRAGMA trusted_schema", [], |row| row.get(0))
+        .map_err(|error| format!("read trusted_schema failed: {error}"))?;
+    let journal: String = connection
+        .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+        .map_err(|error| format!("read journal_mode failed: {error}"))?;
+    if application_id != APPLICATION_ID
+        || user_version != SCHEMA_VERSION
+        || synchronous != 2
+        || foreign_keys != 1
+        || trusted_schema != 0
+        || !journal.eq_ignore_ascii_case("wal")
+    {
+        return Err("directory relay SQLite pragma/schema identity mismatch".to_owned());
+    }
+    let actual = schema_entries(connection)?;
+    let expected_connection = Connection::open_in_memory()
+        .map_err(|error| format!("open expected schema database failed: {error}"))?;
+    expected_connection
+        .execute_batch(SCHEMA)
+        .map_err(|error| format!("create expected directory schema failed: {error}"))?;
+    let expected = schema_entries(&expected_connection)?;
+    if actual != expected {
+        return Err("directory relay SQLite DDL differs from the exact v1 schema".to_owned());
+    }
+    Ok(())
+}
+
+fn schema_entries(connection: &Connection) -> Result<Vec<(String, String, String)>, String> {
+    let mut statement = connection
+        .prepare(
+            "SELECT type, name, sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' \
+             AND type IN ('table', 'index', 'view', 'trigger') AND sql IS NOT NULL \
+             ORDER BY type, name",
+        )
+        .map_err(|error| format!("prepare schema name validation failed: {error}"))?;
+    let entries = statement
+        .query_map([], |row| {
+            let sql: String = row.get(2)?;
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                sql.split_whitespace()
+                    .collect::<String>()
+                    .to_ascii_lowercase(),
+            ))
+        })
+        .map_err(|error| format!("query schema names failed: {error}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("read schema names failed: {error}"))?;
+    Ok(entries)
+}
+
+fn reserve_snapshot_event(total: &mut usize, event: &[u8]) -> Result<(), String> {
+    *total = total
+        .checked_add(event.len())
+        .ok_or_else(|| "snapshot byte count overflow".to_owned())?;
+    if *total > MAX_SNAPSHOT_PAGE_BYTES {
+        return Err("snapshot exceeds the bounded 2 MiB response profile".to_owned());
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SidecarSnapshot {
+    wal: Option<PrivateFileIdentityV1>,
+    shm: Option<PrivateFileIdentityV1>,
+}
+
+fn inspect_sidecars_at_path(database: &Path) -> Result<SidecarSnapshot, String> {
+    let mut identities = [None, None];
+    for (index, suffix) in ["-wal", "-shm"].into_iter().enumerate() {
+        let mut sidecar_name = database.as_os_str().to_os_string();
+        sidecar_name.push(suffix);
+        let path = PathBuf::from(sidecar_name);
+        match fs::symlink_metadata(&path) {
+            Ok(_) => {
+                identities[index] = Some(
+                    checked_existing_private_file_v1(
+                        &path,
+                        PrivateFileModeV1::ReadWrite,
+                        "directory relay SQLite sidecar",
+                    )?
+                    .identity(),
+                );
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "inspect directory relay SQLite sidecar failed: {error}"
+                ));
+            }
+        }
+    }
+    Ok(SidecarSnapshot {
+        wal: identities[0],
+        shm: identities[1],
+    })
+}
+
+fn validate_sidecar_open_transition(
+    before: &SidecarSnapshot,
+    after: &SidecarSnapshot,
+) -> Result<(), String> {
+    for (label, before, after) in [
+        ("WAL", before.wal, after.wal),
+        ("SHM", before.shm, after.shm),
+    ] {
+        if before.is_some() && before != after {
+            return Err(format!(
+                "directory relay SQLite {label} sidecar changed while database opened"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn profile_code(profile: DirectoryEventProfile) -> i64 {
+    match profile {
+        DirectoryEventProfile::Entry => 1,
+        DirectoryEventProfile::Checkpoint => 2,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+    use std::os::unix::fs::PermissionsExt;
+
+    use pir_directory_nostr::{
+        DirectoryCatalogCheckpointV1, DirectoryEntryV1, DirectoryHealthClassV1, DirectoryHealthV1,
+        DirectoryPublisherKeyV1,
+    };
+
+    const NOW: u64 = 2_000_000;
+
+    fn test_store(key: &[u8; 32]) -> (tempfile::TempDir, DirectoryStore) {
+        let directory = tempfile::tempdir().unwrap();
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let path = directory.path().join("relay.sqlite");
+        let store = DirectoryStore::open_or_create(
+            &path,
+            *key,
+            StoreLimits {
+                max_archive_events: 10_000,
+                max_archive_bytes: 64 * 1024 * 1024,
+            },
+            NOW,
+        )
+        .unwrap();
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        (directory, store)
+    }
+
+    fn event(
+        publisher: &DirectoryPublisherKeyV1,
+        provider: [u8; 32],
+        sequence: u64,
+        created_at: u64,
+        randomness: u8,
+    ) -> ValidatedEvent {
+        let entry = DirectoryEntryV1::new_tombstone(
+            provider,
+            sequence,
+            created_at + 10_000,
+            DirectoryHealthV1 {
+                class: DirectoryHealthClassV1::Unknown,
+                observed_bucket: created_at - (created_at % 300),
+            },
+            created_at,
+        )
+        .unwrap();
+        let signed = publisher
+            .sign_entry_event(&entry, created_at, &[randomness; 32])
+            .unwrap();
+        validate_event_json(
+            &signed.to_json_bytes().unwrap(),
+            publisher.public_key(),
+            NOW,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn replacement_duplicate_restart_and_superseded_readback() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([41; 32]).unwrap();
+        let (directory, mut store) = test_store(publisher.public_key());
+        let provider = [0x21; 32];
+        let first = event(&publisher, provider, 1, NOW - 20, 1);
+        let second = event(&publisher, provider, 2, NOW - 10, 2);
+        assert_eq!(store.ingest(&first, NOW).unwrap(), IngestDisposition::Saved);
+        let frozen_before_replacement = store
+            .freeze_snapshot(&RequestFilter::Catalog { shard: 2 })
+            .unwrap();
+        assert_eq!(frozen_before_replacement.event_ids, vec![*first.event.id()]);
+        assert_eq!(
+            store.ingest(&first, NOW).unwrap(),
+            IngestDisposition::Duplicate
+        );
+        assert_eq!(
+            store.ingest(&second, NOW).unwrap(),
+            IngestDisposition::Saved
+        );
+        assert_eq!(
+            store.ingest(&first, NOW).unwrap(),
+            IngestDisposition::Duplicate,
+            "superseded archive remains an idempotent positive duplicate"
+        );
+        let catalog = store
+            .freeze_snapshot(&RequestFilter::Catalog { shard: 2 })
+            .unwrap();
+        assert_eq!(catalog.event_ids, vec![*second.event.id()]);
+        let frozen_events = store
+            .load_snapshot_page(&frozen_before_replacement.event_ids)
+            .unwrap();
+        assert_eq!(frozen_events, vec![first.canonical_json.clone()]);
+        let readback = store
+            .freeze_snapshot(&RequestFilter::Ids(vec![
+                *first.event.id(),
+                *second.event.id(),
+            ]))
+            .unwrap();
+        assert_eq!(readback.event_ids.len(), 2);
+        assert_eq!(
+            store.load_snapshot_page(&readback.event_ids).unwrap().len(),
+            2
+        );
+        let path = directory.path().join("relay.sqlite");
+        drop(store);
+        DirectoryStore::open_or_create(
+            &path,
+            *publisher.public_key(),
+            StoreLimits {
+                max_archive_events: 10_000,
+                max_archive_bytes: 64 * 1024 * 1024,
+            },
+            NOW,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn commit_failure_never_persists_event() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([42; 32]).unwrap();
+        let (directory, mut store) = test_store(publisher.public_key());
+        let candidate = event(&publisher, [0x31; 32], 1, NOW - 1, 3);
+        let result = store.ingest_with_commit(&candidate, NOW, |_transaction| {
+            Err("injected commit failure".to_owned())
+        });
+        assert!(result.is_err());
+        assert!(store
+            .freeze_snapshot(&RequestFilter::Ids(vec![*candidate.event.id()]))
+            .unwrap()
+            .event_ids
+            .is_empty());
+        let path = directory.path().join("relay.sqlite");
+        drop(store);
+        let reopened = DirectoryStore::open_or_create(
+            &path,
+            *publisher.public_key(),
+            StoreLimits {
+                max_archive_events: 10_000,
+                max_archive_bytes: 64 * 1024 * 1024,
+            },
+            NOW,
+        )
+        .unwrap();
+        assert!(reopened
+            .freeze_snapshot(&RequestFilter::Ids(vec![*candidate.event.id()]))
+            .unwrap()
+            .event_ids
+            .is_empty());
+    }
+
+    #[test]
+    fn equal_timestamp_lower_event_id_wins() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([43; 32]).unwrap();
+        let (_directory, mut store) = test_store(publisher.public_key());
+        let a = event(&publisher, [0x41; 32], 1, NOW - 1, 4);
+        // Schnorr auxiliary randomness changes only the signature, while a
+        // Nostr event ID excludes the signature. Vary signed content as well
+        // so this genuinely exercises NIP-01's equal-timestamp event-ID
+        // tiebreak rather than the same ID with non-canonical alternate bytes.
+        let b = event(&publisher, [0x41; 32], 2, NOW - 1, 5);
+        assert_ne!(a.event.id(), b.event.id());
+        let (lower, higher) = if a.event.id() < b.event.id() {
+            (a, b)
+        } else {
+            (b, a)
+        };
+        assert_eq!(
+            store.ingest(&higher, NOW).unwrap(),
+            IngestDisposition::Saved
+        );
+        assert_eq!(store.ingest(&lower, NOW).unwrap(), IngestDisposition::Saved);
+        assert_eq!(
+            store.ingest(&higher, NOW).unwrap(),
+            IngestDisposition::Duplicate
+        );
+        let snapshot = store
+            .freeze_snapshot(&RequestFilter::Catalog { shard: 4 })
+            .unwrap();
+        assert_eq!(snapshot.event_ids, vec![*lower.event.id()]);
+    }
+
+    #[test]
+    fn wrong_key_fails_restart() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([44; 32]).unwrap();
+        let wrong = DirectoryPublisherKeyV1::from_secret_bytes([45; 32]).unwrap();
+        let (directory, store) = test_store(publisher.public_key());
+        let path = directory.path().join("relay.sqlite");
+        drop(store);
+        assert!(DirectoryStore::open_or_create(
+            &path,
+            *wrong.public_key(),
+            StoreLimits {
+                max_archive_events: 10_000,
+                max_archive_bytes: 64 * 1024 * 1024,
+            },
+            NOW,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn expired_and_superseded_exact_duplicate_remains_idempotent() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([46; 32]).unwrap();
+        let (directory, mut store) = test_store(publisher.public_key());
+        let first = event(&publisher, [0x51; 32], 1, NOW - 20, 7);
+        let second = event(&publisher, [0x51; 32], 2, NOW - 10, 8);
+        assert_eq!(store.ingest(&first, NOW).unwrap(), IngestDisposition::Saved);
+        assert_eq!(
+            store.ingest(&second, NOW).unwrap(),
+            IngestDisposition::Saved
+        );
+        assert_eq!(
+            store.ingest(&first, first.event.created_at() - 1).unwrap(),
+            IngestDisposition::Duplicate
+        );
+        assert_eq!(
+            store.ingest(&first, NOW + 20_000).unwrap(),
+            IngestDisposition::Duplicate
+        );
+        let expired_new = event(&publisher, [0x52; 32], 1, NOW - 20, 9);
+        assert_eq!(
+            store.ingest(&expired_new, NOW + 20_000).unwrap(),
+            IngestDisposition::InvalidCurrentEvent
+        );
+        assert!(store
+            .freeze_snapshot(&RequestFilter::Ids(vec![*expired_new.event.id()]))
+            .unwrap()
+            .event_ids
+            .is_empty());
+        let path = directory.path().join("relay.sqlite");
+        drop(store);
+        let mut reopened = DirectoryStore::open_or_create(
+            &path,
+            *publisher.public_key(),
+            StoreLimits {
+                max_archive_events: 10_000,
+                max_archive_bytes: 64 * 1024 * 1024,
+            },
+            NOW + 20_000,
+        )
+        .unwrap();
+        assert_eq!(
+            reopened.ingest(&first, NOW + 20_000).unwrap(),
+            IngestDisposition::Duplicate,
+            "restart and natural expiry cannot invalidate a durable duplicate"
+        );
+    }
+
+    #[test]
+    fn archive_capacity_is_atomic_and_never_evicts_frozen_ids() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([47; 32]).unwrap();
+        let first = event(&publisher, [0x61; 32], 1, NOW - 2, 10);
+        let second = event(&publisher, [0x62; 32], 1, NOW - 1, 11);
+        let directory = tempfile::tempdir().unwrap();
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let path = directory.path().join("capacity.sqlite");
+        let limits = StoreLimits {
+            max_archive_events: 1,
+            max_archive_bytes: first.canonical_json.len() as u64,
+        };
+        let mut store =
+            DirectoryStore::open_or_create(&path, *publisher.public_key(), limits, NOW).unwrap();
+        assert_eq!(store.ingest(&first, NOW).unwrap(), IngestDisposition::Saved);
+        assert_eq!(
+            store.ingest(&second, NOW).unwrap(),
+            IngestDisposition::ArchiveCapacityExceeded
+        );
+        assert_eq!(
+            store
+                .freeze_snapshot(&RequestFilter::Ids(vec![
+                    *first.event.id(),
+                    *second.event.id()
+                ]))
+                .unwrap()
+                .event_ids,
+            vec![*first.event.id()]
+        );
+        drop(store);
+        DirectoryStore::open_or_create(&path, *publisher.public_key(), limits, NOW).unwrap();
+    }
+
+    #[test]
+    fn exact_schema_rejects_added_trigger_on_restart() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([48; 32]).unwrap();
+        let (directory, store) = test_store(publisher.public_key());
+        store
+            .connection
+            .execute_batch(
+                "CREATE TRIGGER forbidden_trigger AFTER INSERT ON events BEGIN SELECT 1; END;",
+            )
+            .unwrap();
+        let path = directory.path().join("relay.sqlite");
+        drop(store);
+        assert!(DirectoryStore::open_or_create(
+            &path,
+            *publisher.public_key(),
+            StoreLimits {
+                max_archive_events: 10_000,
+                max_archive_bytes: 64 * 1024 * 1024,
+            },
+            NOW,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn shard_supports_1024_entries_plus_one_checkpoint() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([49; 32]).unwrap();
+        let (_directory, mut store) = test_store(publisher.public_key());
+        let checkpoint =
+            DirectoryCatalogCheckpointV1::new(0, 1, NOW - 100, NOW + 1_000, vec![], NOW).unwrap();
+        let checkpoint = publisher
+            .sign_checkpoint_event(&checkpoint, NOW, &[12; 32])
+            .unwrap();
+        let checkpoint = validate_event_json(
+            &checkpoint.to_json_bytes().unwrap(),
+            publisher.public_key(),
+            NOW,
+        )
+        .unwrap();
+        assert_eq!(
+            store.ingest(&checkpoint, NOW).unwrap(),
+            IngestDisposition::Saved
+        );
+        for index in 0..MAX_DIRECTORY_ENTRIES_PER_SHARD {
+            let mut provider = [0_u8; 32];
+            provider[0] = 1;
+            provider[24..].copy_from_slice(&(index as u64).to_be_bytes());
+            let entry = event(&publisher, provider, 1, NOW - 1, index as u8);
+            assert_eq!(store.ingest(&entry, NOW).unwrap(), IngestDisposition::Saved);
+        }
+        let mut extra_provider = [0_u8; 32];
+        extra_provider[0] = 1;
+        extra_provider[24..]
+            .copy_from_slice(&(MAX_DIRECTORY_ENTRIES_PER_SHARD as u64).to_be_bytes());
+        let extra = event(&publisher, extra_provider, 1, NOW - 1, 13);
+        assert_eq!(
+            store.ingest(&extra, NOW).unwrap(),
+            IngestDisposition::ShardCapacityExceeded
+        );
+        assert_eq!(
+            store
+                .freeze_snapshot(&RequestFilter::Catalog { shard: 0 })
+                .unwrap()
+                .event_ids
+                .len(),
+            MAX_CATALOG_EVENTS_PER_SHARD
+        );
+    }
+
+    #[test]
+    fn sidecars_reject_broken_symlink_mode_hardlink_and_identity_change() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([50; 32]).unwrap();
+        let limits = StoreLimits {
+            max_archive_events: 10_000,
+            max_archive_bytes: 64 * 1024 * 1024,
+        };
+
+        let broken = tempfile::tempdir().unwrap();
+        fs::set_permissions(broken.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let broken_db = broken.path().join("broken.sqlite");
+        symlink(
+            broken.path().join("missing-target"),
+            broken.path().join("broken.sqlite-wal"),
+        )
+        .unwrap();
+        assert!(
+            DirectoryStore::open_or_create(&broken_db, *publisher.public_key(), limits, NOW)
+                .is_err()
+        );
+
+        let wrong_mode = tempfile::tempdir().unwrap();
+        fs::set_permissions(wrong_mode.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let wrong_mode_db = wrong_mode.path().join("mode.sqlite");
+        let wrong_mode_wal = wrong_mode.path().join("mode.sqlite-wal");
+        fs::write(&wrong_mode_wal, b"not-a-wal").unwrap();
+        fs::set_permissions(&wrong_mode_wal, fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(DirectoryStore::open_or_create(
+            &wrong_mode_db,
+            *publisher.public_key(),
+            limits,
+            NOW
+        )
+        .is_err());
+
+        let linked = tempfile::tempdir().unwrap();
+        fs::set_permissions(linked.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let linked_db = linked.path().join("linked.sqlite");
+        let linked_wal = linked.path().join("linked.sqlite-wal");
+        fs::write(&linked_wal, b"not-a-wal").unwrap();
+        fs::set_permissions(&linked_wal, fs::Permissions::from_mode(0o600)).unwrap();
+        fs::hard_link(&linked_wal, linked.path().join("second-link")).unwrap();
+        assert!(
+            DirectoryStore::open_or_create(&linked_db, *publisher.public_key(), limits, NOW)
+                .is_err()
+        );
+
+        let replaced = tempfile::tempdir().unwrap();
+        fs::set_permissions(replaced.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let replaced_db = replaced.path().join("replaced.sqlite");
+        let replaced_wal = replaced.path().join("replaced.sqlite-wal");
+        fs::write(&replaced_wal, b"first").unwrap();
+        fs::set_permissions(&replaced_wal, fs::Permissions::from_mode(0o600)).unwrap();
+        let before = inspect_sidecars_at_path(&replaced_db).unwrap();
+        let replacement = replaced.path().join("replacement");
+        fs::write(&replacement, b"second").unwrap();
+        fs::set_permissions(&replacement, fs::Permissions::from_mode(0o600)).unwrap();
+        fs::rename(replacement, &replaced_wal).unwrap();
+        let after = inspect_sidecars_at_path(&replaced_db).unwrap();
+        assert!(validate_sidecar_open_transition(&before, &after).is_err());
+    }
+
+    #[test]
+    fn live_sidecar_replacement_fails_before_snapshot_access() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([51; 32]).unwrap();
+        let (directory, store) = test_store(publisher.public_key());
+        assert!(store.sidecars.wal.is_some());
+        let wal = directory.path().join("relay.sqlite-wal");
+        let replacement = directory.path().join("replacement-wal");
+        fs::write(&replacement, b"replacement").unwrap();
+        fs::set_permissions(&replacement, fs::Permissions::from_mode(0o600)).unwrap();
+        fs::rename(replacement, wal).unwrap();
+        assert!(store
+            .freeze_snapshot(&RequestFilter::Catalog { shard: 0 })
+            .is_err());
+    }
+}

--- a/apps/directory-relay/src/wire.rs
+++ b/apps/directory-relay/src/wire.rs
@@ -45,7 +45,7 @@ pub enum RequestFilter {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ClientMessage {
-    Event(ValidatedEvent),
+    Event(Box<ValidatedEvent>),
     Req {
         subscription_id: String,
         filter: RequestFilter,
@@ -104,7 +104,7 @@ pub fn parse_client_message(
             {
                 return Err("EVENT envelope is not the exact canonical encoding".to_owned());
             }
-            Ok(ClientMessage::Event(event))
+            Ok(ClientMessage::Event(Box::new(event)))
         }
         "REQ" => {
             if values.len() != 3 {
@@ -292,7 +292,7 @@ fn parse_request_filter(
 
 fn parse_shard_tag(value: &str) -> Result<u8, String> {
     (0..DIRECTORY_SHARD_COUNT_V1)
-        .find(|shard| value == &shard_tag_value_v1(*shard))
+        .find(|shard| value == shard_tag_value_v1(*shard))
         .ok_or_else(|| "directory shard tag is not canonical".to_owned())
 }
 

--- a/apps/directory-relay/src/wire.rs
+++ b/apps/directory-relay/src/wire.rs
@@ -1,0 +1,518 @@
+//! Strict, bounded wire profile for the BitcoinPIR directory relay.
+
+use std::collections::BTreeSet;
+
+use pir_directory_nostr::{
+    shard_tag_value_v1, verify_directory_checkpoint_event_v1, verify_directory_entry_event_v1,
+    NostrEventV1, BITCOINPIR_DIRECTORY_KIND_V1, DIRECTORY_CHECKPOINT_D_PREFIX_V1,
+    DIRECTORY_ENTRY_D_PREFIX_V1, DIRECTORY_SHARD_COUNT_V1, MAX_NOSTR_EVENT_BYTES_V1,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+
+pub const MAX_WIRE_MESSAGE_BYTES: usize = 2 * 1024 * 1024;
+pub const MAX_EVENT_MESSAGE_BYTES: usize = MAX_NOSTR_EVENT_BYTES_V1 + 32;
+/// ID readback is a recovery/commit-probe facility, not a bulk archive scan.
+/// Catalog refresh uses the single-query shard filter below. Keeping this
+/// bound small prevents one unauthenticated REQ from monopolizing SQLite.
+pub const MAX_READBACK_IDS: usize = 64;
+pub const MAX_CATALOG_EVENTS_PER_SHARD: usize = 1_025;
+pub const MAX_DIRECTORY_ENTRIES_PER_SHARD: usize = 1_024;
+pub const MAX_SNAPSHOT_PAGE_BYTES: usize = 2 * 1024 * 1024;
+pub const MAX_SUBSCRIPTION_ID_BYTES: usize = 128;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DirectoryEventProfile {
+    Entry,
+    Checkpoint,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValidatedEvent {
+    pub event: NostrEventV1,
+    pub canonical_json: Vec<u8>,
+    pub d_tag: String,
+    pub s_tag: String,
+    pub shard: u8,
+    pub profile: DirectoryEventProfile,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RequestFilter {
+    Catalog { shard: u8 },
+    Ids(Vec<[u8; 32]>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ClientMessage {
+    Event(ValidatedEvent),
+    Req {
+        subscription_id: String,
+        filter: RequestFilter,
+    },
+    Close {
+        subscription_id: String,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogFilterWire {
+    authors: Vec<String>,
+    kinds: Vec<u16>,
+    #[serde(rename = "#s")]
+    shard: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct IdFilterWire {
+    ids: Vec<String>,
+}
+
+pub fn parse_client_message(
+    bytes: &[u8],
+    pinned_directory_pubkey: &[u8; 32],
+    now_unix: u64,
+) -> Result<ClientMessage, String> {
+    if bytes.is_empty() || bytes.len() > MAX_WIRE_MESSAGE_BYTES {
+        return Err("wire message exceeds the bounded profile".to_owned());
+    }
+    let values: Vec<Box<RawValue>> =
+        serde_json::from_slice(bytes).map_err(|_| "wire message is not strict JSON".to_owned())?;
+    let command: &str = values
+        .first()
+        .ok_or_else(|| "wire message is empty".to_owned())
+        .and_then(|value| {
+            serde_json::from_str(value.get()).map_err(|_| "wire command is not a string".to_owned())
+        })?;
+    match command {
+        "EVENT" => {
+            if values.len() != 2 || bytes.len() > MAX_EVENT_MESSAGE_BYTES {
+                return Err("EVENT must contain exactly one event object".to_owned());
+            }
+            let event = validate_event_json(
+                values[1].get().as_bytes(),
+                pinned_directory_pubkey,
+                now_unix,
+            )?;
+            if event
+                .event
+                .to_event_message_json_bytes()
+                .map_err(|_| "EVENT envelope canonicalization failed".to_owned())?
+                != bytes
+            {
+                return Err("EVENT envelope is not the exact canonical encoding".to_owned());
+            }
+            Ok(ClientMessage::Event(event))
+        }
+        "REQ" => {
+            if values.len() != 3 {
+                return Err("REQ must contain exactly one filter".to_owned());
+            }
+            let subscription_id: String = serde_json::from_str(values[1].get())
+                .map_err(|_| "REQ subscription id is not a string".to_owned())?;
+            validate_subscription_id(&subscription_id)?;
+            let filter = parse_request_filter(values[2].get(), pinned_directory_pubkey)?;
+            if canonical_req_message(&subscription_id, &filter, pinned_directory_pubkey)? != bytes {
+                return Err("REQ envelope is not the exact canonical encoding".to_owned());
+            }
+            Ok(ClientMessage::Req {
+                subscription_id,
+                filter,
+            })
+        }
+        "CLOSE" => {
+            if values.len() != 2 {
+                return Err("CLOSE must contain exactly one subscription id".to_owned());
+            }
+            let subscription_id: String = serde_json::from_str(values[1].get())
+                .map_err(|_| "CLOSE subscription id is not a string".to_owned())?;
+            validate_subscription_id(&subscription_id)?;
+            if serde_json::to_vec(&("CLOSE", &subscription_id))
+                .map_err(|_| "CLOSE canonicalization failed".to_owned())?
+                != bytes
+            {
+                return Err("CLOSE envelope is not the exact canonical encoding".to_owned());
+            }
+            Ok(ClientMessage::Close { subscription_id })
+        }
+        _ => Err("unsupported wire command".to_owned()),
+    }
+}
+
+fn canonical_req_message(
+    subscription_id: &str,
+    filter: &RequestFilter,
+    pinned_directory_pubkey: &[u8; 32],
+) -> Result<Vec<u8>, String> {
+    match filter {
+        RequestFilter::Catalog { shard } => serde_json::to_vec(&(
+            "REQ",
+            subscription_id,
+            CatalogFilterWire {
+                authors: vec![hex::encode(pinned_directory_pubkey)],
+                kinds: vec![BITCOINPIR_DIRECTORY_KIND_V1],
+                shard: vec![shard_tag_value_v1(*shard)],
+            },
+        )),
+        RequestFilter::Ids(ids) => serde_json::to_vec(&(
+            "REQ",
+            subscription_id,
+            IdFilterWire {
+                ids: ids.iter().map(hex::encode).collect(),
+            },
+        )),
+    }
+    .map_err(|_| "REQ canonicalization failed".to_owned())
+}
+
+pub fn validate_event_json(
+    event_json: &[u8],
+    pinned_directory_pubkey: &[u8; 32],
+    _now_unix: u64,
+) -> Result<ValidatedEvent, String> {
+    if event_json.is_empty() || event_json.len() > MAX_NOSTR_EVENT_BYTES_V1 {
+        return Err("EVENT object exceeds the directory event bound".to_owned());
+    }
+    let event = NostrEventV1::parse_json(event_json)
+        .map_err(|error| format!("EVENT object is invalid: {error}"))?;
+    event
+        .verify_for_directory_key(pinned_directory_pubkey)
+        .map_err(|error| format!("EVENT identity verification failed: {error}"))?;
+    let canonical_json = event
+        .to_json_bytes()
+        .map_err(|error| format!("EVENT canonical encoding failed: {error}"))?;
+    if canonical_json != event_json {
+        return Err("EVENT object is not the exact canonical encoding".to_owned());
+    }
+
+    let tags = event.tags();
+    if tags.len() != 2
+        || tags[0].len() != 2
+        || tags[0][0] != "d"
+        || tags[1].len() != 2
+        || tags[1][0] != "s"
+    {
+        return Err("EVENT does not have the exact ordered d/s profile".to_owned());
+    }
+    let d_tag = tags[0][1].clone();
+    let s_tag = tags[1][1].clone();
+    let shard = parse_shard_tag(&s_tag)?;
+    let profile = if let Some(provider_hex) = d_tag.strip_prefix(DIRECTORY_ENTRY_D_PREFIX_V1) {
+        let provider = decode_lower_hex_32(provider_hex, "entry d-tag provider")?;
+        if provider[0] >> 4 != shard {
+            return Err("entry EVENT d/s shards disagree".to_owned());
+        }
+        DirectoryEventProfile::Entry
+    } else if let Some(checkpoint_shard) = d_tag.strip_prefix(DIRECTORY_CHECKPOINT_D_PREFIX_V1) {
+        if checkpoint_shard.len() != 1
+            || char::from(checkpoint_shard.as_bytes()[0])
+                .to_digit(16)
+                .and_then(|value| u8::try_from(value).ok())
+                != Some(shard)
+            || checkpoint_shard.as_bytes()[0].is_ascii_uppercase()
+        {
+            return Err("checkpoint EVENT d/s shards disagree".to_owned());
+        }
+        DirectoryEventProfile::Checkpoint
+    } else {
+        return Err("EVENT has no BitcoinPIR directory d namespace".to_owned());
+    };
+    // Current content validity is deliberately deferred until the store has
+    // checked its immutable archive. This lets an expired exact duplicate be
+    // acknowledged idempotently without accepting a new expired event.
+    Ok(ValidatedEvent {
+        event,
+        canonical_json,
+        d_tag,
+        s_tag,
+        shard,
+        profile,
+    })
+}
+
+pub fn validate_current_event_profile(
+    event: &ValidatedEvent,
+    pinned_directory_pubkey: &[u8; 32],
+    now_unix: u64,
+) -> Result<(), String> {
+    let entry =
+        verify_directory_entry_event_v1(&event.canonical_json, pinned_directory_pubkey, now_unix);
+    let checkpoint = verify_directory_checkpoint_event_v1(
+        &event.canonical_json,
+        pinned_directory_pubkey,
+        now_unix,
+    );
+    match (event.profile, entry, checkpoint) {
+        (DirectoryEventProfile::Entry, Ok(_), Err(_))
+        | (DirectoryEventProfile::Checkpoint, Err(_), Ok(_)) => Ok(()),
+        _ => Err("EVENT is not one current BitcoinPIR directory profile event".to_owned()),
+    }
+}
+
+fn parse_request_filter(
+    raw: &str,
+    pinned_directory_pubkey: &[u8; 32],
+) -> Result<RequestFilter, String> {
+    if let Ok(filter) = serde_json::from_str::<CatalogFilterWire>(raw) {
+        if filter.authors.len() != 1
+            || filter.kinds.as_slice() != [BITCOINPIR_DIRECTORY_KIND_V1]
+            || filter.shard.len() != 1
+        {
+            return Err("catalog REQ has the wrong exact filter cardinality".to_owned());
+        }
+        let author = decode_lower_hex_32(&filter.authors[0], "catalog author")?;
+        if &author != pinned_directory_pubkey {
+            return Err("catalog REQ author does not match the directory key".to_owned());
+        }
+        return Ok(RequestFilter::Catalog {
+            shard: parse_shard_tag(&filter.shard[0])?,
+        });
+    }
+
+    let filter: IdFilterWire = serde_json::from_str(raw)
+        .map_err(|_| "REQ filter is outside the BitcoinPIR profile".to_owned())?;
+    if filter.ids.is_empty() || filter.ids.len() > MAX_READBACK_IDS {
+        return Err(format!(
+            "ID readback REQ must contain 1..={MAX_READBACK_IDS} ids"
+        ));
+    }
+    let mut unique = BTreeSet::new();
+    let mut ids = Vec::with_capacity(filter.ids.len());
+    for id in filter.ids {
+        let decoded = decode_lower_hex_32(&id, "readback event id")?;
+        if !unique.insert(decoded) {
+            return Err("ID readback REQ contains a duplicate id".to_owned());
+        }
+        ids.push(decoded);
+    }
+    Ok(RequestFilter::Ids(ids))
+}
+
+fn parse_shard_tag(value: &str) -> Result<u8, String> {
+    (0..DIRECTORY_SHARD_COUNT_V1)
+        .find(|shard| value == &shard_tag_value_v1(*shard))
+        .ok_or_else(|| "directory shard tag is not canonical".to_owned())
+}
+
+fn validate_subscription_id(value: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > MAX_SUBSCRIPTION_ID_BYTES
+        || value.chars().any(char::is_control)
+    {
+        return Err("subscription id is empty, oversized, or contains control text".to_owned());
+    }
+    Ok(())
+}
+
+fn decode_lower_hex_32(value: &str, label: &str) -> Result<[u8; 32], String> {
+    if value.len() != 64
+        || !value
+            .as_bytes()
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+    {
+        return Err(format!("{label} must be exact lowercase 32-byte hex"));
+    }
+    let bytes = hex::decode(value).map_err(|_| format!("{label} is invalid hex"))?;
+    bytes
+        .try_into()
+        .map_err(|_| format!("{label} has the wrong length"))
+}
+
+pub fn best_effort_event_id(bytes: &[u8]) -> Option<String> {
+    let values: Vec<Box<RawValue>> = serde_json::from_slice(bytes).ok()?;
+    if values.len() != 2 || values[0].get() != "\"EVENT\"" {
+        return None;
+    }
+    #[derive(Deserialize)]
+    struct EventId<'a> {
+        #[serde(borrow)]
+        id: &'a str,
+    }
+    let id = serde_json::from_str::<EventId<'_>>(values[1].get())
+        .ok()?
+        .id;
+    decode_lower_hex_32(id, "event id").ok()?;
+    Some(id.to_owned())
+}
+
+pub fn best_effort_subscription_id(bytes: &[u8]) -> Option<String> {
+    let values: Vec<Box<RawValue>> = serde_json::from_slice(bytes).ok()?;
+    if values.len() < 2 {
+        return None;
+    }
+    let command: &str = serde_json::from_str(values[0].get()).ok()?;
+    if command != "REQ" && command != "CLOSE" {
+        return None;
+    }
+    let id: String = serde_json::from_str(values[1].get()).ok()?;
+    validate_subscription_id(&id).ok()?;
+    Some(id)
+}
+
+pub fn ok_message(event_id: &[u8; 32], accepted: bool, reason: &str) -> String {
+    serde_json::to_string(&("OK", hex::encode(event_id), accepted, reason))
+        .expect("fixed OK message is serializable")
+}
+
+pub fn ok_message_hex(event_id: &str, accepted: bool, reason: &str) -> String {
+    serde_json::to_string(&("OK", event_id, accepted, reason))
+        .expect("fixed OK message is serializable")
+}
+
+pub fn event_message(subscription_id: &str, canonical_event_json: &[u8]) -> Result<String, String> {
+    let subscription = serde_json::to_string(subscription_id)
+        .map_err(|_| "serialize subscription id failed".to_owned())?;
+    let event = std::str::from_utf8(canonical_event_json)
+        .map_err(|_| "stored event is not UTF-8".to_owned())?;
+    let mut message = String::with_capacity(event.len() + subscription.len() + 16);
+    message.push_str("[\"EVENT\",");
+    message.push_str(&subscription);
+    message.push(',');
+    message.push_str(event);
+    message.push(']');
+    if message.len() > MAX_WIRE_MESSAGE_BYTES {
+        return Err("outbound EVENT exceeds the wire bound".to_owned());
+    }
+    Ok(message)
+}
+
+pub fn eose_message(subscription_id: &str) -> String {
+    serde_json::to_string(&("EOSE", subscription_id)).expect("fixed EOSE is serializable")
+}
+
+pub fn closed_message(subscription_id: &str, reason: &str) -> String {
+    serde_json::to_string(&("CLOSED", subscription_id, reason))
+        .expect("fixed CLOSED is serializable")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pir_directory_nostr::{
+        catalog_req_json_v1, DirectoryEntryV1, DirectoryHealthClassV1, DirectoryHealthV1,
+        DirectoryPublisherKeyV1,
+    };
+
+    const NOW: u64 = 1_800_000;
+
+    fn signed_event(publisher: &DirectoryPublisherKeyV1) -> NostrEventV1 {
+        let entry = DirectoryEntryV1::new_tombstone(
+            [0x21; 32],
+            1,
+            NOW + 10_000,
+            DirectoryHealthV1 {
+                class: DirectoryHealthClassV1::Unknown,
+                observed_bucket: NOW,
+            },
+            NOW,
+        )
+        .unwrap();
+        publisher.sign_entry_event(&entry, NOW, &[8; 32]).unwrap()
+    }
+
+    #[test]
+    fn readback_accepts_current_publish_bound_and_rejects_duplicate() {
+        let ids = (0..MAX_READBACK_IDS)
+            .map(|value| format!("{value:064x}"))
+            .collect::<Vec<_>>();
+        let wire = serde_json::json!(["REQ", "readback", {"ids": ids}]).to_string();
+        let parsed = parse_client_message(wire.as_bytes(), &[7; 32], 1).unwrap();
+        let ClientMessage::Req {
+            filter: RequestFilter::Ids(parsed),
+            ..
+        } = parsed
+        else {
+            panic!("wrong message");
+        };
+        assert_eq!(parsed.len(), MAX_READBACK_IDS);
+        assert!(wire.len() < MAX_WIRE_MESSAGE_BYTES);
+
+        let too_many = (0..=MAX_READBACK_IDS)
+            .map(|value| format!("{value:064x}"))
+            .collect::<Vec<_>>();
+        let too_many = serde_json::json!(["REQ", "readback", {"ids": too_many}]).to_string();
+        assert!(parse_client_message(too_many.as_bytes(), &[7; 32], 1).is_err());
+
+        let duplicate =
+            serde_json::json!(["REQ", "readback", {"ids": ["01".repeat(32), "01".repeat(32)]}])
+                .to_string();
+        assert!(parse_client_message(duplicate.as_bytes(), &[7; 32], 1).is_err());
+    }
+
+    #[test]
+    fn request_filters_are_exact() {
+        let key = [9; 32];
+        let valid = String::from_utf8(catalog_req_json_v1(&key, 10).unwrap()).unwrap();
+        assert!(matches!(
+            parse_client_message(valid.as_bytes(), &key, 1).unwrap(),
+            ClientMessage::Req {
+                filter: RequestFilter::Catalog { shard: 10 },
+                ..
+            }
+        ));
+        for extra in [
+            serde_json::json!(["REQ", "s", {"authors": [hex::encode(key)], "kinds": [30078], "#s": [shard_tag_value_v1(0)], "limit": 1}]),
+            serde_json::json!(["REQ", "s", {"ids": ["01".repeat(32)], "limit": 1}]),
+            serde_json::json!(["REQ", "s", {"ids": ["01"]}]),
+        ] {
+            assert!(parse_client_message(extra.to_string().as_bytes(), &key, 1).is_err());
+        }
+    }
+
+    #[test]
+    fn unknown_and_duplicate_filter_fields_are_rejected() {
+        let key = [3; 32];
+        let duplicate = format!(
+            r#"["REQ","s",{{"ids":["{}"],"ids":["{}"]}}]"#,
+            "01".repeat(32),
+            "02".repeat(32)
+        );
+        assert!(parse_client_message(duplicate.as_bytes(), &key, 1).is_err());
+    }
+
+    #[test]
+    fn event_requires_signature_key_kind_profile_and_exact_envelope() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([51; 32]).unwrap();
+        let wrong = DirectoryPublisherKeyV1::from_secret_bytes([52; 32]).unwrap();
+        let event = signed_event(&publisher);
+        let message = event.to_event_message_json_bytes().unwrap();
+        let parsed = parse_client_message(&message, publisher.public_key(), NOW).unwrap();
+        assert!(matches!(parsed, ClientMessage::Event(_)));
+        assert!(parse_client_message(&message, wrong.public_key(), NOW).is_err());
+
+        let mut whitespace = message.clone();
+        whitespace.push(b' ');
+        assert!(parse_client_message(&whitespace, publisher.public_key(), NOW).is_err());
+
+        let wrong_kind = String::from_utf8(message.clone())
+            .unwrap()
+            .replace("\"kind\":30078", "\"kind\":30079");
+        assert!(parse_client_message(wrong_kind.as_bytes(), publisher.public_key(), NOW).is_err());
+
+        let event_json = String::from_utf8(event.to_json_bytes().unwrap()).unwrap();
+        let duplicate_id = format!(
+            "{{\"id\":\"{}\",{}",
+            hex::encode(event.id()),
+            &event_json[1..]
+        );
+        let duplicate_id = format!("[\"EVENT\",{duplicate_id}]");
+        assert!(
+            parse_client_message(duplicate_id.as_bytes(), publisher.public_key(), NOW).is_err()
+        );
+    }
+
+    #[test]
+    fn wire_size_bounds_are_fail_closed() {
+        let oversized = vec![b' '; MAX_WIRE_MESSAGE_BYTES + 1];
+        assert!(parse_client_message(&oversized, &[7; 32], NOW).is_err());
+        let event_oversized = format!(
+            "[\"EVENT\",{{\"padding\":\"{}\"}}]",
+            "x".repeat(MAX_EVENT_MESSAGE_BYTES)
+        );
+        assert!(event_oversized.len() > MAX_EVENT_MESSAGE_BYTES);
+        assert!(parse_client_message(event_oversized.as_bytes(), &[7; 32], NOW).is_err());
+    }
+}

--- a/apps/payment-issuer/README.md
+++ b/apps/payment-issuer/README.md
@@ -10,7 +10,22 @@ that force debug assertions on. A feature-enabled artifact must never be
 deployed or used with real funds.
 
 Core Lightning support is exposed as the loopback-only `serve-cln` mode behind
-the checked `pir-lightning-backend` Unix-socket boundary. Production TLS, node
+the checked `pir-lightning-backend` Unix-socket boundary. The V1 shared-issuer
+HTTP settlement surface is ledger-accrual only: providers may use
+`POST /v1/redeems` and `POST /v1/settlement/balance`. Payout protocol, store and
+state-machine support remains transport-neutral; the default and production
+binaries return the same `not_found` response for payout-intent, payout and
+payout-status paths as for an unknown path, before parsing their payloads. Only
+the Rust unit suite has a private fixture switch for exercising the historical
+payout HTTP roundtrip. Production constructs the shared service with
+`new_ledger_only`; the transport-neutral payout methods themselves also return
+`NotFound` before decoding input or accessing the store. There is no production
+payout mode or target, fee, or intent-TTL flag. The store's legacy non-zero
+payout-target column receives one fixed domain-separated disabled sentinel,
+never operator or request input. The issuer settlement signing key remains
+required for redeem and balance signatures. Retained settlement verifying keys
+remain optional because exact committed redeem/approval replay after signing-key
+rotation also needs them; they are not payout-only keys. Production TLS, node
 custody, payout execution, real-funds activation and remote deployment remain
 separate approval gates.
 

--- a/apps/payment-issuer/src/main.rs
+++ b/apps/payment-issuer/src/main.rs
@@ -2,8 +2,11 @@
 //!
 //! The production `serve-cln` mode binds only to loopback, uses a locally owned
 //! Core Lightning Unix RPC socket, and is intended to sit behind a separately
-//! managed TLS edge. The deterministic `serve-fake` integration harness is
-//! absent unless a debug/test-only Cargo feature is explicitly enabled.
+//! managed TLS edge. Shared-issuer HTTP settlement is ledger-accrual only:
+//! providers may redeem credentials and read their balance, while payout stays
+//! behind the transport-neutral library/state-machine boundary. The
+//! deterministic `serve-fake` integration harness is absent unless a
+//! debug/test-only Cargo feature is explicitly enabled.
 
 #![forbid(unsafe_code)]
 
@@ -28,10 +31,12 @@ use pir_arc_adapter::{
 use pir_issuer_clearing::RedeemResponseDerivationKeyV1;
 use pir_issuer_core::{QuoteIdSourceErrorV1, QuoteIdSourceV1};
 use pir_issuer_credentials::IssuerCredentialDerivationKeyV1;
+#[cfg(test)]
+use pir_issuer_service::SettlementPayoutPolicyV1;
 use pir_issuer_service::{
     ensure_shared_clearing_binding_material_v1, IssuerAcquisitionServiceV1, IssuerServiceErrorV1,
-    QuoteSigningMaterialV1, ReceiptSigningMaterialV1, SettlementPayoutPolicyV1,
-    SharedIssuerClearingServiceV1, TrustedClearingProviderV1,
+    QuoteSigningMaterialV1, ReceiptSigningMaterialV1, SharedIssuerClearingServiceV1,
+    TrustedClearingProviderV1, LEDGER_ONLY_DISABLED_PAYOUT_TARGET_ID_V1,
 };
 use pir_issuer_store::{
     BatKeyLineageRegistration, IssuerRollbackFloorAuthorityV1, IssuerStore,
@@ -55,19 +60,22 @@ use pir_rollback_authority_client::load_remote_rollback_authority_deployment_for
 use pir_service_protocol::{
     AuthScheme, Bolt11QuoteClaimEnvelopeV1, Bolt11QuoteIntentV1, Bolt11QuoteKeyDelegationV1,
     IssuerClearingApprovalV1, LightningNetworkV1, ProviderClearingAuthorizationV1,
-    ProviderPayoutEnvelopeV1, ProviderPayoutIntentEnvelopeV1, ProviderPayoutStatusEnvelopeV1,
     ProviderRedeemEnvelopeV1, ServicePolicyV1, SettlementModesV1, SettlementUnitV1,
     MAX_BOLT11_QUOTE_CLAIM_ENVELOPE_LEN_V1, MAX_BOLT11_QUOTE_INTENT_LEN,
     MAX_BOLT11_QUOTE_KEY_DELEGATION_LEN, MAX_BOLT11_QUOTE_STATUS_REQUEST_LEN,
     MAX_CREDENTIAL_ISSUANCE_RESPONSE_LEN_V1, MAX_EXECUTABLE_SETTLEMENT_HTTP_ENVELOPE_LEN_V1,
     MAX_PROVIDER_REDEEM_ENVELOPE_LEN_V1,
 };
+#[cfg(test)]
+use pir_service_protocol::{
+    ProviderPayoutEnvelopeV1, ProviderPayoutIntentEnvelopeV1, ProviderPayoutStatusEnvelopeV1,
+};
 use zeroize::{Zeroize, Zeroizing};
 
 const MAX_HEADER_BYTES: usize = 16 * 1024;
 // The only 320 KiB settlement envelope is the 64-note deposit model, which
 // this executable does not serve. Keep the public listener capped by the
-// larger of the actually executable claim/redeem/ledger-only surfaces.
+// larger of the acquisition claim and production redeem/balance surfaces.
 const MAX_HTTP_BODY_BYTES: usize = MAX_BOLT11_QUOTE_CLAIM_ENVELOPE_LEN_V1;
 const _: () = assert!(MAX_PROVIDER_REDEEM_ENVELOPE_LEN_V1 <= MAX_HTTP_BODY_BYTES);
 const _: () = assert!(MAX_EXECUTABLE_SETTLEMENT_HTTP_ENVELOPE_LEN_V1 <= MAX_HTTP_BODY_BYTES);
@@ -97,14 +105,20 @@ const CT_REDEEM_RESULT: &str = "application/vnd.bitcoinpir.redeem-result-v1";
 const CT_FAKE_SETTLEMENT: &str = "application/vnd.bitcoinpir.fake-settlement-v1";
 const CT_BALANCE_ENVELOPE: &str = "application/vnd.bitcoinpir.provider-balance-envelope-v1";
 const CT_BALANCE_RESPONSE: &str = "application/vnd.bitcoinpir.issuer-balance-response-v1";
+#[cfg(test)]
 const CT_PAYOUT_INTENT_ENVELOPE: &str =
     "application/vnd.bitcoinpir.provider-payout-intent-envelope-v1";
+#[cfg(test)]
 const CT_PAYOUT_INTENT_RESPONSE: &str =
     "application/vnd.bitcoinpir.issuer-payout-intent-response-v1";
+#[cfg(test)]
 const CT_PAYOUT_ENVELOPE: &str = "application/vnd.bitcoinpir.provider-payout-envelope-v1";
+#[cfg(test)]
 const CT_PAYOUT_RESPONSE: &str = "application/vnd.bitcoinpir.issuer-payout-response-v1";
+#[cfg(test)]
 const CT_PAYOUT_STATUS_ENVELOPE: &str =
     "application/vnd.bitcoinpir.provider-payout-status-envelope-v1";
+#[cfg(test)]
 const CT_PAYOUT_STATUS_RESPONSE: &str =
     "application/vnd.bitcoinpir.issuer-payout-status-response-v1";
 
@@ -296,27 +310,17 @@ struct ServeCommonArgs {
     /// Repeat one matching issuer approval, in the same order as authorization.
     #[arg(long = "clearing-approval")]
     clearing_approvals: Vec<PathBuf>,
-    /// Repeat `<provider-id-hex>=<issuer-local-payout-target-id-hex>`.
-    #[arg(long = "clearing-payout-target")]
-    clearing_payout_targets: Vec<String>,
     /// Issuer Ed25519 settlement signing key; required when clearing is enabled.
     #[arg(long)]
     issuer_settlement_signing_key: Option<PathBuf>,
-    /// Repeat one retained raw Ed25519 settlement verifying key for recovery
-    /// of payouts accepted before a signing-key rotation.
+    /// Repeat one retained raw Ed25519 settlement verifying key for exact
+    /// recovery of committed redeem responses and approvals accepted before a
+    /// signing-key rotation.
     #[arg(long = "retained-issuer-settlement-verifying-key")]
     retained_issuer_settlement_verifying_keys: Vec<PathBuf>,
     /// Independent deterministic redeem-response derivation key.
     #[arg(long)]
     redeem_response_derivation_key: Option<PathBuf>,
-    /// Commercial issuer fee, in the authorization's settlement unit, quoted
-    /// only in newly signed provider payout intents.
-    #[arg(long)]
-    clearing_payout_fee: Option<u64>,
-    /// Validity of a newly signed payout intent. Required explicitly so
-    /// commercial policy is never inferred from credential entitlement.
-    #[arg(long)]
-    clearing_payout_intent_ttl_seconds: Option<u64>,
 }
 
 #[derive(Args, Debug)]
@@ -448,6 +452,10 @@ struct ServerState {
     mutation_rate: FixedWindowRateLimiterV1,
     #[cfg(test)]
     now_unix_override: Option<u64>,
+    /// Unit-test-only access to the transport-neutral payout state machine.
+    /// There is deliberately no CLI, feature, environment, or config analogue.
+    #[cfg(test)]
+    test_only_payout_http: bool,
 }
 
 impl core::fmt::Debug for ServerState {
@@ -670,6 +678,7 @@ fn is_exact_redeem_replay(store: &IssuerStore, canonical_envelope: &[u8]) -> boo
         .is_ok_and(|existing| existing.is_some())
 }
 
+#[cfg(test)]
 fn is_exact_payout_intent_replay(store: &IssuerStore, canonical_envelope: &[u8]) -> bool {
     let Ok(envelope) = ProviderPayoutIntentEnvelopeV1::decode(canonical_envelope) else {
         return false;
@@ -679,6 +688,7 @@ fn is_exact_payout_intent_replay(store: &IssuerStore, canonical_envelope: &[u8])
         .is_ok_and(|existing| existing.is_some())
 }
 
+#[cfg(test)]
 fn is_exact_payout_replay(store: &IssuerStore, canonical_envelope: &[u8]) -> bool {
     let Ok(envelope) = ProviderPayoutEnvelopeV1::decode(canonical_envelope) else {
         return false;
@@ -688,6 +698,7 @@ fn is_exact_payout_replay(store: &IssuerStore, canonical_envelope: &[u8]) -> boo
         .is_ok_and(|existing| existing.is_some())
 }
 
+#[cfg(test)]
 fn is_exact_payout_status_replay(store: &IssuerStore, canonical_envelope: &[u8]) -> bool {
     let Ok(envelope) = ProviderPayoutStatusEnvelopeV1::decode(canonical_envelope) else {
         return false;
@@ -1511,6 +1522,8 @@ fn serve_with_backend(
         mutation_rate,
         #[cfg(test)]
         now_unix_override: None,
+        #[cfg(test)]
+        test_only_payout_http: false,
     });
     let active = Arc::new(AtomicUsize::new(0));
     spawn_reconciliation_worker(Arc::clone(&state), reconciliation_config)?;
@@ -1726,11 +1739,11 @@ fn load_arc_keyring(specs: &[String]) -> Result<Option<Arc<ArcSecretKeyringV1>>,
         .map_err(|_| "experimental ARC keyring is invalid".to_owned())
 }
 
-/// Installs the local trust configuration for the shared issuer route used by
-/// provider servers.  The first executable surface deliberately supports only
-/// identified ledger credit.  Anonymous blind settlement is implemented in
-/// the transport-neutral service, but requires a separate retained-keyset
-/// operations ceremony before it can be enabled here.
+/// Installs the local trust configuration for the shared issuer routes used by
+/// provider servers. The V1 production HTTP surface deliberately supports only
+/// credential redeem and identified-ledger balance reads. Anonymous blind
+/// settlement and payout remain transport-neutral state machines until their
+/// separate operations and custody ceremonies are complete.
 fn load_ledger_clearing(
     args: &ServeCommonArgs,
     store: &IssuerStore,
@@ -1740,12 +1753,9 @@ fn load_ledger_clearing(
 ) -> Result<Option<SharedIssuerClearingServiceV1>, String> {
     let any_configured = !args.clearing_authorizations.is_empty()
         || !args.clearing_approvals.is_empty()
-        || !args.clearing_payout_targets.is_empty()
         || args.issuer_settlement_signing_key.is_some()
         || !args.retained_issuer_settlement_verifying_keys.is_empty()
-        || args.redeem_response_derivation_key.is_some()
-        || args.clearing_payout_fee.is_some()
-        || args.clearing_payout_intent_ttl_seconds.is_some();
+        || args.redeem_response_derivation_key.is_some();
     if !any_configured {
         return Ok(None);
     }
@@ -1765,15 +1775,6 @@ fn load_ledger_clearing(
         .redeem_response_derivation_key
         .as_deref()
         .ok_or_else(|| "clearing requires --redeem-response-derivation-key".to_owned())?;
-    let payout_fee = args
-        .clearing_payout_fee
-        .ok_or_else(|| "clearing requires explicit --clearing-payout-fee".to_owned())?;
-    let payout_intent_ttl_seconds = args.clearing_payout_intent_ttl_seconds.ok_or_else(|| {
-        "clearing requires explicit --clearing-payout-intent-ttl-seconds".to_owned()
-    })?;
-    let payout_policy = SettlementPayoutPolicyV1::new(payout_fee, payout_intent_ttl_seconds)
-        .map_err(|_| "clearing payout fee or intent TTL is outside V1 bounds".to_owned())?;
-
     let mut settlement_key_bytes =
         read_secret_exact::<32>(settlement_key_path, "issuer settlement signing key")?;
     let issuer_settlement_signing_key = SigningKey::from_bytes(&settlement_key_bytes);
@@ -1799,30 +1800,10 @@ fn load_ledger_clearing(
             .map_err(|_| "redeem response derivation key is invalid".to_owned())?;
     derivation_key_bytes.zeroize();
 
-    let mut payout_targets = BTreeMap::new();
-    for spec in &args.clearing_payout_targets {
-        let (provider_hex, target_hex) = spec.split_once('=').ok_or_else(|| {
-            "--clearing-payout-target must be <provider-id-hex>=<payout-target-id-hex>".to_owned()
-        })?;
-        let provider_id = decode_fixed_hex::<32>(provider_hex, "clearing provider ID")?;
-        let payout_target_id = decode_fixed_hex::<32>(target_hex, "clearing payout target ID")?;
-        if provider_id.iter().all(|byte| *byte == 0)
-            || payout_target_id.iter().all(|byte| *byte == 0)
-            || payout_targets
-                .insert(provider_id, payout_target_id)
-                .is_some()
-        {
-            return Err(
-                "clearing payout targets must be non-zero and unique per provider".to_owned(),
-            );
-        }
-    }
-
     struct PreparedClearingProvider {
         authorization: ProviderClearingAuthorizationV1,
         approval: IssuerClearingApprovalV1,
         operator_key: VerifyingKey,
-        payout_target_id: [u8; 32],
     }
 
     let identity = store
@@ -1920,18 +1901,18 @@ fn load_ledger_clearing(
                 "only one current clearing authorization per provider is allowed".to_owned(),
             );
         }
-        let payout_target_id = payout_targets
-            .remove(&provider_id)
-            .ok_or_else(|| "clearing provider has no configured payout target".to_owned())?;
         prepared.push(PreparedClearingProvider {
             authorization,
             approval,
             operator_key,
-            payout_target_id,
         });
     }
-    if !payout_targets.is_empty() {
-        return Err("clearing payout target has no matching authorization".to_owned());
+
+    if LEDGER_ONLY_DISABLED_PAYOUT_TARGET_ID_V1
+        .iter()
+        .all(|byte| *byte == 0)
+    {
+        return Err("ledger-only disabled payout-target sentinel is invalid".to_owned());
     }
 
     let mut trusted = Vec::with_capacity(prepared.len());
@@ -1943,7 +1924,11 @@ fn load_ledger_clearing(
                 provider_id: claims.provider_id,
                 settlement_account_id: claims.settlement_account_id,
                 provider_request_verifying_key: claims.clearing_verifying_key,
-                payout_target_id: provider.payout_target_id,
+                // The schema predates ledger-only mode and requires a non-zero
+                // target. Production has no target CLI: this domain-separated
+                // constant is a non-routable schema sentinel, never request
+                // input and never interpreted while the service is ledger-only.
+                payout_target_id: LEDGER_ONLY_DISABLED_PAYOUT_TARGET_ID_V1,
                 not_before: claims.not_before,
                 not_after: claims.not_after,
             })
@@ -1964,7 +1949,7 @@ fn load_ledger_clearing(
         });
     }
 
-    SharedIssuerClearingServiceV1::new(
+    SharedIssuerClearingServiceV1::new_ledger_only(
         store.clone(),
         trusted,
         bat_keyring,
@@ -1974,7 +1959,6 @@ fn load_ledger_clearing(
         None,
         Vec::new(),
         response_derivation_key,
-        payout_policy,
     )
     .map(Some)
     .map_err(|error| format!("build shared issuer clearing service failed: {error}"))
@@ -2109,6 +2093,19 @@ fn route_request(
     state: &ServerState,
     request: &ParsedRequest,
 ) -> Result<(&'static str, Vec<u8>), IssuerServiceErrorV1> {
+    // Payout is intentionally outside the production/default binary's HTTP
+    // product surface. Reject these paths exactly like any unknown path before
+    // reading the clock, checking content type, decoding/authenticating a body,
+    // taking a rate-limit token, or touching the issuer store. Unit tests may
+    // opt a fixture into the transport roundtrip through private state only.
+    #[cfg(test)]
+    let test_only_payout_http = state.test_only_payout_http;
+    #[cfg(not(test))]
+    let test_only_payout_http = false;
+    if is_payout_http_path_v1(&request.path) && !test_only_payout_http {
+        return Err(IssuerServiceErrorV1::NotFound);
+    }
+
     #[cfg(test)]
     let now_unix = state
         .now_unix_override
@@ -2176,6 +2173,7 @@ fn route_request(
                 .balance(&request.body, now_unix)
                 .map(|body| (CT_BALANCE_RESPONSE, body))
         }
+        #[cfg(test)]
         "/v1/settlement/payout-intents" => {
             require_executable_settlement_request(request, CT_PAYOUT_INTENT_ENVELOPE)?;
             if !is_exact_payout_intent_replay(&state.store, &request.body)
@@ -2190,6 +2188,7 @@ fn route_request(
                 .payout_intent(&request.body, now_unix)
                 .map(|body| (CT_PAYOUT_INTENT_RESPONSE, body))
         }
+        #[cfg(test)]
         "/v1/settlement/payouts" => {
             require_executable_settlement_request(request, CT_PAYOUT_ENVELOPE)?;
             if !is_exact_payout_replay(&state.store, &request.body)
@@ -2204,6 +2203,7 @@ fn route_request(
                 .payout(&request.body, now_unix)
                 .map(|body| (CT_PAYOUT_RESPONSE, body))
         }
+        #[cfg(test)]
         "/v1/settlement/payout-status" => {
             require_executable_settlement_request(request, CT_PAYOUT_STATUS_ENVELOPE)?;
             if !is_exact_payout_status_replay(&state.store, &request.body)
@@ -2286,6 +2286,13 @@ fn route_request(
             }
         }
     }
+}
+
+fn is_payout_http_path_v1(path: &str) -> bool {
+    matches!(
+        path,
+        "/v1/settlement/payout-intents" | "/v1/settlement/payouts" | "/v1/settlement/payout-status"
+    )
 }
 
 fn require_content_type(
@@ -3064,6 +3071,18 @@ mod tests {
         }
 
         fn state(&self, now_unix_override: u64) -> Arc<ServerState> {
+            self.state_with_payout_http(now_unix_override, false)
+        }
+
+        fn state_with_test_only_payout_http(&self, now_unix_override: u64) -> Arc<ServerState> {
+            self.state_with_payout_http(now_unix_override, true)
+        }
+
+        fn state_with_payout_http(
+            &self,
+            now_unix_override: u64,
+            test_only_payout_http: bool,
+        ) -> Arc<ServerState> {
             let rollback = Arc::new(
                 SqliteIssuerRollbackFloorAuthorityV1::open_existing(
                     &self.rollback_path,
@@ -3152,14 +3171,72 @@ mod tests {
                 mutation_rate: FixedWindowRateLimiterV1::new(100, "settlement HTTP mutation rate")
                     .expect("settlement HTTP mutation rate"),
                 now_unix_override: Some(now_unix_override),
+                test_only_payout_http,
             })
         }
     }
 
     #[test]
-    fn shared_issuer_settlement_http_roundtrip_restarts_and_replays_after_expiry() {
+    fn payout_http_routes_are_unknown_and_side_effect_free_by_default() {
         let fixture = SettlementHttpFixture::new();
         let state = fixture.state(fixture.now_unix);
+        let balance_before = state
+            .store
+            .provider_ledger_balance(&SETTLEMENT_HTTP_PROVIDER_ID)
+            .expect("read provider balance before rejected payout HTTP requests");
+        let inventory_before = state
+            .store
+            .operational_inventory()
+            .expect("read issuer inventory before rejected payout HTTP requests");
+
+        let unknown_response = http_exchange(
+            Arc::clone(&state),
+            "POST",
+            "/v1/settlement/not-a-route",
+            None,
+            "application/octet-stream",
+            b"not-a-canonical-or-authenticated-envelope",
+        );
+        assert_eq!(unknown_response.0, 404);
+
+        for (path, content_type) in [
+            ("/v1/settlement/payout-intents", None),
+            ("/v1/settlement/payouts", Some("application/octet-stream")),
+            (
+                "/v1/settlement/payout-status",
+                Some(CT_PAYOUT_STATUS_ENVELOPE),
+            ),
+        ] {
+            let response = http_exchange(
+                Arc::clone(&state),
+                "POST",
+                path,
+                content_type,
+                "application/octet-stream",
+                b"not-a-canonical-or-authenticated-envelope",
+            );
+            assert_eq!(
+                response, unknown_response,
+                "disabled payout path must be indistinguishable from an unknown path"
+            );
+        }
+
+        let balance_after = state
+            .store
+            .provider_ledger_balance(&SETTLEMENT_HTTP_PROVIDER_ID)
+            .expect("read provider balance after rejected payout HTTP requests");
+        let inventory_after = state
+            .store
+            .operational_inventory()
+            .expect("read issuer inventory after rejected payout HTTP requests");
+        assert_eq!(balance_after, balance_before);
+        assert_eq!(inventory_after, inventory_before);
+    }
+
+    #[test]
+    fn test_only_shared_issuer_payout_http_roundtrip_restarts_and_replays_after_expiry() {
+        let fixture = SettlementHttpFixture::new();
+        let state = fixture.state_with_test_only_payout_http(fixture.now_unix);
         let oversized_ledger_envelope = [0; MAX_EXECUTABLE_SETTLEMENT_HTTP_ENVELOPE_LEN_V1 + 1];
         let (status, _, _) = http_exchange(
             Arc::clone(&state),
@@ -3399,7 +3476,7 @@ mod tests {
         // Reopen every service/store handle before the first status request.
         // This exercises the executable restart path rather than retaining an
         // in-memory payout typestate.
-        let restarted = fixture.state(fixture.now_unix + 5);
+        let restarted = fixture.state_with_test_only_payout_http(fixture.now_unix + 5);
         let registration = restarted
             .store
             .provider_settlement_registration(&SETTLEMENT_HTTP_PROVIDER_ID)
@@ -3461,7 +3538,7 @@ mod tests {
 
         // Exact durable bytes remain recoverable after authorization and
         // registration expiry; fresh reads/mutations remain fail-closed.
-        let expired = fixture.state(fixture.registration_not_after + 1);
+        let expired = fixture.state_with_test_only_payout_http(fixture.registration_not_after + 1);
         for (path, request_type, accept, body, expected) in [
             (
                 "/v1/redeems",
@@ -3802,6 +3879,41 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn production_cli_rejects_payout_configuration() {
+        for (flag, value) in [
+            ("--clearing-payout-target", "11=22"),
+            ("--clearing-payout-fee", "1"),
+            ("--clearing-payout-intent-ttl-seconds", "60"),
+        ] {
+            let mut args = vec![
+                "payment-issuer",
+                "serve-cln",
+                "--store",
+                "/tmp/issuer.sqlite",
+                "--rollback-authority",
+                "/tmp/rollback.sqlite",
+                "--allow-local-rollback-authority-dev",
+                "--quote-delegation",
+                "/tmp/delegation.bin",
+                "--quote-signing-key",
+                "/tmp/quote.key",
+                "--credential-derivation-key",
+                "/tmp/credential.key",
+                "--cln-rpc-socket",
+                "/tmp/lightning-rpc",
+                "--cln-rpc-expected-uid",
+                "501",
+            ];
+            args.extend([flag, value]);
+            assert!(
+                Cli::try_parse_from(args).is_err(),
+                "accepted removed {flag}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn cli_exposes_cln_mode_without_fake_secret_arguments() {
         let cli = Cli::try_parse_from([
             "payment-issuer",
@@ -3817,6 +3929,8 @@ mod tests {
             "/tmp/quote.key",
             "--credential-derivation-key",
             "/tmp/credential.key",
+            "--retained-issuer-settlement-verifying-key",
+            "/tmp/retained-settlement.pub",
             "--allow-experimental-arc",
             "--cln-rpc-socket",
             "/tmp/lightning-rpc",
@@ -3829,6 +3943,10 @@ mod tests {
         };
         assert_eq!(args.common.bind, "127.0.0.1:5610".parse().unwrap());
         assert!(args.common.allow_experimental_arc);
+        assert_eq!(
+            args.common.retained_issuer_settlement_verifying_keys,
+            vec![PathBuf::from("/tmp/retained-settlement.pub")]
+        );
         assert_eq!(args.cln_rpc_expected_uid, 501);
         assert_eq!(args.cln_rpc_timeout_seconds, 10);
         assert_eq!(
@@ -4286,6 +4404,7 @@ mod tests {
             mutation_rate: FixedWindowRateLimiterV1::new(100, "test mutation rate")
                 .expect("mutation rate"),
             now_unix_override: None,
+            test_only_payout_http: false,
         });
 
         let (status, content_type, current_delegation) = http_exchange(

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -63,6 +63,11 @@ remote-authority-process-e2e = ["pir-rollback-authority-client/test-only-webpki-
 # the mandatory leaf-SPKI pin remains signed Cashu-manifest data.
 # `pir-strict-https` independently compile-errors if this reaches a release build.
 standard-cashu-process-e2e = ["pir-strict-https/test-only-webpki-root"]
+# Non-default local process E2E for provider-to-shared-issuer clearing. Reuse
+# the exact Standard-Cashu private-root injection surface so `unified_server`
+# has only one test-only WebPKI escape hatch; `pir-strict-https` rejects that
+# hook in release builds.
+shared-issuer-process-e2e = ["standard-cashu-process-e2e"]
 # Privacy-dangerous query-detail logging for local tests only. The build script
 # rejects this feature outside Cargo's debug profile; normal dev/release
 # binaries do not compile or recognize its CLI switch.
@@ -107,6 +112,8 @@ bitcoinpir-oram = { git = "https://github.com/Bitcoin-PIR/oram.git", rev = "cd2c
 tempfile = "3"
 pir-sdk-client = { path = "../../crates/sdk/client" }
 pir-db-attest = { path = "../../crates/trust/db-attest" }
+pir-issuer-store = { path = "../../crates/payment/issuer-store" }
+pir-lightning-backend = { path = "../../crates/payment/lightning-backend" }
 arc = { git = "https://github.com/Bitcoin-PIR/arc.git", rev = "de6c1709eee0faa32985d5a452be11904ee95de4" }
 rand_chacha = "0.3"
 rollback-authority = { path = "../rollback-authority" }

--- a/apps/server/tests/payment_v1_shared_issuer_process_e2e.rs
+++ b/apps/server/tests/payment_v1_shared_issuer_process_e2e.rs
@@ -1,0 +1,1583 @@
+//! Shared-issuer real-process admission coverage.
+//!
+//! The paid provider is a real `unified_server` subprocess. Its signed clearing
+//! authorization selects a normal WebPKI HTTPS origin and an additional signed
+//! leaf-SPKI pin. A separate TLS-edge subprocess forwards only `/v1/redeems` to
+//! a real `payment-issuer` subprocess. The issuer's test-only fake Lightning
+//! backend is used only to satisfy no-funds startup; this test never creates or
+//! settles an invoice. The peer provider independently selects Free/Open.
+//!
+//! The private test CA hook is inherited from `standard-cashu-process-e2e`, so
+//! there is one test-only WebPKI injection surface and `pir-strict-https` keeps
+//! its release compile guard. All bearer/key fixtures are deterministic public
+//! test material. No public service, Lightning node, wallet, relay, or funds are
+//! contacted.
+
+#![cfg(all(unix, feature = "shared-issuer-process-e2e"))]
+
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use libdpf::Dpf;
+use pir_core::cuckoo::write_header_with_anchor;
+use pir_core::merkle::sha256;
+use pir_core::params::{CHUNK_PARAMS, INDEX_PARAMS};
+use pir_issuer_store::{
+    IssuerStore, SqliteIssuerRollbackFloorAuthorityV1, StoreOptions as IssuerStoreOptions,
+};
+use pir_lightning_backend::FakeLightningNodeV1;
+use pir_payment_crypto::{cashu_hash_to_curve_v1, K256CashuMintKeyringV1};
+use pir_runtime_core::protocol::{BatchQuery, Request, Response};
+use pir_sdk_client::attest::{attest_with_eph_binding, SevStatus};
+use pir_sdk_client::channel::{establish, SecureChannelTransport};
+use pir_sdk_client::{
+    dangerous_unpaired_authorize_service_operation_v1, fetch_verified_service_policy_v1,
+    AcceptedServicePolicyV1, PirTransport, ServicePolicyCheckpointV1, WsConnection,
+};
+use pir_service_protocol::{
+    derive_bat_key_id_v1, derive_issuer_id, derive_provider_id, AcquisitionMethod,
+    AuthPaddingClassV1, AuthScheme, AuthorizationProofV1, BackendId, BitcoinPirCashuBatProofV1,
+    Bolt11QuoteKeyDelegationV1, CredentialKeyBindingClaimsV1, CredentialKeyBindingV1,
+    CredentialUnitV1, DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1,
+    FreeAuthorizationProofV1, FreeModeV1, IssuerClearingApprovalV1, LightningNetworkV1,
+    OperationStartV1, PriceV1, PrivacyLeakageV1, ProviderClearingAuthorizationClaimsV1,
+    ProviderClearingAuthorizationV1, ServiceOfferV1, ServicePolicyV1, ServiceScopePolicyV1,
+    ServiceScopeV1, SettlementModesV1, SettlementRuleV1, SettlementUnitV1, VerificationMode,
+    WorkloadId,
+};
+use pir_service_store::{
+    ProviderStore, SqliteRollbackFloorAuthorityV1, StoreOptions as ProviderStoreOptions,
+};
+use rustls::pki_types::pem::PemObject as _;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::{ServerConfig, ServerConnection, StreamOwned};
+use std::env;
+use std::ffi::OsString;
+use std::fs::{self, File};
+use std::io::{self, Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const SHARED_OFFER_ID: u32 = 61;
+const FREE_OFFER_ID: u32 = 62;
+const OPERATION_PROFILE: u16 = 41;
+const ENTITLEMENT_PROFILE: u16 = 401;
+const TINY_BINS_PER_TABLE: usize = 128;
+const TEST_LEAF_SPKI_SHA256_HEX: &str =
+    "e91550521f8e17b21d99f7e00b99c08be1b1f31fe57772ac8f904ea50c6a609b";
+const TLS_EDGE_HELPER_MARKER: &str = "BITCOINPIR_TEST_ONLY_SHARED_ISSUER_TLS_EDGE_V1";
+const PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
+const TLS_IO_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_PROXY_HTTP_BYTES: usize = 128 * 1024;
+static SESSION_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProviderMethod {
+    SharedIssuerBat,
+    FreeOpen,
+}
+
+struct SharedProviderConfig {
+    authorization_path: PathBuf,
+    approval_path: PathBuf,
+    operator_verifying_key: VerifyingKey,
+    issuer_settlement_verifying_key: VerifyingKey,
+    clearing_key_path: PathBuf,
+    idempotency_key_path: PathBuf,
+    proof: BitcoinPirCashuBatProofV1,
+    account_id: [u8; 32],
+}
+
+struct ProviderFixture {
+    index: u8,
+    method: ProviderMethod,
+    provider_id: [u8; 32],
+    policy_signing_key: SigningKey,
+    policy_path: PathBuf,
+    store_path: PathBuf,
+    rollback_path: PathBuf,
+    scope_id: [u8; 32],
+    policy_digest: [u8; 32],
+    shared: Option<SharedProviderConfig>,
+}
+
+impl ProviderFixture {
+    fn proof(&self) -> AuthorizationProofV1 {
+        match self.method {
+            ProviderMethod::SharedIssuerBat => AuthorizationProofV1::BitcoinPirCashuBat(
+                self.shared
+                    .as_ref()
+                    .expect("shared provider config")
+                    .proof
+                    .clone(),
+            ),
+            ProviderMethod::FreeOpen => {
+                AuthorizationProofV1::Free(FreeAuthorizationProofV1::OpenBestEffort)
+            }
+        }
+    }
+
+    fn offer_id(&self) -> u32 {
+        match self.method {
+            ProviderMethod::SharedIssuerBat => SHARED_OFFER_ID,
+            ProviderMethod::FreeOpen => FREE_OFFER_ID,
+        }
+    }
+}
+
+struct IssuerMaterial {
+    binary: PathBuf,
+    issuer_id: [u8; 32],
+    issuer_root: SigningKey,
+    settlement_signing_key: SigningKey,
+    store_path: PathBuf,
+    rollback_path: PathBuf,
+    quote_delegation_path: PathBuf,
+    quote_signing_key_path: PathBuf,
+    credential_derivation_key_path: PathBuf,
+    bat_key_path: PathBuf,
+    fake_lightning_signing_key_path: PathBuf,
+    fake_lightning_derivation_seed_path: PathBuf,
+    issuer_settlement_signing_key_path: PathBuf,
+    redeem_response_derivation_key_path: PathBuf,
+    bat_keyring: Arc<K256CashuMintKeyringV1>,
+}
+
+struct ChildProcess {
+    label: String,
+    child: Child,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+}
+
+impl ChildProcess {
+    fn wait_until_listening(&mut self, port: u16) {
+        let deadline = Instant::now() + PROCESS_TIMEOUT;
+        loop {
+            if let Some(status) = self.child.try_wait().expect("poll child process") {
+                panic!(
+                    "{} exited before listening ({status})\nstdout:\n{}\nstderr:\n{}",
+                    self.label,
+                    read_log(&self.stdout_path),
+                    read_log(&self.stderr_path),
+                );
+            }
+            if TcpStream::connect_timeout(
+                &format!("127.0.0.1:{port}").parse().unwrap(),
+                Duration::from_millis(100),
+            )
+            .is_ok()
+            {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {}\nstdout:\n{}\nstderr:\n{}",
+                self.label,
+                read_log(&self.stdout_path),
+                read_log(&self.stderr_path),
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    fn stop(mut self) -> (String, String) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        (read_log(&self.stdout_path), read_log(&self.stderr_path))
+    }
+}
+
+impl Drop for ChildProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        if thread::panicking() {
+            eprintln!(
+                "{} logs after test failure\nstdout:\n{}\nstderr:\n{}",
+                self.label,
+                read_log(&self.stdout_path),
+                read_log(&self.stderr_path),
+            );
+        }
+    }
+}
+
+struct TlsMaterial {
+    root: PathBuf,
+    wrong_root: PathBuf,
+    certificate: PathBuf,
+    private_key: PathBuf,
+}
+
+#[test]
+#[ignore = "spawned only by shared_issuer_real_process_tls_e2e"]
+fn shared_issuer_tls_edge_subprocess() {
+    if env::var_os(TLS_EDGE_HELPER_MARKER).is_none() {
+        return;
+    }
+    let bind = required_env("BITCOINPIR_TEST_SHARED_ISSUER_EDGE_BIND")
+        .parse()
+        .expect("TLS edge bind address");
+    let upstream = required_env("BITCOINPIR_TEST_SHARED_ISSUER_UPSTREAM")
+        .parse()
+        .expect("TLS edge upstream address");
+    let certificate = fs::read(required_env("BITCOINPIR_TEST_SHARED_ISSUER_CERT"))
+        .expect("read TLS edge certificate");
+    let private_key = fs::read(required_env("BITCOINPIR_TEST_SHARED_ISSUER_KEY"))
+        .expect("read TLS edge private key");
+    let counter_path = PathBuf::from(required_env(
+        "BITCOINPIR_TEST_SHARED_ISSUER_FORWARD_COUNTER",
+    ));
+    serve_tls_edge(bind, upstream, &certificate, &private_key, &counter_path)
+        .expect("serve shared-issuer TLS edge");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn shared_issuer_real_process_tls_e2e() {
+    let root = tempfile::tempdir().expect("shared-issuer process test root");
+    chmod(root.path(), 0o700);
+    let (db_path, manifest_root) = write_tiny_manifest_database(root.path());
+    let tls = install_tls_material(root.path());
+
+    let issuer_port = unused_loopback_port();
+    let edge_port = distinct_unused_port(&[issuer_port]);
+    let offline_port = distinct_unused_port(&[issuer_port, edge_port]);
+    let redeem_endpoint = format!("https://localhost:{edge_port}");
+    let issuer = build_issuer_material(root.path(), unix_now());
+    let now = unix_now();
+
+    let paid = build_provider(
+        root.path(),
+        0,
+        ProviderMethod::SharedIssuerBat,
+        manifest_root,
+        &issuer,
+        &redeem_endpoint,
+        vec![test_leaf_spki_sha256()],
+        now,
+    );
+    let free = build_provider(
+        root.path(),
+        1,
+        ProviderMethod::FreeOpen,
+        manifest_root,
+        &issuer,
+        "",
+        Vec::new(),
+        now,
+    );
+    let wrong_ca = build_provider(
+        root.path(),
+        10,
+        ProviderMethod::SharedIssuerBat,
+        manifest_root,
+        &issuer,
+        &redeem_endpoint,
+        vec![test_leaf_spki_sha256()],
+        now,
+    );
+    let wrong_pin = build_provider(
+        root.path(),
+        11,
+        ProviderMethod::SharedIssuerBat,
+        manifest_root,
+        &issuer,
+        &redeem_endpoint,
+        vec![[0x5a; 32]],
+        now,
+    );
+    let offline = build_provider(
+        root.path(),
+        12,
+        ProviderMethod::SharedIssuerBat,
+        manifest_root,
+        &issuer,
+        &format!("https://localhost:{offline_port}"),
+        vec![test_leaf_spki_sha256()],
+        now,
+    );
+    // The negative providers must fail at TLS trust or connect time before an
+    // issuer request exists, so the real issuer registers only the paid
+    // provider that can reach `/v1/redeems`. This also preserves the issuer
+    // store invariant that one BAT public key has one immutable lineage.
+    let shared_providers = [&paid];
+
+    init_issuer_store(&issuer);
+    let payment_issuer = spawn_payment_issuer(root.path(), issuer_port, &issuer, &shared_providers);
+    let forward_counter = root.path().join("tls-edge-forwarded.log");
+    write_private_file(&forward_counter, b"");
+    let tls_edge = spawn_tls_edge(root.path(), edge_port, issuer_port, &tls, &forward_counter);
+
+    assert_ne!(paid.provider_id, free.provider_id);
+    assert_ne!(paid.store_path, free.store_path);
+    let paid_port = distinct_unused_port(&[issuer_port, edge_port, offline_port]);
+    let free_port = distinct_unused_port(&[issuer_port, edge_port, offline_port, paid_port]);
+    let paid_server = spawn_provider(root.path(), &db_path, &paid, paid_port, 0, Some(&tls.root));
+    let free_server = spawn_provider(root.path(), &db_path, &free, free_port, 0, None);
+
+    exercise_grant_and_dpf(paid_port, &paid, manifest_root)
+        .await
+        .expect("shared-issuer BAT must redeem and authorize");
+    exercise_grant_and_dpf(free_port, &free, manifest_root)
+        .await
+        .expect("peer provider must independently accept Free/Open");
+
+    let (paid_stdout_first, paid_stderr_first) = paid_server.stop();
+    let (free_stdout, free_stderr) = free_server.stop();
+    assert_server_log(&paid_stdout_first, &paid_stderr_first, paid_port, &paid);
+    assert_server_log(&free_stdout, &free_stderr, free_port, &free);
+
+    // Reopen the paid provider against the same local store. The issuer may
+    // return its exact durable redeem response, but the provider-local claim is
+    // already committed and a second connection grant is forbidden.
+    let paid_server = spawn_provider(root.path(), &db_path, &paid, paid_port, 1, Some(&tls.root));
+    let replay = authorize_only(paid_port, &paid, manifest_root)
+        .await
+        .expect_err("replayed shared-issuer proof must not grant after restart");
+    assert!(
+        replay.contains("invalid-or-spent"),
+        "unexpected replay: {replay}"
+    );
+    let (paid_stdout, paid_stderr) = paid_server.stop();
+    assert_server_log(&paid_stdout, &paid_stderr, paid_port, &paid);
+    assert_eq!(provider_local_claim_count(&paid), 1);
+
+    let forwarded_after_replay = forwarded_request_count(&forward_counter);
+    assert!(
+        (1..=2).contains(&forwarded_after_replay),
+        "initial redeem must be forwarded once; exact replay may be rejected locally or replayed at the issuer"
+    );
+
+    // Every trust failure uses a fresh provider process/store. The signed
+    // authorization is otherwise valid, so only WebPKI, the signed pin, or the
+    // offline origin can account for the fail-closed result.
+    for (fixture, test_root) in [
+        (&wrong_ca, &tls.wrong_root),
+        (&wrong_pin, &tls.root),
+        (&offline, &tls.root),
+    ] {
+        let port =
+            distinct_unused_port(&[issuer_port, edge_port, offline_port, paid_port, free_port]);
+        let server = spawn_provider(root.path(), &db_path, fixture, port, 0, Some(test_root));
+        authorize_only(port, fixture, manifest_root)
+            .await
+            .expect_err("wrong CA/pin/offline issuer must fail closed");
+        let (stdout, stderr) = server.stop();
+        assert_server_log(&stdout, &stderr, port, fixture);
+        assert_eq!(provider_local_claim_count(fixture), 0);
+        assert_eq!(
+            forwarded_request_count(&forward_counter),
+            forwarded_after_replay,
+            "TLS trust/offline failure must not reach the issuer HTTP application"
+        );
+    }
+
+    let (edge_stdout, edge_stderr) = tls_edge.stop();
+    let (issuer_stdout, issuer_stderr) = payment_issuer.stop();
+    for forbidden in ["payment_hash", "preimage", "invoice", "secret_raw"] {
+        assert!(!edge_stdout.contains(forbidden));
+        assert!(!edge_stderr.contains(forbidden));
+    }
+    assert!(issuer_stdout.contains("payment-issuer fake service listening"));
+    assert!(issuer_stdout.contains("issuer_store_startup_check=ok"));
+    for forbidden in ["payment_hash", "preimage", "invoice", "secret_raw"] {
+        assert!(!issuer_stdout.contains(forbidden));
+        assert!(!issuer_stderr.contains(forbidden));
+    }
+
+    assert_issuer_ledger(&issuer, &paid, &[&wrong_ca, &wrong_pin, &offline]);
+}
+
+fn build_issuer_material(root: &Path, now: u64) -> IssuerMaterial {
+    let binary = required_payment_issuer_binary();
+    let issuer_root_dir = root.join("payment-issuer");
+    let store_dir = issuer_root_dir.join("store-domain");
+    let rollback_dir = issuer_root_dir.join("rollback-domain");
+    fs::create_dir_all(&store_dir).unwrap();
+    fs::create_dir_all(&rollback_dir).unwrap();
+    chmod(&issuer_root_dir, 0o700);
+    chmod(&store_dir, 0o700);
+    chmod(&rollback_dir, 0o700);
+
+    let issuer_root = SigningKey::from_bytes(&[0x31; 32]);
+    let quote_signing_key = SigningKey::from_bytes(&[0x32; 32]);
+    let settlement_signing_key = SigningKey::from_bytes(&[0x33; 32]);
+    let fake_lightning_signing_key = [0x34; 32];
+    let fake_lightning_derivation_seed = [0x35; 32];
+    let bat_key = [0x36; 32];
+    let credential_derivation_key = [0x37; 32];
+    let redeem_response_derivation_key = [0x38; 32];
+    let issuer_id = derive_issuer_id(&issuer_root.verifying_key().to_bytes());
+    let fake_lightning = FakeLightningNodeV1::new(
+        LightningNetworkV1::Regtest,
+        fake_lightning_signing_key,
+        fake_lightning_derivation_seed,
+        now,
+    )
+    .expect("construct no-funds fake Lightning identity");
+    let delegation = Bolt11QuoteKeyDelegationV1::sign(
+        LightningNetworkV1::Regtest,
+        fake_lightning.payee_pubkey(),
+        1,
+        now.saturating_sub(60),
+        now + 3_600,
+        quote_signing_key.verifying_key().to_bytes(),
+        &issuer_root,
+    )
+    .expect("sign issuer quote delegation");
+
+    let quote_delegation_path = issuer_root_dir.join("quote-delegation.bin");
+    let quote_signing_key_path = issuer_root_dir.join("quote-signing.key");
+    let credential_derivation_key_path = issuer_root_dir.join("credential-derivation.key");
+    let bat_key_path = issuer_root_dir.join("bat.key");
+    let fake_lightning_signing_key_path = issuer_root_dir.join("fake-lightning-signing.key");
+    let fake_lightning_derivation_seed_path = issuer_root_dir.join("fake-lightning-seed.key");
+    let issuer_settlement_signing_key_path = issuer_root_dir.join("settlement-signing.key");
+    let redeem_response_derivation_key_path = issuer_root_dir.join("redeem-response.key");
+    write_public_file(
+        &quote_delegation_path,
+        &delegation.encode().expect("encode quote delegation"),
+    );
+    write_private_file(&quote_signing_key_path, &quote_signing_key.to_bytes());
+    write_private_file(&credential_derivation_key_path, &credential_derivation_key);
+    write_private_file(&bat_key_path, &bat_key);
+    write_private_file(
+        &fake_lightning_signing_key_path,
+        &fake_lightning_signing_key,
+    );
+    write_private_file(
+        &fake_lightning_derivation_seed_path,
+        &fake_lightning_derivation_seed,
+    );
+    write_private_file(
+        &issuer_settlement_signing_key_path,
+        &settlement_signing_key.to_bytes(),
+    );
+    write_private_file(
+        &redeem_response_derivation_key_path,
+        &redeem_response_derivation_key,
+    );
+
+    IssuerMaterial {
+        binary,
+        issuer_id,
+        issuer_root,
+        settlement_signing_key,
+        store_path: store_dir.join("issuer.sqlite3"),
+        rollback_path: rollback_dir.join("floor.sqlite3"),
+        quote_delegation_path,
+        quote_signing_key_path,
+        credential_derivation_key_path,
+        bat_key_path,
+        fake_lightning_signing_key_path,
+        fake_lightning_derivation_seed_path,
+        issuer_settlement_signing_key_path,
+        redeem_response_derivation_key_path,
+        bat_keyring: Arc::new(
+            K256CashuMintKeyringV1::from_secret_keys([bat_key])
+                .expect("construct deterministic BAT keyring"),
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_provider(
+    root: &Path,
+    index: u8,
+    method: ProviderMethod,
+    manifest_root: [u8; 32],
+    issuer: &IssuerMaterial,
+    redeem_endpoint: &str,
+    redeem_pins: Vec<[u8; 32]>,
+    now: u64,
+) -> ProviderFixture {
+    let provider_root = root.join(format!("provider-{index}"));
+    let store_dir = provider_root.join("store-domain");
+    let rollback_dir = provider_root.join("rollback-domain");
+    fs::create_dir_all(&store_dir).unwrap();
+    fs::create_dir_all(&rollback_dir).unwrap();
+    chmod(&provider_root, 0o700);
+    chmod(&store_dir, 0o700);
+    chmod(&rollback_dir, 0o700);
+
+    let operator = SigningKey::from_bytes(&[0x40u8.wrapping_add(index); 32]);
+    let policy_signing_key = SigningKey::from_bytes(&[0x60u8.wrapping_add(index); 32]);
+    let provider_id = derive_provider_id(
+        &operator.verifying_key().to_bytes(),
+        &format!("shared-issuer-process-provider-{index}"),
+    );
+    let issued_at = now.saturating_sub(60);
+    let expires_at = now + 3_600;
+    let retired_grace = 1_800u32;
+    let scope = ServiceScopeV1 {
+        provider_id,
+        backend: BackendId::DpfPirV1,
+        workload: WorkloadId::DpfEvaluateJobV1,
+        protocol_version: 1,
+        dataset: DatasetBindingV1::ManifestRoot {
+            root: manifest_root,
+        },
+        operation_profile: OPERATION_PROFILE,
+        entitlement_profile: ENTITLEMENT_PROFILE,
+    };
+    let scope_id = scope.scope_id();
+
+    let (offer, shared) = match method {
+        ProviderMethod::SharedIssuerBat => {
+            assert!(redeem_endpoint.starts_with("https://localhost:"));
+            assert!(!redeem_pins.is_empty());
+            let denomination_public_key = issuer.bat_keyring.denomination_public_keys()[0];
+            let credential_key_id = derive_bat_key_id_v1(
+                &provider_id,
+                &scope_id,
+                SHARED_OFFER_ID,
+                ENTITLEMENT_PROFILE,
+                1,
+                &denomination_public_key,
+            );
+            let binding = CredentialKeyBindingV1::sign(
+                CredentialKeyBindingClaimsV1 {
+                    provider_id,
+                    scope_id,
+                    offer_id: SHARED_OFFER_ID,
+                    scheme: AuthScheme::BitcoinPirCashuBatV1,
+                    keyset_epoch: 1,
+                    entitlement_profile: ENTITLEMENT_PROFILE,
+                    unit: CredentialUnitV1::Auth,
+                    amount: 1,
+                    presentation_limit: 1,
+                    not_before: issued_at,
+                    not_after: expires_at + u64::from(retired_grace),
+                    credential_key_id: credential_key_id.to_vec(),
+                    verification_key: denomination_public_key.to_vec(),
+                },
+                &issuer.issuer_root,
+            )
+            .expect("sign shared BAT binding");
+            let offer = ServiceOfferV1 {
+                offer_id: SHARED_OFFER_ID,
+                acquisition: AcquisitionMethod::Bolt11V1,
+                free_mode: FreeModeV1::NotFree,
+                free_quota: 0,
+                free_window_seconds: 0,
+                free_pow_difficulty_bits: 0,
+                priority_class: 10,
+                authorization: AuthScheme::BitcoinPirCashuBatV1,
+                verification: VerificationMode::SharedIssuerOnline,
+                deployment_status: DeploymentStatus::Stable,
+                price: PriceV1::MilliSatoshi(1_000),
+                issuer_id: issuer.issuer_id,
+                key_id: credential_key_id.to_vec(),
+                credential_binding: Some(binding.clone()),
+                cashu_mint_manifest: None,
+                endpoint: redeem_endpoint.to_owned(),
+                invoice_expiry_seconds: 600,
+                claim_window_seconds: 600,
+                minimum_credential_validity_seconds: 60,
+                retired_policy_grace_seconds: retired_grace,
+                credential_count: 1,
+                credential_presentation_limit: 1,
+                privacy_leakage: PrivacyLeakageV1::from_bits(
+                    PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                        | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                        | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+                )
+                .expect("known shared-issuer privacy flags"),
+            };
+            let clearing = SigningKey::from_bytes(&[0x80u8.wrapping_add(index); 32]);
+            let idempotency_key = [0xa0u8.wrapping_add(index); 32];
+            let account_id = [0xb0u8.wrapping_add(index); 32];
+            let authorization = ProviderClearingAuthorizationV1::sign(
+                ProviderClearingAuthorizationClaimsV1 {
+                    authorization_id: [0xd0u8.wrapping_add(index); 16],
+                    authorization_epoch: 1,
+                    provider_id,
+                    issuer_id: issuer.issuer_id,
+                    redeem_endpoint: redeem_endpoint.to_owned(),
+                    redeem_leaf_spki_sha256_pins: redeem_pins,
+                    settlement_account_id: account_id,
+                    clearing_verifying_key: clearing.verifying_key().to_bytes(),
+                    not_before: issued_at,
+                    not_after: expires_at,
+                    rules: vec![SettlementRuleV1 {
+                        credential_binding_digest: binding
+                            .binding_digest()
+                            .expect("shared BAT binding digest"),
+                        unit: SettlementUnitV1::AuthCredit,
+                        accepted_value: 10,
+                        provider_credit: 9,
+                        issuer_fee: 1,
+                        denomination_profile: 1,
+                        settlement_modes: SettlementModesV1::from_bits(
+                            SettlementModesV1::LEDGER_CREDIT,
+                        )
+                        .expect("ledger-credit-only settlement"),
+                        blind_output_minimum_validity_seconds: 0,
+                        blind_output_keyset: None,
+                    }],
+                },
+                &operator,
+            )
+            .expect("sign provider clearing authorization");
+            let approval = IssuerClearingApprovalV1::sign(
+                &authorization,
+                issued_at,
+                expires_at,
+                &issuer.settlement_signing_key,
+            )
+            .expect("sign issuer clearing approval");
+            let secret_raw = [0xe0u8.wrapping_add(index); 32];
+            let hashed = cashu_hash_to_curve_v1(&secret_raw).expect("hash BAT secret to curve");
+            let signed = issuer
+                .bat_keyring
+                .blind_sign_with_dleq_v1(
+                    &denomination_public_key,
+                    &hashed,
+                    &[0xf0u8.wrapping_add(index); 32],
+                )
+                .expect("sign deterministic BAT proof");
+            let proof = BitcoinPirCashuBatProofV1 {
+                secret_raw,
+                c: *signed.blinded_signature(),
+            };
+
+            let authorization_path = provider_root.join("clearing-authorization.bin");
+            let approval_path = provider_root.join("issuer-approval.bin");
+            let clearing_key_path = provider_root.join("clearing.key");
+            let idempotency_key_path = provider_root.join("redeem-idempotency.key");
+            write_public_file(
+                &authorization_path,
+                &authorization
+                    .encode()
+                    .expect("encode clearing authorization"),
+            );
+            write_public_file(&approval_path, &approval.encode());
+            write_private_file(&clearing_key_path, &clearing.to_bytes());
+            write_private_file(&idempotency_key_path, &idempotency_key);
+            (
+                offer,
+                Some(SharedProviderConfig {
+                    authorization_path,
+                    approval_path,
+                    operator_verifying_key: operator.verifying_key(),
+                    issuer_settlement_verifying_key: issuer.settlement_signing_key.verifying_key(),
+                    clearing_key_path,
+                    idempotency_key_path,
+                    proof,
+                    account_id,
+                }),
+            )
+        }
+        ProviderMethod::FreeOpen => {
+            assert!(redeem_endpoint.is_empty());
+            assert!(redeem_pins.is_empty());
+            (
+                ServiceOfferV1 {
+                    offer_id: FREE_OFFER_ID,
+                    acquisition: AcquisitionMethod::FreeV1,
+                    free_mode: FreeModeV1::OpenBestEffort,
+                    free_quota: 0,
+                    free_window_seconds: 0,
+                    free_pow_difficulty_bits: 0,
+                    priority_class: 1,
+                    authorization: AuthScheme::FreeV1,
+                    verification: VerificationMode::ProviderLocal,
+                    deployment_status: DeploymentStatus::Stable,
+                    price: PriceV1::Free,
+                    issuer_id: [0; 32],
+                    key_id: Vec::new(),
+                    credential_binding: None,
+                    cashu_mint_manifest: None,
+                    endpoint: String::new(),
+                    invoice_expiry_seconds: 0,
+                    claim_window_seconds: 0,
+                    minimum_credential_validity_seconds: 60,
+                    retired_policy_grace_seconds: 0,
+                    credential_count: 1,
+                    credential_presentation_limit: 1,
+                    privacy_leakage: PrivacyLeakageV1::from_bits(PrivacyLeakageV1::KNOWN_MASK)
+                        .expect("known Free privacy flags"),
+                },
+                None,
+            )
+        }
+    };
+
+    let policy = ServicePolicyV1::sign(
+        provider_id,
+        1,
+        issued_at,
+        expires_at,
+        AuthPaddingClassV1::Class16KiB,
+        vec![ServiceScopePolicyV1 {
+            scope,
+            limits: EntitlementLimitsV1 {
+                max_logical_inputs: 1,
+                max_frames: 1,
+                max_request_bytes: 16 * 1024,
+                max_response_bytes: 4 * 1024,
+                max_wall_time_ms: 10_000,
+                max_concurrent_sockets: 1,
+                max_hint_groups: 0,
+                max_work_units: 2,
+            },
+            offers: vec![offer],
+        }],
+        &policy_signing_key,
+    )
+    .expect("sign provider policy");
+    let policy_digest = policy.policy_digest().expect("provider policy digest");
+    let policy_path = provider_root.join("service-policy-v1.bin");
+    write_public_file(
+        &policy_path,
+        &policy.encode().expect("encode provider policy"),
+    );
+
+    let store_path = store_dir.join("provider.sqlite3");
+    let rollback_path = rollback_dir.join("floor.sqlite3");
+    let rollback = SqliteRollbackFloorAuthorityV1::create(
+        &rollback_path,
+        ProviderStoreOptions::default().busy_timeout,
+    )
+    .expect("create provider rollback floor");
+    let store = ProviderStore::create(
+        &store_path,
+        [0x20u8.wrapping_add(index); 16],
+        provider_id,
+        ProviderStoreOptions::default(),
+        Arc::new(rollback),
+    )
+    .expect("create provider store");
+    drop(store);
+
+    ProviderFixture {
+        index,
+        method,
+        provider_id,
+        policy_signing_key,
+        policy_path,
+        store_path,
+        rollback_path,
+        scope_id,
+        policy_digest,
+        shared,
+    }
+}
+
+fn init_issuer_store(issuer: &IssuerMaterial) {
+    let output = Command::new(&issuer.binary)
+        .args([
+            OsString::from("init-store"),
+            OsString::from("--store"),
+            issuer.store_path.as_os_str().to_owned(),
+            OsString::from("--rollback-authority"),
+            issuer.rollback_path.as_os_str().to_owned(),
+            OsString::from("--issuer-id-hex"),
+            OsString::from(hex::encode(issuer.issuer_id)),
+            OsString::from("--network"),
+            OsString::from("regtest"),
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("run payment-issuer init-store");
+    assert_command_success("payment-issuer init-store", &output);
+    assert_private_regular_file(&issuer.store_path);
+    assert_private_regular_file(&issuer.rollback_path);
+}
+
+fn spawn_payment_issuer(
+    root: &Path,
+    port: u16,
+    issuer: &IssuerMaterial,
+    providers: &[&ProviderFixture],
+) -> ChildProcess {
+    let label = "payment-issuer-fake".to_owned();
+    let stdout_path = root.join("payment-issuer-stdout.log");
+    let stderr_path = root.join("payment-issuer-stderr.log");
+    let stdout = File::create(&stdout_path).expect("create payment-issuer stdout log");
+    let stderr = File::create(&stderr_path).expect("create payment-issuer stderr log");
+    let mut args = vec![
+        OsString::from("serve-fake"),
+        OsString::from("--bind"),
+        OsString::from(format!("127.0.0.1:{port}")),
+        OsString::from("--store"),
+        issuer.store_path.as_os_str().to_owned(),
+        OsString::from("--rollback-authority"),
+        issuer.rollback_path.as_os_str().to_owned(),
+        OsString::from("--quote-delegation"),
+        issuer.quote_delegation_path.as_os_str().to_owned(),
+        OsString::from("--quote-signing-key"),
+        issuer.quote_signing_key_path.as_os_str().to_owned(),
+        OsString::from("--credential-derivation-key"),
+        issuer.credential_derivation_key_path.as_os_str().to_owned(),
+        OsString::from("--bat-key"),
+        issuer.bat_key_path.as_os_str().to_owned(),
+        OsString::from("--issuer-settlement-signing-key"),
+        issuer
+            .issuer_settlement_signing_key_path
+            .as_os_str()
+            .to_owned(),
+        OsString::from("--redeem-response-derivation-key"),
+        issuer
+            .redeem_response_derivation_key_path
+            .as_os_str()
+            .to_owned(),
+        OsString::from("--fake-lightning-signing-key"),
+        issuer
+            .fake_lightning_signing_key_path
+            .as_os_str()
+            .to_owned(),
+        OsString::from("--fake-lightning-derivation-seed"),
+        issuer
+            .fake_lightning_derivation_seed_path
+            .as_os_str()
+            .to_owned(),
+        OsString::from("--max-connections"),
+        OsString::from("32"),
+        OsString::from("--mutation-rate-per-minute"),
+        OsString::from("1000"),
+    ];
+    for fixture in providers {
+        let shared = fixture.shared.as_ref().expect("shared issuer provider");
+        args.extend([
+            OsString::from("--service-policy"),
+            OsString::from(format!(
+                "{}={}",
+                fixture.policy_path.display(),
+                hex::encode(fixture.policy_signing_key.verifying_key().to_bytes())
+            )),
+            OsString::from("--clearing-authorization"),
+            shared.authorization_path.as_os_str().to_owned(),
+            OsString::from("--clearing-approval"),
+            shared.approval_path.as_os_str().to_owned(),
+        ]);
+    }
+
+    let child = Command::new(&issuer.binary)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .expect("spawn real payment-issuer binary from BITCOINPIR_PAYMENT_ISSUER_BIN");
+    let mut process = ChildProcess {
+        label,
+        child,
+        stdout_path,
+        stderr_path,
+    };
+    process.wait_until_listening(port);
+    process
+}
+
+fn spawn_provider(
+    root: &Path,
+    db_path: &Path,
+    fixture: &ProviderFixture,
+    port: u16,
+    generation: u8,
+    test_root: Option<&Path>,
+) -> ChildProcess {
+    let label = format!("provider-{}-generation-{generation}", fixture.index);
+    let stdout_path = root.join(format!("{label}-stdout.log"));
+    let stderr_path = root.join(format!("{label}-stderr.log"));
+    let stdout = File::create(&stdout_path).expect("create provider stdout log");
+    let stderr = File::create(&stderr_path).expect("create provider stderr log");
+    let mut args = vec![
+        "--bind-address".to_owned(),
+        "127.0.0.1".to_owned(),
+        "--port".to_owned(),
+        port.to_string(),
+        "--data-dir".to_owned(),
+        db_path.to_string_lossy().into_owned(),
+        "--role".to_owned(),
+        "secondary".to_owned(),
+        "--disable-onion".to_owned(),
+        "--serve-queries".to_owned(),
+        "--require-service-auth-v1".to_owned(),
+        "--service-policy".to_owned(),
+        fixture.policy_path.to_string_lossy().into_owned(),
+        "--service-provider-id-hex".to_owned(),
+        hex::encode(fixture.provider_id),
+        "--service-policy-key-hex".to_owned(),
+        hex::encode(fixture.policy_signing_key.verifying_key().to_bytes()),
+        "--service-store".to_owned(),
+        fixture.store_path.to_string_lossy().into_owned(),
+        "--service-rollback-authority".to_owned(),
+        fixture.rollback_path.to_string_lossy().into_owned(),
+        "--allow-local-service-rollback-authority-dev".to_owned(),
+        "--max-connections".to_owned(),
+        "16".to_owned(),
+        "--service-max-concurrent-auth".to_owned(),
+        "4".to_owned(),
+        "--websocket-handshake-timeout-ms".to_owned(),
+        "1000".to_owned(),
+        "--connection-idle-timeout-ms".to_owned(),
+        "60000".to_owned(),
+        "--service-pre-auth-timeout-ms".to_owned(),
+        "60000".to_owned(),
+    ];
+    if let Some(shared) = &fixture.shared {
+        let test_root = test_root.expect("shared issuer provider requires a WebPKI root");
+        args.extend([
+            "--service-shared-authorization".to_owned(),
+            shared.authorization_path.to_string_lossy().into_owned(),
+            "--service-shared-issuer-approval".to_owned(),
+            shared.approval_path.to_string_lossy().into_owned(),
+            "--service-shared-operator-key-hex".to_owned(),
+            hex::encode(shared.operator_verifying_key.to_bytes()),
+            "--service-shared-issuer-settlement-key-hex".to_owned(),
+            hex::encode(shared.issuer_settlement_verifying_key.to_bytes()),
+            "--service-shared-clearing-key".to_owned(),
+            shared.clearing_key_path.to_string_lossy().into_owned(),
+            "--service-shared-idempotency-key".to_owned(),
+            shared.idempotency_key_path.to_string_lossy().into_owned(),
+            "--service-shared-minimum-authorization-epoch".to_owned(),
+            "1".to_owned(),
+            "--test-only-service-https-root-pem".to_owned(),
+            test_root.to_string_lossy().into_owned(),
+        ]);
+    } else {
+        assert!(test_root.is_none());
+    }
+
+    let child = Command::new(env!("CARGO_BIN_EXE_unified_server"))
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .expect("spawn unified_server");
+    let mut process = ChildProcess {
+        label,
+        child,
+        stdout_path,
+        stderr_path,
+    };
+    process.wait_until_listening(port);
+    process
+}
+
+fn spawn_tls_edge(
+    root: &Path,
+    port: u16,
+    issuer_port: u16,
+    material: &TlsMaterial,
+    counter_path: &Path,
+) -> ChildProcess {
+    let label = "shared-issuer-tls-edge".to_owned();
+    let stdout_path = root.join("shared-issuer-tls-edge-stdout.log");
+    let stderr_path = root.join("shared-issuer-tls-edge-stderr.log");
+    let stdout = File::create(&stdout_path).expect("create TLS edge stdout log");
+    let stderr = File::create(&stderr_path).expect("create TLS edge stderr log");
+    let child = Command::new(env::current_exe().expect("current integration test executable"))
+        .args([
+            "--ignored",
+            "--exact",
+            "shared_issuer_tls_edge_subprocess",
+            "--nocapture",
+        ])
+        .env(TLS_EDGE_HELPER_MARKER, "1")
+        .env(
+            "BITCOINPIR_TEST_SHARED_ISSUER_EDGE_BIND",
+            format!("127.0.0.1:{port}"),
+        )
+        .env(
+            "BITCOINPIR_TEST_SHARED_ISSUER_UPSTREAM",
+            format!("127.0.0.1:{issuer_port}"),
+        )
+        .env("BITCOINPIR_TEST_SHARED_ISSUER_CERT", &material.certificate)
+        .env("BITCOINPIR_TEST_SHARED_ISSUER_KEY", &material.private_key)
+        .env(
+            "BITCOINPIR_TEST_SHARED_ISSUER_FORWARD_COUNTER",
+            counter_path,
+        )
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr))
+        .spawn()
+        .expect("spawn shared-issuer TLS edge process");
+    let mut process = ChildProcess {
+        label,
+        child,
+        stdout_path,
+        stderr_path,
+    };
+    process.wait_until_listening(port);
+    process
+}
+
+async fn exercise_grant_and_dpf(
+    port: u16,
+    fixture: &ProviderFixture,
+    manifest_root: [u8; 32],
+) -> Result<(), String> {
+    let request = valid_tiny_dpf_request();
+    let (mut secure, accepted) =
+        open_verified_session(port, fixture, manifest_root, &request).await;
+    let grant = dangerous_unpaired_authorize_service_operation_v1(
+        &mut secure,
+        &accepted,
+        fixture.scope_id,
+        fixture.offer_id(),
+        OperationStartV1::DpfQuery { db_id: 0 },
+        fixture.proof(),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    if grant.scope_id != fixture.scope_id || grant.enforced_profile != ENTITLEMENT_PROFILE {
+        return Err("AUTH grant did not bind the selected scope/profile".to_owned());
+    }
+    let response = secure
+        .roundtrip(&request)
+        .await
+        .map_err(|error| error.to_string())?;
+    match Response::decode(&response).map_err(|error| error.to_string())? {
+        Response::IndexBatch(result)
+            if result.results.len() == 1
+                && result.results[0].len() == 2
+                && result.results[0].iter().all(|item| item.len() == 52) => {}
+        other => {
+            return Err(format!(
+                "authorized DPF frame did not reach handler: {other:?}"
+            ))
+        }
+    }
+    secure.close().await.map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+async fn authorize_only(
+    port: u16,
+    fixture: &ProviderFixture,
+    manifest_root: [u8; 32],
+) -> Result<(), String> {
+    let request = valid_tiny_dpf_request();
+    let (mut secure, accepted) =
+        open_verified_session(port, fixture, manifest_root, &request).await;
+    let result = dangerous_unpaired_authorize_service_operation_v1(
+        &mut secure,
+        &accepted,
+        fixture.scope_id,
+        fixture.offer_id(),
+        OperationStartV1::DpfQuery { db_id: 0 },
+        fixture.proof(),
+    )
+    .await
+    .map(|_| ())
+    .map_err(|error| error.to_string());
+    let _ = secure.close().await;
+    result
+}
+
+async fn open_verified_session(
+    port: u16,
+    fixture: &ProviderFixture,
+    manifest_root: [u8; 32],
+    backend_request: &[u8],
+) -> (
+    SecureChannelTransport<WsConnection>,
+    AcceptedServicePolicyV1,
+) {
+    let mut raw = WsConnection::connect_once(&format!("ws://127.0.0.1:{port}"))
+        .await
+        .expect("connect real provider WebSocket");
+
+    let pre_secure_policy = fetch_verified_service_policy_v1(
+        &mut raw,
+        fixture.provider_id,
+        &fixture.policy_signing_key.verifying_key(),
+        unix_now(),
+        &ServicePolicyCheckpointV1::initial(),
+    )
+    .await
+    .expect_err("policy fetch before secure-channel upgrade must fail");
+    assert!(pre_secure_policy.to_string().contains("secure-channel"));
+    expect_error_response(
+        &raw.roundtrip(backend_request)
+            .await
+            .expect("cleartext backend rejection"),
+        "secure encrypted channel is required",
+    );
+
+    let session_id = SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut eph_seed = [0x21u8.wrapping_add(fixture.index); 32];
+    let mut random = [0x41u8.wrapping_add(fixture.index); 32];
+    let mut handshake_nonce = [0x61u8.wrapping_add(fixture.index); 32];
+    eph_seed[..8].copy_from_slice(&session_id.to_le_bytes());
+    random[..8].copy_from_slice(&session_id.wrapping_add(0x1000).to_le_bytes());
+    handshake_nonce[..8].copy_from_slice(&session_id.wrapping_add(0x2000).to_le_bytes());
+    let attestation = attest_with_eph_binding(&mut raw, eph_seed, random)
+        .await
+        .expect("attestation-bound channel key");
+    assert_eq!(attestation.sev_status, SevStatus::NoSevHost);
+    assert_eq!(attestation.response.manifest_roots, vec![manifest_root]);
+    assert!(attestation
+        .response
+        .server_static_pub
+        .iter()
+        .any(|byte| *byte != 0));
+
+    let mut secure = establish(
+        raw,
+        attestation.response.server_static_pub,
+        eph_seed,
+        handshake_nonce,
+    )
+    .await
+    .expect("mandatory secure-channel upgrade");
+    let accepted = fetch_verified_service_policy_v1(
+        &mut secure,
+        fixture.provider_id,
+        &fixture.policy_signing_key.verifying_key(),
+        unix_now(),
+        &ServicePolicyCheckpointV1::initial(),
+    )
+    .await
+    .expect("verify exact signed provider policy");
+    assert_eq!(accepted.policy_digest(), fixture.policy_digest);
+    assert_eq!(accepted.checkpoint().rollback_guard().highest_epoch, 1);
+    expect_error_response(
+        &secure
+            .roundtrip(backend_request)
+            .await
+            .expect("pre-AUTH backend rejection"),
+        "authorization required",
+    );
+    (secure, accepted)
+}
+
+fn valid_tiny_dpf_request() -> Vec<u8> {
+    let dpf = Dpf::with_default_key();
+    let (key0, key1) = dpf.gen(0, 7);
+    Request::IndexBatch(BatchQuery {
+        level: 0,
+        round_id: 0,
+        db_id: 0,
+        keys: vec![vec![key0.to_bytes(), key1.to_bytes()]],
+    })
+    .encode()
+}
+
+fn expect_error_response(response: &[u8], needle: &str) {
+    match Response::decode(response).expect("decode runtime response") {
+        Response::Error(message) => assert!(
+            message.contains(needle),
+            "expected error containing {needle:?}, got {message:?}"
+        ),
+        other => panic!("expected server error containing {needle:?}, got {other:?}"),
+    }
+}
+
+fn write_tiny_manifest_database(root: &Path) -> (PathBuf, [u8; 32]) {
+    let db = root.join("tiny-db");
+    fs::create_dir(&db).unwrap();
+    write_tiny_table(
+        &db.join("batch_pir_cuckoo.bin"),
+        &INDEX_PARAMS.with_master_seed(0x1111_2222_3333_4444),
+        0x9999_aaaa_bbbb_cccc,
+    );
+    write_tiny_table(
+        &db.join("chunk_pir_cuckoo.bin"),
+        &CHUNK_PARAMS.with_master_seed(0x5555_6666_7777_8888),
+        0,
+    );
+    let zero_hash = "0".repeat(64);
+    let manifest = format!(
+        "[manifest]\nversion = 1\ngenerated_at = \"2026-07-29T00:00:00Z\"\n\n[files]\n\"batch_pir_cuckoo.bin\" = \"{zero_hash}\"\n\"chunk_pir_cuckoo.bin\" = \"{zero_hash}\"\n"
+    );
+    fs::write(db.join("MANIFEST.toml"), manifest.as_bytes()).unwrap();
+    (db, sha256(manifest.as_bytes()))
+}
+
+fn write_tiny_table(path: &Path, params: &pir_core::params::TableParams, tag_seed: u64) {
+    let mut bytes = write_header_with_anchor(params, TINY_BINS_PER_TABLE, tag_seed, None);
+    bytes.resize(
+        bytes.len() + params.k * params.table_byte_size(TINY_BINS_PER_TABLE),
+        0,
+    );
+    fs::write(path, bytes).unwrap();
+}
+
+fn provider_local_claim_count(fixture: &ProviderFixture) -> u64 {
+    let rollback = SqliteRollbackFloorAuthorityV1::open_existing(
+        &fixture.rollback_path,
+        ProviderStoreOptions::default().busy_timeout,
+    )
+    .expect("open provider rollback floor for audit");
+    let store = ProviderStore::open_existing(
+        &fixture.store_path,
+        fixture.provider_id,
+        ProviderStoreOptions::default(),
+        Arc::new(rollback),
+    )
+    .expect("open provider store for audit");
+    store
+        .operational_inventory()
+        .expect("provider operational inventory")
+        .spent_capability_rows
+}
+
+fn assert_issuer_ledger(
+    issuer: &IssuerMaterial,
+    paid: &ProviderFixture,
+    failed: &[&ProviderFixture],
+) {
+    let rollback = SqliteIssuerRollbackFloorAuthorityV1::open_existing(
+        &issuer.rollback_path,
+        IssuerStoreOptions::default().busy_timeout,
+    )
+    .expect("open issuer rollback floor for audit");
+    let store = IssuerStore::open_existing(
+        &issuer.store_path,
+        issuer.issuer_id,
+        LightningNetworkV1::Regtest,
+        IssuerStoreOptions::default(),
+        Arc::new(rollback),
+    )
+    .expect("open issuer store for audit");
+    let paid_balance = store
+        .provider_ledger_balance(&paid.provider_id)
+        .expect("read paid provider ledger")
+        .expect("paid provider ledger exists");
+    assert_eq!(
+        paid_balance.account_id,
+        paid.shared.as_ref().unwrap().account_id
+    );
+    assert_eq!(paid_balance.unit, SettlementUnitV1::AuthCredit);
+    assert_eq!(
+        (paid_balance.available_value, paid_balance.reserved_value),
+        (9, 0)
+    );
+    for fixture in failed {
+        assert!(store
+            .provider_ledger_balance(&fixture.provider_id)
+            .expect("read failed provider ledger")
+            .is_none());
+    }
+    let inventory = store
+        .operational_inventory()
+        .expect("issuer operational inventory");
+    assert_eq!(inventory.redemption_rows, 1);
+    assert_eq!(inventory.payout_rows, 0);
+}
+
+fn assert_server_log(stdout: &str, stderr: &str, port: u16, fixture: &ProviderFixture) {
+    assert!(stdout.contains(&format!("Listening on ws://127.0.0.1:{port}")));
+    assert!(stdout.contains("Service admission V1: enforced"));
+    assert!(!stderr.contains("UNSAFE DEBUG QUERY LOGGING ENABLED"));
+    for forbidden in ["payment_hash", "preimage", "invoice", "secret_raw"] {
+        assert!(!stdout.contains(forbidden));
+        assert!(!stderr.contains(forbidden));
+    }
+    if let Some(shared) = &fixture.shared {
+        assert!(!stdout.contains(&hex::encode(shared.proof.secret_raw)));
+        assert!(!stderr.contains(&hex::encode(shared.proof.secret_raw)));
+    }
+}
+
+fn install_tls_material(root: &Path) -> TlsMaterial {
+    let material = TlsMaterial {
+        root: root.join("shared-issuer-test-root.pem"),
+        wrong_root: root.join("shared-issuer-wrong-root.pem"),
+        certificate: root.join("shared-issuer-test-leaf.pem"),
+        private_key: root.join("shared-issuer-test-leaf.key"),
+    };
+    for (path, bytes) in [
+        (
+            &material.root,
+            include_bytes!("testdata/remote-authority-process-root.pem").as_slice(),
+        ),
+        (
+            &material.wrong_root,
+            include_bytes!("../../../crates/net/strict-https/src/testdata/wrong-root.pem")
+                .as_slice(),
+        ),
+        (
+            &material.certificate,
+            include_bytes!("testdata/remote-authority-process-leaf.pem").as_slice(),
+        ),
+        (
+            &material.private_key,
+            include_bytes!("testdata/remote-authority-process-leaf.key").as_slice(),
+        ),
+    ] {
+        write_private_file(path, bytes);
+        assert_private_regular_file(path);
+    }
+    material
+}
+
+fn serve_tls_edge(
+    bind: SocketAddr,
+    upstream: SocketAddr,
+    certificate_pem: &[u8],
+    private_key_pem: &[u8],
+    counter_path: &Path,
+) -> io::Result<()> {
+    if !bind.ip().is_loopback() || !upstream.ip().is_loopback() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "test TLS edge must remain loopback-only",
+        ));
+    }
+    let certificate = CertificateDer::from_pem_slice(certificate_pem)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid test certificate"))?;
+    let private_key = PrivateKeyDer::from_pem_slice(private_key_pem)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid test private key"))?;
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let config = ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(|_| io::Error::other("configure TLS versions"))?
+        .with_no_client_auth()
+        .with_single_cert(vec![certificate], private_key)
+        .map_err(|_| io::Error::other("configure TLS identity"))?;
+    let config = Arc::new(config);
+    let listener = TcpListener::bind(bind)?;
+    loop {
+        let (socket, _) = listener.accept()?;
+        if serve_one_tls_edge_request(socket, upstream, Arc::clone(&config), counter_path).is_err()
+        {
+            // Readiness probes and malformed TLS/HTTP are deliberately silent.
+            // Never log peer addresses, credential bytes, timing, or responses.
+        }
+    }
+}
+
+fn serve_one_tls_edge_request(
+    socket: TcpStream,
+    upstream_address: SocketAddr,
+    config: Arc<ServerConfig>,
+    counter_path: &Path,
+) -> io::Result<()> {
+    socket.set_read_timeout(Some(TLS_IO_TIMEOUT))?;
+    socket.set_write_timeout(Some(TLS_IO_TIMEOUT))?;
+    let connection = ServerConnection::new(config).map_err(io::Error::other)?;
+    let mut tls = StreamOwned::new(connection, socket);
+    let request = read_bounded_http_request(&mut tls)?;
+    if !request.starts_with(b"POST /v1/redeems HTTP/1.1\r\n") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "TLS edge accepts only the issuer redeem route",
+        ));
+    }
+
+    let mut upstream = TcpStream::connect_timeout(&upstream_address, TLS_IO_TIMEOUT)?;
+    upstream.set_read_timeout(Some(TLS_IO_TIMEOUT))?;
+    upstream.set_write_timeout(Some(TLS_IO_TIMEOUT))?;
+    upstream.write_all(&request)?;
+    upstream.flush()?;
+    upstream.shutdown(std::net::Shutdown::Write)?;
+    append_forward_counter(counter_path)?;
+
+    let mut response = Vec::new();
+    upstream
+        .take((MAX_PROXY_HTTP_BYTES + 1) as u64)
+        .read_to_end(&mut response)?;
+    if response.is_empty() || response.len() > MAX_PROXY_HTTP_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "issuer response is empty or exceeded the proxy bound",
+        ));
+    }
+    tls.write_all(&response)?;
+    tls.flush()?;
+    tls.conn.send_close_notify();
+    let _ = tls.flush();
+    Ok(())
+}
+
+fn read_bounded_http_request(reader: &mut impl Read) -> io::Result<Vec<u8>> {
+    let mut request = Vec::new();
+    let mut total_length = None;
+    loop {
+        if request.len() >= MAX_PROXY_HTTP_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "issuer request exceeded TLS-edge bound",
+            ));
+        }
+        let mut chunk = [0u8; 2048];
+        let read = reader.read(&mut chunk)?;
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "issuer request ended early",
+            ));
+        }
+        request.extend_from_slice(&chunk[..read]);
+        if total_length.is_none() {
+            if let Some(header_end) = request
+                .windows(4)
+                .position(|window| window == b"\r\n\r\n")
+                .map(|position| position + 4)
+            {
+                let header = std::str::from_utf8(&request[..header_end]).map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidData, "non-ASCII issuer headers")
+                })?;
+                let content_length = header
+                    .split("\r\n")
+                    .find_map(|line| {
+                        line.split_once(':').and_then(|(name, value)| {
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())
+                                .flatten()
+                        })
+                    })
+                    .ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::InvalidData, "missing content length")
+                    })?;
+                let total = header_end.checked_add(content_length).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "issuer request length overflow")
+                })?;
+                if total > MAX_PROXY_HTTP_BYTES {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "issuer request exceeded TLS-edge bound",
+                    ));
+                }
+                total_length = Some(total);
+            }
+        }
+        if let Some(total) = total_length.filter(|total| request.len() >= *total) {
+            if request.len() != total {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "issuer request contained trailing bytes",
+                ));
+            }
+            return Ok(request);
+        }
+    }
+}
+
+fn append_forward_counter(path: &Path) -> io::Result<()> {
+    let mut file = fs::OpenOptions::new().append(true).open(path)?;
+    file.write_all(b"1\n")?;
+    file.sync_data()
+}
+
+fn forwarded_request_count(path: &Path) -> u64 {
+    u64::try_from(
+        fs::read(path)
+            .expect("read TLS edge forward counter")
+            .into_iter()
+            .filter(|byte| *byte == b'\n')
+            .count(),
+    )
+    .expect("forward counter fits u64")
+}
+
+fn test_leaf_spki_sha256() -> [u8; 32] {
+    hex::decode(TEST_LEAF_SPKI_SHA256_HEX)
+        .expect("test leaf pin hex")
+        .try_into()
+        .expect("test leaf pin length")
+}
+
+fn required_payment_issuer_binary() -> PathBuf {
+    let path = PathBuf::from(
+        env::var_os("BITCOINPIR_PAYMENT_ISSUER_BIN")
+            .expect("BITCOINPIR_PAYMENT_ISSUER_BIN must name a debug payment-issuer binary built with test-only-fake-lightning"),
+    );
+    assert!(
+        path.is_absolute(),
+        "BITCOINPIR_PAYMENT_ISSUER_BIN must be absolute"
+    );
+    let metadata = fs::symlink_metadata(&path).unwrap_or_else(|error| {
+        panic!("inspect payment-issuer binary {}: {error}", path.display())
+    });
+    assert!(!metadata.file_type().is_symlink());
+    assert!(metadata.file_type().is_file());
+    assert_ne!(
+        metadata.mode() & 0o111,
+        0,
+        "payment-issuer is not executable"
+    );
+    path
+}
+
+fn assert_command_success(label: &str, output: &Output) {
+    assert!(
+        output.status.success(),
+        "{label} failed ({})\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn write_private_file(path: &Path, bytes: &[u8]) {
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .unwrap_or_else(|error| panic!("create private file {}: {error}", path.display()));
+    file.write_all(bytes).unwrap();
+    file.sync_all().unwrap();
+}
+
+fn write_public_file(path: &Path, bytes: &[u8]) {
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o644)
+        .open(path)
+        .unwrap_or_else(|error| panic!("create public file {}: {error}", path.display()));
+    file.write_all(bytes).unwrap();
+    file.sync_all().unwrap();
+}
+
+fn assert_private_regular_file(path: &Path) {
+    let parent = fs::symlink_metadata(path.parent().expect("private test file parent")).unwrap();
+    assert!(parent.file_type().is_dir());
+    assert_eq!(parent.uid(), rustix::process::geteuid().as_raw());
+    assert_eq!(parent.mode() & 0o7777, 0o700);
+    let metadata = fs::symlink_metadata(path).unwrap();
+    assert!(metadata.file_type().is_file());
+    assert_eq!(metadata.uid(), rustix::process::geteuid().as_raw());
+    assert_eq!(metadata.mode() & 0o7777, 0o600);
+    assert_eq!(metadata.nlink(), 1);
+}
+
+fn required_env(name: &str) -> String {
+    env::var(name).unwrap_or_else(|_| panic!("missing {name}"))
+}
+
+fn distinct_unused_port(excluded: &[u16]) -> u16 {
+    loop {
+        let port = unused_loopback_port();
+        if !excluded.contains(&port) {
+            return port;
+        }
+    }
+}
+
+fn unused_loopback_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn chmod(path: &Path, mode: u32) {
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+}
+
+fn read_log(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|error| format!("<read log failed: {error}>"))
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before epoch")
+        .as_secs()
+}

--- a/crates/payment/issuer-service/src/lib.rs
+++ b/crates/payment/issuer-service/src/lib.rs
@@ -1188,6 +1188,19 @@ pub struct SettlementPayoutPolicyV1 {
     pub intent_ttl_seconds: u64,
 }
 
+/// Schema filler used when a provider registration belongs to a ledger-only
+/// issuer. This is SHA-256 of the ASCII domain
+/// `BitcoinPIR/issuer-service/v1/ledger-only-disabled-payout-target`.
+///
+/// The first byte is deliberately non-zero because the V1 store schema rejects
+/// an all-zero payout target. Production code installs this value directly; it
+/// is not accepted from an HTTP request or command-line option. It is not a
+/// payout destination and must never be interpreted as one.
+pub const LEDGER_ONLY_DISABLED_PAYOUT_TARGET_ID_V1: [u8; 32] = [
+    0x85, 0x28, 0x4b, 0xc7, 0xed, 0xff, 0x9a, 0x30, 0x2f, 0xfb, 0x2c, 0xf6, 0x2c, 0xdb, 0x82, 0xe8,
+    0x7d, 0x14, 0x6b, 0xe3, 0x77, 0xa0, 0x7e, 0x2b, 0x60, 0xd7, 0xb3, 0x90, 0xfc, 0xa2, 0x53, 0x73,
+];
+
 impl SettlementPayoutPolicyV1 {
     pub fn new(issuer_fee: u64, intent_ttl_seconds: u64) -> Result<Self, IssuerServiceErrorV1> {
         if issuer_fee > MAX_SERVICE_VALUE_V1 || !(1..=86_400).contains(&intent_ttl_seconds) {
@@ -1225,7 +1238,7 @@ pub struct SharedIssuerClearingServiceV1 {
     settlement_keyring: Option<Arc<K256CashuMintKeyringV1>>,
     retained_settlement_keysets: Vec<CashuKeysetBindingV1>,
     response_derivation_key: RedeemResponseDerivationKeyV1,
-    payout_policy: SettlementPayoutPolicyV1,
+    payout_policy: Option<SettlementPayoutPolicyV1>,
 }
 
 struct LoadedClearingContextV1 {
@@ -1252,7 +1265,7 @@ impl fmt::Debug for SharedIssuerClearingServiceV1 {
                 "retained_settlement_signing_key_count",
                 &self.retained_issuer_settlement_keys.len(),
             )
-            .field("payout_policy", &self.payout_policy)
+            .field("ledger_only", &self.payout_policy.is_none())
             .finish_non_exhaustive()
     }
 }
@@ -1260,6 +1273,62 @@ impl fmt::Debug for SharedIssuerClearingServiceV1 {
 impl SharedIssuerClearingServiceV1 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        store: IssuerStore,
+        providers: Vec<TrustedClearingProviderV1>,
+        bat_keyring: Option<Arc<K256CashuMintKeyringV1>>,
+        arc_keyring_experimental: Option<Arc<ArcSecretKeyringV1>>,
+        issuer_settlement_signing_key: SigningKey,
+        retained_issuer_settlement_keys: Vec<VerifyingKey>,
+        settlement_keyring: Option<Arc<K256CashuMintKeyringV1>>,
+        retained_settlement_keysets: Vec<CashuKeysetBindingV1>,
+        response_derivation_key: RedeemResponseDerivationKeyV1,
+        payout_policy: SettlementPayoutPolicyV1,
+    ) -> Result<Self, IssuerServiceErrorV1> {
+        Self::new_with_payout_mode(
+            store,
+            providers,
+            bat_keyring,
+            arc_keyring_experimental,
+            issuer_settlement_signing_key,
+            retained_issuer_settlement_keys,
+            settlement_keyring,
+            retained_settlement_keysets,
+            response_derivation_key,
+            Some(payout_policy),
+        )
+    }
+
+    /// Builds the production V1 ledger-accrual service. Payout intent,
+    /// execution and status methods are disabled and return `NotFound` before
+    /// decoding input or reading/mutating the store.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_ledger_only(
+        store: IssuerStore,
+        providers: Vec<TrustedClearingProviderV1>,
+        bat_keyring: Option<Arc<K256CashuMintKeyringV1>>,
+        arc_keyring_experimental: Option<Arc<ArcSecretKeyringV1>>,
+        issuer_settlement_signing_key: SigningKey,
+        retained_issuer_settlement_keys: Vec<VerifyingKey>,
+        settlement_keyring: Option<Arc<K256CashuMintKeyringV1>>,
+        retained_settlement_keysets: Vec<CashuKeysetBindingV1>,
+        response_derivation_key: RedeemResponseDerivationKeyV1,
+    ) -> Result<Self, IssuerServiceErrorV1> {
+        Self::new_with_payout_mode(
+            store,
+            providers,
+            bat_keyring,
+            arc_keyring_experimental,
+            issuer_settlement_signing_key,
+            retained_issuer_settlement_keys,
+            settlement_keyring,
+            retained_settlement_keysets,
+            response_derivation_key,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_payout_mode(
         store: IssuerStore,
         mut providers: Vec<TrustedClearingProviderV1>,
         bat_keyring: Option<Arc<K256CashuMintKeyringV1>>,
@@ -1269,7 +1338,7 @@ impl SharedIssuerClearingServiceV1 {
         settlement_keyring: Option<Arc<K256CashuMintKeyringV1>>,
         retained_settlement_keysets: Vec<CashuKeysetBindingV1>,
         response_derivation_key: RedeemResponseDerivationKeyV1,
-        payout_policy: SettlementPayoutPolicyV1,
+        payout_policy: Option<SettlementPayoutPolicyV1>,
     ) -> Result<Self, IssuerServiceErrorV1> {
         providers.sort_by_key(|provider| provider.provider_id);
         if providers.is_empty()
@@ -1303,6 +1372,10 @@ impl SharedIssuerClearingServiceV1 {
             response_derivation_key,
             payout_policy,
         })
+    }
+
+    pub const fn is_ledger_only(&self) -> bool {
+        self.payout_policy.is_none()
     }
 
     /// `POST /v1/redeems` body handler. A committed exact replay authenticates
@@ -1507,6 +1580,7 @@ impl SharedIssuerClearingServiceV1 {
         canonical_envelope: &[u8],
         now_unix: u64,
     ) -> Result<Vec<u8>, IssuerServiceErrorV1> {
+        let payout_policy = self.payout_policy.ok_or(IssuerServiceErrorV1::NotFound)?;
         let envelope = ProviderPayoutIntentEnvelopeV1::decode(canonical_envelope)
             .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?;
         let context = self.load_clearing_context(
@@ -1556,11 +1630,11 @@ impl SharedIssuerClearingServiceV1 {
         )
         .map_err(|_| IssuerServiceErrorV1::Unauthorized)?;
         let expires_at = now_unix
-            .checked_add(self.payout_policy.intent_ttl_seconds)
+            .checked_add(payout_policy.intent_ttl_seconds)
             .ok_or(IssuerServiceErrorV1::InvalidRequest)?;
         let response = prepare_payout_intent_response_v1(
             &envelope.request,
-            self.payout_policy.issuer_fee,
+            payout_policy.issuer_fee,
             expires_at,
             &self.issuer_settlement_signing_key,
         )
@@ -1592,6 +1666,9 @@ impl SharedIssuerClearingServiceV1 {
         canonical_envelope: &[u8],
         now_unix: u64,
     ) -> Result<Vec<u8>, IssuerServiceErrorV1> {
+        if self.payout_policy.is_none() {
+            return Err(IssuerServiceErrorV1::NotFound);
+        }
         let envelope = ProviderPayoutEnvelopeV1::decode(canonical_envelope)
             .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?;
         let context = self.load_clearing_context(
@@ -1684,6 +1761,9 @@ impl SharedIssuerClearingServiceV1 {
         canonical_envelope: &[u8],
         now_unix: u64,
     ) -> Result<Vec<u8>, IssuerServiceErrorV1> {
+        if self.payout_policy.is_none() {
+            return Err(IssuerServiceErrorV1::NotFound);
+        }
         let envelope = ProviderPayoutStatusEnvelopeV1::decode(canonical_envelope)
             .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?;
         let identity = self.store.identity().map_err(map_store_error)?;

--- a/crates/payment/issuer-service/src/settlement_service_tests.rs
+++ b/crates/payment/issuer-service/src/settlement_service_tests.rs
@@ -182,6 +182,25 @@ impl Fixture {
         self.service_with_settlement_lineage(SETTLEMENT_SIGNING_SEED, Vec::new())
     }
 
+    fn ledger_only_service(&self) -> SharedIssuerClearingServiceV1 {
+        SharedIssuerClearingServiceV1::new_ledger_only(
+            self.store.clone(),
+            vec![TrustedClearingProviderV1 {
+                provider_id: PROVIDER_ID,
+                operator_key: self.operator.verifying_key(),
+                minimum_authorization_epoch: 1,
+            }],
+            Some(Arc::clone(&self.bat_keyring)),
+            None,
+            SigningKey::from_bytes(&SETTLEMENT_SIGNING_SEED),
+            Vec::new(),
+            None,
+            Vec::new(),
+            RedeemResponseDerivationKeyV1::from_bytes([0x46; 32]).expect("redeem derivation key"),
+        )
+        .expect("ledger-only clearing service")
+    }
+
     fn service_with_settlement_lineage(
         &self,
         current_seed: [u8; 32],
@@ -225,6 +244,37 @@ impl Fixture {
         .expect("BAT proof encoding")
         .to_vec()
     }
+}
+
+#[test]
+fn ledger_only_service_rejects_every_payout_method_before_decode_or_store_access() {
+    let fixture = Fixture::new();
+    let service = fixture.ledger_only_service();
+    assert!(service.is_ledger_only());
+    assert_ne!(LEDGER_ONLY_DISABLED_PAYOUT_TARGET_ID_V1, [0; 32]);
+
+    let before = fixture
+        .store
+        .operational_inventory()
+        .expect("inventory before disabled payout calls");
+    let invalid = b"not-a-canonical-payout-envelope";
+    assert_eq!(
+        service.payout_intent(invalid, u64::MAX),
+        Err(IssuerServiceErrorV1::NotFound)
+    );
+    assert_eq!(
+        service.payout(invalid, u64::MAX),
+        Err(IssuerServiceErrorV1::NotFound)
+    );
+    assert_eq!(
+        service.payout_status(invalid, u64::MAX),
+        Err(IssuerServiceErrorV1::NotFound)
+    );
+    let after = fixture
+        .store
+        .operational_inventory()
+        .expect("inventory after disabled payout calls");
+    assert_eq!(after, before);
 }
 
 #[test]

--- a/crates/payment/lightning-backend/Cargo.toml
+++ b/crates/payment/lightning-backend/Cargo.toml
@@ -8,6 +8,9 @@ description = "Fail-closed Lightning invoice backend boundary and fake node for 
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Bitcoin-PIR/Bitcoin-PIR"
 
+[features]
+cln-rpc-guard = []
+
 [dependencies]
 bitcoin = { version = "0.32", default-features = false, features = ["secp-recovery"] }
 lightning-invoice = { version = "=0.34.0", default-features = false }
@@ -19,6 +22,7 @@ zeroize = "1"
 
 [target.'cfg(unix)'.dependencies]
 pir-private-files = { path = "../../security/private-files" }
+rustix = { version = "1", features = ["fs"] }
 socket2 = "0.6"
 
 [lints.rust]

--- a/crates/payment/lightning-backend/src/core_lightning.rs
+++ b/crates/payment/lightning-backend/src/core_lightning.rs
@@ -632,6 +632,12 @@ mod unix_transport {
                 "Core Lightning RPC socket",
             )
             .map_err(|_| ClnRpcTransportErrorV1::UnavailableBeforeWrite)?;
+            // Construction is the process-startup preflight used by both the
+            // issuer and the dedicated RPC guard. Validate the named socket
+            // itself here as well as before and after every connect, so a
+            // hard-linked or otherwise untrusted endpoint cannot survive
+            // startup merely because the first RPC has not run yet.
+            checked_socket_metadata(&socket_path, policy)?;
             Ok(Self {
                 socket_path,
                 policy,

--- a/crates/payment/lightning-backend/src/core_lightning.rs
+++ b/crates/payment/lightning-backend/src/core_lightning.rs
@@ -59,6 +59,14 @@ impl ClnRpcResponseV1 {
     fn as_bytes(&self) -> &[u8] {
         self.bytes.as_slice()
     }
+
+    /// Copy a bounded secret-bearing response into another zeroizing buffer
+    /// for the dedicated local RPC guard. This deliberate feature-gated API
+    /// keeps raw CLN responses unavailable to ordinary backend consumers.
+    #[cfg(feature = "cln-rpc-guard")]
+    pub fn copy_for_local_guard(&self) -> Zeroizing<Vec<u8>> {
+        Zeroizing::new(self.bytes.to_vec())
+    }
 }
 
 impl fmt::Debug for ClnRpcResponseV1 {
@@ -763,9 +771,13 @@ mod unix_transport {
         path: &Path,
         policy: UnixClnRpcSocketPolicyV1,
     ) -> Result<(u64, u64), ClnRpcTransportErrorV1> {
+        reject_linux_socket_acl(path)?;
         let metadata = fs::symlink_metadata(path)
             .map_err(|_| ClnRpcTransportErrorV1::UnavailableBeforeWrite)?;
-        if !metadata.file_type().is_socket() || metadata.uid() != policy.expected_uid {
+        if !metadata.file_type().is_socket()
+            || metadata.uid() != policy.expected_uid
+            || metadata.nlink() != 1
+        {
             return Err(ClnRpcTransportErrorV1::UnavailableBeforeWrite);
         }
         let mode = metadata.mode() & 0o7777;
@@ -775,6 +787,25 @@ mod unix_transport {
             _ => return Err(ClnRpcTransportErrorV1::UnavailableBeforeWrite),
         }
         Ok((metadata.dev(), metadata.ino()))
+    }
+
+    #[cfg(target_os = "linux")]
+    fn reject_linux_socket_acl(path: &Path) -> Result<(), ClnRpcTransportErrorV1> {
+        let mut attributes = Vec::<u8>::with_capacity(4096);
+        rustix::fs::llistxattr(path, rustix::buffer::spare_capacity(&mut attributes))
+            .map_err(|_| ClnRpcTransportErrorV1::UnavailableBeforeWrite)?;
+        if attributes
+            .split(|byte| *byte == 0)
+            .any(|name| name == b"system.posix_acl_access" || name == b"system.posix_acl_default")
+        {
+            return Err(ClnRpcTransportErrorV1::UnavailableBeforeWrite);
+        }
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn reject_linux_socket_acl(_path: &Path) -> Result<(), ClnRpcTransportErrorV1> {
+        Ok(())
     }
 
     pub use UnixClnRpcSocketPolicyV1 as ExportedUnixClnRpcSocketPolicyV1;
@@ -1313,6 +1344,36 @@ mod tests {
         )
         .is_err());
         drop(listener);
+        fs::remove_file(path).unwrap();
+        fs::remove_dir(directory).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_transport_rejects_a_hard_linked_socket() {
+        use std::fs;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        use std::os::unix::net::UnixListener;
+        use std::time::Duration;
+
+        let (directory, path) = private_unix_socket_test_path("hardlink");
+        let listener = UnixListener::bind(&path).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        let uid = fs::symlink_metadata(&path).unwrap().uid();
+        let alias = directory.join("lightning-rpc-alias");
+        fs::hard_link(&path, &alias).unwrap();
+        assert_eq!(fs::symlink_metadata(&path).unwrap().nlink(), 2);
+        assert!(UnixClnRpcTransportV1::new(
+            path.clone(),
+            UnixClnRpcSocketPolicyV1 {
+                expected_uid: uid,
+                expected_gid: None,
+            },
+            Duration::from_secs(1),
+        )
+        .is_err());
+        drop(listener);
+        fs::remove_file(alias).unwrap();
         fs::remove_file(path).unwrap();
         fs::remove_dir(directory).unwrap();
     }

--- a/deploy/payment-v1/README.md
+++ b/deploy/payment-v1/README.md
@@ -1,0 +1,94 @@
+# Payment V1 deployment templates
+
+These files are review inputs, not installed service definitions. Every service
+template ends in `.in`, has no `[Install]` section, and requires an explicit
+`/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED` sentinel after rendering. The
+VPSBG input is only a non-executable argument fragment; it is neither a runit
+service nor a replacement for the measured Tier 3 run script.
+
+The templates divide responsibilities as follows:
+
+- `systemd/hetzner-provider.service.in` is the paid/provider process on Hetzner.
+  Its signed policy, not the unit, binds backend-specific scopes and prices.
+  Harmony hint generation and Harmony query execution must remain separate
+  scopes because they have different costs. The first production profile loads
+  provider-local BAT, Standard Cashu recovery/custody/exposure controls, and one
+  fully authorized shared issuer; direct receipt needs no provider secret and
+  ARC remains forbidden. A provider-local BAT offer deliberately shares one
+  policy-bound DHKE scalar between its issuer and that provider; compromise of
+  either copy can forge that BAT lineage. Omit this method and use online
+  shared-issuer redemption when that shared-secret boundary is unacceptable.
+- `systemd/hetzner-cln-rpc-guard.service.in` is the only principal other than
+  CLN and the dedicated one-shot preflight that may traverse the native CLN
+  socket directory. It parses and reconstructs bounded JSON-RPC, permits only
+  the issuer's exact `getinfo`, `listinvoices`, and `invoice` shapes, and emits
+  a separate issuer-group socket below a boot-created `0710` directory. Its
+  per-runtime invoice deadman is protected by `Restart=no`; a crash stops the
+  bound issuer until an operator explicitly reviews and starts a new guard
+  generation.
+- `systemd/hetzner-payment-issuer.service.in` is the sole loopback-only Core
+  Lightning issuer and integrated clearing unit. It requires and binds to the
+  exact CLN unit, RPC guard, and successful live preflight, and it never runs a
+  fake settlement backend. The issuer has no native CLN or Bitcoin-cookie
+  group and `/srv/lightning` plus `/srv/bitcoin` are inaccessible in its mount
+  namespace. The public edge exposes only credential redemption and
+  authenticated provider-balance lookup; payout-intent, payout and
+  payout-status routes are not part of the V1 production product. Its command
+  has no payout target, fee, or intent-TTL argument; the source gate rejects
+  reintroducing any of those flags.
+- `systemd/rollback-authority.service.in` is instantiated only on a separately
+  administered authority host. Provider 0, Provider 1, and the issuer each need
+  their own host, keys, database, TLS edge, administrator, logs, and backup
+  domain.
+- `systemd/hetzner-directory-relay.service.in` is deliberately blocked while
+  `relay-selection.toml.example` is `UNRESOLVED`. It is a deployment contract
+  for the repository's directory-only relay, not a generic Nostr relay unit.
+  A future resolved service may pass only one absolute owner-only TOML path via
+  `--config`; direct command-line overrides remain forbidden.
+- `vpsbg/vpsbg-free-pow-service-auth.args.in` is the only VPSBG change described
+  by this directory. It lists the enforced Payment V1 arguments that a reviewed
+  UKI rebuild would append to the existing query-only provider's final exec. It
+  deliberately omits that measured script's ORAM build/verification, identity,
+  database, attestation and cloudflared logic so it cannot be mistaken for a
+  standalone replacement. It does not add an issuer, relay, mint, Lightning
+  node, Cashu/ARC key, or rollback-authority process to VPSBG.
+
+Production templates use only remote rollback authorities. Issuer and rollback
+authority application listeners remain on loopback behind separately reviewed,
+same-host TLS edges. ARC, fake Lightning, local rollback flags, legacy payment
+gates, test-only trust roots, and source-IP Free quotas behind a proxy are
+forbidden.
+
+The signed policy is the price/resource contract. DPF query, Harmony hint,
+Harmony query, Onion query and Direct ORAM require distinct scopes and may have
+different prices or methods. V1 has no class-aware scheduler, so every initial
+offer must use `priority_class = 1`; neither the directory nor Web UI may claim
+paid QoS.
+
+The VPSBG owner/mode rules do not provide secrecy from its hosting operator.
+The deployment document records this as a P1 activation blocker rather than
+treating guest-local filesystem permissions as hostile-host protection.
+
+Run the repository gate before reviewing a rendered deployment:
+
+```sh
+node scripts/payment-v1-deployment-template-gate.mjs
+node --test scripts/payment-v1-deployment-template-gate.test.mjs
+```
+
+The gate also pins hashes of the pre-existing active systemd units and the
+measured Tier 3 runit script. A change to those files is outside this preparation
+slice and fails closed.
+
+This source-template gate is not proof of installed bytes. Use
+`scripts/payment-v1-rendered-artifact-gate.mjs` to render one closed deployment
+profile from an externally digest-approved plan, recompute every referenced
+artifact/hash manifest, and reject placeholders, extra files, symlinks and
+cross-profile dependencies. Then use
+`scripts/payment-v1-linux-runtime-evidence.mjs` as root on the exact Linux host
+to bind effective systemd state, running process identities, NSS, ACLs, xattrs,
+capabilities, boot and host identity to that manifest. Offline review without
+the externally transferred full evidence digest is not activation evidence.
+
+See `docs/payment/HETZNER_VPSBG_DEPLOYMENT.md` for topology, rendering,
+activation, rollback, and remote-approval boundaries.

--- a/deploy/payment-v1/directory-relay.toml.example
+++ b/deploy/payment-v1/directory-relay.toml.example
@@ -1,0 +1,31 @@
+# BitcoinPIR directory-only relay v1 production-shape example.
+# This file contains no signing key. Render DIRECTORY_PUBLISHER_PUBKEY_HEX as
+# the dedicated non-zero x-only public key, then keep the rendered config 0400
+# or 0600 below /etc/bitcoinpir/payment-v1/directory-relay.
+
+profile = "bitcoinpir-directory-relay-v1"
+listen = "127.0.0.1:8080"
+database = "/var/lib/bitcoinpir-directory-relay/relay.sqlite3"
+directory_pubkey_hex = "@DIRECTORY_PUBLISHER_PUBKEY_HEX@"
+
+# These are relay abuse/capacity limits, not commercial policy. The cumulative
+# connection budget intentionally does not permit count and event-size maxima
+# to be saturated simultaneously. The supplied stock-Caddy edge is not
+# source-aware; a reviewed non-persistent source-fair boundary remains an
+# activation prerequisite.
+max_connections = 64
+max_in_flight_operations = 8
+max_operations_per_second = 64
+max_egress_bytes_per_second = 16777216
+max_egress_bytes_per_connection = 67108864
+
+# max_archive_bytes counts immutable event_json BLOB bytes, not SQLite/WAL/index
+# disk usage. Filesystem quota and free-space alerts remain mandatory.
+max_archive_events = 100000
+max_archive_bytes = 268435456
+
+handshake_timeout_seconds = 10
+idle_timeout_seconds = 60
+connection_timeout_seconds = 300
+operation_timeout_seconds = 10
+egress_timeout_seconds = 5

--- a/deploy/payment-v1/edge/README.md
+++ b/deploy/payment-v1/edge/README.md
@@ -1,0 +1,97 @@
+# Payment V1 production edge templates
+
+These are non-activating review inputs. They do not authorize DNS changes,
+certificate issuance, public listeners, a remote-host change, or production
+deployment. Rendered files remain blocked by the Payment V1 activation
+sentinel and by exact binary/configuration hash manifests.
+
+The reviewed edge binary is stock Caddy. Do not add modules. Pin the complete
+single-file binary, its exact `caddy version` output, the rendered Caddyfile,
+and the rendered systemd unit before activation. The Caddy admin API,
+persistent autosaved configuration, HTTP redirects, 0-RTT, debug/trace,
+access logs and request/header/body logs are disabled. Operational logging is
+limited to non-request ERROR events; `http.log.access` and `http.log.error`
+are excluded explicitly.
+
+## Public surfaces
+
+`hetzner-public.Caddyfile.in` exposes exactly three independent TLS names:
+
+| Public surface | Exact public path | Loopback upstream | Protocol bound |
+| --- | --- | --- | --- |
+| PIR provider | `/v1/pir` | `127.0.0.1:8191` | WebSocket upgrade; application frames are capped by `unified_server` at 512 KiB |
+| payment/credential issuer | the enumerated `/v1/...` paths in the template | `127.0.0.1:5610` | HTTP/1.1; body at most 66,445 bytes |
+| directory relay | `/v1/directory` | `127.0.0.1:8080` | WebSocket upgrade; relay frames are capped by the relay at 2 MiB |
+
+The edge does not inspect upgraded WebSocket frames. The application servers'
+fixed frame limits therefore remain part of the security boundary. The edge
+does bound the TLS handshake HTTP headers and the pre-upgrade request body.
+Do not replace either backend with one lacking those frame limits.
+
+The three loopback ports are cross-file invariants, not deployment choices:
+the rendered edge, application unit, and application configuration must agree
+exactly. In particular, the directory-only relay configuration already fixes
+`127.0.0.1:8080`; rendering `7447` or any other relay upstream must fail the
+rendered-artifact gate.
+
+`rollback-authority.Caddyfile.in` is rendered separately on each independent
+authority host. It exposes only `POST /v1/rollback-authority/calls`, caps the
+body at 1,404 bytes, and proxies to `127.0.0.1:8099`. Its upstream header
+rewrite is deliberately narrower than a normal reverse proxy: the authority's
+strict parser accepts no `Forwarded`, `X-Forwarded-*`, `Via`, authorization,
+cookie, transfer-encoding, expect or upgrade headers and requires
+`Connection: close`.
+
+No edge forwards a client IP or proxy identity header to an application
+upstream. The edge host itself still observes source IP, TLS timing, SNI and
+traffic volume. This topology does not claim network-observer unlinkability.
+
+## Rate and concurrency boundary
+
+Stock Caddy has no bundled request-rate module, and this template forbids
+unreviewed third-party modules. It therefore applies fixed upstream connection
+ceilings rather than maintaining a new per-IP identity table: provider 128,
+issuer 128, directory relay 64, and rollback authority 32. The corresponding
+applications remain authoritative and fail closed at the same or tighter
+bounds. In particular, the issuer enforces quote 60/minute, status 600/minute,
+mutation 120/minute, and reconciliation 120/minute budgets; the directory
+relay enforces 64 operations/second; and the provider combines 128 total
+connections with its Payment V1 authentication/concurrency and signed-policy
+quota gates. A rendered-artifact validator must compare those values across
+edge, unit, application configuration, and signed policy instead of treating
+the prose as configuration.
+
+Volumetric protection before Caddy is a separate host/network deployment
+decision. It must not reintroduce credential-bearing access logs or forward a
+source-IP header into PIR, issuer, relay, or authority application logs.
+
+The global ceilings above are vulnerable to low-bandwidth starvation and are
+not production availability protection: one source can occupy the WebSocket
+pool, consume the anonymous quote budget, or hold the authority queue. Public
+activation is blocked until a reviewed edge/network control enforces ephemeral
+source-fair connection and request admission without persistent IP/request
+logs or forwarding source identity to the business services. Directory
+publishing additionally needs a separately reserved private ingress/budget.
+Every rollback authority must be reachable only through its client-specific
+private boundary (for example WireGuard, mutually authenticated TLS, or an
+equivalent narrow firewall allowlist), never as an ordinary public endpoint.
+
+## Rendering and activation boundary
+
+Replace every `@...@` token with a reviewed value; tokens must not remain in a
+rendered file. Public host tokens are bare lower-case DNS names without a
+scheme, path, port, wildcard or trailing dot. Loopback ports are fixed in the
+templates and must match the corresponding application unit.
+
+Render `systemd/payment-v1-edge.service.in` with one absolute Caddyfile path.
+Create root-owned, non-writable checksum manifests whose sole entries are the
+exact absolute binary and rendered-config paths. The service performs strict
+`sha256sum --check` and `caddy validate` before `caddy run`. Provisioning the
+sentinel, starting the unit and changing DNS remain separate approved actions.
+
+Certificate automation may contact the configured public CA and stores state
+under `/var/lib/bitcoinpir-payment-edge`. If certificate issuance is not the
+reviewed production choice, replace automatic management with separately
+reviewed certificate/key custody before rendering; never place a private key
+on a command line. `auto_https disable_redirects` intentionally permits
+certificate management but forbids HTTP-to-HTTPS redirects.

--- a/deploy/payment-v1/edge/hetzner-public.Caddyfile.in
+++ b/deploy/payment-v1/edge/hetzner-public.Caddyfile.in
@@ -1,0 +1,344 @@
+# BitcoinPIR Payment V1 Hetzner public edge; rendered file is hash-pinned.
+{
+	admin off
+	persist_config off
+	auto_https disable_redirects
+
+	servers :443 {
+		protocols h1 h2
+		timeouts {
+			read_header 5s
+			read_body 15s
+			# An absolute HTTP-server write deadline is unsafe for upgraded
+			# WebSockets. Application egress/idle/lifetime deadlines remain
+			# mandatory and are enforced by each loopback upstream.
+			write 0s
+			idle 60s
+		}
+		max_header_size 16KiB
+		0rtt off
+		strict_sni_host on
+	}
+
+	# Site blocks below do not enable Caddy's access logger. Excluding both
+	# request logger namespaces prevents a later global logger from recording
+	# IP, Host, path, headers or credential-bearing error context.
+	log default {
+		level ERROR
+		exclude http.log.access http.log.error http.handlers.reverse_proxy
+	}
+}
+
+@PROVIDER_WSS_HOST@ {
+	@provider_ws {
+		method GET
+		path /v1/pir
+		header Host @PROVIDER_WSS_HOST@
+		header Connection *Upgrade*
+		header Upgrade websocket
+		header Sec-WebSocket-Version 13
+		header_regexp Sec-WebSocket-Key ^[A-Za-z0-9+/]{22}==$
+		expression {http.request.uri} == "/v1/pir"
+	}
+
+	handle @provider_ws {
+		request_body {
+			max_size 1KiB
+		}
+		reverse_proxy 127.0.0.1:8191 {
+			header_up -*
+			header_up Host @PROVIDER_WSS_HOST@
+			header_up Connection Upgrade
+			header_up Upgrade websocket
+			header_up Sec-WebSocket-Version 13
+			header_up Sec-WebSocket-Key {http.request.header.Sec-WebSocket-Key}
+			header_down -Via
+			flush_interval -1
+			transport http {
+				versions 1.1
+				dial_timeout 3s
+				response_header_timeout 10s
+				max_response_header 16KiB
+				max_conns_per_host 128
+				keepalive off
+				compression off
+			}
+		}
+	}
+
+	handle {
+		respond "" 404
+	}
+}
+
+@PAYMENT_ISSUER_HTTPS_HOST@ {
+	@issuer_quote_keys {
+		method GET OPTIONS
+		header Host @PAYMENT_ISSUER_HTTPS_HOST@
+		path_regexp issuer_key ^/v1/quote-keys/(current|[0-9a-f]{32})$
+		expression {http.request.uri.query} == ""
+	}
+	@issuer_quote_create {
+		method POST OPTIONS
+		header Host @PAYMENT_ISSUER_HTTPS_HOST@
+		path /v1/quotes/bolt11
+		expression {http.request.uri} == "/v1/quotes/bolt11"
+	}
+	@issuer_quote_action {
+		method POST OPTIONS
+		header Host @PAYMENT_ISSUER_HTTPS_HOST@
+		path_regexp issuer_action ^/v1/quotes/[0-9a-f]{64}/(status|claim)$
+		expression {http.request.uri.query} == ""
+	}
+		@issuer_provider_call {
+			method POST
+			header Host @PAYMENT_ISSUER_HTTPS_HOST@
+			path /v1/redeems /v1/settlement/balance
+			expression {http.request.uri.query} == ""
+		}
+
+	handle @issuer_quote_keys {
+		request_body {
+			max_size 66445B
+		}
+		reverse_proxy 127.0.0.1:5610 {
+			header_up Host @PAYMENT_ISSUER_HTTPS_HOST@
+			header_up Connection close
+			header_up -Accept
+			header_up -Accept-Encoding
+			header_up -Accept-Language
+			header_up -Authorization
+			header_up -Baggage
+			header_up -Cookie
+			header_up -DNT
+			header_up -Forwarded
+			header_up -Priority
+			header_up -Proxy-Authorization
+			header_up -Referer
+			header_up -Sec-CH-UA
+			header_up -Sec-CH-UA-Mobile
+			header_up -Sec-CH-UA-Platform
+			header_up -Sec-Fetch-Dest
+			header_up -Sec-Fetch-Mode
+			header_up -Sec-Fetch-Site
+			header_up -Sec-Fetch-User
+			header_up -Traceparent
+			header_up -Tracestate
+			header_up -User-Agent
+			header_up -Via
+			header_up -X-Correlation-ID
+			header_up -X-Forwarded-For
+			header_up -X-Forwarded-Host
+			header_up -X-Forwarded-Proto
+			header_up -X-Real-IP
+			header_up -X-Request-ID
+			header_down -Via
+			transport http {
+				versions 1.1
+				dial_timeout 3s
+				response_header_timeout 15s
+				read_timeout 15s
+				write_timeout 15s
+				max_response_header 32KiB
+				max_conns_per_host 128
+				keepalive off
+				compression off
+			}
+		}
+	}
+
+	handle @issuer_quote_create {
+		request_body {
+			max_size 66445B
+		}
+		reverse_proxy 127.0.0.1:5610 {
+			header_up Host @PAYMENT_ISSUER_HTTPS_HOST@
+			header_up Connection close
+			header_up -Accept
+			header_up -Accept-Encoding
+			header_up -Accept-Language
+			header_up -Authorization
+			header_up -Baggage
+			header_up -Cookie
+			header_up -DNT
+			header_up -Forwarded
+			header_up -Priority
+			header_up -Proxy-Authorization
+			header_up -Referer
+			header_up -Sec-CH-UA
+			header_up -Sec-CH-UA-Mobile
+			header_up -Sec-CH-UA-Platform
+			header_up -Sec-Fetch-Dest
+			header_up -Sec-Fetch-Mode
+			header_up -Sec-Fetch-Site
+			header_up -Sec-Fetch-User
+			header_up -Traceparent
+			header_up -Tracestate
+			header_up -User-Agent
+			header_up -Via
+			header_up -X-Correlation-ID
+			header_up -X-Forwarded-For
+			header_up -X-Forwarded-Host
+			header_up -X-Forwarded-Proto
+			header_up -X-Real-IP
+			header_up -X-Request-ID
+			header_down -Via
+			transport http {
+				versions 1.1
+				dial_timeout 3s
+				response_header_timeout 15s
+				read_timeout 15s
+				write_timeout 15s
+				max_response_header 32KiB
+				max_conns_per_host 128
+				keepalive off
+				compression off
+			}
+		}
+	}
+
+	handle @issuer_quote_action {
+		request_body {
+			max_size 66445B
+		}
+		reverse_proxy 127.0.0.1:5610 {
+			header_up Host @PAYMENT_ISSUER_HTTPS_HOST@
+			header_up Connection close
+			header_up -Accept
+			header_up -Accept-Encoding
+			header_up -Accept-Language
+			header_up -Authorization
+			header_up -Baggage
+			header_up -Cookie
+			header_up -DNT
+			header_up -Forwarded
+			header_up -Priority
+			header_up -Proxy-Authorization
+			header_up -Referer
+			header_up -Sec-CH-UA
+			header_up -Sec-CH-UA-Mobile
+			header_up -Sec-CH-UA-Platform
+			header_up -Sec-Fetch-Dest
+			header_up -Sec-Fetch-Mode
+			header_up -Sec-Fetch-Site
+			header_up -Sec-Fetch-User
+			header_up -Traceparent
+			header_up -Tracestate
+			header_up -User-Agent
+			header_up -Via
+			header_up -X-Correlation-ID
+			header_up -X-Forwarded-For
+			header_up -X-Forwarded-Host
+			header_up -X-Forwarded-Proto
+			header_up -X-Real-IP
+			header_up -X-Request-ID
+			header_down -Via
+			transport http {
+				versions 1.1
+				dial_timeout 3s
+				response_header_timeout 15s
+				read_timeout 15s
+				write_timeout 15s
+				max_response_header 32KiB
+				max_conns_per_host 128
+				keepalive off
+				compression off
+			}
+		}
+	}
+
+	handle @issuer_provider_call {
+		request_body {
+			max_size 66445B
+		}
+		reverse_proxy 127.0.0.1:5610 {
+			header_up Host @PAYMENT_ISSUER_HTTPS_HOST@
+			header_up Connection close
+			header_up -Accept
+			header_up -Accept-Encoding
+			header_up -Accept-Language
+			header_up -Authorization
+			header_up -Baggage
+			header_up -Cookie
+			header_up -DNT
+			header_up -Forwarded
+			header_up -Priority
+			header_up -Proxy-Authorization
+			header_up -Referer
+			header_up -Sec-CH-UA
+			header_up -Sec-CH-UA-Mobile
+			header_up -Sec-CH-UA-Platform
+			header_up -Sec-Fetch-Dest
+			header_up -Sec-Fetch-Mode
+			header_up -Sec-Fetch-Site
+			header_up -Sec-Fetch-User
+			header_up -Traceparent
+			header_up -Tracestate
+			header_up -User-Agent
+			header_up -Via
+			header_up -X-Correlation-ID
+			header_up -X-Forwarded-For
+			header_up -X-Forwarded-Host
+			header_up -X-Forwarded-Proto
+			header_up -X-Real-IP
+			header_up -X-Request-ID
+			header_down -Via
+			transport http {
+				versions 1.1
+				dial_timeout 3s
+				response_header_timeout 15s
+				read_timeout 15s
+				write_timeout 15s
+				max_response_header 32KiB
+				max_conns_per_host 128
+				keepalive off
+				compression off
+			}
+		}
+	}
+
+	handle {
+		respond "" 404
+	}
+}
+@DIRECTORY_RELAY_WSS_HOST@ {
+	@directory_ws {
+		method GET
+		path /v1/directory
+		header Host @DIRECTORY_RELAY_WSS_HOST@
+		header Connection *Upgrade*
+		header Upgrade websocket
+		header Sec-WebSocket-Version 13
+		header_regexp Sec-WebSocket-Key ^[A-Za-z0-9+/]{22}==$
+		expression {http.request.uri} == "/v1/directory"
+	}
+
+	handle @directory_ws {
+		request_body {
+			max_size 1KiB
+		}
+		reverse_proxy 127.0.0.1:8080 {
+			header_up -*
+			header_up Host @DIRECTORY_RELAY_WSS_HOST@
+			header_up Connection Upgrade
+			header_up Upgrade websocket
+			header_up Sec-WebSocket-Version 13
+			header_up Sec-WebSocket-Key {http.request.header.Sec-WebSocket-Key}
+			header_down -Via
+			flush_interval -1
+			transport http {
+				versions 1.1
+				dial_timeout 3s
+				response_header_timeout 10s
+				max_response_header 16KiB
+				max_conns_per_host 64
+				keepalive off
+				compression off
+			}
+		}
+	}
+
+	handle {
+		respond "" 404
+	}
+}

--- a/deploy/payment-v1/edge/rollback-authority.Caddyfile.in
+++ b/deploy/payment-v1/edge/rollback-authority.Caddyfile.in
@@ -1,0 +1,68 @@
+# BitcoinPIR Payment V1 independent rollback-authority edge.
+{
+	admin off
+	persist_config off
+	auto_https disable_redirects
+
+	servers :443 {
+		protocols h1 h2
+		timeouts {
+			read_header 5s
+			read_body 10s
+			write 15s
+			idle 30s
+		}
+		max_header_size 8KiB
+		0rtt off
+		strict_sni_host on
+	}
+
+	log default {
+		level ERROR
+		exclude http.log.access http.log.error http.handlers.reverse_proxy
+	}
+}
+
+@ROLLBACK_AUTHORITY_HTTPS_HOST@ {
+	@authority_call {
+		method POST
+		path /v1/rollback-authority/calls
+		header Host @ROLLBACK_AUTHORITY_HTTPS_HOST@
+		header Content-Type application/vnd.bitcoinpir.rollback-authority-request-v1
+		header Accept "application/vnd.bitcoinpir.rollback-authority-response-v1, application/problem+json"
+		header Connection close
+		header User-Agent BitcoinPIR-service-admission/1
+		header Content-Length *
+		expression {http.request.uri} == "/v1/rollback-authority/calls"
+	}
+
+	handle @authority_call {
+		request_body {
+			max_size 1404B
+		}
+		reverse_proxy 127.0.0.1:8099 {
+			header_up -*
+			header_up Host @ROLLBACK_AUTHORITY_HTTPS_HOST@
+			header_up Content-Type application/vnd.bitcoinpir.rollback-authority-request-v1
+			header_up Accept "application/vnd.bitcoinpir.rollback-authority-response-v1, application/problem+json"
+			header_up Connection close
+			header_up User-Agent BitcoinPIR-service-admission/1
+			header_down -Via
+			transport http {
+				versions 1.1
+				dial_timeout 3s
+				response_header_timeout 10s
+				read_timeout 10s
+				write_timeout 10s
+				max_response_header 8KiB
+				max_conns_per_host 32
+				keepalive off
+				compression off
+			}
+		}
+	}
+
+	handle {
+		respond "" 404
+	}
+}

--- a/deploy/payment-v1/lightning/README.md
+++ b/deploy/payment-v1/lightning/README.md
@@ -1,0 +1,139 @@
+# Hetzner Core Lightning path templates
+
+These files are non-activating review inputs. They create no wallet, node
+identity, channel or funds, and they do not authorize a remote-host change.
+The first persistent identity ceremony, Signet funding, public peer/channel
+work, mainnet use and real-value funds each remain separately approved actions.
+
+## Frozen runtime boundary
+
+`lightningd` is launched with exactly one explicit, absolute `--conf` path.
+Core Lightning treats an explicit config as the complete file configuration,
+so it does not also load mutable `config` files from the base or network data
+directory. The rendered file must contain no `include` line. Command-line
+arguments contain no RPC password, HSM passphrase, seed, macaroon or other
+secret.
+
+The rendered bundle manifest must enumerate and hash every shipped CLN binary,
+subdaemon, shared object and the only two allowed plugins. The service performs
+strict bundle/config/layout checks before launch. `clear-plugins` removes the
+default plugin set; only pinned `bcli` and `chanbackup` are restored as
+important plugins. Consequently there is no gRPC, REST, Commando, WebSocket
+proxy, recklessrpc, dynamic plugin directory or remote Lightning RPC surface.
+The native socket is an administrative CLN RPC surface, not a method-scoped
+capability. It is reachable only by CLN, the dedicated one-shot preflight, and
+the separately pinned `bitcoinpir-cln-rpc-guard`. The long-running issuer
+reaches only the guard's second Unix socket. The guard parses and reconstructs
+bounded JSON-RPC and allows exact `getinfo`, private-label `listinvoices`, and
+anonymous bounded `invoice` requests; it reconstructs minimal responses and
+never forwards a payment preimage. The guard remains part of the Lightning
+custody TCB, while compromise of the issuer no longer grants arbitrary CLN RPC.
+
+The exact runtime socket is:
+
+```text
+/srv/lightning/@LIGHTNING_NETWORK@/lightning-rpc
+```
+
+Provision `/srv/lightning/@LIGHTNING_NETWORK@` as
+`bitcoinpir-lightning:bitcoinpir-cln-guard` mode `0710`; render the numeric CLN
+UID and guard-only GID into all templates. `rpc-file-mode=0660` yields a socket
+owned by that UID/GID and is the cross-UID shape required by the guard's
+`UnixClnRpcTransportV1`: final parent `0710`, socket `0660`, no symlink and no
+extended ACL. Every regular CLN datastore/secret file remains CLN-owned,
+single-link and owner-only; the layout verifier rejects any group/world file
+permission.
+
+`cln-rpc-guard-tmpfiles.conf.in` creates guard/issuer mode-`0710` runtime root
+and final directories. The guard creates its downstream
+socket as guard-UID/issuer-GID mode `0660`, validates kernel peer credentials,
+and fails on a stale or replaced path. The issuer has no guard-native group,
+cannot traverse `/srv/lightning`, and cannot bypass the method guard. The
+dedicated preflight UID temporarily receives both the native CLN group and the
+Bitcoin-cookie group; it is deliberately not the issuer UID.
+
+`hetzner-payment-issuer.service.in` is the only renderable issuer unit and is
+installed as `bitcoinpir-payment-issuer.service`. It binds the guarded socket
+path and requires both the guard and successful live preflight. There is
+deliberately no generic or alternate issuer unit: a second runnable template
+would make it too easy to bypass either boundary.
+
+## Bitcoin RPC and network boundary
+
+The config fixes Core RPC to loopback and omits all RPC user/password options,
+so a password can never appear in the rendered config or process arguments.
+Bitcoin Core must create its cookie as bitcoind-UID/`bitcoinpir-bitcoin-rpc`
+GID mode `0640` below a bitcoind-owned/group mode-`0710` final directory. Only
+CLN and the dedicated preflight UID receive that group; neither the issuer nor
+the CLN guard does. The preflight checks the exact EUID/supplementary GID,
+canonical no-symlink path, single-link regular file, ACL policy, and metadata
+stability around the same open file descriptor. Do not insert an RPC password
+into this template or give the cookie group to the issuer.
+
+The P2P bind and announced address are exact rendered values. They are not an
+HTTP/RPC service and are not proxied by the Payment V1 edge. DNS discovery is
+disabled; peer/bootstrap endpoints must be pinned and reviewed separately.
+
+The current repository preflight deliberately accepts only Bitcoin default
+Signet and exact `network=signet`. Therefore `@LIGHTNING_NETWORK@` must render to
+`signet` for the first deployment/acceptance phase. Rendering `bitcoin` cannot
+activate the issuer: the preflight service fails closed until a separately
+reviewed production-mainnet preflight is implemented and real funds are
+approved. `testnet`, `testnet4`, custom Signet and persistent `regtest` are not
+accepted aliases.
+
+The supplied prerequisite record consequently keeps `network = "UNRESOLVED"`
+and `real_funds_authorized = false`. The first rendered acceptance environment
+must set the network to Signet; changing that field to `bitcoin` is not a
+mainnet approval mechanism.
+
+## Remaining activation gates
+
+The templates require the cross-UID CLN and Bitcoin-cookie validators plus the
+method guard; none has a source-level bypass flag. Activation still requires a
+Linux rendered-artifact/runtime-evidence pass, exact binary/config hashes,
+separate restore rehearsals, and live default-Signet preflight evidence. The
+repository preflight deliberately rejects mainnet, custom Signet, testnet and
+regtest. Mainnet support, any real-value wallet/channel, remote installation,
+and the corresponding custody decision remain separate reviewed and approved
+work. A generated node ID or test liquidity is not that approval.
+
+## Backup and activation prerequisites
+
+Before the global activation sentinel is provisioned, all of the following
+must be true and independently recorded:
+
+1. the node identity secret or approved signer seed has an offline,
+   restore-tested backup in a separate custody domain;
+2. current `staticbackup`/`emergency.recover` material has been exported and
+   restore-tested after channel changes;
+3. the dynamic CLN datastore has supported live replication, or a cold backup
+   taken only while `lightningd` was stopped, plus a restore rehearsal;
+4. rollback/failover does not restore stale channel state;
+5. the owner-only backup receipt has been written by
+   `bpir-admin lightning-staging record-backup-receipt`; and
+6. the CLN UID's pre-start layout verifier passes before `lightningd` starts;
+   it rejects namespace symlinks, ACLs, unexpected special files, non-private
+   datastore files, hard links, and the wrong socket owner/group/mode; and
+7. `bitcoinpir-lightning-preflight.service` passes as its dedicated preflight UID against
+   the running exact binaries, plugins, Core chain, node identity, channels,
+   liquidity, strict cross-UID socket metadata and fresh backup receipt.
+
+The issuer UID cannot traverse the native CLN namespace at all. The dedicated
+preflight UID can traverse but cannot list the mode-`0710` CLN directory. For
+that reason the live preflight does not rerun the recursive datastore verifier;
+it relies on the verifier run by the CLN UID before startup, then exercises the
+repository's per-RPC secure path walker and exact socket check as the issuer.
+Granting directory read permission merely to rerun `find` would violate the
+cross-UID privacy boundary.
+
+`staticbackup` is not a live database backup. Never copy a running SQLite CLN
+database. The two approval sentinels in the CLN unit are operator gates, not
+cryptographic proof; the issuer additionally requires both the live preflight
+oneshot and RPC guard, which are bound to the CLN unit lifecycle.
+
+Start from `docs/payment/LIGHTNING_STAGING_PREFLIGHT.toml.example` and render
+the exact Hetzner paths/hashes/UIDs into
+`/etc/bitcoinpir/payment-v1/lightning/preflight.toml`. The preflight config,
+backup receipt, `bpir-admin`, layout verifier, CLN bundle and `lightningd.conf`
+all have separate root-owned checksum manifests.

--- a/deploy/payment-v1/lightning/activation-prerequisites.toml.example
+++ b/deploy/payment-v1/lightning/activation-prerequisites.toml.example
@@ -1,0 +1,32 @@
+schema_version = 1
+status = "UNRESOLVED"
+network = "UNRESOLVED"
+cln_bundle_sha256 = "UNRESOLVED"
+bitcoin_core_bundle_sha256 = "UNRESOLVED"
+cln_rpc_guard_binary_sha256 = "UNRESOLVED"
+cln_rpc_guard_unit_sha256 = "UNRESOLVED"
+cln_rpc_guard_tmpfiles_sha256 = "UNRESOLVED"
+lightningd_config_sha256 = "UNRESOLVED"
+preflight_config_sha256 = "UNRESOLVED"
+backup_receipt_sha256 = "UNRESOLVED"
+expected_cln_version = "UNRESOLVED"
+expected_node_id_hex = "UNRESOLVED"
+
+# These booleans are operator-review inputs, not an activation mechanism.
+identity_secret_offline_restore_rehearsed = false
+channel_recovery_restore_rehearsed = false
+dynamic_datastore_restore_rehearsed = false
+stale_channel_state_rollback_rejected = false
+default_signet_chain_pins_verified = false
+exact_plugin_allowlist_verified = false
+strict_rpc_socket_layout_verified = false
+cross_uid_preflight_policy_verified = false
+bitcoin_rpc_cookie_boundary_verified = false
+cln_rpc_method_allowlist_guard_verified = false
+live_read_only_preflight_passed = false
+real_funds_authorized = false
+
+# Before mainnet/real value, a method-allowlisting RPC guard must be deployed
+# and hash-pinned, and the issuer must have no direct path to the native CLN
+# administrative socket. Risk acceptance does not replace this control. This
+# example authorizes no funds and is not an activation sentinel.

--- a/deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in
+++ b/deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in
@@ -1,0 +1,3 @@
+# Created at boot before activation; the guard validates every component again.
+d /run/bitcoinpir-cln-rpc-guard        0710 bitcoinpir-cln-rpc-guard bitcoinpir-issuer    - -
+d /run/bitcoinpir-cln-rpc-guard/issuer 0710 bitcoinpir-cln-rpc-guard bitcoinpir-issuer    - -

--- a/deploy/payment-v1/lightning/issuer-cln.args.in
+++ b/deploy/payment-v1/lightning/issuer-cln.args.in
@@ -1,0 +1,6 @@
+# Replace only the three guarded Core Lightning adapter arguments in the
+# reviewed payment-issuer service. This is not an executable fragment. The
+# issuer has no native CLN group and cannot traverse `/srv/lightning`.
+--cln-rpc-socket /run/bitcoinpir-cln-rpc-guard/issuer/issuer-rpc
+--cln-rpc-expected-uid @CLN_GUARD_UID@
+--cln-rpc-expected-gid @ISSUER_GID@

--- a/deploy/payment-v1/lightning/lightningd.conf.in
+++ b/deploy/payment-v1/lightning/lightningd.conf.in
@@ -1,0 +1,42 @@
+# BitcoinPIR Hetzner issuer Core Lightning config; render and hash-pin exactly.
+# No includes, passwords, passphrases, seeds or mutable plugin directories.
+network=@LIGHTNING_NETWORK@
+lightning-dir=/srv/lightning
+pid-file=/run/bitcoinpir-core-lightning/lightningd.pid
+rpc-file=lightning-rpc
+rpc-file-mode=0660
+allow-deprecated-apis=false
+database-upgrade=false
+
+# The issuer node has one reviewed P2P listener/announcement. These are
+# Lightning peer transport, never a remote RPC surface.
+bind-addr=@CLN_P2P_BIND_ADDR@
+announce-addr=@CLN_P2P_ANNOUNCE_ADDR@
+announce-addr-discovered=false
+autoconnect-seeker-peers=0
+disable-dns
+
+# Avoid adding an on-chain fallback identity to anonymous Payment V1 invoices.
+invoices-onchain-fallback=false
+
+# Minimize payment metadata in the journal. Debug/IO logging is forbidden.
+log-level=unusual
+log-timestamps=true
+
+# Core RPC is loopback and cookie-only. No rpcuser/rpcpassword option is
+# present in the complete explicit config, so neither a rendered file nor the
+# process argv can carry that plaintext secret. The protected cookie boundary
+# is an activation decision and must be exercised by preflight.
+bitcoin-cli=/opt/bitcoinpir/bitcoin-core/@BITCOIN_CORE_BUNDLE_SHA256@/bin/bitcoin-cli
+bitcoin-datadir=/srv/bitcoin
+bitcoin-rpcconnect=127.0.0.1
+bitcoin-rpcport=@BITCOIN_RPC_PORT@
+bitcoin-rpcclienttimeout=30
+bitcoin-retry-timeout=30
+
+# Remove every default/plugin-directory surface, including grpc, REST,
+# Commando, recklessrpc and wss-proxy. These two exact executables are the full
+# allowlist and their hashes are included in the CLN bundle manifest/preflight.
+clear-plugins
+important-plugin=/opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@/plugins/bcli
+important-plugin=/opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@/plugins/chanbackup

--- a/deploy/payment-v1/lightning/verify-layout.sh.in
+++ b/deploy/payment-v1/lightning/verify-layout.sh.in
@@ -1,0 +1,89 @@
+#!/bin/sh
+# Rendered helper is installed root-owned and hash-pinned; this source .in is
+# intentionally not executable.
+set -eu
+export LC_ALL=C
+
+bpir_lightning_uid='@LIGHTNING_UID@'
+bpir_lightning_gid='@LIGHTNING_GID@'
+bpir_lightning_network='@LIGHTNING_NETWORK@'
+bpir_srv_dir='/srv'
+bpir_lightning_base='/srv/lightning'
+bpir_lightning_dir="${bpir_lightning_base}/${bpir_lightning_network}"
+bpir_lightning_socket="${bpir_lightning_dir}/lightning-rpc"
+
+bpir_fail() {
+    echo 'lightning-layout-preflight=FAIL' >&2
+    exit 1
+}
+
+case "${bpir_lightning_uid}:${bpir_lightning_gid}" in
+    *[!0-9:]* | :* | *: | *:*:*) bpir_fail ;;
+esac
+[ "${bpir_lightning_uid}" -ne 0 ] && [ "${bpir_lightning_gid}" -ne 0 ] || bpir_fail
+[ "${bpir_lightning_network}" = 'signet' ] || bpir_fail
+[ -d "${bpir_srv_dir}" ] && [ ! -L "${bpir_srv_dir}" ] || bpir_fail
+[ -d "${bpir_lightning_base}" ] && [ ! -L "${bpir_lightning_base}" ] || bpir_fail
+[ -d "${bpir_lightning_dir}" ] && [ ! -L "${bpir_lightning_dir}" ] || bpir_fail
+
+[ "$(/usr/bin/stat -c '%u:%g:%a' -- "${bpir_srv_dir}")" = '0:0:755' ] || bpir_fail
+[ "$(/usr/bin/stat -c '%u:%g:%a' -- "${bpir_lightning_base}")" = '0:0:755' ] || bpir_fail
+[ "$(/usr/bin/stat -c '%u:%g:%a' -- "${bpir_lightning_dir}")" = "${bpir_lightning_uid}:${bpir_lightning_gid}:710" ] || bpir_fail
+
+# Explicit --conf means these are ignored by CLN, but rejecting them keeps the
+# trust boundary legible and prevents accidental future fallback to implicit
+# configuration or dynamic plugins.
+for bpir_forbidden in \
+    "${bpir_lightning_base}/config" \
+    "${bpir_lightning_dir}/config" \
+    "${bpir_lightning_dir}/config.setconfig" \
+    "${bpir_lightning_dir}/plugins"
+do
+    [ ! -e "${bpir_forbidden}" ] && [ ! -L "${bpir_forbidden}" ] || bpir_fail
+done
+
+bpir_scan_dump=$(/usr/bin/mktemp /run/bitcoinpir-core-lightning/layout-scan.XXXXXX) || bpir_fail
+bpir_remove_scan_dump() {
+    /usr/bin/rm -f -- "${bpir_scan_dump}"
+}
+trap bpir_remove_scan_dump EXIT HUP INT TERM
+
+bpir_require_empty_find() {
+    : >"${bpir_scan_dump}" || bpir_fail
+    /usr/bin/find "$@" >"${bpir_scan_dump}" 2>/dev/null || bpir_fail
+    [ ! -s "${bpir_scan_dump}" ] || bpir_fail
+}
+
+bpir_require_empty_find "${bpir_lightning_dir}" -xdev -type l -print -quit
+bpir_require_empty_find "${bpir_lightning_dir}" -xdev -type f ! -user "${bpir_lightning_uid}" -print -quit
+bpir_require_empty_find "${bpir_lightning_dir}" -xdev -type f ! -group "${bpir_lightning_gid}" -print -quit
+bpir_require_empty_find "${bpir_lightning_dir}" -xdev -type f -perm /077 -print -quit
+bpir_require_empty_find "${bpir_lightning_dir}" -xdev -type f -links +1 -print -quit
+bpir_require_empty_find "${bpir_lightning_dir}" -xdev -mindepth 1 -type d ! -user "${bpir_lightning_uid}" -print -quit
+bpir_require_empty_find "${bpir_lightning_dir}" -xdev -mindepth 1 -type d ! -group "${bpir_lightning_gid}" -print -quit
+bpir_require_empty_find "${bpir_lightning_dir}" -xdev -mindepth 1 -type d -perm /077 -print -quit
+bpir_require_empty_find "${bpir_lightning_dir}" -xdev -mindepth 1 ! -type d ! -type f ! -path "${bpir_lightning_socket}" -print -quit
+
+# Linux POSIX ACLs can grant access beyond mode bits. The production image
+# must provide the pinned distro /usr/bin/getfacl; named users/groups, masks,
+# and default ACLs are all forbidden on the namespace and datastore.
+[ -x /usr/bin/getfacl ] || bpir_fail
+/usr/bin/getfacl -c -p -n -- "${bpir_srv_dir}" "${bpir_lightning_base}" \
+    >"${bpir_scan_dump}" 2>/dev/null || bpir_fail
+/usr/bin/getfacl -R -c -p -n -- "${bpir_lightning_dir}" \
+    >>"${bpir_scan_dump}" 2>/dev/null || bpir_fail
+if /usr/bin/grep -Eq '^(default:|mask:|user:[^:]|group:[^:])' "${bpir_scan_dump}"; then
+    bpir_fail
+else
+    bpir_grep_status=$?
+    [ "${bpir_grep_status}" -eq 1 ] || bpir_fail
+fi
+/usr/bin/rm -f -- "${bpir_scan_dump}" || bpir_fail
+trap - EXIT HUP INT TERM
+
+if [ -e "${bpir_lightning_socket}" ] || [ -L "${bpir_lightning_socket}" ]; then
+    [ -S "${bpir_lightning_socket}" ] && [ ! -L "${bpir_lightning_socket}" ] || bpir_fail
+    [ "$(/usr/bin/stat -c '%u:%g:%a' -- "${bpir_lightning_socket}")" = "${bpir_lightning_uid}:${bpir_lightning_gid}:660" ] || bpir_fail
+fi
+
+echo 'lightning-layout-preflight=PASS'

--- a/deploy/payment-v1/relay-selection.toml.example
+++ b/deploy/payment-v1/relay-selection.toml.example
@@ -1,0 +1,27 @@
+version = 1
+status = "UNRESOLVED"
+implementation = "UNRESOLVED"
+source_repository = "UNRESOLVED"
+source_commit = "UNRESOLVED"
+source_archive_sha256 = "UNRESOLVED"
+cargo_lock_sha256 = "UNRESOLVED"
+binary_sha256 = "UNRESOLVED"
+binary_version_output = "UNRESOLVED"
+config_sha256 = "UNRESOLVED"
+publisher_pubkey_hex = "UNRESOLVED"
+
+# Fixed BitcoinPIR directory-relay profile. These are not commercial policy.
+listen_host = "127.0.0.1"
+allowed_kind = 30078
+max_event_message_bytes = 262176
+max_content_bytes = 196608
+config_max_bytes = 16384
+config_profile = "bitcoinpir-directory-relay-v1"
+publisher_private_key_installed = false
+nip42_auth = false
+access_logging = false
+mutable_source_ref = false
+
+# Production resolution is allowed only for the repository's reviewed
+# directory-only relay with a full commit and exact artifact hashes. The gate
+# explicitly rejects nostr-rs-relay 0.9.0/0.10.0 and mutable refs.

--- a/deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in
+++ b/deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in
@@ -1,0 +1,65 @@
+# BitcoinPIR CLN RPC method guard; never install this .in file directly.
+[Unit]
+Description=BitcoinPIR Core Lightning RPC allowlist guard (template only)
+After=bitcoinpir-core-lightning.service
+Requires=bitcoinpir-core-lightning.service
+BindsTo=bitcoinpir-core-lightning.service
+Before=bitcoinpir-payment-issuer.service
+ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/LIGHTNING-CUSTODY-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/LIGHTNING-BACKUP-RESTORE-APPROVED
+
+[Service]
+Type=simple
+User=bitcoinpir-cln-rpc-guard
+Group=bitcoinpir-cln-guard
+SupplementaryGroups=bitcoinpir-issuer
+UMask=0077
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/cln-rpc-guard/@CLN_RPC_GUARD_SHA256@/bitcoinpir-cln-rpc-guard
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/cln-rpc-guard.sha256
+ExecStart=/opt/bitcoinpir/cln-rpc-guard/@CLN_RPC_GUARD_SHA256@/bitcoinpir-cln-rpc-guard \
+    --listen-socket /run/bitcoinpir-cln-rpc-guard/issuer/issuer-rpc \
+    --upstream-socket /srv/lightning/@LIGHTNING_NETWORK@/lightning-rpc \
+    --guard-uid @CLN_GUARD_UID@ \
+    --guard-gid @LIGHTNING_GID@ \
+    --issuer-uid @ISSUER_UID@ \
+    --issuer-gid @ISSUER_GID@ \
+    --upstream-expected-uid @LIGHTNING_UID@ \
+    --upstream-expected-gid @LIGHTNING_GID@ \
+    --timeout-seconds 10 \
+    --max-in-flight 32 \
+    --max-invoice-msat @CLN_GUARD_MAX_INVOICE_MSAT@ \
+    --max-invoices-per-minute @CLN_GUARD_MAX_INVOICES_PER_MINUTE@ \
+    --max-invoice-burst @CLN_GUARD_MAX_INVOICE_BURST@ \
+    --max-invoices-per-runtime @CLN_GUARD_MAX_INVOICES_PER_RUNTIME@
+# The per-runtime invoice deadman is a custody containment boundary. Automatic
+# restart would silently reset it, so only an explicit operator ceremony may
+# start a new guard generation.
+Restart=no
+TimeoutStopSec=30
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX
+ReadOnlyPaths=/srv/lightning/@LIGHTNING_NETWORK@ /opt/bitcoinpir/cln-rpc-guard/@CLN_RPC_GUARD_SHA256@
+ReadWritePaths=/run/bitcoinpir-cln-rpc-guard
+
+# The guard deliberately has no network address and no [Install] section. Its
+# primary group reaches only the native CLN socket. Its sole supplementary
+# group lets it assign the issuer group to the separately guarded socket.

--- a/deploy/payment-v1/systemd/hetzner-core-lightning.service.in
+++ b/deploy/payment-v1/systemd/hetzner-core-lightning.service.in
@@ -1,0 +1,56 @@
+# BitcoinPIR Core Lightning template; never install this .in file directly.
+[Unit]
+Description=BitcoinPIR Hetzner issuer Core Lightning (template only)
+After=network-online.target @BITCOIND_SYSTEMD_UNIT@
+Wants=network-online.target
+Requires=@BITCOIND_SYSTEMD_UNIT@
+ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/LIGHTNING-CUSTODY-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/LIGHTNING-BACKUP-RESTORE-APPROVED
+
+[Service]
+Type=simple
+User=bitcoinpir-lightning
+Group=bitcoinpir-cln-guard
+SupplementaryGroups=bitcoinpir-bitcoin-rpc
+UMask=0077
+RuntimeDirectory=bitcoinpir-core-lightning
+RuntimeDirectoryMode=0700
+WorkingDirectory=/srv/lightning/@LIGHTNING_NETWORK@
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@/bin/lightningd
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/cln-bundle.sha256
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/bitcoin-core-bundle.sha256
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/lightningd-config.sha256
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/layout-verifier.sha256
+ExecStartPre=/usr/local/libexec/bitcoinpir/verify-lightning-layout
+ExecStart=/opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@/bin/lightningd --conf=/etc/bitcoinpir/payment-v1/lightning/lightningd.conf
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=120
+TimeoutStopSec=120
+LimitNOFILE=65535
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+RestrictNamespaces=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/lightning /opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@ /opt/bitcoinpir/bitcoin-core/@BITCOIN_CORE_BUNDLE_SHA256@
+ReadWritePaths=/srv/lightning/@LIGHTNING_NETWORK@ /run/bitcoinpir-core-lightning
+
+# There is intentionally no [Install] section. Identity creation, backup,
+# preflight, funding and service start are separately approved actions.

--- a/deploy/payment-v1/systemd/hetzner-directory-relay.service.in
+++ b/deploy/payment-v1/systemd/hetzner-directory-relay.service.in
@@ -1,0 +1,53 @@
+# BitcoinPIR Payment V1 deployment template; relay selection is initially UNRESOLVED.
+[Unit]
+Description=BitcoinPIR Hetzner directory-only relay (blocked template)
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/RELAY-SELECTION-RESOLVED
+
+[Service]
+Type=simple
+User=bitcoinpir-directory-relay
+Group=bitcoinpir-directory-relay
+UMask=0077
+StateDirectory=bitcoinpir-directory-relay
+StateDirectoryMode=0700
+WorkingDirectory=/var/lib/bitcoinpir-directory-relay
+Environment=RUST_LOG=error
+# The reviewed directory-only relay exposes only --config with an absolute,
+# owner-only TOML path. Keeping ExecStart as an unconditional failure prevents
+# use before the final implementation audit and exact artifact selection. The
+# pinned binary path, binary/config hash checks and sole --config argument must
+# replace this line in the same PR that changes relay-selection.toml from
+# UNRESOLVED to RESOLVED.
+ExecStart=/usr/bin/false
+Restart=no
+TimeoutStopSec=30
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+IPAddressDeny=any
+IPAddressAllow=localhost
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/directory-relay
+ReadWritePaths=/var/lib/bitcoinpir-directory-relay
+
+# A resolved relay config must bind the application to loopback; a same-host
+# WebSocket TLS edge provides public reads/writes. The directory publisher
+# private key is never installed on this host. There is intentionally no
+# [Install] section.

--- a/deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in
+++ b/deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in
@@ -1,0 +1,54 @@
+# Live read-only Signet preflight; never install this .in file directly.
+[Unit]
+Description=BitcoinPIR Hetzner live Core Lightning preflight (template only)
+Requires=bitcoinpir-core-lightning.service
+BindsTo=bitcoinpir-core-lightning.service
+After=bitcoinpir-core-lightning.service
+Before=bitcoinpir-payment-issuer.service
+ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/LIGHTNING-CUSTODY-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/LIGHTNING-BACKUP-RESTORE-APPROVED
+
+[Service]
+Type=oneshot
+User=bitcoinpir-lightning-preflight
+Group=bitcoinpir-lightning-preflight
+SupplementaryGroups=bitcoinpir-cln-guard bitcoinpir-bitcoin-rpc
+UMask=0077
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/bpir-admin/@BPIR_ADMIN_SHA256@/bpir-admin
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/bpir-admin.sha256
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/preflight-config.sha256
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/backup-receipt.sha256
+ExecStart=/opt/bitcoinpir/bpir-admin/@BPIR_ADMIN_SHA256@/bpir-admin lightning-staging preflight \
+    --config /etc/bitcoinpir/payment-v1/lightning/preflight.toml \
+    --config-protected-parent /etc/bitcoinpir/payment-v1/lightning \
+    --config-expected-uid @PREFLIGHT_UID@ \
+    --config-expected-gid @PREFLIGHT_GID@
+RemainAfterExit=yes
+TimeoutStartSec=60
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+RestrictNamespaces=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+IPAddressDeny=any
+IPAddressAllow=localhost
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/lightning /srv/lightning/@LIGHTNING_NETWORK@ /opt/bitcoinpir/bpir-admin/@BPIR_ADMIN_SHA256@ /opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@ /opt/bitcoinpir/bitcoin-core/@BITCOIN_CORE_BUNDLE_SHA256@
+
+# There is intentionally no [Install] section. A successful oneshot is a
+# prerequisite of the issuer service, not authorization for funds or deploy.

--- a/deploy/payment-v1/systemd/hetzner-payment-issuer.service.in
+++ b/deploy/payment-v1/systemd/hetzner-payment-issuer.service.in
@@ -1,0 +1,81 @@
+# BitcoinPIR Payment V1 deployment template; non-activating until reviewed and rendered.
+[Unit]
+Description=BitcoinPIR Hetzner Core Lightning payment issuer (template only)
+After=network-online.target bitcoinpir-core-lightning.service bitcoinpir-cln-rpc-guard.service bitcoinpir-lightning-preflight.service
+Wants=network-online.target
+Requires=bitcoinpir-core-lightning.service bitcoinpir-cln-rpc-guard.service bitcoinpir-lightning-preflight.service
+BindsTo=bitcoinpir-core-lightning.service bitcoinpir-cln-rpc-guard.service bitcoinpir-lightning-preflight.service
+ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/LIGHTNING-CUSTODY-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/LIGHTNING-BACKUP-RESTORE-APPROVED
+
+[Service]
+Type=simple
+User=bitcoinpir-issuer
+Group=bitcoinpir-issuer
+UMask=0077
+StateDirectory=bitcoinpir-payment-issuer
+StateDirectoryMode=0700
+WorkingDirectory=/var/lib/bitcoinpir-payment-issuer
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@/payment-issuer
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/issuer/payment-issuer.sha256
+ExecStart=/opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@/payment-issuer serve-cln \
+    --bind 127.0.0.1:5610 \
+    --max-connections 128 \
+    --quote-rate-per-minute 60 \
+    --status-rate-per-minute 600 \
+    --mutation-rate-per-minute 120 \
+    --reconciliation-rate-per-minute 120 \
+    --reconciliation-batch-size 32 \
+    --reconciliation-interval-seconds 15 \
+    --reconciliation-tick-budget-ms 5000 \
+    --max-outstanding-quotes 4096 \
+    --max-total-quotes 16384 \
+    --allow-origin @BITCOINPIR_WEB_ORIGIN@ \
+    --store /var/lib/bitcoinpir-payment-issuer/issuer.sqlite3 \
+    --remote-rollback-authority-config /etc/bitcoinpir/payment-v1/issuer/remote-rollback-authority.toml \
+    --quote-delegation /etc/bitcoinpir/payment-v1/issuer/quote-delegation.bin \
+    --quote-signing-key /etc/bitcoinpir/payment-v1/issuer/quote-signing.key \
+    --credential-derivation-key /etc/bitcoinpir/payment-v1/issuer/credential-derivation.key \
+    --service-policy /etc/bitcoinpir/payment-v1/issuer/service-policy.bin=@HETZNER_POLICY_PUBKEY_HEX@ \
+    --receipt-signing-key /etc/bitcoinpir/payment-v1/issuer/direct-receipt-signing.key \
+    --bat-key /etc/bitcoinpir/payment-v1/issuer/cashu-bat.key \
+    --clearing-authorization /etc/bitcoinpir/payment-v1/issuer/provider-clearing-authorization.bin \
+    --clearing-approval /etc/bitcoinpir/payment-v1/issuer/provider-clearing-approval.bin \
+    --issuer-settlement-signing-key /etc/bitcoinpir/payment-v1/issuer/issuer-settlement-signing.key \
+    --redeem-response-derivation-key /etc/bitcoinpir/payment-v1/issuer/redeem-response-derivation.key \
+    --cln-rpc-socket /run/bitcoinpir-cln-rpc-guard/issuer/issuer-rpc \
+    --cln-rpc-expected-uid @CLN_GUARD_UID@ \
+    --cln-rpc-expected-gid @ISSUER_GID@ \
+    --cln-rpc-timeout-seconds 10
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/issuer /run/bitcoinpir-cln-rpc-guard/issuer /opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@
+ReadWritePaths=/var/lib/bitcoinpir-payment-issuer
+InaccessiblePaths=/srv/lightning /srv/bitcoin
+
+# Clearing is part of payment-issuer serve-cln; no separate clearing daemon is
+# installed. There is intentionally no [Install] section. The final unit name
+# is bitcoinpir-payment-issuer.service; it is bound to the exact CLN unit, its
+# method guard, and the successful live preflight, so none may be bypassed.

--- a/deploy/payment-v1/systemd/hetzner-provider.service.in
+++ b/deploy/payment-v1/systemd/hetzner-provider.service.in
@@ -1,0 +1,87 @@
+# BitcoinPIR Payment V1 deployment template; non-activating until reviewed and rendered.
+[Unit]
+Description=BitcoinPIR Hetzner Payment V1 provider (template only)
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED
+
+[Service]
+Type=simple
+User=bitcoinpir-provider
+Group=bitcoinpir-provider
+UMask=0077
+StateDirectory=bitcoinpir-provider-payment-v1
+StateDirectoryMode=0700
+WorkingDirectory=/var/lib/bitcoinpir-provider-payment-v1
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/unified-server/@UNIFIED_SERVER_SHA256@/unified_server
+ExecStartPre=/usr/bin/sha256sum --check /etc/bitcoinpir/payment-v1/provider/unified-server.sha256
+ExecStart=/opt/bitcoinpir/unified-server/@UNIFIED_SERVER_SHA256@/unified_server \
+    --bind-address 127.0.0.1 \
+    --port 8191 \
+    --role primary \
+    --serve-hints \
+    --serve-queries \
+    --pool-size 8 \
+    --pool-dir /var/lib/bitcoinpir-provider-payment-v1/hint-pool \
+    --config /etc/bitcoinpir/payment-v1/provider/databases.toml \
+    --identity-key-path /etc/bitcoinpir/payment-v1/provider/provider-identity.key \
+    --identity-cert-path /etc/bitcoinpir/payment-v1/provider/provider-identity.cert \
+    --identity-server-id @HETZNER_PROVIDER_SERVER_ID@ \
+    --require-service-auth-v1 \
+    --service-policy /etc/bitcoinpir/payment-v1/provider/service-policy.bin \
+    --service-provider-id-hex @HETZNER_PROVIDER_ID_HEX@ \
+    --service-policy-key-hex @HETZNER_POLICY_PUBKEY_HEX@ \
+    --service-store /var/lib/bitcoinpir-provider-payment-v1/provider.sqlite3 \
+    --service-remote-rollback-authority-config /etc/bitcoinpir/payment-v1/provider/remote-rollback-authority.toml \
+    --service-bat-key /etc/bitcoinpir/payment-v1/provider/cashu-bat.key \
+    --service-cashu-recovery-key 1=/etc/bitcoinpir/payment-v1/provider/cashu-recovery-epoch-1.key \
+    --service-cashu-recovery-active-epoch 1 \
+    --service-cashu-custody-key 1=/etc/bitcoinpir/payment-v1/provider/cashu-custody-epoch-1.key \
+    --service-cashu-custody-active-epoch 1 \
+    --service-cashu-exposure-limit @CASHU_MINT_ID_HEX@:sat:@CASHU_MAX_UNSETTLED_VALUE@:@CASHU_MAX_UNSETTLED_NOTES@ \
+    --service-shared-authorization /etc/bitcoinpir/payment-v1/provider/shared-clearing-authorization.bin \
+    --service-shared-issuer-approval /etc/bitcoinpir/payment-v1/provider/shared-clearing-approval.bin \
+    --service-shared-operator-key-hex @HETZNER_OPERATOR_PUBKEY_HEX@ \
+    --service-shared-issuer-settlement-key-hex @ISSUER_SETTLEMENT_PUBKEY_HEX@ \
+    --service-shared-clearing-key /etc/bitcoinpir/payment-v1/provider/provider-clearing-signing.key \
+    --service-shared-idempotency-key /etc/bitcoinpir/payment-v1/provider/shared-redeem-idempotency.key \
+    --service-shared-minimum-authorization-epoch @SHARED_MINIMUM_AUTHORIZATION_EPOCH@ \
+    --max-connections 128 \
+    --service-max-concurrent-auth 16 \
+    --service-max-concurrent-online-v2full-auth 4 \
+    --websocket-handshake-timeout-ms 10000 \
+    --connection-idle-timeout-ms 30000 \
+    --service-pre-auth-timeout-ms 60000
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+LimitNOFILE=65535
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/provider
+ReadWritePaths=/var/lib/bitcoinpir-provider-payment-v1
+
+# The signed policy may use direct receipts, provider-local BAT, Standard Cashu
+# and the approved shared issuer. Runtime method-coverage validation rejects
+# startup if it advertises a method whose complete material is absent. ARC is
+# deliberately unavailable.
+# There is intentionally no [Install] section. Rendering, provisioning the
+# activation sentinel, and starting the unit are separate approved actions.

--- a/deploy/payment-v1/systemd/payment-v1-edge.service.in
+++ b/deploy/payment-v1/systemd/payment-v1-edge.service.in
@@ -1,0 +1,53 @@
+# BitcoinPIR Payment V1 TLS edge template; never install this .in file directly.
+[Unit]
+Description=BitcoinPIR Payment V1 pinned TLS edge (template only)
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/EDGE-PREFLIGHT-APPROVED
+
+[Service]
+Type=notify
+User=bitcoinpir-payment-edge
+Group=bitcoinpir-payment-edge
+UMask=0077
+StateDirectory=bitcoinpir-payment-edge
+StateDirectoryMode=0700
+WorkingDirectory=/var/lib/bitcoinpir-payment-edge
+Environment=XDG_DATA_HOME=/var/lib/bitcoinpir-payment-edge/data XDG_CONFIG_HOME=/var/lib/bitcoinpir-payment-edge/config
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/caddy.sha256
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/edge-config.sha256
+ExecStartPre=/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy validate --config /etc/bitcoinpir/payment-v1/edge/@EDGE_CADDYFILE@ --adapter caddyfile
+ExecStart=/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy run --config /etc/bitcoinpir/payment-v1/edge/@EDGE_CADDYFILE@ --adapter caddyfile
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=60
+TimeoutStopSec=30
+LimitNOFILE=65535
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+RestrictNamespaces=true
+SystemCallArchitectures=native
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/edge
+ReadWritePaths=/var/lib/bitcoinpir-payment-edge
+
+# There is intentionally no [Install] section. Rendering this unit, approving
+# edge preflight, creating the global activation sentinel and starting the
+# service are separate production actions.

--- a/deploy/payment-v1/systemd/rollback-authority.service.in
+++ b/deploy/payment-v1/systemd/rollback-authority.service.in
@@ -1,0 +1,55 @@
+# BitcoinPIR Payment V1 deployment template; non-activating until reviewed and rendered.
+[Unit]
+Description=BitcoinPIR independent rollback authority (template only)
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED
+
+[Service]
+Type=simple
+User=bitcoinpir-rollback-authority
+Group=bitcoinpir-rollback-authority
+UMask=0077
+StateDirectory=bitcoinpir-rollback-authority
+StateDirectoryMode=0700
+WorkingDirectory=/var/lib/bitcoinpir-rollback-authority
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/rollback-authority/@ROLLBACK_AUTHORITY_SHA256@/rollback-authority
+ExecStartPre=/usr/bin/sha256sum --check /etc/bitcoinpir/payment-v1/rollback-authority/rollback-authority.sha256
+ExecStart=/opt/bitcoinpir/rollback-authority/@ROLLBACK_AUTHORITY_SHA256@/rollback-authority serve \
+    --bind 127.0.0.1:8099 \
+    --store /var/lib/bitcoinpir-rollback-authority/authority.sqlite3 \
+    --authority-secret /etc/bitcoinpir/payment-v1/rollback-authority/authority.seed \
+    --authority-metadata /etc/bitcoinpir/payment-v1/rollback-authority/authority-public.txt \
+    --expected-authority-pubkey-hex @AUTHORITY_PUBKEY_HEX@ \
+    --busy-timeout-ms 5000 \
+    --io-timeout-ms 10000 \
+    --max-connections 32
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+IPAddressDeny=any
+IPAddressAllow=localhost
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/rollback-authority
+ReadWritePaths=/var/lib/bitcoinpir-rollback-authority
+
+# Terminate pinned WebPKI TLS on a reviewed edge on this same host. Never place
+# this instance on the host whose detailed provider/issuer store it protects.
+# There is intentionally no [Install] section.

--- a/deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in
+++ b/deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in
@@ -1,0 +1,16 @@
+# BitcoinPIR VPSBG Payment V1 service-auth argument fragment; not a run script.
+# Review and merge these arguments into the final unified_server exec of the
+# existing measured Tier 3 script during a separately approved UKI rebuild.
+# Never execute, source, or install this file by itself.
+#
+# The frozen signed policy MUST contain only current FreeV1 / ProofOfWork offers.
+# Inspect its canonical contents and sha256 during the UKI ceremony.
+
+--require-service-auth-v1
+--service-policy /home/pir/data/payment-v1/vpsbg-free-pow-only-policy.bin
+--service-provider-id-hex @VPSBG_PROVIDER_ID_HEX@
+--service-policy-key-hex @VPSBG_POLICY_PUBKEY_HEX@
+--service-store /home/pir/data/payment-v1/provider.sqlite3
+--service-remote-rollback-authority-config /home/pir/data/payment-v1/remote-rollback-authority.toml
+--service-max-concurrent-auth 16
+--service-pre-auth-timeout-ms 60000

--- a/deploy/systemd/cloudflared.service
+++ b/deploy/systemd/cloudflared.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=Cloudflare Tunnel (BitcoinPIR)
+Documentation=https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
+After=network-online.target pir-primary.service pir-secondary.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=cloudflared
+Group=cloudflared
+EnvironmentFile=/etc/cloudflared/tunnel.env
+ExecStart=/usr/bin/cloudflared --no-autoupdate tunnel run
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+SystemCallArchitectures=native
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=cloudflared
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/payment/DIRECTORY_PROTOCOL.md
+++ b/docs/payment/DIRECTORY_PROTOCOL.md
@@ -358,6 +358,63 @@ address or payment event.
 Low-bandwidth single-shard fetch remains an explicit privacy tradeoff, never a
 method/provider-pair lookup API.
 
+## Repository directory-only relay profile
+
+`apps/directory-relay` implements the server-side subset needed by this
+protocol. It is not a general-purpose Nostr relay. The sole process interface
+is `bitcoinpir-directory-relay --config /absolute/owner-only.toml`; the
+configuration fixes one loopback listener, one absolute SQLite database, one
+pinned non-zero directory publisher key and explicit concurrency, ingress,
+egress, archive and timeout bounds. No publisher private key is present.
+
+The accepted client messages are only the exact canonical NIP-01 `EVENT`,
+`REQ`, and `CLOSE` shapes used here. EVENT requires the pinned key, kind 30078,
+valid signature, canonical JSON, and the exact `d`/`s` namespaces. There is no
+generic subscription language, live push, NIP-42 AUTH, NOTICE, or application
+heartbeat path. A reverse proxy may handle WebSocket control frames, but it
+must not log frames or silently transform application messages.
+
+SQLite keeps an immutable event archive and a separate addressable-event head.
+An unseen current event, its archive counters, and any head replacement commit
+in one `BEGIN IMMEDIATE` transaction. Positive `OK` is possible only after that
+commit returns. An exact archived duplicate is positively idempotent even if it
+has since expired or lost the replacement race; an unseen expired event is
+rejected. If a started write's durable result cannot be recovered, the relay
+closes without sending a false negative acknowledgement.
+
+REQ first freezes the ordered event-ID set and exact logical response bytes.
+Pages are then loaded from the non-deleting archive, so concurrent replacements
+cannot create a mixed snapshot. The relay reserves the complete EVENT-plus-EOSE
+response against the connection's cumulative egress budget before sending a
+prefix, streams bounded pages under a process-wide byte rate and emits EOSE
+only after the frozen set is complete. A configured budget may deliberately
+prevent the count and maximum-event-size limits from being saturated together;
+clients treat a closed/over-budget view as unusable, never as a partial catalog.
+
+ID-filter readback is limited to 64 unique IDs and is intended only for
+commit probes and bounded recovery, not archive enumeration. It is executed as
+one bounded SQL `IN` query and reordered to the canonical request order before
+the snapshot is frozen. Global admission charges one work unit per eight IDs,
+and every connection has a cumulative 256-unit work budget in addition to the
+message, concurrency, byte, idle and absolute-lifetime limits. Catalog filters
+remain one work unit because each shard is one indexed SQL query; clients still
+fetch all 16 shards independently of query state.
+
+Shutdown first stops acceptance, signals every tracked connection, calls the
+SQLite interrupt handle and then drains all connection tasks; blocking workers
+are not detached. SQLite interruption makes a current statement return, but a
+filesystem that stalls inside an uninterruptible kernel write can still exceed
+the service stop timeout. Activation therefore still requires a Linux shutdown
+fault drill rather than treating this source property as timing proof.
+
+The archive event/byte caps are permanent capacity decisions, not an eviction
+policy. `max_archive_bytes` counts canonical event JSON BLOB bytes rather than
+SQLite/WAL/index disk usage. Operators must add filesystem quota and free-space
+monitoring, back up the database and WAL as one consistent state domain, and
+restore only a fully checked copy with the same publisher key and configured
+capacity. Two relay origins remain required; two names reaching the same relay
+do not create an independent view.
+
 ## Publisher artifacts and relay transport
 
 The `assertion`, `entry`, and `checkpoints` commands build signed artifacts

--- a/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
+++ b/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
@@ -1,0 +1,391 @@
+# Hetzner and VPSBG Payment V1 deployment preparation
+
+Status: non-activating deployment contract. This document does not authorize a
+remote host change, public Nostr publication, a VPSBG UKI upload/reboot, or use
+of real Lightning funds.
+
+## Topology
+
+The first deployment shape keeps provider selection independent. A client may
+select one Hetzner provider and later select the VPSBG provider; neither server
+needs to know the other's identity or payment method.
+
+```text
+                         separately administered hosts
+                       +-------------------------------+
+                       | provider-0 rollback authority |
+                       | provider-1 rollback authority |
+                       | issuer rollback authority     |
+                       +-------------------------------+
+                              ^ pinned HTTPS/CAS
+                              |
+  Hetzner                     |                    VPSBG Tier 3
+  +----------------------+    |                    +----------------------+
+  | Payment V1 provider  |----+                    | existing PIR process |
+  | payment-issuer + CLN |----+                    | + enforced V1        |
+  | directory-only relay|                         | + Free/PoW only      |
+  | same-host TLS edges |                         | no issuer/relay/mint |
+  +----------------------+                         +----------------------+
+```
+
+The rollback authorities are not extra processes on the Hetzner provider or
+VPSBG detailed-store hosts. Provider 0, Provider 1, and the issuer require
+separate authority hosts, service accounts, TLS keys, Ed25519 keys, namespaces,
+administrators, logs, and backup/restore domains. Co-location is permitted only
+for an explicitly non-production exercise.
+
+## Frozen active-service boundary
+
+This preparation does not modify or replace:
+
+- `deploy/systemd/pir-primary.service`;
+- `deploy/systemd/pir-secondary.service`;
+- `deploy/systemd/pir-vpsbg.service`;
+- `deploy/systemd/dev-issuer.service`;
+- `deploy/systemd/cloudflared.service`; or
+- `scripts/dracut/97bpir-tier3-init/unified-server-run.sh`.
+
+The deployment-template gate pins the SHA-256 of each file. It also verifies
+that none of those active definitions contains Payment V1 enforcement flags.
+This makes the preparation PR unable to activate charging by changing an old
+unit in place.
+
+All files below `deploy/payment-v1/` are inputs. Systemd templates use the
+`.service.in` suffix, omit `[Install]`, and require an activation sentinel. The
+VPSBG `.args.in` is a non-executable argument fragment with no shebang or exec;
+it cannot start a process by itself.
+
+## Hetzner provider
+
+`deploy/payment-v1/systemd/hetzner-provider.service.in` describes a new
+loopback-bound process rather than a drop-in for either active provider. It
+requires:
+
+- strict `--require-service-auth-v1` enforcement;
+- one frozen signed current policy and provider/policy-key pins;
+- an existing provider spend store;
+- a separately hosted remote rollback authority;
+- bounded connections, authorization concurrency, WebSocket handshake, idle,
+  and absolute pre-authorization timeouts; and
+- identity, binary and database material that remains subject to the existing
+  strict client verification chain.
+
+The template contains no ARC, local rollback, fake/test trust, legacy gate, or
+source-IP Free quota option. It binds to loopback because the current public
+path uses a proxy; `--service-trust-direct-peer-ip` would otherwise treat the
+proxy as the user and is forbidden.
+
+The first Hetzner production profile loads all reviewed non-ARC method material:
+
+- a provider-local Cashu BAT key. Issuance and provider verification use the
+  same DHKE scalar and exact policy binding: generate it once, verify the
+  derived public key against the policy, then copy it through an approved
+  secret-transfer ceremony to the issuer and this provider. Compromise of
+  either copy can forge BATs for that provider. Operators unwilling to share
+  this private scalar must omit the provider-local BAT offer and use the
+  shared-issuer online redemption method instead;
+- separate Standard Cashu recovery and custody AEAD epoch keyrings, with byte
+  reuse forbidden, plus an explicit finite value/note exposure limit for each
+  mint/unit;
+- one operator-signed shared clearing authorization and matching issuer
+  approval, with pinned operator and issuer-settlement public keys;
+- a provider clearing signing key, separately generated shared-redeem
+  idempotency HMAC key, and non-zero minimum authorization epoch.
+
+Direct BOLT11 receipts require no provider secret beyond their signed policy
+binding. Every method advertised by the current or retained signed policies
+must have its complete runtime material. `validate_policy_method_coverage_v1`
+rejects startup if any method is missing; operators must remove an offer from
+the policy rather than weakening this check. Extra retained keys are permitted
+only for a documented rotation/grace window. ARC remains unavailable.
+
+The signed policy is the commercial and resource contract. Every backend and
+operation needs its own scope. In particular, Harmony hint generation and
+Harmony query execution are distinct scopes with separately selected limits,
+payment method and price. V1 has no class-aware work scheduler, so every first-
+release offer must use `priority_class = 1` and neither directory nor UI may
+promise paid QoS. A general "one query" price must not be silently reused
+across DPF-PIR, HarmonyPIR hint, HarmonyPIR query, OnionPIR, or Direct ORAM
+workloads.
+
+Do not start the new Hetzner hint pool alongside another live pool without the
+existing capacity/stagger review. A public cutover follows a private canary and
+must not create concurrent cold-pool generation that starves query work.
+
+## Hetzner issuer
+
+`deploy/payment-v1/systemd/hetzner-payment-issuer.service.in` runs only
+`payment-issuer serve-cln`. The application listener is `127.0.0.1:5610`; a
+reviewed same-host WebPKI TLS edge is the only public origin. The Core Lightning
+RPC Unix socket has exact expected UID/GID and a bounded call timeout.
+
+This is the only renderable issuer unit. It has `Requires`, `After`, and
+`BindsTo` dependencies on the exact CLN service, method-allowlist guard, and
+successful live preflight, plus separate global, Lightning-custody, and
+backup/restore sentinels. There is no generic alternate unit that can use the
+global activation sentinel while bypassing either boundary.
+
+The issuer detailed store uses its own remote rollback authority. Quote,
+credential-derivation, direct-receipt, Cashu BAT, issuer-settlement, clearing,
+and redeem-derivation keys remain role-separated. Clearing is integrated into
+the issuer process; there is no separate clearing daemon.
+
+The production unit contains no `serve-fake`, fake signing seed, local rollback
+acknowledgement, ARC key, experimental acknowledgement, or test-only WebPKI
+root. The public edge forwards only `/v1/redeems` and the authenticated
+`/v1/settlement/balance` lookup. Payout-intent, payout and payout-status are not
+V1 production routes. The production CLI and unit accept no payout target, fee
+or intent TTL; the shared service is constructed explicitly in ledger-only mode
+and fails closed at the payout method boundary as well. The store schema's
+required non-zero payout-target field receives one fixed domain-separated
+disabled sentinel that is neither operator nor request input and is never a
+value-transfer destination.
+
+Registration remains append-only and fail closed. A pre-production store that
+already registered the same provider epoch with a different payout target will
+not be silently rewritten and will fail issuer startup. Do not edit that SQLite
+row in place: either initialize the first production ledger-only store with the
+reviewed sentinel-bearing build, or design and review a separate authenticated
+offline migration before preserving such a prototype store.
+
+`BITCOINPIR_WEB_ORIGIN` is one complete canonical HTTPS origin. Every
+`*_PUBKEY_HEX` placeholder is public verification material, never a private
+seed. The renderer must type- and length-check these values and reject any
+unresolved placeholder before producing a unit. The CLN RPC socket is
+network-specific at `/srv/lightning/<network>/lightning-rpc`; the rendered
+issuer unit, CLN configuration and read-only Lightning preflight must agree on
+that exact path, UID, GID, filesystem ownership and mode.
+
+The daemon-owned/guard-group parent (`0710`) and native CLN socket (`0660`) are
+not accessible to the long-running issuer. A separately pinned guard is the
+only long-running non-CLN principal in that group; it parses and reconstructs
+bounded JSON-RPC, permits exactly `getinfo`, private-label `listinvoices`, and
+bounded anonymous `invoice`, and exposes a guard-UID/issuer-GID `0660` socket
+below a distinct `0710` directory. The issuer mount namespace also marks
+`/srv/lightning` and `/srv/bitcoin` inaccessible.
+
+The guard unit uses `Restart=no`. Its finite per-runtime invoice counter is a
+custody deadman, so an automatic crash loop must not reset it. Guard exit stops
+the issuer through the unit dependency; starting a new generation requires an
+operator to inspect the failure, account for the prior generation and perform
+an explicit start.
+
+The live preflight uses a third, dedicated UID—not the issuer UID—with temporary
+membership in the native CLN and Bitcoin-cookie groups. It validates the exact
+cross-UID `0710`/`0660` CLN shape and bitcoind-UID/cookie-GID `0710`/`0640`
+cookie shape. The supplied CLN configuration and prerequisite record remain
+default-Signet-only with `real_funds_authorized = false`; Linux artifact/runtime
+evidence, restore drills, remote installation and any real funds remain
+separate activation gates.
+
+## Hetzner directory relay
+
+The directory publisher key is a dedicated offline BIP340 key and is never
+installed on the relay. The relay sees only public signed directory events; it
+must accept writes only from the pinned publisher and only kind `30078`.
+
+`deploy/payment-v1/relay-selection.toml.example` deliberately starts with
+`status = "UNRESOLVED"`. While unresolved, the relay service has
+`ExecStart=/usr/bin/false` and requires a separate
+`RELAY-SELECTION-RESOLVED` sentinel. The selection may become resolved only in a
+reviewed PR that freezes the repository's directory-only relay interface and
+records:
+
+- a full 40-hex source commit;
+- source archive and Cargo.lock SHA-256;
+- exact binary SHA-256 and `--version` output;
+- exact bounded config SHA-256; and
+- the pinned directory publisher public key.
+
+Mutable branches, mutable container tags, `nostr-rs-relay` 0.9.0 at
+`ff65ec2acd781150a585a78e1c60b0cdb104698e`, and its 0.10.0/master at
+`b5c1f642e4f4c3b9c54f5d18d66f4c53642076b4` fail the repository gate. No
+generic third-party relay template is supplied.
+
+A resolved relay must bind its application listener to loopback, use a
+same-host WSS edge, disable access/event/body/IP logging, disable NIP-42 for the
+current publisher, retain the NIP-01 addressable-event replacement ordering,
+and enforce the
+BitcoinPIR bounds: 262,176-byte outer EVENT message, 192 KiB content, kind
+30078, and a deployment-config size no greater than 16 KiB. At least two relay
+hostnames are still required for directory use; two aliases on one Hetzner host
+do not provide operator or failure independence.
+
+The reviewed process interface is intentionally narrow: exactly
+`bitcoinpir-directory-relay --config /absolute/owner-only.toml`, with no CLI
+overrides. The TOML must declare `profile = "bitcoinpir-directory-relay-v1"` and
+contain exactly the required fields `profile`, `listen`, `database`,
+`directory_pubkey_hex`, `max_connections`, `max_in_flight_operations`,
+`max_operations_per_second`, `max_egress_bytes_per_second`,
+`max_egress_bytes_per_connection`, `max_archive_events`, `max_archive_bytes`,
+`handshake_timeout_seconds`, `idle_timeout_seconds`,
+`connection_timeout_seconds`, `operation_timeout_seconds`, and
+`egress_timeout_seconds`; unknown fields and missing fields fail closed.
+`deploy/payment-v1/directory-relay.toml.example` fixes the database below the
+unit's only writable StateDirectory at
+`/var/lib/bitcoinpir-directory-relay/relay.sqlite3`. The config must be mode
+0400 or 0600 under a private parent directory.
+
+The relay reserves the exact complete snapshot response against a per-
+connection cumulative byte budget before sending its first EVENT, and applies
+a separate process-wide egress byte rate. The example intentionally does not
+allow the event-count and maximum-event-size dimensions to be saturated at the
+same time. Public ID readback is capped at 64 unique IDs, charged globally at
+one work unit per eight IDs, executed as one bounded SQL query, and also charged
+against a fixed 256-unit cumulative connection work budget. This prevents a
+single valid REQ from turning one operation-rate token into thousands of
+serialized SQLite point lookups. `max_archive_bytes` counts immutable canonical event JSON BLOB bytes;
+it is not a SQLite file, WAL, index, or filesystem hard limit. Provision a
+separate filesystem quota/free-space alarm, choose a finite archive lifetime
+capacity, and rehearse consistent database-plus-WAL backup/restore. Immutable
+events are never automatically deleted because frozen ID readback and duplicate
+idempotency depend on them.
+
+This preparation remains unresolved until the final implementation audit and
+exact binary/config pins are recorded.
+
+## VPSBG minimal change
+
+The current Tier 3 process is runit inside a measured UKI and has no systemd or
+SSH administration path.
+`deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in` is therefore only
+a reviewable set of arguments to merge into the existing measured script's
+final `unified_server` exec during a later UKI ceremony. It is not a replacement
+run script: it contains no shebang, exec, ORAM path, ORAM build/verification,
+identity, attestation, database startup, port/bind, cloudflared or service-tree
+logic. The existing query, ORAM, attestation, identity, database and cloudflared
+behavior remains authoritative.
+
+The frozen VPSBG policy must contain only current `FreeV1` ProofOfWork offers.
+It may expose multiple backend-specific scopes, but every offer has
+`free_mode = proof-of-work`, a non-zero bounded difficulty, no issuer/key
+binding, and a zero price. Before baking, inspect the canonical signed policy
+and verify its SHA-256 against the UKI manifest. The CLI alone cannot prove the
+contents of a signed policy.
+
+The VPSBG template deliberately has no:
+
+- issuer, Lightning, Cashu mint, BAT, ARC or directory relay;
+- provider-local or shared issuer credential key;
+- Free IP HMAC key or direct-peer-IP trust;
+- local rollback database or local-development acknowledgement; or
+- online-authority method material; a Free-PoW-only policy creates no online
+  V2Full authorization route and needs no V2Full override flag.
+
+### P1 activation blocker: VPSBG hostile-host secrecy
+
+The existing Tier 3 `/home/pir/data` is supplied by a host-visible rootfs. The
+repository does not yet implement SEV-SNP sealing, a vTPM, or
+attestation-gated key release for this data. An effective-user-owned mode-0700
+subtree and single-link mode-0600 files protect only against ordinary accounts
+inside the guest. They do not protect against the VPSBG operator: the VPSBG
+host can read or copy the ProviderStore and the remote rollback client's
+Ed25519 seed/value-root key material.
+
+This is an activation blocker even for the Free-PoW canary while it requires a
+ProviderStore. Before production activation, the user must explicitly approve
+one of two designs:
+
+1. implement and review attestation-gated key release or equivalent sealing; or
+2. expand the trust boundary and accept that the VPSBG host can steal these
+   availability/rollback credentials.
+
+The second choice also abandons the remote authority's anti-rollback guarantee
+*against the VPSBG host itself*: a host that steals the client signing and
+value-root keys can create correctly signed Read/CAS traffic that the
+independent authority cannot distinguish from the guest. The authority still
+separates other failure and administration domains, but it no longer protects
+the detailed store from a malicious VPSBG operator.
+
+Owner-only permissions remain required defense in depth, but must never be
+presented as hostile-host secrecy. The provider rollback authority itself
+remains on an independently administered remote host.
+
+Any binary, policy, run-script or initramfs change requires a new UKI, preserved
+previous known-good UKI, portal upload, reboot, fresh SEV-SNP measurement,
+binary hash, attestation verification and client pin update. Those are remote
+activation actions and require separate approval.
+
+## Rendering and preflight
+
+### P1 activation blocker: source-fair admission
+
+The supplied stock-Caddy templates have only global upstream connection caps;
+the issuer, relay and rollback-authority applications also use global budgets.
+A single low-bandwidth source can therefore starve anonymous quote creation,
+directory read/publish capacity, or rollback-floor calls without possessing a
+credential. Do not publicly activate these surfaces until the reviewed host or
+network layer supplies ephemeral source-fair admission without request/IP
+logging or source headers to the business services. Reserve a distinct private
+publisher ingress/budget for the directory, and place every rollback authority
+behind its one client's WireGuard, mTLS or equivalent narrow allowlist. These
+controls and their negative tests are required live deployment evidence, not a
+commercial pricing decision.
+
+1. Freeze exact BitcoinPIR commit, binaries, policies, directory artifacts,
+   authority metadata and key-role inventory.
+2. Run `node scripts/payment-v1-deployment-template-gate.mjs` on the unrendered
+   repository inputs.
+3. Render into a new private staging directory; never render over an active
+   unit or runit script. Treat the VPSBG file only as reviewed patch input for
+   the existing final exec after its ORAM build/verification logic.
+4. Reject any unresolved placeholder. Verify binary/config/policy hashes and
+   owner/mode/single-link rules.
+5. Run `systemd-analyze verify` on Linux for rendered systemd units. After the
+   VPSBG arguments are merged, run `sh -n` and `shellcheck` on the complete
+   measured run script; do not execute or lint the argument fragment as a
+   standalone service.
+   Reject any Lightning rendering other than default Signet, and require the
+   prerequisite record to retain `real_funds_authorized = false`; the guarded
+   socket topology does not authorize mainnet or real-value use.
+6. Run each provider/issuer `check-store` and the complete multi-role
+   `rollback-authority-deployment-lint` before any listener starts.
+7. Confirm provider, issuer and authority application origins are loopback;
+   confirm same-host TLS edges have no redirects, access logs, identity headers
+   or unpinned certificate path.
+8. Start private/unrouted canaries. Verify identity, binary/attestation,
+   database proof/root, signed policy, remote rollback failure behavior and
+   exact method/scope matching from a strict client.
+9. Publish directory artifacts only after every advertised live value matches.
+10. Provision an activation sentinel and change public routing only under the
+    separately approved activation plan.
+
+Production deployment, remote server changes, public relay writes, UKI
+upload/reboot, and real Lightning funds remain separate approval gates.
+
+The source-template gate is deliberately **not** rendered-artifact evidence.
+For a future `RESOLVED` relay it checks canonical metadata shape and source-unit
+binding only; it does not fetch the claimed commit or recompute an archive,
+`Cargo.lock`, binary, config, policy or publisher-key digest. Repeated-digit
+test hashes are accepted only inside negative/shape fixtures.
+
+`scripts/payment-v1-rendered-artifact-gate.mjs` now renders and verifies one
+closed profile from an externally digest-approved plan. It recomputes every
+digest from exact staged bytes, rejects unresolved placeholders and extra or
+cross-profile artifacts, validates class/path/owner/mode/link rules and emits a
+manifest-derived runtime-evidence request. It still does not prove installation.
+On the exact Linux staging host, a root operator must run
+`scripts/payment-v1-linux-runtime-evidence.mjs collect-live`, pin the expected
+machine/boot and approved plan/manifest digests, and transfer the resulting
+full-file evidence digest over the approved out-of-band channel. The verifier
+checks effective systemd state, process credentials for long-running units,
+the successful exited state of the reviewed one-shot preflight, installed
+bytes, NSS, ACLs, xattrs, capabilities and `systemd-analyze verify`. Until that
+live evidence passes, these inputs remain deployment preparation rather than
+an activatable bundle.
+
+## Failure and rollback
+
+The strict mode never falls back to an old credential gate, unsigned policy,
+local rollback file, plaintext transport, free query, or unverified provider.
+Issuer or remote-authority outage fails the affected acquisition/mutation
+closed. A purchased capability remains governed by its normal idempotent
+claim/redemption semantics; deployment automation does not synthesize refunds
+or retry a PIR query automatically.
+
+Hetzner rollback changes routing back to the previously verified process and
+preserves both detailed stores and remote authority floors; it never restores a
+stale store snapshot or lowers an authority. VPSBG rollback selects the
+preserved previous known-good UKI through the portal and restores the matching
+client measurement/binary pins. It does not edit the measured run script in
+place.

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # Payment platform implementation status
 
-Status snapshot: 2026-07-28. This document describes repository code and local
+Status snapshot: 2026-07-29. This document describes repository code and local
 tests, not a production deployment. “Implemented” means that a code path exists;
 “tested” names the boundary actually exercised. It does not mean that an
 operator has activated the path with real money or public infrastructure.
@@ -210,15 +210,31 @@ operator has activated the path with real money or public infrastructure.
       the same deterministic transcript. The official Web path deletes/burns
       the proof before transmission and does not automatically retry; loss of
       `AUTH_GRANTED` after the local claim consumes the entitlement.
-- [x] `payment-issuer` serves ledger-only `/v1/redeems`, balance,
-      payout-intent, payout and payout-status routes. A raw loopback HTTP test
-      covers BAT redeem through payout/status, store reopen, exact response
-      replay after authorization/registration expiry and provider request-key
+- [x] The production/default `payment-issuer` HTTP surface is ledger-accrual
+      only: `/v1/redeems` credits the authenticated provider account and
+      `/v1/settlement/balance` returns a signed balance. Payout-intent, payout
+      and payout-status paths return the exact unknown-path response before
+      clock access, content-type/body parsing, authentication, rate limiting or
+      store access; their match arms and decoders are absent from non-test
+      builds and there is no production enable flag. Production uses the
+      explicit ledger-only service constructor and has no payout-target, fee or
+      intent-TTL CLI/configuration. Each required store registration receives a
+      fixed, domain-separated, non-zero disabled-target sentinel which cannot be
+      selected by a request; all three transport-neutral payout methods also
+      return `NotFound` before input decoding or store access in this mode. The
+      settlement signing key remains necessary for redeem/balance signatures,
+      and retained verifying keys remain available for exact committed redeem
+      and approval recovery after rotation. A private Rust unit-fixture
+      switch retains the raw loopback payout/status roundtrip solely to test the
+      transport-neutral state machines, store reopen, exact response replay
+      after authorization/registration expiry and provider request-key
       rotation. Provider registration epochs are append-only issuer history;
       old keys authenticate only the durable latest exact replay, while old
-      fresh, signature-tampered and wrong-provider requests fail closed. The
-      final history-integrity implementation is covered by focused issuer-store
-      and issuer-service payout/restart tests.
+      fresh, signature-tampered and wrong-provider requests fail closed.
+      Focused Rust cases now assert removed production CLI flags and
+      side-effect-free ledger-only method rejection; this no-Cargo deployment
+      hardening pass formatted and parsed those files but leaves execution of
+      the Rust cases to the exact-commit CI run.
 - [x] The transport-neutral provider settlement client covers authenticated
       balance, payout-intent, payout and status requests; canonical bounded
       response verification; retained issuer signing keys and provider
@@ -253,7 +269,9 @@ operator has activated the path with real money or public infrastructure.
       first external submission, uses the stable command ID as the executor
       idempotency key, and performs reconcile-only handling after restart or an
       ambiguous result. Its bundled `NoFundsPayoutExecutorV1` is deliberately
-      never ready and cannot move value.
+      never ready and cannot move value. No application binary instantiates the
+      worker in V1, and the production issuer cannot create its payout/outbox
+      records through HTTP.
 - [x] `StrictHttpsProviderSettlementTransportV1` is the concrete provider-to-
       issuer HTTPS adapter. Its production constructor requires normal WebPKI
       verification plus one or two distinct out-of-band leaf-SPKI SHA-256 pins;
@@ -262,12 +280,15 @@ operator has activated the path with real money or public infrastructure.
       redirect/cookie/proxy/decompression path, bounded responses, and
       conservative outcome-unknown classification after any request byte may
       have been sent. It has not been deployed.
-- [ ] A truly independent production floor adapter, real-funds payout executor
-      and deployment remain unselected. A real executor must
+- [ ] The remote production floor adapters exist for provider, issuer and
+      provider-settlement state, but truly independent authority deployments,
+      a real-funds payout executor and payout product remain unselected. A real
+      executor must
       provide a linearizable durable command-ID lookup/submission primitive or
       equivalent no-submit fence; neither the worker lease nor local SQLite
-      creates external exactly-once semantics. The local implementations do not
-      enable production settlement payout.
+      creates external exactly-once semantics. Ledger accrual and authenticated
+      balance are the complete V1 settlement product; they do not promise or
+      enable automatic value transfer.
 - [ ] Settlement Cashu `/v1/settlement/keysets` and
       `/v1/settlement/deposits` remain transport-neutral protocol/store code;
       `payment-issuer` does not route them and no production ceremony enables
@@ -285,6 +306,14 @@ operator has activated the path with real money or public infrastructure.
       one absolute wall-clock deadline across Unix-socket connect, complete
       request write and complete response read; trickled bytes cannot refresh
       that budget, and write-before/after failure classification is preserved.
+      The prepared deployment adds a separately pinned, separate-UID method
+      guard: it alone reaches the native CLN group socket, accepts only exact
+      bounded `getinfo`, private-label `listinvoices` and invoice-creation
+      shapes, reconstructs minimal responses, strips preimage/error payloads,
+      enforces invoice amount/rate/burst/runtime ceilings and exposes a second
+      issuer-group socket. The long-running issuer receives neither the native
+      CLN group nor the Bitcoin-cookie group. Latest Linux ACL/hardlink and
+      complete guard test evidence remains an exact-commit CI requirement.
 - [x] Pure-Rust/WASM BOLT11 parser with signature recovery, canonical lowercase
       round-trip, fixed non-zero amount, network and payee verification. The
       browser controller persists encrypted recovery state before displaying
@@ -299,7 +328,8 @@ operator has activated the path with real money or public infrastructure.
       settlement route are absent from default artifacts and require the
       explicit `test-only-fake-lightning` debug/test feature; build-script and
       source guards reject that feature in release profiles, even with forced
-      debug assertions. `serve-cln` uses a checked local Core Lightning Unix RPC socket.
+      debug assertions. `serve-cln` reaches only the checked guard Unix socket
+      in the prepared production topology; no application flag bypasses it.
       Neither substitutes for a separately operated production TLS/abuse edge.
 - [x] The shared strict HTTPS client gives DNS plus all candidate addresses one
       bounded connect deadline and gives TLS handshake plus the full request and
@@ -339,6 +369,16 @@ operator has activated the path with real money or public infrastructure.
 
 - [x] Canonical NIP-01 event verification, provider assertion, 16-shard catalog
       checkpoints, tombstones, relay split-view checks and rollback state.
+- [x] A repository-owned directory-only Nostr relay now implements the exact
+      bounded `EVENT`/`REQ`/`CLOSE` subset for one pinned kind-30078 publisher.
+      It binds loopback, stores an immutable canonical-event archive plus
+      addressable heads in owner-only SQLite WAL/FULL state, makes duplicate
+      publish acknowledgement idempotent, freezes paged snapshots, bounds
+      connections/operations/work/egress/archive/time and exposes no publisher
+      private key, generic subscription language, live push, NIP-42 or event
+      logging. Its current macOS library and binary unit suites passed 23/23;
+      Linux clippy, installed shutdown/backup drills and public WSS behavior
+      remain exact-commit/deployment evidence rather than source claims.
 - [x] Browser relay fetching and encrypted IndexedDB directory state.
 - [x] A no-account, process-local NIP-01 fake-relay integration test closes the
       signed publisher-artifact to two-relay read path through all 16 shards,
@@ -477,6 +517,22 @@ operator has activated the path with real money or public infrastructure.
       It remains `NoSevHost` deterministic local evidence, not production
       identity, proof-chain, independent rollback-floor or external
       public-WebPKI mint evidence.
+- [x] A separate non-default shared-issuer process E2E is implemented and wired
+      into Payment CI. It builds a real test-only-fake-Lightning
+      `payment-issuer`, places a private WebPKI TLS edge with a signed leaf-SPKI
+      pin in front of its redeem-only route, and launches a real paid
+      `unified_server` plus an independently selected Free/Open peer. A BAT
+      redemption credits the authenticated provider's shared ledger exactly
+      once and creates exactly one provider-local delivery claim; provider
+      restart/replay cannot create a second grant. Wrong CA, wrong signed pin
+      and offline issuer all fail closed before issuer application handling and
+      create neither a local claim nor a provider account. The test also checks
+      that payout rows remain zero and server logs contain no invoice, payment
+      hash, preimage or raw BAT secret. The fake-Lightning issuer binary is
+      supplied only by an absolute, non-symlink path and the shared test feature
+      inherits the release-rejected WebPKI hook. This branch's first executable
+      proof is intentionally pending the Linux Payment CI run; implementation
+      and static formatting alone are not recorded as a pass.
 - [x] Web unit tests cover acquisition recovery, directory storage, vault
       locking and local pair-selection boundaries.
 - [x] A dedicated Playwright job runs the production browser vault and
@@ -596,10 +652,9 @@ unique aggregate count. Exact-head pushed CI remains a separate merge gate.
       and binds a fresh backup receipt to the current SCB digest. Atomic receipt
       writes explicitly unlock the pinned output-parent descriptor on every
       ordinary success/error path; the primary operation error wins, while a
-      successful write followed by unlock failure fails closed. The current
-      default-parallel admin suite passed 106/106 five times, then 106/106
-      single-threaded with warnings denied. Its command runner is mock-tested
-      against a fixed
+      successful write followed by unlock failure fails closed. The latest
+      focused admin suite passed 126/126 with warnings denied. Its command
+      runner is mock-tested against a fixed
       read-only RPC allowlist. It has not yet been run on the final persistent
       Signet hosts and does not replace actual liquidity, payment, restore or
       peer/bootstrap acceptance. The receipt is an operator assertion:
@@ -609,13 +664,27 @@ unique aggregate count. Exact-head pushed CI remains a separate merge gate.
 - [ ] The `payment-issuer serve-cln` executable path is implemented and has
       crossed the current disposable three-node local-regtest boundary below,
       but has not been connected to a persistent, external or public-network node.
-      It deliberately binds loopback and expects an exact-owner local Unix RPC
-      socket. Production TLS ingress, source-aware abuse controls, process
-      supervision and operational key custody remain deployment work.
+      It deliberately binds loopback and, in the prepared production topology,
+      expects the guard-UID/issuer-GID method-scoped Unix socket. A separate
+      one-shot preflight UID checks the native cross-UID CLN socket and Bitcoin
+      cookie after the CLN daemon itself runs the recursive layout verifier.
+      Production TLS ingress, source-aware abuse controls, Linux installed-
+      artifact/runtime evidence, process supervision and operational key
+      custody remain deployment work.
 - [x] Issuer startup authenticates the current quote delegation and validates
       the configured Lightning backend before opening or mutating the issuer
       store. A wrong CLN socket, payee identity or network therefore cannot
       advance retained-policy or key-lineage state during a failed start.
+- [x] `bitcoinpir-cln-rpc-guard` implements the production method-scoped Unix
+      boundary between the issuer and Core Lightning. It validates kernel peer
+      credentials plus parent/socket identity, mode, single-link and Linux ACL
+      state; reconstructs only bounded `getinfo`, private-label `listinvoices`
+      and anonymous `invoice` RPCs; enforces absolute deadlines, inflight and
+      per-generation invoice limits; and never forwards raw CLN errors or logs
+      invoice, hash or preimage material. Its production unit deliberately uses
+      `Restart=no` so a crash cannot silently reset the custody deadman. The
+      source and deterministic tests are present, but Linux CI and a target-host
+      cross-UID access drill remain required before activation.
 - [x] The current opt-in local-regtest runner wires the production CLN adapter
       to three disposable Core Lightning nodes and two 1,000,000-sat announced
       localhost channels. There is no payer-to-issuer channel: payer gossip must
@@ -646,6 +715,25 @@ unique aggregate count. Exact-head pushed CI remains a separate merge gate.
       failure behavior. Its `--validate-only` preflight applies the exact
       artifact/key/time/relay checks without invoking transport. Distinct
       hostnames do not prove independent operators.
+- [x] `bitcoinpir-directory-relay` implements the intentionally narrow
+      directory-only Nostr surface: canonical signed EVENT validation for one
+      pinned publisher/kind, bounded ID-filtered REQ/EOSE readback, immutable
+      SQLite event archive plus current heads, durable duplicate handling,
+      bounded connection/work/egress/archive/time dimensions and graceful
+      drain. It is not a general-purpose relay. The production selection and
+      unit remain `UNRESOLVED`/`ExecStart=/usr/bin/false`; final merged source,
+      binary/config/public-key hashes, source-fair ingress and a second
+      independently operated relay are activation gates.
+- [x] Source-template, rendered-profile and live-Linux evidence tools are
+      checked in. The source gate freezes inactive templates and the unchanged
+      VPSBG baseline. The rendered gate binds one externally approved plan to
+      exact staged bytes, path/file classes and consuming service identities;
+      the live collector binds installed bytes, systemd state and real process
+      credentials to one machine/boot/invocation. The current source gate passed
+      16/16 and the combined rendered/live-evidence Node suite passed 63/63 on
+      this preparation tree. The first root-only target Linux collection still
+      remains candidate-commit/host evidence and cannot be inferred from those
+      deterministic tests.
 - [x] One authorized public-relay smoke published a 30-minute, empty 16-shard
       checkpoint signed by a disposable test key. nos.lol and
       `relay.primal.net` each returned 16 positive matching OKs, then returned

--- a/docs/payment/LIGHTNING_STAGING.md
+++ b/docs/payment/LIGHTNING_STAGING.md
@@ -88,6 +88,53 @@ Mutinynet additionally requires its exact signet challenge, Bitcoin peer set
 and Lightning peers to be pinned. A generic `--network=signet` is not proof
 that the node joined Mutinynet.
 
+The Core RPC cookie has an access policy independent of the CLN socket
+policy. Omitting `bitcoin.rpc_cookie.access_policy` preserves schema V1's
+`same-uid-owner-only` layout: the preflight EUID must equal the bitcoind UID,
+the final cookie directory is exact mode 0700, and the single-link cookie is
+exact mode 0600. `cross-uid-shared-group` requires the separate
+`bitcoin.rpc_cookie.cross_uid_access` table, a root:root mode-0755 broad
+parent (normally `/srv/bitcoin`), exactly one directly nested
+bitcoind-UID/cookie-GID mode-0710 network directory, and a
+bitcoind-UID/cookie-GID mode-0640 cookie with link count one. The preflight
+must run under its separately pinned EUID and have that cookie GID as its
+effective or supplementary group. Configure bitcoind with
+`rpccookieperms=group` and the cookie-only group so it creates the required
+0640 file; the preflight never changes ownership or permissions. Bitcoin
+Core documents that cookie read access is a powerful RPC trust boundary and
+supports `owner`, `group`, or `all` via
+[`rpccookieperms`](https://github.com/bitcoin/bitcoin/blob/master/src/init.cpp).
+
+The cookie group must be different from the native CLN RPC group. CLN requires
+the cookie group for its bcli plugin; only CLN and the short-lived, read-only
+preflight unit receive it. The long-lived payment issuer and CLN RPC guard must
+never list the cookie group in `Group=`, `SupplementaryGroups=`, container
+membership, `/etc/group` membership, ACLs, or an interactive login. Grant it
+to CLN and with unit-scoped `SupplementaryGroups=bitcoinpir-bitcoin-rpc` on the
+one-shot preflight service; do not add the preflight or issuer account
+persistently to that group. Activation evidence must inspect rendered units
+and the live issuer, guard, preflight and CLN processes' `Groups:` sets.
+Otherwise issuer or guard compromise could gain the much larger Bitcoin Core
+RPC authority. Whenever Core uses
+cross-UID mode, the config validates Core and CLN daemon owners/groups as
+distinct and requires both policies to name the same preflight EUID without
+reusing either subsystem's identity fields.
+
+Cookie validation canonicalizes the broad parent, final directory and cookie;
+walks every parent component using `O_NOFOLLOW`; applies the platform ACL
+policy; and opens the cookie itself with `O_NOFOLLOW`. It checks type,
+UID/GID, exact mode, link count and bounded size on the same open file
+descriptor before and after reading, rereads that descriptor from offset zero,
+requires both bounded reads to match byte-for-byte and equal the pinned size,
+validates the cookie format without logging it, then
+rechecks the named path and parent namespace. A symlink, hardlink, replacement,
+permission/ACL change, truncation or other metadata drift fails closed.
+The omitted-policy default is compatible only with a genuinely same-UID Core
+layout. If CLN is already split-UID while Core names a different bitcoind UID,
+the two required preflight EUIDs conflict and static validation fails; the
+operator must add the explicit Core cross-UID table rather than obtaining an
+implicit policy downgrade.
+
 The CLN adapter's timeout is one process-local monotonic budget covering
 socket metadata validation, connect, complete request write and complete
 response read. Filesystem metadata calls cannot be force-cancelled by that
@@ -102,7 +149,29 @@ daemon-owner/group mode-0710 final parent and mode-0660 socket; this permits
 traversal and connection but not directory listing or name replacement. It
 also checks the final `lightning-rpc` socket's type, UID/GID and device/inode
 before and after connect. Deployment preflight
-independently pins the broader protected executable/configuration boundary.
+uses the same two socket layouts explicitly: an omitted
+`lightning.rpc_access_policy` retains the schema-V1
+`same-uid-owner-only` staging policy, while
+`cross-uid-shared-group` additionally requires the strict
+`lightning.cross_uid_access` table. Cross-UID preflight must run as the exact
+configured dedicated preflight EUID with the socket GID present as its effective or
+supplementary group. It pins a canonical root-owned mode-0755 broad parent
+(normally `/srv/lightning`), one directly nested CLN-owned/group-owned
+mode-0710 network directory, and the CLN-owned/group-owned mode-0660 socket.
+The same-UID policy instead requires the preflight EUID/socket UID to agree,
+an exact mode-0700 final parent, and an exact mode-0600 socket. Both modes
+require socket link count one and reject namespace or metadata drift across
+the component-by-component validation.
+
+The Core-cookie and CLN-socket parent walks reject symlinks,
+writable/untrusted ancestors and extended ACL grants wherever the shared
+private-files policy can inspect them. On
+macOS this includes the extended ACL checks; the current Linux implementation
+is deliberately DAC-only until a reviewed POSIX/NFS ACL parser exists. The
+preflight therefore does not claim to detect Linux POSIX/NFS ACL grants and
+operators must keep this tree on a local filesystem whose ACL policy is
+disabled or separately enforced. Deployment preflight also independently pins
+the broader protected executable/configuration boundary.
 Keep that tree on a protected local Unix/POSIX filesystem; NFS/FUSE stalls,
 another process under the same UID and root compromise are operator
 trust-boundary failures. These checks harden local routing but are not
@@ -126,6 +195,17 @@ fixed, read-only probe: it calls only Core `getnetworkinfo`,
 no bootstrap, wallet, address, faucet, channel mutation, payment, SSH or remote
 execution path.
 
+The `--config-expected-uid` and `--config-expected-gid` arguments always pin
+the protected TOML file and are neither the Core-cookie nor CLN-socket
+owner/group. For the published cross-UID example, run the command as the
+dedicated preflight UID with both unit-scoped `bitcoinpir-bitcoin-rpc` and
+`bitcoinpir-cln-guard` groups, while using the config owner's UID/GID for those CLI
+arguments. `bitcoin.rpc_cookie.expected_uid/gid` remain the bitcoind UID and
+cookie-only GID; `lightning.expected_uid/gid` remain the CLN UID and its
+different shared group GID. The short-lived preflight EUID is configured
+independently in both cross-UID tables and must agree. None of these identity
+sets may be substituted for another.
+
 The preflight fails closed on an unknown TOML field and checks all of the
 following before emitting one bounded `result=PASS` line:
 
@@ -133,8 +213,15 @@ following before emitting one bounded `result=PASS` line:
   SHA-256 values, owners and non-writable executable modes, all below explicit
   protected parent boundaries without writable or symlinked descendants;
 - an explicit loopback Core RPC address and non-zero port plus one exact
-  `rpccookiefile` path. The owner-only mode-`0600` cookie and all descendants
-  below its protected parent are owner/GID checked and symlink/write rejected;
+  `rpccookiefile` path. Same-UID mode requires the exact preflight/bitcoind
+  EUID, a mode-0700 final directory and a mode-0600 single-link cookie.
+  Cross-UID mode requires the exact preflight EUID plus effective or
+  supplementary cookie-only GID, root:root 0755 on the broad parent, exactly
+  one bitcoind-UID/cookie-GID 0710 network directory below it, and a
+  bitcoind-UID/cookie-GID 0640 single-link cookie. The cookie path is canonical
+  and `O_NOFOLLOW`-opened, its parents and ACL policy are checked, and the same
+  descriptor's identity/size plus two matching bounded content reads and the
+  named namespace are checked before and after access. The cookie is never logged;
   `-conf`, inline credentials, implicit port/cookie selection and non-loopback
   RPC targets are forbidden. Exact empty command-line `rpcuser`/`rpcpassword`
   values must clear any credentials from the automatically read datadir config,
@@ -143,8 +230,13 @@ following before emitting one bounded `result=PASS` line:
   challenge and genesis, `initialblockdownload=false`, and bounded header lag;
 - exact CLN role identity, version, `network=signet`, height lag and an exact
   active plugin allowlist whose executable hashes are also pinned;
-- an owner-controlled, symlink-free `lightning-rpc` subtree and owner-only
-  socket;
+- a canonical `lightning-rpc` path with no symlinked component, exact runtime
+  EUID and (for cross-UID) effective/supplementary shared-group membership.
+  Same-UID staging requires an owner/GID-pinned non-writable tree, exact 0700
+  final parent and exact 0600 socket. Cross-UID requires root:root 0755 on the
+  broad parent, exactly one CLN-UID/shared-GID 0710 network directory below it,
+  and a CLN-UID/shared-GID 0660 socket. Socket link count must be one, and
+  owner/mode/inode/link metadata must not drift during validation;
 - exactly one connected, reestablished, `CHANNELD_NORMAL`, public announced
   channel per role edge, plus bidirectional active gossip for the required
   edges. In particular the payer must see `router <-> issuer`;
@@ -181,8 +273,8 @@ with the narrowly scoped local ceremony (run as the configured receipt owner):
 bpir-admin lightning-staging record-backup-receipt \
   --config /absolute/path/preflight.toml \
   --config-protected-parent /absolute/trusted/config-parent \
-  --config-expected-uid 991 \
-  --config-expected-gid 991 \
+  --config-expected-uid 995 \
+  --config-expected-gid 995 \
   --acknowledge-identity-secret-offline-backup-restore-checked \
   --acknowledge-channel-state-recovery-backup-restore-checked
 ```

--- a/docs/payment/LIGHTNING_STAGING_PREFLIGHT.toml.example
+++ b/docs/payment/LIGHTNING_STAGING_PREFLIGHT.toml.example
@@ -3,6 +3,14 @@
 # Copy this public, non-secret template separately onto each payer/router/issuer
 # host. Replace every placeholder and set `role` for that host. The preflight
 # is intentionally read-only and will fail on these zero hash placeholders.
+# In this numeric example the protected config and backup receipt are owned by
+# the dedicated preflight service (UID/GID 995), so invoke both commands with:
+#   --config-expected-uid 995 --config-expected-gid 995
+# UID 990 is bitcoind, UID 991 is CLN, UID/GID 992 is the long-lived issuer,
+# GID 993 is the native CLN RPC guard group, GID 994 is the Bitcoin-cookie
+# group, and UID/GID 995 is the one-shot preflight. CLN and preflight receive
+# GID 994; the RPC guard and preflight receive GID 993. The issuer receives
+# neither group and reaches only the guard's downstream issuer-group socket.
 
 schema_version = 1
 role = "payer" # payer | router | issuer
@@ -36,8 +44,22 @@ expected_subversion = "/Satoshi:29.0.0/"
 [bitcoin.rpc_cookie]
 path = "/srv/bitcoin/signet/.cookie"
 protected_parent = "/srv/bitcoin"
+access_policy = "cross-uid-shared-group"
+# Cookie/final-network-directory owner (bitcoind UID) and the distinct,
+# CLN/preflight-only cookie group. Cross-UID mode requires 0710 on
+# `/srv/bitcoin/signet` and 0640 with link count one on `.cookie`.
 expected_uid = 990
-expected_gid = 990
+expected_gid = 994
+
+[bitcoin.rpc_cookie.cross_uid_access]
+# The read-only preflight must run with this exact EUID and must have cookie
+# GID 994 as its effective or supplementary group. CLN also needs GID 994 for
+# bcli; the issuer and CLN RPC guard must not receive it.
+preflight_expected_uid = 995
+# V1 cross-UID policy deliberately requires a root:root mode-0755 broad
+# boundary at `/srv/bitcoin`.
+protected_parent_expected_uid = 0
+protected_parent_expected_gid = 0
 
 [bitcoin.daemon]
 path = "/usr/local/libexec/bitcoinpir/bitcoind"
@@ -56,9 +78,22 @@ expected_gid = 0
 [lightning]
 rpc_socket = "/srv/lightning/signet/lightning-rpc"
 protected_parent = "/srv/lightning"
+rpc_access_policy = "cross-uid-shared-group"
+# Socket and final network-directory owner (CLN UID) plus the exact shared
+# group. Cross-UID mode requires 0710 on `/srv/lightning/signet` and 0660 on
+# the socket; these are not the config-file ownership CLI arguments above.
 expected_uid = 991
-expected_gid = 991
+expected_gid = 993
 expected_version = "v26.06.6"
+
+[lightning.cross_uid_access]
+# The preflight must run with this exact dedicated EUID and must have
+# `expected_gid = 993` as its effective or supplementary group.
+client_expected_uid = 995
+# V1 cross-UID policy deliberately requires a root:root mode-0755 broad
+# boundary at `/srv/lightning`.
+protected_parent_expected_uid = 0
+protected_parent_expected_gid = 0
 
 [lightning.daemon]
 path = "/usr/local/libexec/bitcoinpir/lightningd"
@@ -90,6 +125,6 @@ expected_gid = 0
 # after both separately controlled backups were restore-checked.
 receipt = "/srv/bitcoinpir-backup/default-signet-payer.toml"
 protected_parent = "/srv/bitcoinpir-backup"
-expected_uid = 991
-expected_gid = 991
+expected_uid = 995
+expected_gid = 995
 max_age_seconds = 86400

--- a/docs/payment/LOCAL_ACCEPTANCE.md
+++ b/docs/payment/LOCAL_ACCEPTANCE.md
@@ -149,7 +149,7 @@ string copies. This is evidence hygiene, not a production secret-memory claim.
 The full command mirrors the default Rust/WASM portions of
 `.github/workflows/payment-platform.yml`, including the Harmony hint-pool
 library tests, the selected `unified_server` binary/process targets and the
-feature-enabled remote-authority and Standard Cashu targets. It regenerates the
+feature-enabled remote-authority, Standard Cashu and shared-issuer targets. It regenerates the
 WASM JS/TypeScript bindings and adds the Web unit suite plus the local Chromium
 multi-tab vault, real-WASM/no-funds-issuer and browser/two-provider full local
 DPF-query boundaries. It
@@ -653,6 +653,34 @@ and `NoSevHost`; it does not prove an
 external public-WebPKI mint, production server identity/attestation or an
 independent production rollback floor.
 
+An additional non-default shared-issuer process cell is also part of full mode
+and Payment Platform CI:
+
+```sh
+issuer_e2e_target_dir="$PWD/target/payment-issuer-shared-e2e"
+cargo build --locked --offline \
+  -p payment-issuer \
+  --features test-only-fake-lightning \
+  --bin payment-issuer \
+  --target-dir "$issuer_e2e_target_dir"
+BITCOINPIR_PAYMENT_ISSUER_BIN="$issuer_e2e_target_dir/debug/payment-issuer" \
+  cargo test --locked --offline \
+    -p runtime \
+    --features shared-issuer-process-e2e \
+    --test payment_v1_shared_issuer_process_e2e \
+    shared_issuer_real_process_tls_e2e -- --exact
+```
+
+This is the executable provider-to-shared-clearing seam: a real issuer behind
+a private signed-pin TLS edge, a real paid provider and an independent Free
+peer. It proves one issuer redemption/ledger credit, one provider-local grant,
+restart/replay at-most-once behavior, and fail-closed wrong-CA/wrong-pin/offline
+dependencies without invoice creation or real funds. It does not prove public
+source-fair ingress, independent production rollback domains, real Lightning,
+automated payout, or target-host systemd state. The source is wired into CI,
+but this preparation branch must not record a pass until the Linux cell has run
+on the exact candidate commit.
+
 ## Standard Cashu custody boundary
 
 Full mode and Payment Platform CI include:
@@ -777,9 +805,13 @@ cargo test --offline -p pir-issuer-clearing payout_worker
 cargo test --offline -p payment-issuer settlement_http
 ```
 
-These suites cover canonical bounded settlement HTTP envelopes, authenticated
-balance/payout-intent/payout/status calls, payout state verification, response
-loss and exact latest-status replay. For a **status successor**, the provider
+These suites cover canonical bounded settlement envelopes, the production
+authenticated balance route, and a private Rust unit-fixture switch for the
+otherwise non-routed payout-intent/payout/status HTTP roundtrip. They exercise
+payout state verification, response loss and exact latest-status replay without
+making payout part of the production/default binary's HTTP product. Production
+returns unknown-path before parsing or store access for all three payout paths.
+For a **status successor**, the provider
 client persists the exact pending envelope before send, then commits its
 successor state and mandatory external rollback floor together through its
 state-store boundary.

--- a/docs/payment/OFFLINE_OPERATOR_TOOLING.md
+++ b/docs/payment/OFFLINE_OPERATOR_TOOLING.md
@@ -30,6 +30,10 @@ bpir-admin service-keygen --role quote-ed25519 --out quote-online.key
 bpir-admin service-keygen --role bip340-claim --out claim-test.key
 bpir-admin service-keygen --role credential-derivation --out credential-derivation.key
 bpir-admin service-keygen --role redeem-derivation --out redeem-derivation.key
+bpir-admin service-keygen --role free-ip-hmac --out free-ip-hmac.key
+bpir-admin service-keygen --role cashu-recovery-aead --out cashu-recovery-1.key
+bpir-admin service-keygen --role cashu-custody-aead --out cashu-custody-1.key
+bpir-admin service-keygen --role provider-shared-idempotency-hmac --out shared-idempotency.key
 bpir-admin service-keygen --role receipt-ed25519 --out receipt.key
 bpir-admin service-keygen --role cashu-bat --out bat.key
 bpir-admin service-keygen --role cashu-ecash --out cashu-denomination.key
@@ -37,10 +41,14 @@ bpir-admin service-keygen --role arc-experimental --out arc.key
 ```
 
 Other supported roles are `policy-ed25519`, `anonymous-ticket-ed25519`,
-`clearing-ed25519`, and `directory-nostr`. Do not reuse one raw key across
-roles, providers, BAT offers, or ARC lineages. `bip340-claim` is normally
-browser-generated; the operator command exists for isolated tests and recovery
-fixtures, not as a recommendation to centralize browser claim keys.
+`clearing-ed25519`, and `directory-nostr`. The six symmetric or derivation
+roles (`credential-derivation`, `redeem-derivation`, and the four roles added
+above) print only a domain-separated operator fingerprint, never a public key
+or secret. Do not
+reuse one raw key across roles, providers, BAT offers, ARC lineages, recovery
+epochs, custody epochs, or shared-issuer relationships. `bip340-claim` is
+normally browser-generated; the operator command exists for isolated tests and
+recovery fixtures, not as a recommendation to centralize browser claim keys.
 
 ARC uses a 128-byte four-scalar key and remains experimental pending an
 independent cryptographic review.

--- a/docs/payment/OPERATOR_RUNBOOK.md
+++ b/docs/payment/OPERATOR_RUNBOOK.md
@@ -184,6 +184,19 @@ The stronger `secret_write_status=committed_path_unknown` marker means a
 post-commit check could no longer prove that the requested pathname names the
 new inode; stop and reconcile the pinned directory inode, target and printed
 public identity without retrying rotation.
+Keygen explicitly unlocks its pinned parent descriptor before returning, so a
+descriptor inherited by a concurrently forked process cannot retain the
+advisory lock until that process execs or exits. If a committed write cannot
+confirm that unlock, the command still prints the new public identity and exits
+`2`; a lock-only incident uses
+`secret_write_status=committed_lock_release_unknown`. When path or durability
+is already unknown, that primary marker remains authoritative. In every
+committed case with an unlock failure, the additional stable marker
+`secret_write_lock_release_status=unknown` is emitted. Do not retry; preserve
+the printed identity, inspect the exact target, determine whether any duplicated
+or inherited descriptor still holds the parent directory open, and diagnose the
+unlock error. A pre-commit operation failure remains the primary error and
+appends the lock-release failure as secondary diagnostic text.
 
 On macOS, the CLI rejects any extended ACL on a secret parent or an existing
 secret. It also clears and re-reads the temporary file's extended ACL before

--- a/docs/payment/PROTOCOL.md
+++ b/docs/payment/PROTOCOL.md
@@ -907,37 +907,51 @@ returns `InvalidOrSpent` at the provider rather than installing a second grant.
 
 ### Settlement
 
-Executable ledger-only `payment-issuer` routes:
+Executable ledger-accrual `payment-issuer` settlement route:
 
 ```text
 POST /v1/settlement/balance
+```
+
+`POST /v1/redeems` performs the authenticated credential-to-ledger-credit
+mutation described above. The following are transport-neutral model/store
+surfaces only and are **not routed by the production/default
+`payment-issuer`** in V1:
+
+```text
+GET  /v1/settlement/keysets
+POST /v1/settlement/deposits
 POST /v1/settlement/payout-intents
 POST /v1/settlement/payouts
 POST /v1/settlement/payout-status
 ```
 
-The following are transport-neutral model/store surfaces only and are **not
-routed by `payment-issuer`** in V1:
-
-```text
-GET  /v1/settlement/keysets
-POST /v1/settlement/deposits
-```
-
 The modeled deposit is authenticated, batched, idempotent, and double-spend
 safe, but serving it requires a separate retained-keyset operations ceremony
-that is not enabled. This distinction also keeps the executable HTTP listener
-at the smaller ledger-envelope bound rather than the deposit-only 64-note
-bound. Actual Lightning payout is an operator action outside the query path
-and requires separate production/funds approval in this project.
+that is not enabled. The payout state machine similarly has no shipped
+real-funds executor or application worker. The three payout paths return the
+same response as an unknown path before parsing or store access; only a private
+Rust unit fixture exercises their historical HTTP roundtrip. Production uses an
+explicit ledger-only service mode, whose payout methods also return `NotFound`
+before decoding or store access, and its CLI accepts no payout target, fee or
+intent TTL. The registration schema's mandatory target column is filled only by
+one fixed domain-separated non-zero disabled sentinel; neither an operator nor
+a request can select it, and it is never interpreted as a destination. This
+distinction keeps the executable listener at the smaller ledger-envelope bound,
+prevents an accepted-but-never-executed payout from reserving provider credit,
+and makes V1's product promise exactly ledger accrual plus authenticated
+balance. Any actual payout is an operator/product action outside the query path
+and requires a separately reviewed executor or manual reconciliation design
+plus explicit production/funds approval.
 
 Every retained settlement Cashu keyset registry is local trusted context bound
 to one `issuer_id`; a matching keyset ID from a different issuer lineage is
 rejected before note verification or ledger credit. Settlement-signature keys
 use a separate trusted keyring containing one current key and retained
-historical keys for the same `issuer_id`. Historical payout responses are
-resolved by their signed `issuer_settlement_key_id`, so rotating the current
-key does not strand an in-flight payout.
+historical keys for the same `issuer_id`. Production ledger-only operation still
+needs retained keys to authenticate exact committed redeem responses and their
+historical approvals after rotation. The transport-neutral payout model also
+resolves historical responses by their signed `issuer_settlement_key_id`.
 
 Payout is intentionally two-step. The provider first requests an issuer-signed
 intent that fixes account, opaque payout target ID, unit, value, fee, total

--- a/docs/payment/SECURITY_REVIEW_2026-07-29_DEPLOYMENT.md
+++ b/docs/payment/SECURITY_REVIEW_2026-07-29_DEPLOYMENT.md
@@ -1,0 +1,199 @@
+# Payment V1 deployment security review — 2026-07-29
+
+Status: pre-PR review of `codex/payment-deployment-prep`. This document is not
+production approval. It records source-level findings, closure evidence and
+the remaining live activation decisions. No remote host, public Nostr relay,
+Lightning wallet, channel or real-value payment was touched during this review.
+
+## Reviewed boundary
+
+The focused review covered:
+
+- the repository directory-only Nostr relay and its SQLite archive/head model;
+- the Core Lightning Unix-RPC guard and the `pir-lightning-backend` transport;
+- production `payment-issuer` routing and shared-issuer ledger accrual;
+- Hetzner provider, issuer, CLN, edge and directory templates;
+- independent rollback-authority templates and clients;
+- source, rendered-bundle and Linux runtime evidence gates; and
+- the proposed topology in which Hetzner hosts new public services while the
+  existing VPSBG provider remains unchanged except for a later minimal
+  Payment V1 admission integration.
+
+No P0 source flaw was found in this focused pass. That does not convert ARC
+into reviewed cryptography: ARC remains experimental and production-disabled.
+
+## Findings closed in this preparation branch
+
+### Production payout surface
+
+The first production shared-issuer product is ledger accrual, not automated
+value transfer. The public edge exposes only `POST /v1/redeems` and
+`POST /v1/settlement/balance`. The three payout paths are rejected as unknown
+before application decoding/authentication/store work and are absent from the
+non-test route handlers. A private Rust unit fixture retains the
+transport-neutral payout state-machine roundtrip; there is no CLI, feature or
+environment switch that enables it in production.
+
+The dormant payout target, fee and intent-TTL configuration has been removed
+from the production CLI, unit and ledger-only constructor in this branch. The
+issuer settlement signing key remains necessary because redeem and balance
+responses are signed, and retained verifying keys remain necessary for exact
+redeem/approval recovery across key rotation.
+
+### Core Lightning socket isolation and deadman
+
+`apps/cln-rpc-guard` reconstructs a strict allowlist of `getinfo`, private-label
+`listinvoices` and bounded anonymous `invoice` requests and responses. It does
+not pass CLN error payloads, invoices, payment hashes or preimages through
+logs. Kernel peer credentials, parent/socket owner/mode/link checks and Linux
+ACL rejection protect both Unix socket boundaries.
+
+The production guard unit uses `Restart=no`. Its per-runtime invoice counter is
+a custody deadman; an automatic crash loop would reset that bound. Guard exit
+stops the bound issuer and a new generation requires an explicit operator
+review/start ceremony.
+
+### Source and rendered deployment closure
+
+The source gate freezes all pre-existing active provider units and the measured
+VPSBG run script, rejects activatable `.in` templates, validates closed command
+lines and forbids fake Lightning, test trust roots, ARC, local rollback and
+legacy credential gates in the first production profile.
+
+The rendered gate requires an externally approved plan digest, one closed
+profile, exact artifact dependencies and hash manifests, target-derived file
+classes, bounded/sorted trees and no placeholder, extra file, symlink,
+hardlink, reset, drop-in, environment-file, credential or cross-profile path.
+Secret ownership is bound to the exact consuming service identity rather than
+an arbitrary non-root UID/GID.
+
+The Linux collector is deliberately root-only and live-only. It binds the
+approved plan/manifest to machine ID, boot ID, uptime, a fresh internal
+challenge, installed bytes, owner/mode/link state, ACLs, xattrs, file
+capabilities, NSS, effective systemd state and `systemd-analyze verify`.
+Long-running units additionally bind `MainPID`/invocation and the real
+`/proc/<pid>` UID/GID/supplementary-group set across a no-restart collection
+window. The reviewed preflight is the sole active-exited one-shot and instead
+must prove a successful zero-status completion in the current boot. Offline
+review is meaningful only with an independently transferred full evidence
+digest.
+
+These gates are source and staging controls, not hardware attestation. Their
+first real systemd/Linux execution on the target Hetzner staging host remains
+mandatory.
+
+## P1 production activation blockers
+
+### Source-fair public admission
+
+The stock-Caddy templates and the application processes currently use global
+connection and operation budgets. A single low-bandwidth source can occupy the
+provider or directory WebSocket pool, consume the anonymous quote budget, or
+hold the rollback-authority queue without a payment or publisher key. This is
+not volumetric DDoS and cannot be dismissed as upstream capacity planning.
+
+Before public activation:
+
+1. add an ephemeral source-fair connection/request boundary in front of the
+   public provider, issuer and directory surfaces;
+2. do not persist IP/request records or forward source identity into the PIR,
+   payment, directory or rollback business processes;
+3. give the signed directory publisher a separate private ingress and reserved
+   connection/operation/egress budget;
+4. place each rollback authority behind its sole client's WireGuard, mTLS or
+   equivalent narrow firewall allowlist; and
+5. collect negative live evidence that one source cannot exhaust every global
+   slot or quote token.
+
+The directory unit remains `UNRESOLVED` with `ExecStart=/usr/bin/false`, so the
+repository cannot accidentally activate it before this boundary and the final
+source/binary/config pins are reviewed.
+
+### Independent rollback domains
+
+“New services run on Hetzner” applies to the relay, payment/credential issuer,
+CLN guard/edge and an optional new provider. It must not place Provider 0,
+Provider 1 and issuer rollback authorities on that same host or administration
+domain. Each stateful detailed store needs its own authority host, service
+account, TLS/key material, administrator, log stream and backup/restore domain.
+Co-location removes the independent anti-rollback and non-collusion failure
+boundary even though authority values are opaque.
+
+### VPSBG hostile-host state custody
+
+The prepared VPSBG change is only a non-executable Free/PoW service-auth
+argument fragment. Its ProviderStore and remote-authority client secrets would
+still reside in host-visible `/home/pir/data`; ordinary file modes do not hide
+them from the VPSBG operator. Production activation therefore requires either
+attestation-gated key release/sealing or explicit user acceptance that the
+VPSBG host joins this trust boundary. Until that decision, the live VPSBG
+service and measured UKI remain unchanged.
+
+### Real staging evidence and resource isolation
+
+No source test proves the installed Linux filesystem, systemd serialization,
+supplementary groups, mount namespace, cgroup limits, CLN/Bitcoin socket shape
+or restart behavior. A private no-funds staging drill must run the live
+collector and access probes. Memory/task/file-descriptor/OOM budgets also need
+workload measurements before co-locating relay, issuer, CLN and provider on one
+Hetzner host; arbitrary unmeasured limits are not safe defaults.
+
+## P2 follow-up boundaries
+
+- A dedicated source-fair edge implementation and its privacy review should be
+  versioned separately from commercial pricing. Anonymous PoW for quote
+  creation is an optional second layer, not a substitute for authority ACLs.
+- The directory relay needs an activatable rendered profile only after the
+  merged source commit, source archive, `Cargo.lock`, binary, config and
+  publisher public-key digests are frozen. Two independently operated relay
+  origins are still required; two DNS aliases on one Hetzner host are not
+  independent.
+- The payout protocol/store/worker code remains useful future work, but no real
+  executor or automatic value-transfer product is enabled in V1.
+- ARC needs a separate cryptographic and implementation review before any
+  production policy may advertise it. Its integration tests do not satisfy
+  that review.
+
+## Invariants that remain mandatory
+
+1. Each PIR provider independently publishes and enforces its own signed
+   backend/workload scope, method, amount and limits. There is no pair ID or
+   shared spent set between the two PIR servers.
+2. DPF, Harmony hint, Harmony query, Onion and TEE-ORAM scopes are distinct.
+   V1 uses `priority_class = 1` only and makes no paid-QoS claim.
+3. The browser verifies provider identity/binary/attestation where available,
+   upgrades the secure channel, verifies database proof/root and current signed
+   policy before retiring or transmitting a capability.
+4. Paid authorization commits before expensive backend work. Any ambiguity or
+   dependency outage fails closed; strict mode never falls back to plaintext,
+   unsigned policy, an unverified server or a free query.
+5. Provider-local one-use credentials have independent server-specific spent
+   state. Shared-issuer redemption credits only the authenticated provider and
+   sends neither query bytes nor a cross-provider pair identifier to the
+   issuer.
+6. BOLT11 direct receipt is an explicitly linkable option. The privacy-preferred
+   path purchases blinded BAT/Cashu/ARC capabilities; PIR providers never see
+   the invoice or payment hash. The Web UI must display the method-specific
+   leakage rather than flattening every payment into the same privacy claim.
+7. No normal log contains invoice strings, payment hashes, preimages, Cashu or
+   ARC proofs, capability identifiers, query addresses/results, request bodies
+   or forwarded client IPs.
+8. ARC remains visibly experimental, opt-in and production-disabled.
+9. Production deployment, DNS/public relay publication, remote host mutation,
+   Lightning wallet/channel creation and real-value operations require the
+   user's separate approval.
+
+## Required evidence before activation
+
+- green Linux CI for all Payment V1 crates, process E2Es and warnings-denied
+  builds, including release rejection of every test-only feature;
+- reviewed merged commit and exact reproducible source/binary/config hashes;
+- passing rendered-profile gate and target-host live evidence collector;
+- independent rollback-authority topology lint plus private-network negative
+  tests;
+- no-funds local regtest and persistent default-Signet Lightning drills,
+  including backup/restore and lost-response reconciliation;
+- source-fair starvation and cgroup pressure tests;
+- private provider/issuer/directory canaries with strict client verification;
+  and
+- final manual browser acceptance by the user before public routing changes.

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -205,6 +205,36 @@ inputs `SPENT`, first custody `UNSPENT -> SPENT`, and independently encrypted
 successor custody `UNSPENT`. This is not an admin-retirement, unified-server or
 public-WebPKI process cell.
 
+A separate non-default shared-issuer process cell joins the provider and
+clearing boundary without creating an invoice or contacting Lightning:
+
+```sh
+issuer_e2e_target_dir="$PWD/target/payment-issuer-shared-e2e"
+cargo build --locked --offline \
+  -p payment-issuer \
+  --features test-only-fake-lightning \
+  --bin payment-issuer \
+  --target-dir "$issuer_e2e_target_dir"
+BITCOINPIR_PAYMENT_ISSUER_BIN="$issuer_e2e_target_dir/debug/payment-issuer" \
+  cargo test --locked --offline \
+    -p runtime \
+    --features shared-issuer-process-e2e \
+    --test payment_v1_shared_issuer_process_e2e \
+    shared_issuer_real_process_tls_e2e -- --exact
+```
+
+It launches a real `payment-issuer`, a redeem-only private WebPKI TLS edge, one
+real shared-BAT `unified_server`, and an independently selected Free/Open peer.
+The paid provider must verify the signed issuer origin and leaf-SPKI pin,
+redeem exactly once, accrue one ledger credit, and durably claim one local
+grant. Restart/replay cannot create a second grant. Wrong CA, wrong signed pin
+and offline issuer fail before issuer HTTP application handling and create no
+local claim or ledger account. CI additionally denies warnings for the exact
+runtime/test targets and proves the test-only WebPKI feature cannot compile in
+a release profile. The current preparation branch has static source evidence
+only until that Linux CI cell passes; it is not public ingress, production
+rollback-authority, real Lightning or payout-executor evidence.
+
 ### First-version executable path ledger
 
 This ledger is a source-level audit of the executable seams, not a claim that a

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -1,0 +1,1753 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const ACTIVE_BASELINES = Object.freeze({
+  "deploy/systemd/pir-primary.service":
+    "bec78a3771c3e4cb56445ba21842bdbb4198b4ccba2af3740ec39ffc8f929e7f",
+  "deploy/systemd/pir-secondary.service":
+    "177c238658dd00edb59e4d8c48776a3117c8fccf903317f8c1843d837a3848aa",
+  "deploy/systemd/pir-vpsbg.service":
+    "4b329ed00d182a09f1832218fd6683bc1e98087ee4ab3ece1ecf264bc422dba9",
+  "deploy/systemd/dev-issuer.service":
+    "07e500d2997ca50bc558d7694b54f709a338c16d1cf37cc05cceeb01c89f90de",
+  "deploy/systemd/cloudflared.service":
+    "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
+  "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
+    "5e1a0bc588326c0355f17a473d1c962b172f2aa4c4c0f1d9b18520964c5dc27c",
+});
+
+export const REVIEWED_PREPARATION_HASHES = Object.freeze({
+  "deploy/payment-v1/edge/hetzner-public.Caddyfile.in":
+    "d54ae5e0ec9fea4a72b1eb83ebe1225f18d386437b639db7bc49fa03f730a3d8",
+  "deploy/payment-v1/edge/rollback-authority.Caddyfile.in":
+    "7aa07c8d18c94708e6e58034066b1908456e6a5ac64d2ac2d169f4ed6822b95d",
+  "deploy/payment-v1/lightning/activation-prerequisites.toml.example":
+    "937737e212f2be0a2fda92fe1aaa421b1aeefdd074261ca78485ca9430d0c443",
+  "deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in":
+    "62b6a6108b4c5768f5de522d72d93a84e97e07f0d93f5dfc02265a87eb18fc31",
+  "deploy/payment-v1/lightning/issuer-cln.args.in":
+    "1da053febf373f7166935e0d57abe140e129931accbb856d93889c4fc979b6f4",
+  "deploy/payment-v1/lightning/lightningd.conf.in":
+    "58973f2b3992a6eb0a2cd4b94b6d878f01240b5ba92d84da5a91ef0c442159f9",
+  "deploy/payment-v1/lightning/verify-layout.sh.in":
+    "a3e3c9033bb0e258c2393117a4b3d17388002a21ae9b8259eed64b90bf2f57ea",
+  "deploy/payment-v1/systemd/hetzner-core-lightning.service.in":
+    "50e86c87bf435c94d62265854e211abb93bb25d6f3c1636c6893a25be80a8df9",
+  "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in":
+    "119ed3ce7b9c48c68b85dc8a37325a8c8c35b6a5f45137859d9b4fbe3f35b9aa",
+  "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in":
+    "e0fa6b1213ae660f74a541d086a16f0c20b8b8eac91f7afe780ffb4ff67ed2ee",
+  "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in":
+    "c9557f8d547bc4b800593452f5308d91d65419603e5a5f046f5d06af9033b4e9",
+  "deploy/payment-v1/systemd/payment-v1-edge.service.in":
+    "49edab939937c98d420e6a6bef6ad3a834effa502630deb666229272993ca841",
+});
+
+export const REQUIRED_PREPARATION_FILES = Object.freeze([
+  "deploy/payment-v1/README.md",
+  "deploy/payment-v1/directory-relay.toml.example",
+  "deploy/payment-v1/relay-selection.toml.example",
+  "deploy/payment-v1/edge/README.md",
+  "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
+  "deploy/payment-v1/edge/rollback-authority.Caddyfile.in",
+  "deploy/payment-v1/lightning/README.md",
+  "deploy/payment-v1/lightning/activation-prerequisites.toml.example",
+  "deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in",
+  "deploy/payment-v1/lightning/issuer-cln.args.in",
+  "deploy/payment-v1/lightning/lightningd.conf.in",
+  "deploy/payment-v1/lightning/verify-layout.sh.in",
+  "deploy/payment-v1/systemd/hetzner-core-lightning.service.in",
+  "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in",
+  "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in",
+  "deploy/payment-v1/systemd/payment-v1-edge.service.in",
+  "deploy/payment-v1/systemd/hetzner-provider.service.in",
+  "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+  "deploy/payment-v1/systemd/rollback-authority.service.in",
+  "deploy/payment-v1/systemd/hetzner-directory-relay.service.in",
+  "deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in",
+  "docs/payment/HETZNER_VPSBG_DEPLOYMENT.md",
+]);
+
+const TEMPLATE_ROOT = "deploy/payment-v1";
+const ACTIVATION_SENTINEL =
+  "ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED";
+const UNSAFE_RELAY_COMMITS = new Set([
+  "ff65ec2acd781150a585a78e1c60b0cdb104698e",
+  "b5c1f642e4f4c3b9c54f5d18d66f4c53642076b4",
+]);
+const HASH_FIELDS = Object.freeze([
+  "source_archive_sha256",
+  "cargo_lock_sha256",
+  "binary_sha256",
+  "config_sha256",
+]);
+const UNRESOLVED_FIELDS = Object.freeze([
+  "implementation",
+  "source_repository",
+  "source_commit",
+  ...HASH_FIELDS,
+  "binary_version_output",
+  "publisher_pubkey_hex",
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function readRequired(root, relativePath) {
+  const absolute = join(root, relativePath);
+  let stat;
+  try {
+    stat = lstatSync(absolute);
+  } catch {
+    fail(`required deployment file is missing: ${relativePath}`);
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    fail(`deployment input must be a regular non-symlink file: ${relativePath}`);
+  }
+  return { absolute, stat, text: readFileSync(absolute, "utf8") };
+}
+
+function sha256File(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function requireText(text, needle, label) {
+  if (!text.includes(needle)) {
+    fail(`${label} is missing required text: ${needle}`);
+  }
+}
+
+function rejectPattern(text, pattern, label, description) {
+  if (pattern.test(text)) {
+    fail(`${label} contains forbidden ${description}`);
+  }
+}
+
+function parseSystemdUnit(text, label) {
+  const logicalLines = [];
+  let pending = "";
+  for (const original of text.split(/\r?\n/u)) {
+    const trimmed = original.trim();
+    if (trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith(";")) {
+      continue;
+    }
+    const continued = original.trimEnd().endsWith("\\");
+    const fragment = continued
+      ? original.trimEnd().slice(0, -1).trim()
+      : original.trim();
+    pending = pending === "" ? fragment : `${pending} ${fragment}`;
+    if (!continued) {
+      logicalLines.push(pending);
+      pending = "";
+    }
+  }
+  if (pending !== "") fail(`${label} ends with an unterminated continuation`);
+
+  const sections = new Map();
+  let section;
+  for (const line of logicalLines) {
+    const sectionMatch = /^\[([A-Za-z][A-Za-z0-9]*)\]$/.exec(line);
+    if (sectionMatch) {
+      section = sectionMatch[1];
+      if (sections.has(section)) fail(`${label} repeats [${section}]`);
+      if (section !== "Unit" && section !== "Service") {
+        fail(`${label} contains forbidden [${section}] section`);
+      }
+      sections.set(section, new Map());
+      continue;
+    }
+    if (section === undefined) fail(`${label} has a directive outside a section`);
+    const directive = /^([A-Za-z][A-Za-z0-9]*)=(.*)$/.exec(line);
+    if (!directive) fail(`${label} has a malformed systemd directive: ${line}`);
+    const key = directive[1];
+    const value = directive[2].trim();
+    if (value === "" && key !== "CapabilityBoundingSet" && key !== "AmbientCapabilities") {
+      fail(`${label} contains forbidden empty ${key}= reset`);
+    }
+    const values = sections.get(section).get(key) ?? [];
+    values.push(value);
+    sections.get(section).set(key, values);
+  }
+  for (const required of ["Unit", "Service"]) {
+    if (!sections.has(required)) fail(`${label} is missing [${required}]`);
+  }
+  return sections;
+}
+
+function directiveValues(unit, section, key) {
+  return unit.get(section)?.get(key) ?? [];
+}
+
+function exactDirectiveValues(unit, section, key, expected, label) {
+  const actual = directiveValues(unit, section, key);
+  if (
+    actual.length !== expected.length ||
+    actual.some((value, index) => value !== expected[index])
+  ) {
+    fail(
+      `${label} ${section}.${key} must equal ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function onlyDirectiveValue(unit, section, key, label) {
+  const values = directiveValues(unit, section, key);
+  if (values.length !== 1) {
+    fail(`${label} must contain exactly one ${section}.${key}`);
+  }
+  return values[0];
+}
+
+function exactDirectiveKeys(unit, section, expected, label) {
+  const actual = [...(unit.get(section)?.keys() ?? [])].sort();
+  const wanted = [...expected].sort();
+  if (
+    actual.length !== wanted.length ||
+    actual.some((value, index) => value !== wanted[index])
+  ) {
+    fail(
+      `${label} ${section} directive keys must equal ${JSON.stringify(wanted)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function validateExactCommand(command, prefix, options, label) {
+  rejectPattern(command, /["'`;|&<>$]/u, label, "shell/meta syntax in ExecStart");
+  const tokens = command.trim().split(/\s+/u);
+  let cursor = 0;
+  for (const expected of prefix) {
+    if (tokens[cursor] !== expected) {
+      fail(`${label} command prefix must contain ${expected} at argv[${cursor}]`);
+    }
+    cursor += 1;
+  }
+  for (const [flag, value] of options) {
+    if (tokens[cursor] !== flag) {
+      fail(`${label} must contain ${flag} exactly once and in canonical order`);
+    }
+    cursor += 1;
+    if (value !== null) {
+      if (tokens[cursor] !== value) {
+        fail(`${label} ${flag} must equal ${value}`);
+      }
+      cursor += 1;
+    }
+  }
+  if (cursor !== tokens.length) {
+    fail(`${label} contains an unreviewed, duplicate, or positional argv value`);
+  }
+}
+
+const COMMON_UNIT_KEYS = new Set([
+  "Description",
+  "After",
+  "Wants",
+  "Requires",
+  "BindsTo",
+  "Before",
+  "ConditionPathExists",
+]);
+const BASIC_UNIT_KEYS = Object.freeze([
+  "Description",
+  "After",
+  "Wants",
+  "ConditionPathExists",
+]);
+const COMMON_SERVICE_KEYS = new Set([
+  "Type",
+  "User",
+  "Group",
+  "UMask",
+  "StateDirectory",
+  "StateDirectoryMode",
+  "RuntimeDirectory",
+  "RuntimeDirectoryMode",
+  "WorkingDirectory",
+  "ExecStart",
+  "Restart",
+  "RestartSec",
+  "TimeoutStopSec",
+  "TimeoutStartSec",
+  "LimitNOFILE",
+  "SupplementaryGroups",
+  "Environment",
+  "NoNewPrivileges",
+  "PrivateTmp",
+  "PrivateDevices",
+  "ProtectSystem",
+  "ProtectHome",
+  "ProtectKernelTunables",
+  "ProtectKernelModules",
+  "ProtectKernelLogs",
+  "ProtectControlGroups",
+  "ProtectClock",
+  "ProtectHostname",
+  "LockPersonality",
+  "MemoryDenyWriteExecute",
+  "RestrictSUIDSGID",
+  "RestrictNamespaces",
+  "RestrictRealtime",
+  "SystemCallArchitectures",
+  "CapabilityBoundingSet",
+  "AmbientCapabilities",
+  "RestrictAddressFamilies",
+  "IPAddressDeny",
+  "IPAddressAllow",
+  "ReadOnlyPaths",
+  "ReadWritePaths",
+  "InaccessiblePaths",
+  "ExecStartPre",
+  "RemainAfterExit",
+]);
+
+function validateDirectiveShape(unit, label) {
+  for (const [section, directives] of unit) {
+    const allowed = section === "Unit" ? COMMON_UNIT_KEYS : COMMON_SERVICE_KEYS;
+    for (const [key, values] of directives) {
+      if (!allowed.has(key)) fail(`${label} contains unreviewed ${section}.${key}`);
+      if (
+        values.length !== 1 &&
+        key !== "ExecStartPre" &&
+        key !== "ConditionPathExists"
+      ) {
+        fail(`${label} repeats singleton ${section}.${key}`);
+      }
+    }
+  }
+}
+
+function validateInactiveSystemdTemplate(
+  text,
+  label,
+  expectedConditions,
+  { requireStateDirectoryMode = true } = {},
+) {
+  rejectPattern(text, /^\s*\[Install\]\s*$/m, label, "[Install] section");
+  const unit = parseSystemdUnit(text, label);
+  validateDirectiveShape(unit, label);
+  exactDirectiveValues(
+    unit,
+    "Unit",
+    "ConditionPathExists",
+    expectedConditions,
+    label,
+  );
+  if (requireStateDirectoryMode) {
+    exactDirectiveValues(unit, "Service", "StateDirectoryMode", ["0700"], label);
+  }
+  exactDirectiveValues(unit, "Service", "NoNewPrivileges", ["true"], label);
+  exactDirectiveValues(unit, "Service", "ProtectSystem", ["strict"], label);
+  exactDirectiveValues(unit, "Service", "ProtectHome", ["true"], label);
+  onlyDirectiveValue(unit, "Service", "ExecStart", label);
+  return unit;
+}
+
+function validateCommonServiceHardening(unit, label, privateDevices) {
+  for (const [key, value] of [
+    ["Type", "simple"],
+    ["UMask", "0077"],
+    ["StateDirectoryMode", "0700"],
+    ["TimeoutStopSec", "30"],
+    ["NoNewPrivileges", "true"],
+    ["PrivateTmp", "true"],
+    ["ProtectSystem", "strict"],
+    ["ProtectHome", "true"],
+    ["ProtectKernelTunables", "true"],
+    ["ProtectKernelModules", "true"],
+    ["ProtectKernelLogs", "true"],
+    ["ProtectControlGroups", "true"],
+    ["LockPersonality", "true"],
+    ["MemoryDenyWriteExecute", "true"],
+    ["RestrictSUIDSGID", "true"],
+    ["RestrictNamespaces", "true"],
+    ["RestrictRealtime", "true"],
+    ["SystemCallArchitectures", "native"],
+    ["RestrictAddressFamilies", "AF_UNIX AF_INET AF_INET6"],
+  ]) {
+    exactDirectiveValues(unit, "Service", key, [value], label);
+  }
+  exactDirectiveValues(unit, "Service", "CapabilityBoundingSet", [""], label);
+  exactDirectiveValues(unit, "Service", "AmbientCapabilities", [""], label);
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "PrivateDevices",
+    privateDevices ? ["true"] : [],
+    label,
+  );
+}
+
+function validatePinnedServiceSandbox(unit, label, type, capabilities) {
+  exactDirectiveValues(unit, "Service", "Type", [type], label);
+  exactDirectiveValues(unit, "Service", "UMask", ["0077"], label);
+  for (const key of [
+    "NoNewPrivileges",
+    "PrivateDevices",
+    "PrivateTmp",
+    "ProtectHome",
+    "ProtectKernelTunables",
+    "ProtectKernelModules",
+    "ProtectKernelLogs",
+    "ProtectControlGroups",
+    "ProtectClock",
+    "ProtectHostname",
+    "LockPersonality",
+    "MemoryDenyWriteExecute",
+    "RestrictSUIDSGID",
+    "RestrictNamespaces",
+    "RestrictRealtime",
+  ]) {
+    exactDirectiveValues(unit, "Service", key, ["true"], label);
+  }
+  exactDirectiveValues(unit, "Service", "ProtectSystem", ["strict"], label);
+  exactDirectiveValues(unit, "Service", "SystemCallArchitectures", ["native"], label);
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "CapabilityBoundingSet",
+    [capabilities],
+    label,
+  );
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "AmbientCapabilities",
+    [capabilities],
+    label,
+  );
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "RestrictAddressFamilies",
+    ["AF_UNIX AF_INET AF_INET6"],
+    label,
+  );
+}
+
+function validateProductionForbiddenFlags(text, label) {
+  const forbidden = [
+    [/--allow-local-service-rollback-authority-dev(?:\s|$)/, "local provider rollback acknowledgement"],
+    [/--allow-local-rollback-authority-dev(?:\s|$)/, "local issuer rollback acknowledgement"],
+    [/(?:^|\s)--service-rollback-authority(?:\s|=)/m, "local provider rollback authority"],
+    [/(?:^|\s)--rollback-authority(?:\s|=)/m, "local issuer rollback authority"],
+    [/--allow-experimental-arc(?:\s|$)/, "experimental ARC acknowledgement"],
+    [/--service-arc-key(?:\s|$)/, "provider ARC key"],
+    [/(?:^|\s)--arc-key(?:\s|$)/m, "issuer ARC key"],
+    [/--require-arc(?:\s|$)/, "legacy ARC gate"],
+    [/--require-cashu(?:\s|$)/, "legacy Cashu gate"],
+    [/--cashu-keyset(?:\s|$)/, "legacy Cashu keyset"],
+    [/\bserve-fake\b/, "fake Lightning serving mode"],
+    [/--fake-lightning-[a-z-]+(?:\s|$)/, "fake Lightning material"],
+    [/--test-only-service-https-root-pem(?:\s|$)/, "test-only trust root"],
+    [/--unsafe-debug-query-logging(?:\s|$)/, "unsafe query logging"],
+    [/--service-free-ip-key(?:\s|$)/, "Free IP key behind a proxy"],
+    [/--service-trust-direct-peer-ip(?:\s|$)/, "direct peer-IP trust behind a proxy"],
+    [/--clearing-payout-target(?:\s|=|$)/, "production clearing payout target"],
+    [/--clearing-payout-fee(?:\s|=|$)/, "production clearing payout fee"],
+    [/--clearing-payout-intent-ttl-seconds(?:\s|=|$)/, "production payout intent TTL"],
+  ];
+  for (const [pattern, description] of forbidden) {
+    rejectPattern(text, pattern, label, description);
+  }
+}
+
+function validateHetznerProvider(text) {
+  const label = "Hetzner provider template";
+  const unit = validateInactiveSystemdTemplate(text, label, [
+    "/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+  ]);
+  exactDirectiveKeys(unit, "Unit", BASIC_UNIT_KEYS, label);
+  exactDirectiveKeys(
+    unit,
+    "Service",
+    [
+      "Type", "User", "Group", "UMask", "StateDirectory", "StateDirectoryMode",
+      "WorkingDirectory", "ExecStartPre", "ExecStart", "Restart", "RestartSec",
+      "TimeoutStopSec", "LimitNOFILE", "NoNewPrivileges", "PrivateTmp",
+      "PrivateDevices", "ProtectSystem", "ProtectHome", "ProtectKernelTunables",
+      "ProtectKernelModules", "ProtectKernelLogs", "ProtectControlGroups",
+      "ProtectClock", "ProtectHostname", "LockPersonality",
+      "MemoryDenyWriteExecute", "RestrictSUIDSGID", "RestrictNamespaces",
+      "RestrictRealtime", "SystemCallArchitectures", "CapabilityBoundingSet",
+      "AmbientCapabilities", "RestrictAddressFamilies", "ReadOnlyPaths", "ReadWritePaths",
+    ],
+    label,
+  );
+  validateCommonServiceHardening(unit, label, true);
+  exactDirectiveValues(unit, "Unit", "Description", ["BitcoinPIR Hetzner Payment V1 provider (template only)"], label);
+  exactDirectiveValues(unit, "Unit", "After", ["network-online.target"], label);
+  exactDirectiveValues(unit, "Unit", "Wants", ["network-online.target"], label);
+  exactDirectiveValues(unit, "Service", "User", ["bitcoinpir-provider"], label);
+  exactDirectiveValues(unit, "Service", "Group", ["bitcoinpir-provider"], label);
+  exactDirectiveValues(unit, "Service", "StateDirectory", ["bitcoinpir-provider-payment-v1"], label);
+  exactDirectiveValues(unit, "Service", "WorkingDirectory", ["/var/lib/bitcoinpir-provider-payment-v1"], label);
+  exactDirectiveValues(unit, "Service", "Restart", ["on-failure"], label);
+  exactDirectiveValues(unit, "Service", "RestartSec", ["5"], label);
+  exactDirectiveValues(unit, "Service", "LimitNOFILE", ["65535"], label);
+  exactDirectiveValues(unit, "Service", "ProtectClock", ["true"], label);
+  exactDirectiveValues(unit, "Service", "ProtectHostname", ["true"], label);
+  exactDirectiveValues(unit, "Service", "ReadOnlyPaths", ["/etc/bitcoinpir/payment-v1/provider"], label);
+  exactDirectiveValues(unit, "Service", "ReadWritePaths", ["/var/lib/bitcoinpir-provider-payment-v1"], label);
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ExecStartPre",
+    [
+      "/usr/bin/test -x /opt/bitcoinpir/unified-server/@UNIFIED_SERVER_SHA256@/unified_server",
+      "/usr/bin/sha256sum --check /etc/bitcoinpir/payment-v1/provider/unified-server.sha256",
+    ],
+    label,
+  );
+  const command = onlyDirectiveValue(unit, "Service", "ExecStart", label);
+  validateProductionForbiddenFlags(command, label);
+  validateExactCommand(
+    command,
+    ["/opt/bitcoinpir/unified-server/@UNIFIED_SERVER_SHA256@/unified_server"],
+    [
+      ["--bind-address", "127.0.0.1"],
+      ["--port", "8191"],
+      ["--role", "primary"],
+      ["--serve-hints", null],
+      ["--serve-queries", null],
+      ["--pool-size", "8"],
+      ["--pool-dir", "/var/lib/bitcoinpir-provider-payment-v1/hint-pool"],
+      ["--config", "/etc/bitcoinpir/payment-v1/provider/databases.toml"],
+      ["--identity-key-path", "/etc/bitcoinpir/payment-v1/provider/provider-identity.key"],
+      ["--identity-cert-path", "/etc/bitcoinpir/payment-v1/provider/provider-identity.cert"],
+      ["--identity-server-id", "@HETZNER_PROVIDER_SERVER_ID@"],
+      ["--require-service-auth-v1", null],
+      ["--service-policy", "/etc/bitcoinpir/payment-v1/provider/service-policy.bin"],
+      ["--service-provider-id-hex", "@HETZNER_PROVIDER_ID_HEX@"],
+      ["--service-policy-key-hex", "@HETZNER_POLICY_PUBKEY_HEX@"],
+      ["--service-store", "/var/lib/bitcoinpir-provider-payment-v1/provider.sqlite3"],
+      ["--service-remote-rollback-authority-config", "/etc/bitcoinpir/payment-v1/provider/remote-rollback-authority.toml"],
+      ["--service-bat-key", "/etc/bitcoinpir/payment-v1/provider/cashu-bat.key"],
+      ["--service-cashu-recovery-key", "1=/etc/bitcoinpir/payment-v1/provider/cashu-recovery-epoch-1.key"],
+      ["--service-cashu-recovery-active-epoch", "1"],
+      ["--service-cashu-custody-key", "1=/etc/bitcoinpir/payment-v1/provider/cashu-custody-epoch-1.key"],
+      ["--service-cashu-custody-active-epoch", "1"],
+      ["--service-cashu-exposure-limit", "@CASHU_MINT_ID_HEX@:sat:@CASHU_MAX_UNSETTLED_VALUE@:@CASHU_MAX_UNSETTLED_NOTES@"],
+      ["--service-shared-authorization", "/etc/bitcoinpir/payment-v1/provider/shared-clearing-authorization.bin"],
+      ["--service-shared-issuer-approval", "/etc/bitcoinpir/payment-v1/provider/shared-clearing-approval.bin"],
+      ["--service-shared-operator-key-hex", "@HETZNER_OPERATOR_PUBKEY_HEX@"],
+      ["--service-shared-issuer-settlement-key-hex", "@ISSUER_SETTLEMENT_PUBKEY_HEX@"],
+      ["--service-shared-clearing-key", "/etc/bitcoinpir/payment-v1/provider/provider-clearing-signing.key"],
+      ["--service-shared-idempotency-key", "/etc/bitcoinpir/payment-v1/provider/shared-redeem-idempotency.key"],
+      ["--service-shared-minimum-authorization-epoch", "@SHARED_MINIMUM_AUTHORIZATION_EPOCH@"],
+      ["--max-connections", "128"],
+      ["--service-max-concurrent-auth", "16"],
+      ["--service-max-concurrent-online-v2full-auth", "4"],
+      ["--websocket-handshake-timeout-ms", "10000"],
+      ["--connection-idle-timeout-ms", "30000"],
+      ["--service-pre-auth-timeout-ms", "60000"],
+    ],
+    label,
+  );
+  const recovery = /--service-cashu-recovery-key\s+1=(\S+)/.exec(command)?.[1];
+  const custody = /--service-cashu-custody-key\s+1=(\S+)/.exec(command)?.[1];
+  if (recovery === undefined || custody === undefined || recovery === custody) {
+    fail(`${label} must use distinct explicit Cashu recovery and custody keys`);
+  }
+}
+
+function validateHetznerIssuer(text) {
+  const label = "Hetzner issuer template";
+  const unit = validateInactiveSystemdTemplate(text, label, [
+    "/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+    "/etc/bitcoinpir/payment-v1/LIGHTNING-CUSTODY-APPROVED",
+    "/etc/bitcoinpir/payment-v1/LIGHTNING-BACKUP-RESTORE-APPROVED",
+  ]);
+  exactDirectiveKeys(
+    unit,
+    "Unit",
+    [
+      "Description",
+      "After",
+      "Wants",
+      "Requires",
+      "BindsTo",
+      "ConditionPathExists",
+    ],
+    label,
+  );
+  exactDirectiveKeys(
+    unit,
+    "Service",
+    [
+      "Type", "User", "Group", "UMask", "StateDirectory",
+      "StateDirectoryMode", "WorkingDirectory", "ExecStartPre", "ExecStart", "Restart",
+      "RestartSec", "TimeoutStopSec", "NoNewPrivileges", "PrivateTmp", "ProtectSystem",
+      "PrivateDevices", "ProtectHome", "ProtectKernelTunables", "ProtectKernelModules",
+      "ProtectKernelLogs", "ProtectControlGroups", "LockPersonality",
+      "ProtectClock", "ProtectHostname",
+      "MemoryDenyWriteExecute", "RestrictSUIDSGID", "RestrictNamespaces",
+      "RestrictRealtime", "SystemCallArchitectures", "CapabilityBoundingSet",
+      "AmbientCapabilities", "RestrictAddressFamilies", "ReadOnlyPaths", "ReadWritePaths",
+      "InaccessiblePaths",
+    ],
+    label,
+  );
+  validateCommonServiceHardening(unit, label, true);
+  exactDirectiveValues(unit, "Unit", "Description", ["BitcoinPIR Hetzner Core Lightning payment issuer (template only)"], label);
+  exactDirectiveValues(unit, "Unit", "After", ["network-online.target bitcoinpir-core-lightning.service bitcoinpir-cln-rpc-guard.service bitcoinpir-lightning-preflight.service"], label);
+  exactDirectiveValues(unit, "Unit", "Wants", ["network-online.target"], label);
+  exactDirectiveValues(unit, "Unit", "Requires", ["bitcoinpir-core-lightning.service bitcoinpir-cln-rpc-guard.service bitcoinpir-lightning-preflight.service"], label);
+  exactDirectiveValues(unit, "Unit", "BindsTo", ["bitcoinpir-core-lightning.service bitcoinpir-cln-rpc-guard.service bitcoinpir-lightning-preflight.service"], label);
+  exactDirectiveValues(unit, "Service", "User", ["bitcoinpir-issuer"], label);
+  exactDirectiveValues(unit, "Service", "Group", ["bitcoinpir-issuer"], label);
+  exactDirectiveValues(unit, "Service", "StateDirectory", ["bitcoinpir-payment-issuer"], label);
+  exactDirectiveValues(unit, "Service", "WorkingDirectory", ["/var/lib/bitcoinpir-payment-issuer"], label);
+  exactDirectiveValues(unit, "Service", "Restart", ["on-failure"], label);
+  exactDirectiveValues(unit, "Service", "RestartSec", ["5"], label);
+  exactDirectiveValues(unit, "Service", "ProtectClock", ["true"], label);
+  exactDirectiveValues(unit, "Service", "ProtectHostname", ["true"], label);
+  exactDirectiveValues(unit, "Service", "ReadOnlyPaths", ["/etc/bitcoinpir/payment-v1/issuer /run/bitcoinpir-cln-rpc-guard/issuer /opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@"], label);
+  exactDirectiveValues(unit, "Service", "ReadWritePaths", ["/var/lib/bitcoinpir-payment-issuer"], label);
+  exactDirectiveValues(unit, "Service", "InaccessiblePaths", ["/srv/lightning /srv/bitcoin"], label);
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ExecStartPre",
+    [
+      "/usr/bin/test -x /opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@/payment-issuer",
+      "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/issuer/payment-issuer.sha256",
+    ],
+    label,
+  );
+  const command = onlyDirectiveValue(unit, "Service", "ExecStart", label);
+  validateProductionForbiddenFlags(command, label);
+  validateExactCommand(
+    command,
+    [
+      "/opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@/payment-issuer",
+      "serve-cln",
+    ],
+    [
+      ["--bind", "127.0.0.1:5610"],
+      ["--max-connections", "128"],
+      ["--quote-rate-per-minute", "60"],
+      ["--status-rate-per-minute", "600"],
+      ["--mutation-rate-per-minute", "120"],
+      ["--reconciliation-rate-per-minute", "120"],
+      ["--reconciliation-batch-size", "32"],
+      ["--reconciliation-interval-seconds", "15"],
+      ["--reconciliation-tick-budget-ms", "5000"],
+      ["--max-outstanding-quotes", "4096"],
+      ["--max-total-quotes", "16384"],
+      ["--allow-origin", "@BITCOINPIR_WEB_ORIGIN@"],
+      ["--store", "/var/lib/bitcoinpir-payment-issuer/issuer.sqlite3"],
+      ["--remote-rollback-authority-config", "/etc/bitcoinpir/payment-v1/issuer/remote-rollback-authority.toml"],
+      ["--quote-delegation", "/etc/bitcoinpir/payment-v1/issuer/quote-delegation.bin"],
+      ["--quote-signing-key", "/etc/bitcoinpir/payment-v1/issuer/quote-signing.key"],
+      ["--credential-derivation-key", "/etc/bitcoinpir/payment-v1/issuer/credential-derivation.key"],
+      ["--service-policy", "/etc/bitcoinpir/payment-v1/issuer/service-policy.bin=@HETZNER_POLICY_PUBKEY_HEX@"],
+      ["--receipt-signing-key", "/etc/bitcoinpir/payment-v1/issuer/direct-receipt-signing.key"],
+      ["--bat-key", "/etc/bitcoinpir/payment-v1/issuer/cashu-bat.key"],
+      ["--clearing-authorization", "/etc/bitcoinpir/payment-v1/issuer/provider-clearing-authorization.bin"],
+      ["--clearing-approval", "/etc/bitcoinpir/payment-v1/issuer/provider-clearing-approval.bin"],
+      ["--issuer-settlement-signing-key", "/etc/bitcoinpir/payment-v1/issuer/issuer-settlement-signing.key"],
+      ["--redeem-response-derivation-key", "/etc/bitcoinpir/payment-v1/issuer/redeem-response-derivation.key"],
+      ["--cln-rpc-socket", "/run/bitcoinpir-cln-rpc-guard/issuer/issuer-rpc"],
+      ["--cln-rpc-expected-uid", "@CLN_GUARD_UID@"],
+      ["--cln-rpc-expected-gid", "@ISSUER_GID@"],
+      ["--cln-rpc-timeout-seconds", "10"],
+    ],
+    label,
+  );
+}
+
+function validateRollbackAuthority(text) {
+  const label = "rollback-authority template";
+  const unit = validateInactiveSystemdTemplate(text, label, [
+    "/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+  ]);
+  exactDirectiveKeys(unit, "Unit", BASIC_UNIT_KEYS, label);
+  exactDirectiveKeys(
+    unit,
+    "Service",
+    [
+      "Type", "User", "Group", "UMask", "StateDirectory", "StateDirectoryMode",
+      "WorkingDirectory", "ExecStartPre", "ExecStart", "Restart", "RestartSec",
+      "TimeoutStopSec", "NoNewPrivileges", "PrivateTmp", "ProtectSystem", "ProtectHome",
+      "PrivateDevices", "ProtectKernelTunables", "ProtectKernelModules", "ProtectKernelLogs",
+      "ProtectControlGroups", "LockPersonality", "MemoryDenyWriteExecute",
+      "RestrictSUIDSGID", "RestrictNamespaces", "RestrictRealtime",
+      "SystemCallArchitectures", "CapabilityBoundingSet", "AmbientCapabilities",
+      "RestrictAddressFamilies", "IPAddressDeny", "IPAddressAllow", "ReadOnlyPaths",
+      "ReadWritePaths",
+    ],
+    label,
+  );
+  validateCommonServiceHardening(unit, label, true);
+  exactDirectiveValues(unit, "Unit", "Description", ["BitcoinPIR independent rollback authority (template only)"], label);
+  exactDirectiveValues(unit, "Unit", "After", ["network-online.target"], label);
+  exactDirectiveValues(unit, "Unit", "Wants", ["network-online.target"], label);
+  exactDirectiveValues(unit, "Service", "User", ["bitcoinpir-rollback-authority"], label);
+  exactDirectiveValues(unit, "Service", "Group", ["bitcoinpir-rollback-authority"], label);
+  exactDirectiveValues(unit, "Service", "StateDirectory", ["bitcoinpir-rollback-authority"], label);
+  exactDirectiveValues(unit, "Service", "WorkingDirectory", ["/var/lib/bitcoinpir-rollback-authority"], label);
+  exactDirectiveValues(unit, "Service", "Restart", ["on-failure"], label);
+  exactDirectiveValues(unit, "Service", "RestartSec", ["5"], label);
+  exactDirectiveValues(unit, "Service", "ReadOnlyPaths", ["/etc/bitcoinpir/payment-v1/rollback-authority"], label);
+  exactDirectiveValues(unit, "Service", "ReadWritePaths", ["/var/lib/bitcoinpir-rollback-authority"], label);
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ExecStartPre",
+    [
+      "/usr/bin/test -x /opt/bitcoinpir/rollback-authority/@ROLLBACK_AUTHORITY_SHA256@/rollback-authority",
+      "/usr/bin/sha256sum --check /etc/bitcoinpir/payment-v1/rollback-authority/rollback-authority.sha256",
+    ],
+    label,
+  );
+  const command = onlyDirectiveValue(unit, "Service", "ExecStart", label);
+  validateExactCommand(
+    command,
+    [
+      "/opt/bitcoinpir/rollback-authority/@ROLLBACK_AUTHORITY_SHA256@/rollback-authority",
+      "serve",
+    ],
+    [
+      ["--bind", "127.0.0.1:8099"],
+      ["--store", "/var/lib/bitcoinpir-rollback-authority/authority.sqlite3"],
+      ["--authority-secret", "/etc/bitcoinpir/payment-v1/rollback-authority/authority.seed"],
+      ["--authority-metadata", "/etc/bitcoinpir/payment-v1/rollback-authority/authority-public.txt"],
+      ["--expected-authority-pubkey-hex", "@AUTHORITY_PUBKEY_HEX@"],
+      ["--busy-timeout-ms", "5000"],
+      ["--io-timeout-ms", "10000"],
+      ["--max-connections", "32"],
+    ],
+    label,
+  );
+  exactDirectiveValues(unit, "Service", "IPAddressDeny", ["any"], label);
+  exactDirectiveValues(unit, "Service", "IPAddressAllow", ["localhost"], label);
+}
+
+function validateCoreLightningUnit(text) {
+  const label = "Hetzner Core Lightning template";
+  const unit = validateInactiveSystemdTemplate(
+    text,
+    label,
+    [
+      "/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+      "/etc/bitcoinpir/payment-v1/LIGHTNING-CUSTODY-APPROVED",
+      "/etc/bitcoinpir/payment-v1/LIGHTNING-BACKUP-RESTORE-APPROVED",
+    ],
+    { requireStateDirectoryMode: false },
+  );
+  exactDirectiveKeys(
+    unit,
+    "Unit",
+    ["Description", "After", "Wants", "Requires", "ConditionPathExists"],
+    label,
+  );
+  exactDirectiveKeys(
+    unit,
+    "Service",
+    [
+      "Type", "User", "Group", "SupplementaryGroups", "UMask", "RuntimeDirectory", "RuntimeDirectoryMode",
+      "WorkingDirectory", "ExecStartPre", "ExecStart", "Restart", "RestartSec",
+      "TimeoutStartSec", "TimeoutStopSec", "LimitNOFILE", "NoNewPrivileges",
+      "PrivateDevices", "PrivateTmp", "ProtectSystem", "ProtectHome",
+      "ProtectKernelTunables", "ProtectKernelModules", "ProtectKernelLogs",
+      "ProtectControlGroups", "ProtectClock", "ProtectHostname", "LockPersonality",
+      "MemoryDenyWriteExecute", "RestrictSUIDSGID", "RestrictRealtime",
+      "RestrictNamespaces", "SystemCallArchitectures", "CapabilityBoundingSet",
+      "AmbientCapabilities", "RestrictAddressFamilies", "ReadOnlyPaths", "ReadWritePaths",
+    ],
+    label,
+  );
+  validatePinnedServiceSandbox(unit, label, "simple", "");
+  exactDirectiveValues(unit, "Unit", "Description", ["BitcoinPIR Hetzner issuer Core Lightning (template only)"], label);
+  exactDirectiveValues(unit, "Unit", "After", ["network-online.target @BITCOIND_SYSTEMD_UNIT@"], label);
+  exactDirectiveValues(unit, "Unit", "Wants", ["network-online.target"], label);
+  exactDirectiveValues(unit, "Unit", "Requires", ["@BITCOIND_SYSTEMD_UNIT@"], label);
+  exactDirectiveValues(unit, "Service", "User", ["bitcoinpir-lightning"], label);
+  exactDirectiveValues(unit, "Service", "Group", ["bitcoinpir-cln-guard"], label);
+  exactDirectiveValues(unit, "Service", "SupplementaryGroups", ["bitcoinpir-bitcoin-rpc"], label);
+  exactDirectiveValues(unit, "Service", "RuntimeDirectory", ["bitcoinpir-core-lightning"], label);
+  exactDirectiveValues(unit, "Service", "RuntimeDirectoryMode", ["0700"], label);
+  exactDirectiveValues(unit, "Service", "WorkingDirectory", ["/srv/lightning/@LIGHTNING_NETWORK@"], label);
+  exactDirectiveValues(unit, "Service", "Restart", ["on-failure"], label);
+  exactDirectiveValues(unit, "Service", "RestartSec", ["5"], label);
+  exactDirectiveValues(unit, "Service", "TimeoutStartSec", ["120"], label);
+  exactDirectiveValues(unit, "Service", "TimeoutStopSec", ["120"], label);
+  exactDirectiveValues(unit, "Service", "LimitNOFILE", ["65535"], label);
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ExecStartPre",
+    [
+      "/usr/bin/test -x /opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@/bin/lightningd",
+      "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/cln-bundle.sha256",
+      "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/bitcoin-core-bundle.sha256",
+      "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/lightningd-config.sha256",
+      "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/layout-verifier.sha256",
+      "/usr/local/libexec/bitcoinpir/verify-lightning-layout",
+    ],
+    label,
+  );
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ExecStart",
+    ["/opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@/bin/lightningd --conf=/etc/bitcoinpir/payment-v1/lightning/lightningd.conf"],
+    label,
+  );
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ReadOnlyPaths",
+    ["/etc/bitcoinpir/payment-v1/lightning /opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@ /opt/bitcoinpir/bitcoin-core/@BITCOIN_CORE_BUNDLE_SHA256@"],
+    label,
+  );
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ReadWritePaths",
+    ["/srv/lightning/@LIGHTNING_NETWORK@ /run/bitcoinpir-core-lightning"],
+    label,
+  );
+}
+
+function validateClnRpcGuardUnit(text) {
+  const label = "Hetzner CLN RPC guard template";
+  const unit = validateInactiveSystemdTemplate(
+    text,
+    label,
+    [
+      "/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+      "/etc/bitcoinpir/payment-v1/LIGHTNING-CUSTODY-APPROVED",
+      "/etc/bitcoinpir/payment-v1/LIGHTNING-BACKUP-RESTORE-APPROVED",
+    ],
+    { requireStateDirectoryMode: false },
+  );
+  exactDirectiveKeys(
+    unit,
+    "Unit",
+    ["Description", "After", "Requires", "BindsTo", "Before", "ConditionPathExists"],
+    label,
+  );
+  exactDirectiveKeys(
+    unit,
+    "Service",
+    [
+      "Type", "User", "Group", "SupplementaryGroups", "UMask", "ExecStartPre",
+      "ExecStart", "Restart", "TimeoutStopSec", "NoNewPrivileges",
+      "PrivateTmp", "PrivateDevices", "ProtectSystem", "ProtectHome",
+      "ProtectKernelTunables", "ProtectKernelModules", "ProtectKernelLogs",
+      "ProtectControlGroups", "ProtectClock", "ProtectHostname", "LockPersonality",
+      "MemoryDenyWriteExecute", "RestrictSUIDSGID", "RestrictNamespaces",
+      "RestrictRealtime", "SystemCallArchitectures", "CapabilityBoundingSet",
+      "AmbientCapabilities", "RestrictAddressFamilies", "ReadOnlyPaths", "ReadWritePaths",
+    ],
+    label,
+  );
+  for (const [key, value] of [
+    ["Type", "simple"],
+    ["User", "bitcoinpir-cln-rpc-guard"],
+    ["Group", "bitcoinpir-cln-guard"],
+    ["SupplementaryGroups", "bitcoinpir-issuer"],
+    ["UMask", "0077"],
+    ["Restart", "no"],
+    ["TimeoutStopSec", "30"],
+    ["NoNewPrivileges", "true"],
+    ["PrivateTmp", "true"],
+    ["PrivateDevices", "true"],
+    ["ProtectSystem", "strict"],
+    ["ProtectHome", "true"],
+    ["ProtectKernelTunables", "true"],
+    ["ProtectKernelModules", "true"],
+    ["ProtectKernelLogs", "true"],
+    ["ProtectControlGroups", "true"],
+    ["ProtectClock", "true"],
+    ["ProtectHostname", "true"],
+    ["LockPersonality", "true"],
+    ["MemoryDenyWriteExecute", "true"],
+    ["RestrictSUIDSGID", "true"],
+    ["RestrictNamespaces", "true"],
+    ["RestrictRealtime", "true"],
+    ["SystemCallArchitectures", "native"],
+    ["RestrictAddressFamilies", "AF_UNIX"],
+  ]) {
+    exactDirectiveValues(unit, "Service", key, [value], label);
+  }
+  exactDirectiveValues(unit, "Unit", "Description", ["BitcoinPIR Core Lightning RPC allowlist guard (template only)"], label);
+  exactDirectiveValues(unit, "Unit", "After", ["bitcoinpir-core-lightning.service"], label);
+  exactDirectiveValues(unit, "Unit", "Requires", ["bitcoinpir-core-lightning.service"], label);
+  exactDirectiveValues(unit, "Unit", "BindsTo", ["bitcoinpir-core-lightning.service"], label);
+  exactDirectiveValues(unit, "Unit", "Before", ["bitcoinpir-payment-issuer.service"], label);
+  exactDirectiveValues(unit, "Service", "CapabilityBoundingSet", [""], label);
+  exactDirectiveValues(unit, "Service", "AmbientCapabilities", [""], label);
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ExecStartPre",
+    [
+      "/usr/bin/test -x /opt/bitcoinpir/cln-rpc-guard/@CLN_RPC_GUARD_SHA256@/bitcoinpir-cln-rpc-guard",
+      "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/cln-rpc-guard.sha256",
+    ],
+    label,
+  );
+  validateExactCommand(
+    onlyDirectiveValue(unit, "Service", "ExecStart", label),
+    ["/opt/bitcoinpir/cln-rpc-guard/@CLN_RPC_GUARD_SHA256@/bitcoinpir-cln-rpc-guard"],
+    [
+      ["--listen-socket", "/run/bitcoinpir-cln-rpc-guard/issuer/issuer-rpc"],
+      ["--upstream-socket", "/srv/lightning/@LIGHTNING_NETWORK@/lightning-rpc"],
+      ["--guard-uid", "@CLN_GUARD_UID@"],
+      ["--guard-gid", "@LIGHTNING_GID@"],
+      ["--issuer-uid", "@ISSUER_UID@"],
+      ["--issuer-gid", "@ISSUER_GID@"],
+      ["--upstream-expected-uid", "@LIGHTNING_UID@"],
+      ["--upstream-expected-gid", "@LIGHTNING_GID@"],
+      ["--timeout-seconds", "10"],
+      ["--max-in-flight", "32"],
+      ["--max-invoice-msat", "@CLN_GUARD_MAX_INVOICE_MSAT@"],
+      ["--max-invoices-per-minute", "@CLN_GUARD_MAX_INVOICES_PER_MINUTE@"],
+      ["--max-invoice-burst", "@CLN_GUARD_MAX_INVOICE_BURST@"],
+      ["--max-invoices-per-runtime", "@CLN_GUARD_MAX_INVOICES_PER_RUNTIME@"],
+    ],
+    label,
+  );
+  exactDirectiveValues(unit, "Service", "ReadOnlyPaths", ["/srv/lightning/@LIGHTNING_NETWORK@ /opt/bitcoinpir/cln-rpc-guard/@CLN_RPC_GUARD_SHA256@"], label);
+  exactDirectiveValues(unit, "Service", "ReadWritePaths", ["/run/bitcoinpir-cln-rpc-guard"], label);
+}
+
+function validateLightningPreflightUnit(text) {
+  const label = "Hetzner Lightning live-preflight template";
+  const unit = validateInactiveSystemdTemplate(
+    text,
+    label,
+    [
+      "/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+      "/etc/bitcoinpir/payment-v1/LIGHTNING-CUSTODY-APPROVED",
+      "/etc/bitcoinpir/payment-v1/LIGHTNING-BACKUP-RESTORE-APPROVED",
+    ],
+    { requireStateDirectoryMode: false },
+  );
+  exactDirectiveKeys(
+    unit,
+    "Unit",
+    ["Description", "Requires", "BindsTo", "After", "Before", "ConditionPathExists"],
+    label,
+  );
+  exactDirectiveKeys(
+    unit,
+    "Service",
+    [
+      "Type", "User", "Group", "SupplementaryGroups", "UMask", "ExecStartPre",
+      "ExecStart", "RemainAfterExit", "TimeoutStartSec", "NoNewPrivileges",
+      "PrivateDevices", "PrivateTmp", "ProtectSystem", "ProtectHome",
+      "ProtectKernelTunables", "ProtectKernelModules", "ProtectKernelLogs",
+      "ProtectControlGroups", "ProtectClock", "ProtectHostname", "LockPersonality",
+      "MemoryDenyWriteExecute", "RestrictSUIDSGID", "RestrictRealtime",
+      "RestrictNamespaces", "SystemCallArchitectures", "CapabilityBoundingSet",
+      "AmbientCapabilities", "RestrictAddressFamilies", "IPAddressDeny",
+      "IPAddressAllow", "ReadOnlyPaths",
+    ],
+    label,
+  );
+  validatePinnedServiceSandbox(unit, label, "oneshot", "");
+  exactDirectiveValues(unit, "Unit", "Description", ["BitcoinPIR Hetzner live Core Lightning preflight (template only)"], label);
+  exactDirectiveValues(unit, "Unit", "Requires", ["bitcoinpir-core-lightning.service"], label);
+  exactDirectiveValues(unit, "Unit", "BindsTo", ["bitcoinpir-core-lightning.service"], label);
+  exactDirectiveValues(unit, "Unit", "After", ["bitcoinpir-core-lightning.service"], label);
+  exactDirectiveValues(unit, "Unit", "Before", ["bitcoinpir-payment-issuer.service"], label);
+  exactDirectiveValues(unit, "Service", "User", ["bitcoinpir-lightning-preflight"], label);
+  exactDirectiveValues(unit, "Service", "Group", ["bitcoinpir-lightning-preflight"], label);
+  exactDirectiveValues(unit, "Service", "SupplementaryGroups", ["bitcoinpir-cln-guard bitcoinpir-bitcoin-rpc"], label);
+  exactDirectiveValues(unit, "Service", "RemainAfterExit", ["yes"], label);
+  exactDirectiveValues(unit, "Service", "TimeoutStartSec", ["60"], label);
+  exactDirectiveValues(unit, "Service", "IPAddressDeny", ["any"], label);
+  exactDirectiveValues(unit, "Service", "IPAddressAllow", ["localhost"], label);
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ExecStartPre",
+    [
+      "/usr/bin/test -x /opt/bitcoinpir/bpir-admin/@BPIR_ADMIN_SHA256@/bpir-admin",
+      "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/bpir-admin.sha256",
+      "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/preflight-config.sha256",
+      "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/lightning/backup-receipt.sha256",
+    ],
+    label,
+  );
+  validateExactCommand(
+    onlyDirectiveValue(unit, "Service", "ExecStart", label),
+    [
+      "/opt/bitcoinpir/bpir-admin/@BPIR_ADMIN_SHA256@/bpir-admin",
+      "lightning-staging",
+      "preflight",
+    ],
+    [
+      ["--config", "/etc/bitcoinpir/payment-v1/lightning/preflight.toml"],
+      ["--config-protected-parent", "/etc/bitcoinpir/payment-v1/lightning"],
+      ["--config-expected-uid", "@PREFLIGHT_UID@"],
+      ["--config-expected-gid", "@PREFLIGHT_GID@"],
+    ],
+    label,
+  );
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ReadOnlyPaths",
+    ["/etc/bitcoinpir/payment-v1/lightning /srv/lightning/@LIGHTNING_NETWORK@ /opt/bitcoinpir/bpir-admin/@BPIR_ADMIN_SHA256@ /opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@ /opt/bitcoinpir/bitcoin-core/@BITCOIN_CORE_BUNDLE_SHA256@"],
+    label,
+  );
+}
+
+function validatePaymentEdgeUnit(text) {
+  const label = "Payment V1 Caddy edge template";
+  const unit = validateInactiveSystemdTemplate(text, label, [
+    "/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+    "/etc/bitcoinpir/payment-v1/EDGE-PREFLIGHT-APPROVED",
+  ]);
+  exactDirectiveKeys(unit, "Unit", BASIC_UNIT_KEYS, label);
+  exactDirectiveKeys(
+    unit,
+    "Service",
+    [
+      "Type", "User", "Group", "UMask", "StateDirectory", "StateDirectoryMode",
+      "WorkingDirectory", "Environment", "ExecStartPre", "ExecStart", "Restart",
+      "RestartSec", "TimeoutStartSec", "TimeoutStopSec", "LimitNOFILE",
+      "AmbientCapabilities", "CapabilityBoundingSet", "NoNewPrivileges",
+      "PrivateDevices", "PrivateTmp", "ProtectSystem", "ProtectHome",
+      "ProtectKernelTunables", "ProtectKernelModules", "ProtectKernelLogs",
+      "ProtectControlGroups", "ProtectClock", "ProtectHostname", "LockPersonality",
+      "MemoryDenyWriteExecute", "RestrictSUIDSGID", "RestrictRealtime",
+      "RestrictNamespaces", "SystemCallArchitectures", "RestrictAddressFamilies",
+      "ReadOnlyPaths", "ReadWritePaths",
+    ],
+    label,
+  );
+  validatePinnedServiceSandbox(unit, label, "notify", "CAP_NET_BIND_SERVICE");
+  exactDirectiveValues(unit, "Unit", "Description", ["BitcoinPIR Payment V1 pinned TLS edge (template only)"], label);
+  exactDirectiveValues(unit, "Unit", "After", ["network-online.target"], label);
+  exactDirectiveValues(unit, "Unit", "Wants", ["network-online.target"], label);
+  exactDirectiveValues(unit, "Service", "User", ["bitcoinpir-payment-edge"], label);
+  exactDirectiveValues(unit, "Service", "Group", ["bitcoinpir-payment-edge"], label);
+  exactDirectiveValues(unit, "Service", "StateDirectory", ["bitcoinpir-payment-edge"], label);
+  exactDirectiveValues(unit, "Service", "StateDirectoryMode", ["0700"], label);
+  exactDirectiveValues(unit, "Service", "WorkingDirectory", ["/var/lib/bitcoinpir-payment-edge"], label);
+  exactDirectiveValues(unit, "Service", "Environment", ["XDG_DATA_HOME=/var/lib/bitcoinpir-payment-edge/data XDG_CONFIG_HOME=/var/lib/bitcoinpir-payment-edge/config"], label);
+  exactDirectiveValues(unit, "Service", "Restart", ["on-failure"], label);
+  exactDirectiveValues(unit, "Service", "RestartSec", ["5"], label);
+  exactDirectiveValues(unit, "Service", "TimeoutStartSec", ["60"], label);
+  exactDirectiveValues(unit, "Service", "TimeoutStopSec", ["30"], label);
+  exactDirectiveValues(unit, "Service", "LimitNOFILE", ["65535"], label);
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ExecStartPre",
+    [
+      "/usr/bin/test -x /opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy",
+      "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/caddy.sha256",
+      "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/edge-config.sha256",
+      "/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy validate --config /etc/bitcoinpir/payment-v1/edge/@EDGE_CADDYFILE@ --adapter caddyfile",
+    ],
+    label,
+  );
+  exactDirectiveValues(
+    unit,
+    "Service",
+    "ExecStart",
+    ["/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy run --config /etc/bitcoinpir/payment-v1/edge/@EDGE_CADDYFILE@ --adapter caddyfile"],
+    label,
+  );
+  exactDirectiveValues(unit, "Service", "ReadOnlyPaths", ["/etc/bitcoinpir/payment-v1/edge"], label);
+  exactDirectiveValues(unit, "Service", "ReadWritePaths", ["/var/lib/bitcoinpir-payment-edge"], label);
+}
+
+function activeTemplateLines(text, label) {
+  rejectPattern(text, /\r/u, label, "carriage return");
+  rejectPattern(text, /\0/u, label, "NUL byte");
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"));
+}
+
+function validateLightningdConfig(text) {
+  const label = "Core Lightning configuration template";
+  const actual = activeTemplateLines(text, label);
+  const expected = [
+    "network=@LIGHTNING_NETWORK@",
+    "lightning-dir=/srv/lightning",
+    "pid-file=/run/bitcoinpir-core-lightning/lightningd.pid",
+    "rpc-file=lightning-rpc",
+    "rpc-file-mode=0660",
+    "allow-deprecated-apis=false",
+    "database-upgrade=false",
+    "bind-addr=@CLN_P2P_BIND_ADDR@",
+    "announce-addr=@CLN_P2P_ANNOUNCE_ADDR@",
+    "announce-addr-discovered=false",
+    "autoconnect-seeker-peers=0",
+    "disable-dns",
+    "invoices-onchain-fallback=false",
+    "log-level=unusual",
+    "log-timestamps=true",
+    "bitcoin-cli=/opt/bitcoinpir/bitcoin-core/@BITCOIN_CORE_BUNDLE_SHA256@/bin/bitcoin-cli",
+    "bitcoin-datadir=/srv/bitcoin",
+    "bitcoin-rpcconnect=127.0.0.1",
+    "bitcoin-rpcport=@BITCOIN_RPC_PORT@",
+    "bitcoin-rpcclienttimeout=30",
+    "bitcoin-retry-timeout=30",
+    "clear-plugins",
+    "important-plugin=/opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@/plugins/bcli",
+    "important-plugin=/opt/bitcoinpir/core-lightning/@CLN_BUNDLE_SHA256@/plugins/chanbackup",
+  ];
+  if (
+    actual.length !== expected.length ||
+    actual.some((line, index) => line !== expected[index])
+  ) {
+    fail(`${label} active lines must equal the reviewed closed-world configuration`);
+  }
+  rejectPattern(
+    text,
+    /(?:^|\n)\s*(?:include|plugin|plugin-dir|rpcuser|rpcpassword|grpc-port|commando|developer)(?:=|\s|$)/iu,
+    label,
+    "dynamic plugin, include, credential, or remote-RPC option",
+  );
+}
+
+function validateIssuerClnArgs(text, mode) {
+  const label = "issuer Core Lightning argument template";
+  requireText(text, "not an executable fragment", label);
+  rejectPattern(text, /^\s*#!/mu, label, "shebang");
+  rejectPattern(text, /^\s*exec(?:\s|$)/mu, label, "exec command");
+  validateExactCommand(
+    activeTemplateLines(text, label).join(" "),
+    [],
+    [
+      ["--cln-rpc-socket", "/run/bitcoinpir-cln-rpc-guard/issuer/issuer-rpc"],
+      ["--cln-rpc-expected-uid", "@CLN_GUARD_UID@"],
+      ["--cln-rpc-expected-gid", "@ISSUER_GID@"],
+    ],
+    label,
+  );
+  if ((mode & 0o111) !== 0) fail(`${label} must remain non-executable`);
+}
+
+function validateClnGuardTmpfiles(text, mode) {
+  const label = "CLN RPC guard tmpfiles template";
+  const expected = [
+    "d /run/bitcoinpir-cln-rpc-guard 0710 bitcoinpir-cln-rpc-guard bitcoinpir-issuer - -",
+    "d /run/bitcoinpir-cln-rpc-guard/issuer 0710 bitcoinpir-cln-rpc-guard bitcoinpir-issuer - -",
+  ];
+  const actual = activeTemplateLines(text, label)
+    .map((line) => line.split(/\s+/u).join(" "));
+  if (
+    actual.length !== expected.length ||
+    actual.some((line, index) => line !== expected[index])
+  ) {
+    fail(`${label} active lines must equal the reviewed closed-world layout`);
+  }
+  if ((mode & 0o111) !== 0) fail(`${label} must remain non-executable`);
+}
+
+function validateActivationPrerequisites(text) {
+  const label = "Lightning activation-prerequisites example";
+  const values = parseRelaySelection(text);
+  const unresolved = [
+    "status",
+    "network",
+    "cln_bundle_sha256",
+    "bitcoin_core_bundle_sha256",
+    "cln_rpc_guard_binary_sha256",
+    "cln_rpc_guard_unit_sha256",
+    "cln_rpc_guard_tmpfiles_sha256",
+    "lightningd_config_sha256",
+    "preflight_config_sha256",
+    "backup_receipt_sha256",
+    "expected_cln_version",
+    "expected_node_id_hex",
+  ];
+  const booleans = [
+    "identity_secret_offline_restore_rehearsed",
+    "channel_recovery_restore_rehearsed",
+    "dynamic_datastore_restore_rehearsed",
+    "stale_channel_state_rollback_rejected",
+    "default_signet_chain_pins_verified",
+    "exact_plugin_allowlist_verified",
+    "strict_rpc_socket_layout_verified",
+    "cross_uid_preflight_policy_verified",
+    "bitcoin_rpc_cookie_boundary_verified",
+    "cln_rpc_method_allowlist_guard_verified",
+    "live_read_only_preflight_passed",
+    "real_funds_authorized",
+  ];
+  const expectedKeys = ["schema_version", ...unresolved, ...booleans].sort();
+  const actualKeys = [...values.keys()].sort();
+  if (
+    actualKeys.length !== expectedKeys.length ||
+    actualKeys.some((key, index) => key !== expectedKeys[index])
+  ) {
+    fail(`${label} fields must equal the reviewed closed-world schema`);
+  }
+  exactField(values, "schema_version", 1);
+  for (const field of unresolved) exactField(values, field, "UNRESOLVED");
+  for (const field of booleans) exactField(values, field, false);
+  requireText(text, "Before mainnet/real value", label);
+}
+
+function validateCaddyTemplate(text, label, requiredUpstreams) {
+  requireText(text, "admin off", label);
+  requireText(text, "persist_config off", label);
+  requireText(text, "auto_https disable_redirects", label);
+  requireText(text, "0rtt off", label);
+  requireText(text, "strict_sni_host on", label);
+  requireText(
+    text,
+    "exclude http.log.access http.log.error http.handlers.reverse_proxy",
+    label,
+  );
+  rejectPattern(text, /\b(?:debug|trace)\b/iu, label, "debug/trace logging");
+  rejectPattern(text, /(?:^|\n)\s*log\s*\{/mu, label, "site access-log directive");
+  rejectPattern(text, /(?:^|\n)\s*(?:forward_auth|php_fastcgi|file_server|redir)\b/mu, label, "unreviewed handler");
+  for (const upstream of requiredUpstreams) {
+    const escaped = upstream.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+    const matches = text.match(new RegExp(`reverse_proxy\\s+${escaped}`, "gu")) ?? [];
+    if (matches.length === 0) fail(`${label} must contain reviewed loopback upstream ${upstream}`);
+  }
+  rejectPattern(
+    text,
+    /(?:^|\n)\s*reverse_proxy[ \t]+(?!127\.0\.0\.1:(?:5610|8191|8080|8099)\b)\S+/gu,
+    label,
+    "non-reviewed or non-loopback upstream",
+  );
+}
+
+function validateVpsbgFreePow(text, mode) {
+  const label = "VPSBG Free-PoW argument fragment";
+  requireText(text, "not a run script", label);
+  requireText(text, "existing measured Tier 3 script", label);
+  requireText(text, "FreeV1 / ProofOfWork", label);
+  rejectPattern(text, /^\s*#!+/m, label, "shebang");
+  rejectPattern(text, /^\s*exec(?:\s|$)/m, label, "exec command");
+  const active = text
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"))
+    .join(" ");
+  validateProductionForbiddenFlags(active, label);
+  validateExactCommand(
+    active,
+    [],
+    [
+      ["--require-service-auth-v1", null],
+      ["--service-policy", "/home/pir/data/payment-v1/vpsbg-free-pow-only-policy.bin"],
+      ["--service-provider-id-hex", "@VPSBG_PROVIDER_ID_HEX@"],
+      ["--service-policy-key-hex", "@VPSBG_POLICY_PUBKEY_HEX@"],
+      ["--service-store", "/home/pir/data/payment-v1/provider.sqlite3"],
+      ["--service-remote-rollback-authority-config", "/home/pir/data/payment-v1/remote-rollback-authority.toml"],
+      ["--service-max-concurrent-auth", "16"],
+      ["--service-pre-auth-timeout-ms", "60000"],
+    ],
+    label,
+  );
+  if ((mode & 0o111) !== 0) {
+    fail(`${label} must remain non-executable`);
+  }
+}
+
+function parseScalar(raw, lineNumber) {
+  if (/^"[^"\r\n]*"$/.test(raw)) {
+    return raw.slice(1, -1);
+  }
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (/^(0|[1-9][0-9]*)$/.test(raw)) return Number(raw);
+  fail(`relay selection line ${lineNumber} has a non-canonical scalar`);
+}
+
+export function parseRelaySelection(text) {
+  const result = new Map();
+  for (const [index, original] of text.split(/\r?\n/u).entries()) {
+    const line = original.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const match = /^([a-z][a-z0-9_]*)\s*=\s*(.*?)\s*$/.exec(line);
+    if (!match) fail(`relay selection line ${index + 1} is not canonical key=value`);
+    if (result.has(match[1])) fail(`relay selection repeats ${match[1]}`);
+    result.set(match[1], parseScalar(match[2], index + 1));
+  }
+  return result;
+}
+
+function exactField(selection, name, expected) {
+  if (selection.get(name) !== expected) {
+    fail(`relay selection ${name} must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+function stringField(selection, name) {
+  const value = selection.get(name);
+  if (typeof value !== "string") fail(`relay selection ${name} must be a string`);
+  return value;
+}
+
+export function validateRelaySelection(text) {
+  const selection = parseRelaySelection(text);
+  exactField(selection, "version", 1);
+  exactField(selection, "listen_host", "127.0.0.1");
+  exactField(selection, "allowed_kind", 30078);
+  exactField(selection, "max_event_message_bytes", 262176);
+  exactField(selection, "max_content_bytes", 196608);
+  exactField(selection, "config_max_bytes", 16384);
+  exactField(selection, "config_profile", "bitcoinpir-directory-relay-v1");
+  exactField(selection, "publisher_private_key_installed", false);
+  exactField(selection, "nip42_auth", false);
+  exactField(selection, "access_logging", false);
+  exactField(selection, "mutable_source_ref", false);
+
+  const values = [...selection.values()].filter((value) => typeof value === "string");
+  for (const value of values) {
+    const lower = value.toLowerCase();
+    if (lower.includes("nostr-rs-relay")) {
+      fail("relay selection refuses nostr-rs-relay");
+    }
+    if (UNSAFE_RELAY_COMMITS.has(lower)) {
+      fail(`relay selection refuses audited unsafe commit ${lower}`);
+    }
+  }
+
+  const status = stringField(selection, "status");
+  if (status === "UNRESOLVED") {
+    for (const field of UNRESOLVED_FIELDS) exactField(selection, field, "UNRESOLVED");
+    return { status };
+  }
+  if (status !== "RESOLVED") {
+    fail("relay selection status must be UNRESOLVED or RESOLVED");
+  }
+
+  exactField(selection, "implementation", "bitcoinpir-directory-only");
+  exactField(
+    selection,
+    "source_repository",
+    "https://github.com/Bitcoin-PIR/Bitcoin-PIR.git",
+  );
+  const sourceCommit = stringField(selection, "source_commit");
+  if (!/^[0-9a-f]{40}$/.test(sourceCommit)) {
+    fail("resolved relay source_commit must be a full lowercase 40-hex commit");
+  }
+  if (UNSAFE_RELAY_COMMITS.has(sourceCommit)) {
+    fail(`relay selection refuses audited unsafe commit ${sourceCommit}`);
+  }
+  for (const field of HASH_FIELDS) {
+    if (!/^[0-9a-f]{64}$/.test(stringField(selection, field))) {
+      fail(`resolved relay ${field} must be a lowercase SHA-256`);
+    }
+  }
+  if (!/^bitcoinpir-directory-relay [0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/.test(
+    stringField(selection, "binary_version_output"),
+  )) {
+    fail("resolved relay binary_version_output is not exact and canonical");
+  }
+  const publisherPubkey = stringField(selection, "publisher_pubkey_hex");
+  if (!/^[0-9a-f]{64}$/.test(publisherPubkey)) {
+    fail("resolved relay publisher_pubkey_hex must be lowercase 32-byte hex");
+  }
+  if (/^0{64}$/.test(publisherPubkey)) {
+    fail("resolved relay publisher_pubkey_hex must be non-zero");
+  }
+  return {
+    status,
+    binarySha256: stringField(selection, "binary_sha256"),
+    publisherPubkey,
+  };
+}
+
+function validateRelayConfigExample(text, selection) {
+  const label = "directory relay configuration example";
+  if (Buffer.byteLength(text, "utf8") > 16 * 1024) {
+    fail(`${label} exceeds the application 16 KiB input bound`);
+  }
+  const config = parseRelaySelection(text);
+  const expectedKeys = [
+    "profile",
+    "listen",
+    "database",
+    "directory_pubkey_hex",
+    "max_connections",
+    "max_in_flight_operations",
+    "max_operations_per_second",
+    "max_egress_bytes_per_second",
+    "max_egress_bytes_per_connection",
+    "max_archive_events",
+    "max_archive_bytes",
+    "handshake_timeout_seconds",
+    "idle_timeout_seconds",
+    "connection_timeout_seconds",
+    "operation_timeout_seconds",
+    "egress_timeout_seconds",
+  ].sort();
+  const actualKeys = [...config.keys()].sort();
+  if (
+    actualKeys.length !== expectedKeys.length ||
+    actualKeys.some((value, index) => value !== expectedKeys[index])
+  ) {
+    fail(`${label} fields do not match the application schema`);
+  }
+  for (const [field, expected] of [
+    ["profile", "bitcoinpir-directory-relay-v1"],
+    ["listen", "127.0.0.1:8080"],
+    ["database", "/var/lib/bitcoinpir-directory-relay/relay.sqlite3"],
+    ["max_connections", 64],
+    ["max_in_flight_operations", 8],
+    ["max_operations_per_second", 64],
+    ["max_egress_bytes_per_second", 16_777_216],
+    ["max_egress_bytes_per_connection", 67_108_864],
+    ["max_archive_events", 100_000],
+    ["max_archive_bytes", 268_435_456],
+    ["handshake_timeout_seconds", 10],
+    ["idle_timeout_seconds", 60],
+    ["connection_timeout_seconds", 300],
+    ["operation_timeout_seconds", 10],
+    ["egress_timeout_seconds", 5],
+  ]) {
+    exactField(config, field, expected);
+  }
+  const expectedPublisher =
+    selection.status === "RESOLVED"
+      ? selection.publisherPubkey
+      : "@DIRECTORY_PUBLISHER_PUBKEY_HEX@";
+  exactField(config, "directory_pubkey_hex", expectedPublisher);
+}
+
+function recursiveFiles(root) {
+  const output = [];
+  const walk = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const absolute = join(directory, entry.name);
+      if (entry.isSymbolicLink()) fail(`deployment template tree contains symlink: ${absolute}`);
+      if (entry.isDirectory()) walk(absolute);
+      else if (entry.isFile()) output.push(absolute);
+      else fail(`deployment template tree contains non-regular entry: ${absolute}`);
+    }
+  };
+  walk(root);
+  return output;
+}
+
+function validateTemplateTreeShape(root) {
+  const absoluteRoot = join(root, TEMPLATE_ROOT);
+  const allowedPaths = new Set(
+    REQUIRED_PREPARATION_FILES.filter((path) => path.startsWith(`${TEMPLATE_ROOT}/`)),
+  );
+  for (const absolute of recursiveFiles(absoluteRoot)) {
+    const rel = relative(root, absolute);
+    const stat = lstatSync(absolute);
+    if ((stat.mode & 0o111) !== 0) {
+      fail(`deployment template must not be executable: ${rel}`);
+    }
+    if (rel.endsWith(".service") || /\/run$/u.test(rel)) {
+      fail(`deployment tree must not contain an activatable unit/script: ${rel}`);
+    }
+    if (
+      !rel.endsWith(".service.in") &&
+      !rel.endsWith(".args.in") &&
+      !rel.endsWith(".Caddyfile.in") &&
+      !rel.endsWith(".conf.in") &&
+      !rel.endsWith(".sh.in") &&
+      !rel.endsWith(".toml.example") &&
+      !rel.endsWith(".md")
+    ) {
+      fail(`deployment tree contains an unreviewed file type: ${rel}`);
+    }
+    if (!allowedPaths.has(rel)) {
+      fail(`deployment tree contains an unreviewed path: ${rel}`);
+    }
+  }
+}
+
+function validateActiveBaselines(root) {
+  for (const [relativePath, expected] of Object.entries(ACTIVE_BASELINES)) {
+    const { absolute, text } = readRequired(root, relativePath);
+    const actual = sha256File(absolute);
+    if (actual !== expected) {
+      fail(`active deployment file changed outside this slice: ${relativePath}`);
+    }
+    rejectPattern(
+      text,
+      /--require-service-auth-v1|--service-policy(?:\s|=)|--service-store(?:\s|=)/,
+      relativePath,
+      "Payment V1 activation",
+    );
+  }
+}
+
+function validateReviewedPreparationHashes(root) {
+  for (const [relativePath, expected] of Object.entries(
+    REVIEWED_PREPARATION_HASHES,
+  )) {
+    const { absolute } = readRequired(root, relativePath);
+    const actual = sha256File(absolute);
+    if (actual !== expected) {
+      fail(`reviewed deployment source SHA-256 changed: ${relativePath}`);
+    }
+  }
+}
+
+export function validateDeploymentTree(rootInput) {
+  const root = resolve(rootInput);
+  for (const required of REQUIRED_PREPARATION_FILES) readRequired(root, required);
+  validateTemplateTreeShape(root);
+  validateActiveBaselines(root);
+
+  const provider = readRequired(
+    root,
+    "deploy/payment-v1/systemd/hetzner-provider.service.in",
+  );
+  validateHetznerProvider(provider.text);
+
+  const issuer = readRequired(
+    root,
+    "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+  );
+  validateHetznerIssuer(issuer.text);
+
+  const coreLightning = readRequired(
+    root,
+    "deploy/payment-v1/systemd/hetzner-core-lightning.service.in",
+  );
+  validateCoreLightningUnit(coreLightning.text);
+
+  const clnRpcGuard = readRequired(
+    root,
+    "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in",
+  );
+  validateClnRpcGuardUnit(clnRpcGuard.text);
+
+  const lightningPreflight = readRequired(
+    root,
+    "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in",
+  );
+  validateLightningPreflightUnit(lightningPreflight.text);
+
+  const paymentEdge = readRequired(
+    root,
+    "deploy/payment-v1/systemd/payment-v1-edge.service.in",
+  );
+  validatePaymentEdgeUnit(paymentEdge.text);
+
+  const activationPrerequisites = readRequired(
+    root,
+    "deploy/payment-v1/lightning/activation-prerequisites.toml.example",
+  );
+  validateActivationPrerequisites(activationPrerequisites.text);
+
+  const lightningdConfig = readRequired(
+    root,
+    "deploy/payment-v1/lightning/lightningd.conf.in",
+  );
+  validateLightningdConfig(lightningdConfig.text);
+
+  const issuerClnArgs = readRequired(
+    root,
+    "deploy/payment-v1/lightning/issuer-cln.args.in",
+  );
+  validateIssuerClnArgs(issuerClnArgs.text, issuerClnArgs.stat.mode);
+
+  const clnGuardTmpfiles = readRequired(
+    root,
+    "deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in",
+  );
+  validateClnGuardTmpfiles(clnGuardTmpfiles.text, clnGuardTmpfiles.stat.mode);
+
+  const layoutVerifier = readRequired(
+    root,
+    "deploy/payment-v1/lightning/verify-layout.sh.in",
+  );
+  if ((layoutVerifier.stat.mode & 0o111) !== 0) {
+    fail("Lightning layout verifier source template must remain non-executable");
+  }
+  for (const required of [
+    "[ \"${bpir_lightning_network}\" = 'signet' ] || bpir_fail",
+    "-perm /077",
+    "-links +1",
+    "/usr/bin/getfacl",
+    "${bpir_lightning_uid}:${bpir_lightning_gid}:660",
+  ]) {
+    requireText(layoutVerifier.text, required, "Lightning layout verifier template");
+  }
+
+  const publicEdge = readRequired(
+    root,
+    "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
+  );
+  validateCaddyTemplate(
+    publicEdge.text,
+    "Hetzner public Caddy template",
+    ["127.0.0.1:8191", "127.0.0.1:5610", "127.0.0.1:8080"],
+  );
+  requireText(
+    publicEdge.text,
+    "path /v1/redeems /v1/settlement/balance",
+    "Hetzner public Caddy template",
+  );
+  rejectPattern(
+    publicEdge.text,
+    /\/v1\/settlement\/(?:payout-intents|payouts|payout-status)\b/u,
+    "Hetzner public Caddy template",
+    "production payout route",
+  );
+
+  const authorityEdge = readRequired(
+    root,
+    "deploy/payment-v1/edge/rollback-authority.Caddyfile.in",
+  );
+  validateCaddyTemplate(
+    authorityEdge.text,
+    "rollback-authority Caddy template",
+    ["127.0.0.1:8099"],
+  );
+
+  const authority = readRequired(
+    root,
+    "deploy/payment-v1/systemd/rollback-authority.service.in",
+  );
+  validateRollbackAuthority(authority.text);
+
+  const vpsbg = readRequired(
+    root,
+    "deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in",
+  );
+  validateVpsbgFreePow(vpsbg.text, vpsbg.stat.mode);
+  const deploymentDoc = readRequired(
+    root,
+    "docs/payment/HETZNER_VPSBG_DEPLOYMENT.md",
+  );
+  for (const required of [
+    "P1 activation blocker",
+    "attestation-gated key release",
+    "host can read or copy",
+  ]) {
+    requireText(deploymentDoc.text, required, "Hetzner/VPSBG deployment document");
+  }
+
+  const selectionFile = readRequired(
+    root,
+    "deploy/payment-v1/relay-selection.toml.example",
+  );
+  const selection = validateRelaySelection(selectionFile.text);
+  const relayConfig = readRequired(
+    root,
+    "deploy/payment-v1/directory-relay.toml.example",
+  );
+  validateRelayConfigExample(relayConfig.text, selection);
+  const relayUnit = readRequired(
+    root,
+    "deploy/payment-v1/systemd/hetzner-directory-relay.service.in",
+  );
+  const relayLabel = "Hetzner directory relay template";
+  const relayParsed = validateInactiveSystemdTemplate(relayUnit.text, relayLabel, [
+    "/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+    "/etc/bitcoinpir/payment-v1/RELAY-SELECTION-RESOLVED",
+  ]);
+  exactDirectiveKeys(relayParsed, "Unit", BASIC_UNIT_KEYS, relayLabel);
+  exactDirectiveKeys(
+    relayParsed,
+    "Service",
+    [
+      "Type", "User", "Group", "UMask", "StateDirectory", "StateDirectoryMode",
+      "WorkingDirectory", "Environment", "ExecStart", "Restart", "TimeoutStopSec",
+      "NoNewPrivileges", "PrivateTmp", "PrivateDevices", "ProtectSystem", "ProtectHome",
+      "ProtectKernelTunables", "ProtectKernelModules", "ProtectKernelLogs",
+      "ProtectControlGroups", "LockPersonality", "MemoryDenyWriteExecute",
+      "RestrictSUIDSGID", "RestrictNamespaces", "RestrictRealtime",
+      "SystemCallArchitectures", "CapabilityBoundingSet", "AmbientCapabilities",
+      "RestrictAddressFamilies", "IPAddressDeny", "IPAddressAllow", "ReadOnlyPaths",
+      "ReadWritePaths",
+      ...(selection.status === "RESOLVED" ? ["ExecStartPre"] : []),
+      ...(selection.status === "RESOLVED" ? ["RestartSec"] : []),
+    ],
+    relayLabel,
+  );
+  validateCommonServiceHardening(relayParsed, relayLabel, true);
+  exactDirectiveValues(relayParsed, "Unit", "Description", ["BitcoinPIR Hetzner directory-only relay (blocked template)"], relayLabel);
+  exactDirectiveValues(relayParsed, "Unit", "After", ["network-online.target"], relayLabel);
+  exactDirectiveValues(relayParsed, "Unit", "Wants", ["network-online.target"], relayLabel);
+  exactDirectiveValues(relayParsed, "Service", "User", ["bitcoinpir-directory-relay"], relayLabel);
+  exactDirectiveValues(relayParsed, "Service", "Group", ["bitcoinpir-directory-relay"], relayLabel);
+  exactDirectiveValues(relayParsed, "Service", "StateDirectory", ["bitcoinpir-directory-relay"], relayLabel);
+  exactDirectiveValues(relayParsed, "Service", "WorkingDirectory", ["/var/lib/bitcoinpir-directory-relay"], relayLabel);
+  exactDirectiveValues(relayParsed, "Service", "Environment", ["RUST_LOG=error"], relayLabel);
+  exactDirectiveValues(relayParsed, "Service", "IPAddressDeny", ["any"], relayLabel);
+  exactDirectiveValues(relayParsed, "Service", "IPAddressAllow", ["localhost"], relayLabel);
+  exactDirectiveValues(relayParsed, "Service", "ReadOnlyPaths", ["/etc/bitcoinpir/payment-v1/directory-relay"], relayLabel);
+  exactDirectiveValues(relayParsed, "Service", "ReadWritePaths", ["/var/lib/bitcoinpir-directory-relay"], relayLabel);
+  rejectPattern(
+    relayUnit.text,
+    /publisher-(?:private|signing)-key|directory-(?:private|signing)-key/i,
+    relayLabel,
+    "directory publisher private-key installation",
+  );
+  const relayCommand = onlyDirectiveValue(relayParsed, "Service", "ExecStart", relayLabel);
+  if (selection.status === "UNRESOLVED") {
+    if (relayCommand !== "/usr/bin/false") {
+      fail("unresolved relay template must fail closed with ExecStart=/usr/bin/false");
+    }
+    exactDirectiveValues(relayParsed, "Service", "ExecStartPre", [], relayLabel);
+    exactDirectiveValues(relayParsed, "Service", "Restart", ["no"], relayLabel);
+  } else {
+    const expectedExecStart =
+      `/opt/bitcoinpir/directory-relay/${selection.binarySha256}/` +
+      "bitcoinpir-directory-relay --config " +
+      "/etc/bitcoinpir/payment-v1/directory-relay/relay.toml";
+    if (relayCommand !== expectedExecStart) {
+      fail("resolved relay template must use only the pinned binary and one absolute --config path");
+    }
+    exactDirectiveValues(
+      relayParsed,
+      "Service",
+      "ExecStartPre",
+      [
+        "/usr/bin/sha256sum --check /etc/bitcoinpir/payment-v1/directory-relay/binary.sha256",
+        "/usr/bin/sha256sum --check /etc/bitcoinpir/payment-v1/directory-relay/config.sha256",
+      ],
+      relayLabel,
+    );
+    exactDirectiveValues(relayParsed, "Service", "Restart", ["on-failure"], relayLabel);
+    exactDirectiveValues(relayParsed, "Service", "RestartSec", ["5"], relayLabel);
+  }
+
+  validateReviewedPreparationHashes(root);
+
+  return true;
+}
+
+function parseCli(argv) {
+  let root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--root" && i + 1 < argv.length) {
+      root = resolve(argv[++i]);
+    } else {
+      fail(`usage: payment-v1-deployment-template-gate.mjs [--root REPOSITORY]`);
+    }
+  }
+  return { root };
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (invokedDirectly) {
+  try {
+    const { root } = parseCli(process.argv.slice(2));
+    validateDeploymentTree(root);
+    console.log("payment-v1-deployment-template-gate=PASS");
+  } catch (error) {
+    console.error(`payment-v1-deployment-template-gate=FAIL: ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/payment-v1-deployment-template-gate.test.mjs
+++ b/scripts/payment-v1-deployment-template-gate.test.mjs
@@ -1,0 +1,667 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import {
+  ACTIVE_BASELINES,
+  REQUIRED_PREPARATION_FILES,
+  validateDeploymentTree,
+  validateRelaySelection,
+} from "./payment-v1-deployment-template-gate.mjs";
+
+const REPOSITORY = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "bitcoinpir-deployment-gate-"));
+  const paths = new Set([
+    ...Object.keys(ACTIVE_BASELINES),
+    ...REQUIRED_PREPARATION_FILES,
+  ]);
+  for (const relativePath of paths) {
+    const destination = join(root, relativePath);
+    mkdirSync(dirname(destination), { recursive: true });
+    copyFileSync(join(REPOSITORY, relativePath), destination);
+    chmodSync(destination, 0o644);
+  }
+  return root;
+}
+
+function withFixture(run) {
+  const root = fixture();
+  try {
+    run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function mutate(root, relativePath, transform) {
+  const path = join(root, relativePath);
+  const before = readFileSync(path, "utf8");
+  const after = transform(before);
+  assert.notEqual(after, before, `test mutation must change ${relativePath}`);
+  writeFileSync(path, after, "utf8");
+}
+
+function replaceRelayField(text, field, value) {
+  const expression = new RegExp(`^${field}\\s*=.*$`, "m");
+  assert.match(text, expression);
+  return text.replace(expression, `${field} = ${JSON.stringify(value)}`);
+}
+
+function resolvedRelaySelection(text, overrides = {}) {
+  const values = {
+    status: "RESOLVED",
+    implementation: "bitcoinpir-directory-only",
+    source_repository: "https://github.com/Bitcoin-PIR/Bitcoin-PIR.git",
+    source_commit: "1".repeat(40),
+    source_archive_sha256: "2".repeat(64),
+    cargo_lock_sha256: "3".repeat(64),
+    binary_sha256: "4".repeat(64),
+    binary_version_output: "bitcoinpir-directory-relay 0.1.0",
+    config_sha256: "5".repeat(64),
+    publisher_pubkey_hex: "6".repeat(64),
+    ...overrides,
+  };
+  let output = text;
+  for (const [field, value] of Object.entries(values)) {
+    output = replaceRelayField(output, field, value);
+  }
+  return output;
+}
+
+test("repository deployment preparation passes its fail-closed gate", () => {
+  assert.equal(validateDeploymentTree(REPOSITORY), true);
+});
+
+test("a copied positive fixture passes", () => {
+  withFixture((root) => assert.equal(validateDeploymentTree(root), true));
+});
+
+test("provider enforcement, ledger-only issuer and remote rollback are mandatory", () => {
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-provider.service.in",
+      (text) => text.replace("    --require-service-auth-v1 \\\n", ""),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /--require-service-auth-v1/,
+    );
+  });
+
+  for (const [flag, expected] of [
+    ["--clearing-payout-target 11=22", /production clearing payout target/],
+    ["--clearing-payout-fee 1", /production clearing payout fee/],
+    ["--clearing-payout-intent-ttl-seconds 60", /production payout intent TTL/],
+  ]) {
+    withFixture((root) => {
+      mutate(
+        root,
+        "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+        (text) => text.replace(
+          "    --issuer-settlement-signing-key",
+          `    ${flag} \\\n    --issuer-settlement-signing-key`,
+        ),
+      );
+      assert.throws(() => validateDeploymentTree(root), expected);
+    });
+  }
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-provider.service.in",
+      (text) =>
+        text.replace(
+          "--service-remote-rollback-authority-config",
+          "--service-rollback-authority",
+        ),
+    );
+    assert.throws(() => validateDeploymentTree(root), /local provider rollback authority/);
+  });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-provider.service.in",
+      (text) => text.replace(/^.*--service-shared-idempotency-key.*\n/m, ""),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /--service-shared-idempotency-key/,
+    );
+  });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-provider.service.in",
+      (text) =>
+        text.replace(
+          "cashu-custody-epoch-1.key",
+          "cashu-recovery-epoch-1.key",
+        ),
+    );
+    assert.throws(() => validateDeploymentTree(root), /--service-cashu-custody-key/);
+  });
+});
+
+test("production templates reject ARC, fake, local and proxied Free-IP flags", () => {
+  const mutations = [
+    ["--allow-experimental-arc", /experimental ARC/],
+    ["--service-arc-key /private/arc.key", /provider ARC key/],
+    ["--allow-local-service-rollback-authority-dev", /local provider rollback/],
+    ["--service-free-ip-key /private/free-ip.key", /Free IP key behind a proxy/],
+    ["--service-trust-direct-peer-ip", /direct peer-IP trust/],
+    ["--test-only-service-https-root-pem /private/test.pem", /test-only trust root/],
+  ];
+  for (const [flag, expected] of mutations) {
+    withFixture((root) => {
+      mutate(
+        root,
+        "deploy/payment-v1/systemd/hetzner-provider.service.in",
+        (text) => text.replace("    --max-connections 128", `    ${flag} \\\n    --max-connections 128`),
+      );
+      assert.throws(() => validateDeploymentTree(root), expected);
+    });
+  }
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+      (text) => text.replace("payment-issuer serve-cln", "payment-issuer serve-fake"),
+    );
+    assert.throws(() => validateDeploymentTree(root), /fake Lightning serving mode/);
+  });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+      (text) => text.replace(/^.*--receipt-signing-key.*\n/m, ""),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /--receipt-signing-key/,
+    );
+  });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+      (text) => text.replace(/^.*--clearing-approval.*\n/m, ""),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /--clearing-approval/,
+    );
+  });
+});
+
+test("issuer and authority origins must remain loopback", () => {
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+      (text) => text.replace("--bind 127.0.0.1:5610", "--bind 0.0.0.0:5610"),
+    );
+    assert.throws(() => validateDeploymentTree(root), /--bind must equal/);
+  });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/rollback-authority.service.in",
+      (text) => text.replace("--bind 127.0.0.1:8099", "--bind 0.0.0.0:8099"),
+    );
+    assert.throws(() => validateDeploymentTree(root), /--bind must equal/);
+  });
+});
+
+test("VPSBG fragment remains service-auth-only, Free-PoW-only and remote-authority-only", () => {
+  for (const flag of [
+    "--serve-hints",
+    "--service-bat-key /home/pir/data/bat.key",
+    "--service-cashu-recovery-key 1=/home/pir/data/recovery.key",
+    "--service-shared-authorization /home/pir/data/shared.bin",
+  ]) {
+    withFixture((root) => {
+      mutate(
+        root,
+        "deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in",
+        (text) => `${text}\n${flag}\n`,
+      );
+      assert.throws(() => validateDeploymentTree(root), /unreviewed|canonical order/);
+    });
+  }
+
+  for (const [line, expected] of [
+    ["#!/bin/sh", /shebang/],
+    ["exec /usr/local/bin/unified_server", /exec command/],
+    ["--direct-oram-db 0=/wrong/path", /canonical order|unreviewed/],
+  ]) {
+    withFixture((root) => {
+      mutate(
+        root,
+        "deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in",
+        (text) => `${line}\n${text}`,
+      );
+      assert.throws(() => validateDeploymentTree(root), expected);
+    });
+  }
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "docs/payment/HETZNER_VPSBG_DEPLOYMENT.md",
+      (text) => text.replaceAll("P1 activation blocker", "deployment note"),
+    );
+    assert.throws(() => validateDeploymentTree(root), /P1 activation blocker/);
+  });
+});
+
+test("systemd resets, duplicate CLI overrides, and secret argv fail closed", () => {
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-provider.service.in",
+      (text) => text.replace("[Service]", "ConditionPathExists=\n\n[Service]"),
+    );
+    assert.throws(() => validateDeploymentTree(root), /empty ConditionPathExists= reset/);
+  });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-provider.service.in",
+      (text) => `${text}\nExecStart=\nExecStart=/usr/bin/true\n`,
+    );
+    assert.throws(() => validateDeploymentTree(root), /empty ExecStart= reset/);
+  });
+
+  for (const injected of [
+    "--bind-address 0.0.0.0",
+    "--direct-oram-key-hex deadbeef",
+  ]) {
+    withFixture((root) => {
+      mutate(
+        root,
+        "deploy/payment-v1/systemd/hetzner-provider.service.in",
+        (text) =>
+          text.replace(
+            "    --service-pre-auth-timeout-ms 60000",
+            `    --service-pre-auth-timeout-ms 60000 \\\n    ${injected}`,
+          ),
+      );
+      assert.throws(
+        () => validateDeploymentTree(root),
+        /unreviewed, duplicate, or positional argv value/,
+      );
+    });
+  }
+});
+
+test("systemd hardening values and relay environment are exact", () => {
+  const providerMutations = [
+    ["User=bitcoinpir-provider", "User=root", /Service\.User must equal/],
+    ["UMask=0077", "UMask=0000", /Service\.UMask must equal/],
+    ["PrivateTmp=true", "PrivateTmp=false", /Service\.PrivateTmp must equal/],
+    [
+      "ProtectKernelLogs=true",
+      "ProtectKernelLogs=false",
+      /Service\.ProtectKernelLogs must equal/,
+    ],
+    [
+      "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6",
+      "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_PACKET",
+      /Service\.RestrictAddressFamilies must equal/,
+    ],
+    [
+      "ReadWritePaths=/var/lib/bitcoinpir-provider-payment-v1",
+      "ReadWritePaths=/",
+      /Service\.ReadWritePaths must equal/,
+    ],
+  ];
+  for (const [before, after, expected] of providerMutations) {
+    withFixture((root) => {
+      mutate(
+        root,
+        "deploy/payment-v1/systemd/hetzner-provider.service.in",
+        (text) => text.replace(before, after),
+      );
+      assert.throws(() => validateDeploymentTree(root), expected);
+    });
+  }
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-directory-relay.service.in",
+      (text) => text.replace("Environment=RUST_LOG=error", "Environment=LD_PRELOAD=/tmp/evil.so"),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /Service\.Environment must equal/,
+    );
+  });
+});
+
+test("edge and Lightning templates reject reviewed P1 bypass mutations", () => {
+  const mutations = [
+    [
+      "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
+      (text) => text.replace("reverse_proxy 127.0.0.1:8191", "reverse_proxy attacker.example:443"),
+      /reviewed loopback upstream|non-reviewed or non-loopback upstream/,
+    ],
+    [
+      "deploy/payment-v1/lightning/lightningd.conf.in",
+      (text) => text.replace("clear-plugins", "plugin=/tmp/evil-plugin"),
+      /closed-world configuration|dynamic plugin/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in",
+      (text) => text.replace(
+        "/opt/bitcoinpir/bpir-admin/@BPIR_ADMIN_SHA256@/bpir-admin lightning-staging preflight",
+        "/usr/bin/true",
+      ),
+      /command prefix/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-core-lightning.service.in",
+      (text) => text.replace("User=bitcoinpir-lightning", "User=root"),
+      /Service\.User must equal/,
+    ],
+    [
+      "deploy/payment-v1/systemd/payment-v1-edge.service.in",
+      (text) => text.replace(
+        "CapabilityBoundingSet=CAP_NET_BIND_SERVICE",
+        "CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SYS_ADMIN",
+      ),
+      /Service\.CapabilityBoundingSet must equal/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-provider.service.in",
+      (text) => text.replace("PrivateDevices=true", "PrivateDevices=false"),
+      /Service\.PrivateDevices must equal/,
+    ],
+  ];
+  for (const [relativePath, transform, expected] of mutations) {
+    withFixture((root) => {
+      mutate(root, relativePath, transform);
+      assert.throws(() => validateDeploymentTree(root), expected);
+    });
+  }
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/lightning/activation-prerequisites.toml.example",
+      (text) => text.replace("real_funds_authorized = false", "real_funds_authorized = true"),
+    );
+    assert.throws(() => validateDeploymentTree(root), /real_funds_authorized must equal false/);
+  });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+      (text) => text.replace(
+        "Requires=bitcoinpir-core-lightning.service bitcoinpir-cln-rpc-guard.service bitcoinpir-lightning-preflight.service\n",
+        "",
+      ),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /Unit directive keys|Unit\.Requires must equal/,
+    );
+  });
+});
+
+test("public issuer edge exposes ledger accrual only", () => {
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
+      (text) => text.replace(
+        "path /v1/redeems /v1/settlement/balance",
+        "path /v1/redeems /v1/settlement/balance /v1/settlement/payouts",
+      ),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /production payout route/,
+    );
+  });
+});
+
+test("CLN guard and cross-UID isolation reject topology regressions", () => {
+  const mutations = [
+    [
+      "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in",
+      (text) => text.replace("--max-invoice-msat", "--unsafe-max-invoice-msat"),
+      /--max-invoice-msat|argument set/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in",
+      (text) => text.replace("--max-invoices-per-minute", "--unsafe-max-invoices-per-minute"),
+      /--max-invoices-per-minute|argument set/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in",
+      (text) => text.replace("--max-invoice-burst", "--unsafe-max-invoice-burst"),
+      /--max-invoice-burst|argument set/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in",
+      (text) => text.replace("--max-invoices-per-runtime", "--unsafe-max-invoices-per-runtime"),
+      /--max-invoices-per-runtime|argument set/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in",
+      (text) => text.replace("Restart=no", "Restart=on-failure"),
+      /Service\.Restart must equal/,
+    ],
+    [
+      "deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in",
+      (text) => text.replace("0710 bitcoinpir-cln-rpc-guard", "0700 bitcoinpir-cln-rpc-guard"),
+      /closed-world layout/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+      (text) => text.replace(
+        "Group=bitcoinpir-issuer\n",
+        "Group=bitcoinpir-issuer\nSupplementaryGroups=bitcoinpir-cln-guard\n",
+      ),
+      /Service directive keys/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+      (text) => text.replace("InaccessiblePaths=/srv/lightning /srv/bitcoin\n", ""),
+      /InaccessiblePaths/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in",
+      (text) => text.replace("User=bitcoinpir-lightning-preflight", "User=bitcoinpir-issuer"),
+      /Service\.User must equal/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-core-lightning.service.in",
+      (text) => text.replace("SupplementaryGroups=bitcoinpir-bitcoin-rpc\n", ""),
+      /SupplementaryGroups/,
+    ],
+    [
+      "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in",
+      (text) => text.replace("User=bitcoinpir-cln-rpc-guard", "User=root"),
+      /Service\.User must equal/,
+    ],
+  ];
+
+  for (const [relativePath, transform, expected] of mutations) {
+    withFixture((root) => {
+      mutate(root, relativePath, transform);
+      assert.throws(() => validateDeploymentTree(root), expected);
+    });
+  }
+});
+
+test("reviewed edge and Lightning source bytes are frozen", () => {
+  for (const relativePath of [
+    "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
+    "deploy/payment-v1/lightning/verify-layout.sh.in",
+    "deploy/payment-v1/systemd/hetzner-core-lightning.service.in",
+  ]) {
+    withFixture((root) => {
+      mutate(root, relativePath, (text) => `${text}\n# unreviewed but semantic no-op\n`);
+      assert.throws(
+        () => validateDeploymentTree(root),
+        /reviewed deployment source SHA-256 changed/,
+      );
+    });
+  }
+});
+
+test("relay selection defaults to unresolved and rejects unsafe implementations", () => {
+  const unresolved = readFileSync(
+    join(REPOSITORY, "deploy/payment-v1/relay-selection.toml.example"),
+    "utf8",
+  );
+  assert.deepEqual(validateRelaySelection(unresolved), { status: "UNRESOLVED" });
+
+  const thirdParty = replaceRelayField(
+    unresolved,
+    "implementation",
+    "nostr-rs-relay",
+  );
+  assert.throws(() => validateRelaySelection(thirdParty), /refuses nostr-rs-relay/);
+
+  const unsafePin = resolvedRelaySelection(unresolved, {
+    source_commit: "ff65ec2acd781150a585a78e1c60b0cdb104698e",
+  });
+  assert.throws(() => validateRelaySelection(unsafePin), /refuses audited unsafe commit/);
+
+  const mutable = resolvedRelaySelection(unresolved, { source_commit: "master" });
+  assert.throws(() => validateRelaySelection(mutable), /full lowercase 40-hex commit/);
+
+  const zeroPublisher = resolvedRelaySelection(unresolved, {
+    publisher_pubkey_hex: "0".repeat(64),
+  });
+  assert.throws(() => validateRelaySelection(zeroPublisher), /must be non-zero/);
+});
+
+test("a future directory-only exact-hash relay selection is accepted", () => {
+  const unresolved = readFileSync(
+    join(REPOSITORY, "deploy/payment-v1/relay-selection.toml.example"),
+    "utf8",
+  );
+  assert.deepEqual(validateRelaySelection(resolvedRelaySelection(unresolved)), {
+    status: "RESOLVED",
+    binarySha256: "4".repeat(64),
+    publisherPubkey: "6".repeat(64),
+  });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/relay-selection.toml.example",
+      (text) => resolvedRelaySelection(text),
+    );
+    mutate(
+      root,
+      "deploy/payment-v1/directory-relay.toml.example",
+      (text) =>
+        text.replace(
+          "@DIRECTORY_PUBLISHER_PUBKEY_HEX@",
+          "6".repeat(64),
+        ),
+    );
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-directory-relay.service.in",
+      (text) =>
+        text
+          .replace(
+            "ExecStart=/usr/bin/false",
+            `ExecStartPre=/usr/bin/sha256sum --check /etc/bitcoinpir/payment-v1/directory-relay/binary.sha256\nExecStartPre=/usr/bin/sha256sum --check /etc/bitcoinpir/payment-v1/directory-relay/config.sha256\nExecStart=/opt/bitcoinpir/directory-relay/${"4".repeat(64)}/bitcoinpir-directory-relay --config /etc/bitcoinpir/payment-v1/directory-relay/relay.toml`,
+          )
+          .replace("Restart=no", "Restart=on-failure\nRestartSec=5"),
+    );
+    assert.equal(validateDeploymentTree(root), true);
+  });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/relay-selection.toml.example",
+      (text) => resolvedRelaySelection(text),
+    );
+    mutate(
+      root,
+      "deploy/payment-v1/directory-relay.toml.example",
+      (text) =>
+        text.replace(
+          "@DIRECTORY_PUBLISHER_PUBKEY_HEX@",
+          "6".repeat(64),
+        ),
+    );
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-directory-relay.service.in",
+      (text) =>
+        text
+          .replace(
+            "ExecStart=/usr/bin/false",
+            `ExecStartPre=/usr/bin/sha256sum --check /etc/bitcoinpir/payment-v1/directory-relay/binary.sha256\nExecStartPre=/usr/bin/sha256sum --check /etc/bitcoinpir/payment-v1/directory-relay/config.sha256\nExecStart=/opt/bitcoinpir/directory-relay/${"4".repeat(64)}/bitcoinpir-directory-relay --config /etc/bitcoinpir/payment-v1/directory-relay/relay.toml --listen 0.0.0.0:8080`,
+          )
+          .replace("Restart=no", "Restart=on-failure\nRestartSec=5"),
+    );
+    assert.throws(() => validateDeploymentTree(root), /only the pinned binary and one absolute --config path/);
+  });
+});
+
+test("any active unit or measured runit mutation fails the frozen baseline", () => {
+  for (const relativePath of Object.keys(ACTIVE_BASELINES)) {
+    withFixture((root) => {
+      mutate(root, relativePath, (text) => `${text}\n# unauthorized mutation\n`);
+      assert.throws(
+        () => validateDeploymentTree(root),
+        new RegExp(`active deployment file changed.*${relativePath.replaceAll("/", "\\/")}`),
+      );
+    });
+  }
+});
+
+test("activatable or executable files are forbidden in the template tree", () => {
+  withFixture((root) => {
+    const path = join(root, "deploy/payment-v1/systemd/accidental.service");
+    writeFileSync(path, "[Service]\nExecStart=/usr/bin/true\n", "utf8");
+    assert.throws(() => validateDeploymentTree(root), /activatable unit\/script/);
+  });
+
+  withFixture((root) => {
+    const path = join(root, "deploy/payment-v1/runit/replacement.run.in");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "exec /usr/local/bin/unified_server\n", "utf8");
+    assert.throws(() => validateDeploymentTree(root), /unreviewed file type/);
+  });
+
+  withFixture((root) => {
+    const path = join(root, "deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in");
+    chmodSync(path, 0o755);
+    assert.throws(() => validateDeploymentTree(root), /must not be executable/);
+  });
+});

--- a/scripts/payment-v1-linux-runtime-evidence.mjs
+++ b/scripts/payment-v1-linux-runtime-evidence.mjs
@@ -1,0 +1,1602 @@
+#!/usr/bin/env node
+
+// Production runtime evidence is collected and checked in one root-owned Linux
+// process.  Offline JSON is only meaningful when its complete SHA-256 digest is
+// approved out of band; this program never accepts caller-authored JSON in the
+// collect-live path.
+
+import { spawnSync } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  readSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  RUNTIME_COLLECTOR,
+  RUNTIME_SYSTEMCTL_SHOW_PROPERTIES,
+  canonicalJson,
+  parseStrictJson,
+  runtimeRequestFromManifest,
+} from "./payment-v1-rendered-artifact-gate.mjs";
+
+export const LIVE_EVIDENCE_KIND = "bitcoinpir-payment-v1-linux-root-live-v1";
+const LIVE_SCHEMA_VERSION = 1;
+const MAX_JSON_BYTES = 8 * 1024 * 1024;
+const MAX_COMMAND_OUTPUT_BYTES = 2 * 1024 * 1024;
+const MAX_COLLECTION_SECONDS = 120;
+const MAX_PROC_STAT_BYTES = 16 * 1024;
+const MAX_PROC_STATUS_BYTES = 256 * 1024;
+const REVIEWED_ONESHOT_UNIT = "bitcoinpir-lightning-preflight.service";
+const REVIEWED_ONESHOT_FRAGMENT = "/etc/systemd/system/bitcoinpir-lightning-preflight.service";
+const REQUIRED_COMMANDS = Object.freeze([
+  "/usr/bin/getent",
+  "/usr/bin/getfacl",
+  "/usr/bin/getfattr",
+  "/usr/bin/id",
+  "/usr/bin/setpriv",
+  "/usr/bin/sha256sum",
+  "/usr/bin/stat",
+  "/usr/bin/systemctl",
+  "/usr/bin/systemd-analyze",
+  "/usr/bin/test",
+  "/usr/bin/uname",
+  "/usr/sbin/getcap",
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function hashBytes(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function validateDigest(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value) || /^0{64}$/u.test(value)) {
+    fail(`${label} must be a non-zero lowercase SHA-256 digest`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (canonicalJson(actual) !== canonicalJson(expected)) {
+    fail(`${label} keys must equal ${JSON.stringify(expected)}`);
+  }
+}
+
+function validateAbsolutePath(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length < 2 ||
+    value.length > 512 ||
+    !value.startsWith("/") ||
+    value.includes("\\") ||
+    !/^\/[A-Za-z0-9._/-]+$/u.test(value) ||
+    resolve(value) !== value
+  ) {
+    fail(`${label} must be one canonical absolute ASCII path`);
+  }
+  return value;
+}
+
+function validateUuid(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u.test(value)) {
+    fail(`${label} must be a lowercase UUID`);
+  }
+}
+
+function readOneLinkRegular(path, label, maxBytes = MAX_JSON_BYTES) {
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) {
+    fail(`${label} must be a one-link regular file: ${path}`);
+  }
+  if (realpathSync(path) !== path) fail(`${label} resolves through a symlink: ${path}`);
+  if (!Number.isSafeInteger(stat.size) || stat.size < 0 || stat.size > maxBytes) {
+    fail(`${label} exceeds its size limit: ${path}`);
+  }
+  return readFileSync(path);
+}
+
+function strictJsonBytes(bytes, label) {
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    fail(`${label} is not UTF-8`);
+  }
+  return parseStrictJson(text, label);
+}
+
+function readPinnedBundle(bundleRoot, manifestPin, planPin) {
+  const canonicalRoot = realpathSync(resolve(bundleRoot));
+  if (canonicalRoot !== resolve(bundleRoot) || !lstatSync(canonicalRoot).isDirectory()) {
+    fail("bundle root must be a canonical real directory");
+  }
+  const manifestPath = `${canonicalRoot}/payment-v1-manifest.json`;
+  const manifestBytes = readOneLinkRegular(manifestPath, "rendered manifest");
+  if (hashBytes(manifestBytes) !== manifestPin) {
+    fail("rendered manifest does not match the externally approved manifest SHA-256");
+  }
+  const manifest = strictJsonBytes(manifestBytes, "rendered manifest");
+  if (manifest.approved_plan_sha256 !== planPin || manifest.plan_sha256 !== planPin) {
+    fail("rendered manifest does not match the externally approved plan SHA-256");
+  }
+  const request = runtimeRequestFromManifest(manifest, manifestPin);
+  const requestPath = `${canonicalRoot}/runtime-evidence-request.json`;
+  const requestBytes = readOneLinkRegular(requestPath, "runtime evidence request");
+  if (!requestBytes.equals(Buffer.from(canonicalJson(request)))) {
+    fail("bundled runtime request is not the deterministic manifest-derived request");
+  }
+  return { manifest, request };
+}
+
+function runAbsolute(command, args, { allowOutput = true, timeout = 10_000 } = {}) {
+  validateAbsolutePath(command, "subprocess executable");
+  if (!REQUIRED_COMMANDS.includes(command)) fail(`subprocess executable is not reviewed: ${command}`);
+  if (!Array.isArray(args) || args.some((entry) => typeof entry !== "string" || /[\0\r\n]/u.test(entry))) {
+    fail(`subprocess argv is malformed for ${command}`);
+  }
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    env: { LC_ALL: "C", PATH: "/usr/sbin:/usr/bin" },
+    maxBuffer: MAX_COMMAND_OUTPUT_BYTES,
+    shell: false,
+    timeout,
+  });
+  if (result.error) fail(`${command} failed to execute: ${result.error.message}`);
+  const record = {
+    argv: [command, ...args],
+    exit_status: result.status,
+    stderr: result.stderr ?? "",
+    stdout: result.stdout ?? "",
+  };
+  if (!allowOutput && (record.stdout !== "" || record.stderr !== "")) {
+    fail(`${command} unexpectedly produced output`);
+  }
+  return record;
+}
+
+function inspectTrustedCommand(path) {
+  const stat = lstatSync(path);
+  if (
+    !stat.isFile() ||
+    stat.isSymbolicLink() ||
+    stat.uid !== 0 ||
+    stat.nlink !== 1 ||
+    (stat.mode & 0o022) !== 0 ||
+    realpathSync(path) !== path
+  ) {
+    fail(`runtime helper is not a root-owned, one-link, non-writable regular file: ${path}`);
+  }
+  return {
+    gid: stat.gid,
+    mode: (stat.mode & 0o7777).toString(8).padStart(4, "0"),
+    nlink: stat.nlink,
+    path,
+    sha256: hashBytes(readFileSync(path)),
+    uid: stat.uid,
+  };
+}
+
+function stableStat(stat) {
+  return {
+    dev: stat.dev.toString(),
+    gid: stat.gid,
+    ino: stat.ino.toString(),
+    mode: (stat.mode & 0o7777).toString(8).padStart(4, "0"),
+    nlink: stat.nlink,
+    size: stat.size,
+    uid: stat.uid,
+  };
+}
+
+function collectExtendedMetadata(path, expectedType) {
+  const statRecord = runAbsolute("/usr/bin/stat", ["-c", "%d:%i:%u:%g:%a:%h:%s:%F", "--", path]);
+  if (statRecord.exit_status !== 0 || statRecord.stderr !== "") fail(`stat failed for ${path}`);
+  const nodeStat = lstatSync(path);
+  const expectedStatLine = `${nodeStat.dev}:${nodeStat.ino}:${nodeStat.uid}:${nodeStat.gid}:${(
+    nodeStat.mode & 0o7777
+  ).toString(8)}:${nodeStat.nlink}:${nodeStat.size}:${expectedType === "regular" ? "regular file" : "directory"}\n`;
+  if (statRecord.stdout !== expectedStatLine) fail(`independent stat mismatch for ${path}`);
+
+  const acl = runAbsolute("/usr/bin/getfacl", ["-c", "-p", "-n", "--", path]);
+  if (acl.exit_status !== 0 || acl.stderr !== "") fail(`getfacl failed for ${path}`);
+  if (/^(?:default:|mask:|user:[^:]|group:[^:])/mu.test(acl.stdout)) {
+    fail(`extended or named ACL is forbidden: ${path}`);
+  }
+
+  const xattrs = runAbsolute("/usr/bin/getfattr", ["--absolute-names", "--dump", "--match", "-", "--", path]);
+  if (xattrs.exit_status !== 0 || xattrs.stderr !== "") fail(`getfattr failed for ${path}`);
+  const xattrPayload = xattrs.stdout.split("\n").filter((line) => line !== "" && !line.startsWith("#"));
+  if (xattrPayload.length !== 0) fail(`extended attributes are forbidden: ${path}`);
+
+  const capabilities = runAbsolute("/usr/sbin/getcap", ["-n", "--", path]);
+  if (capabilities.exit_status !== 0 || capabilities.stderr !== "" || capabilities.stdout !== "") {
+    fail(`file capabilities are forbidden: ${path}`);
+  }
+  return {
+    acl_sha256: hashBytes(Buffer.from(acl.stdout)),
+    capability_sha256: hashBytes(Buffer.from(capabilities.stdout)),
+    expected_type: expectedType,
+    stat_command_sha256: hashBytes(Buffer.from(statRecord.stdout)),
+    xattr_sha256: hashBytes(Buffer.from(xattrs.stdout)),
+  };
+}
+
+function collectInstalledFile(expected) {
+  const path = expected.target_path;
+  const before = lstatSync(path);
+  if (!before.isFile() || before.isSymbolicLink() || realpathSync(path) !== path) {
+    fail(`installed artifact is not a canonical regular file: ${path}`);
+  }
+  const fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const opened = fstatSync(fd);
+    const bytes = readFileSync(fd);
+    const after = fstatSync(fd);
+    if (canonicalJson(stableStat(opened)) !== canonicalJson(stableStat(after))) {
+      fail(`installed artifact metadata changed while hashing: ${path}`);
+    }
+    const sha256Command = runAbsolute("/usr/bin/sha256sum", ["--binary", "--", path]);
+    const shaMatch = /^([0-9a-f]{64}) \*.+\n$/u.exec(sha256Command.stdout);
+    if (sha256Command.exit_status !== 0 || sha256Command.stderr !== "" || !shaMatch) {
+      fail(`sha256sum failed for ${path}`);
+    }
+    const observed = {
+      ...stableStat(after),
+      file_type: "regular",
+      sha256: hashBytes(bytes),
+      sha256_command_sha256: hashBytes(Buffer.from(sha256Command.stdout)),
+      target_path: path,
+      ...collectExtendedMetadata(path, "regular"),
+    };
+    if (shaMatch[1] !== observed.sha256) fail(`independent SHA-256 mismatch: ${path}`);
+    for (const key of ["gid", "mode", "nlink", "sha256", "uid"]) {
+      if (observed[key] !== expected[key]) fail(`installed artifact ${key} mismatch: ${path}`);
+    }
+    return observed;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function parseGetentLine(record, label) {
+  if (record.exit_status !== 0 || record.stderr !== "") fail(`${label} NSS lookup failed`);
+  const line = record.stdout.trim();
+  if (line === "" || line.includes("\n")) fail(`${label} NSS lookup was ambiguous`);
+  return line.split(":");
+}
+
+function collectNss(request) {
+  const userNames = new Set();
+  const groupNames = new Set();
+  for (const unit of request.units) {
+    for (const value of unit.hardening.User ?? []) userNames.add(value);
+    for (const value of unit.hardening.Group ?? []) groupNames.add(value);
+    for (const directive of unit.hardening.SupplementaryGroups ?? []) {
+      for (const value of directive.split(/\s+/u)) groupNames.add(value);
+    }
+  }
+  for (const directory of request.tmpfiles_directories) {
+    userNames.add(directory.user_name);
+    groupNames.add(directory.group_name);
+  }
+  const users = [...userNames].sort().map((name) => {
+    const fields = parseGetentLine(runAbsolute("/usr/bin/getent", ["passwd", name]), `user ${name}`);
+    if (fields.length !== 7 || fields[0] !== name) fail(`user ${name} has malformed NSS data`);
+    const groupsRecord = runAbsolute("/usr/bin/id", ["-G", name]);
+    if (groupsRecord.exit_status !== 0 || groupsRecord.stderr !== "") fail(`id -G failed for ${name}`);
+    const supplementaryGids = groupsRecord.stdout.trim().split(/\s+/u).map(Number);
+    if (supplementaryGids.some((gid) => !Number.isSafeInteger(gid) || gid < 1)) {
+      fail(`user ${name} has malformed group membership`);
+    }
+    return {
+      name,
+      primary_gid: Number(fields[3]),
+      supplementary_gids: [...new Set(supplementaryGids)].sort((left, right) => left - right),
+      uid: Number(fields[2]),
+    };
+  });
+  const groups = [...groupNames].sort().map((name) => {
+    const fields = parseGetentLine(runAbsolute("/usr/bin/getent", ["group", name]), `group ${name}`);
+    if (fields.length !== 4 || fields[0] !== name) fail(`group ${name} has malformed NSS data`);
+    return {
+      gid: Number(fields[2]),
+      members: fields[3] === "" ? [] : fields[3].split(",").sort(),
+      name,
+    };
+  });
+  return { groups, users };
+}
+
+function collectTmpfilesDirectory(expected, nss) {
+  const user = nss.users.find((entry) => entry.name === expected.user_name);
+  const group = nss.groups.find((entry) => entry.name === expected.group_name);
+  if (!user || !group) fail(`tmpfiles directory has unresolved NSS owner: ${expected.target_path}`);
+  const stat = lstatSync(expected.target_path);
+  if (!stat.isDirectory() || stat.isSymbolicLink() || realpathSync(expected.target_path) !== expected.target_path) {
+    fail(`tmpfiles target is not a canonical directory: ${expected.target_path}`);
+  }
+  const observed = {
+    ...stableStat(stat),
+    file_type: "directory",
+    group_name: expected.group_name,
+    target_path: expected.target_path,
+    user_name: expected.user_name,
+    ...collectExtendedMetadata(expected.target_path, "directory"),
+  };
+  if (observed.uid !== user.uid || observed.gid !== group.gid || observed.mode !== expected.mode) {
+    fail(`tmpfiles directory owner or mode mismatch: ${expected.target_path}`);
+  }
+  return observed;
+}
+
+function secretParentPaths(secretFiles) {
+  const paths = new Set();
+  for (const secret of secretFiles) {
+    let cursor = dirname(secret.target_path);
+    for (;;) {
+      paths.add(cursor);
+      if (cursor === "/") break;
+      cursor = dirname(cursor);
+    }
+  }
+  return [...paths].sort();
+}
+
+function collectSecretParentDirectory(path) {
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink() || realpathSync(path) !== path) {
+    fail(`secret parent is not a canonical directory: ${path}`);
+  }
+  return {
+    ...stableStat(stat),
+    file_type: "directory",
+    target_path: path,
+    ...collectExtendedMetadata(path, "directory"),
+  };
+}
+
+function secretProbeArgv(identity, targetPath) {
+  return [
+    "/usr/bin/setpriv",
+    "--no-new-privs",
+    "--inh-caps=-all",
+    "--ambient-caps=-all",
+    "--bounding-set=-all",
+    "--reuid", String(identity.uid),
+    "--regid", String(identity.gid),
+    "--groups", identity.groups.join(","),
+    "--",
+    "/usr/bin/test",
+    "-r",
+    targetPath,
+  ];
+}
+
+function collectSecretAccessChecks(request, nss) {
+  const checks = [];
+  for (const secret of request.secret_files) {
+    const consumer = request.service_identities.find(
+      (identity) => identity.unit_name === secret.consumer_unit_name,
+    );
+    if (!consumer) fail(`secret consumer identity is missing: ${secret.target_path}`);
+    for (const identity of request.service_identities) {
+      const unit = request.units.find((entry) => entry.unit_name === identity.unit_name);
+      if (!unit) fail(`secret access probe unit is missing: ${identity.unit_name}`);
+      const expectedIdentity = resolveExpectedUnitProcessIdentity(
+        unit,
+        nss,
+        request.service_identities,
+      );
+      const expectedReadable = identity.unit_name === consumer.unit_name;
+      const argv = secretProbeArgv(expectedIdentity, secret.target_path);
+      const record = runAbsolute(argv[0], argv.slice(1));
+      if (record.stdout !== "" || record.stderr !== "") {
+        fail(`secret access probe produced output: ${identity.unit_name} -> ${secret.target_path}`);
+      }
+      if (record.exit_status !== (expectedReadable ? 0 : 1)) {
+        fail(
+          `secret access isolation failed: ${identity.unit_name} -> ${secret.target_path}`,
+        );
+      }
+      checks.push({
+        argv: record.argv,
+        exit_status: record.exit_status,
+        expected_readable: expectedReadable,
+        stderr: record.stderr,
+        stdout: record.stdout,
+        target_path: secret.target_path,
+        unit_name: identity.unit_name,
+      });
+    }
+  }
+  return checks;
+}
+
+function nssMaps(nss) {
+  return {
+    groupsByName: new Map(nss.groups.map((group) => [group.name, group])),
+    usersByName: new Map(nss.users.map((user) => [user.name, user])),
+  };
+}
+
+function resolveExpectedUnitProcessIdentity(unit, nss, serviceIdentities) {
+  const { groupsByName, usersByName } = nssMaps(nss);
+  const userName = unit.hardening.User?.[0];
+  const groupName = unit.hardening.Group?.[0];
+  const user = usersByName.get(userName);
+  const group = groupsByName.get(groupName);
+  const pinned = serviceIdentities.find((identity) => identity.unit_name === unit.unit_name);
+  if (
+    !user ||
+    !group ||
+    !pinned ||
+    pinned.user_name !== userName ||
+    pinned.group_name !== groupName ||
+    pinned.uid !== user.uid ||
+    pinned.gid !== group.gid ||
+    !Number.isSafeInteger(user.uid) ||
+    user.uid < 1 ||
+    !Number.isSafeInteger(group.gid) ||
+    group.gid < 1 ||
+    user.primary_gid !== group.gid
+  ) {
+    fail(`unit has unresolved or inconsistent runtime identity: ${unit.unit_name}`);
+  }
+  const gids = new Set([group.gid]);
+  for (const directive of unit.hardening.SupplementaryGroups ?? []) {
+    for (const supplementaryName of directive.split(/\s+/u)) {
+      const supplementary = groupsByName.get(supplementaryName);
+      if (!supplementary || !Number.isSafeInteger(supplementary.gid) || supplementary.gid < 1) {
+        fail(`unit supplementary group is unresolved: ${unit.unit_name}.${supplementaryName}`);
+      }
+      gids.add(supplementary.gid);
+    }
+  }
+  return {
+    gid: group.gid,
+    groups: [...gids].sort((left, right) => left - right),
+    uid: user.uid,
+  };
+}
+
+function readBoundedProcFile(path, label, maxBytes) {
+  const before = lstatSync(path);
+  if (
+    !before.isFile() ||
+    before.isSymbolicLink() ||
+    before.nlink !== 1 ||
+    (before.mode & 0o222) !== 0 ||
+    realpathSync(path) !== path
+  ) {
+    fail(`${label} is not a canonical read-only one-link procfs file`);
+  }
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_NOFOLLOW | (constants.O_CLOEXEC ?? 0),
+  );
+  try {
+    const opened = fstatSync(fd);
+    if (
+      !opened.isFile() ||
+      opened.dev !== before.dev ||
+      opened.ino !== before.ino ||
+      (opened.mode & 0o222) !== 0
+    ) {
+      fail(`${label} changed before it could be opened safely`);
+    }
+    const buffer = Buffer.allocUnsafe(maxBytes + 1);
+    let offset = 0;
+    while (offset <= maxBytes) {
+      const count = readSync(fd, buffer, offset, maxBytes + 1 - offset, null);
+      if (count === 0) break;
+      offset += count;
+    }
+    if (offset > maxBytes) fail(`${label} exceeds its reviewed size bound`);
+    const after = fstatSync(fd);
+    if (after.dev !== opened.dev || after.ino !== opened.ino || (after.mode & 0o222) !== 0) {
+      fail(`${label} metadata changed while it was read`);
+    }
+    return buffer.subarray(0, offset);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function decodeProcText(bytes, label) {
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    fail(`${label} is not valid UTF-8`);
+  }
+  if (text.includes("\0")) fail(`${label} contains NUL`);
+  return text;
+}
+
+function parseProcStat(bytes, pid) {
+  const label = `/proc/${pid}/stat`;
+  const text = decodeProcText(bytes, label).trimEnd();
+  const prefix = `${pid} (`;
+  const close = text.lastIndexOf(")");
+  if (!text.startsWith(prefix) || close < prefix.length || text[close + 1] !== " ") {
+    fail(`${label} has malformed pid/comm framing`);
+  }
+  const fields = text.slice(close + 2).split(/\s+/u);
+  if (fields.length < 20 || !/^[A-Za-z]$/u.test(fields[0])) {
+    fail(`${label} has an incomplete field layout`);
+  }
+  const startTimeTicks = fields[19];
+  if (!/^[1-9][0-9]*$/u.test(startTimeTicks)) fail(`${label} has malformed starttime`);
+  if (["X", "x", "Z"].includes(fields[0])) fail(`${label} describes a dead process`);
+  return { processState: fields[0], startTimeTicks };
+}
+
+function parseProcStatus(bytes, pid) {
+  const label = `/proc/${pid}/status`;
+  const lines = decodeProcText(bytes, label).split("\n");
+  const field = (name) => {
+    const matches = lines.filter((line) => line.startsWith(`${name}:`));
+    if (matches.length !== 1) fail(`${label} must contain exactly one ${name}: field`);
+    return matches[0].slice(name.length + 1).trim();
+  };
+  const parseIds = (name, count) => {
+    const tokens = field(name).split(/\s+/u);
+    if (tokens.length !== count || tokens.some((token) => !/^(?:0|[1-9][0-9]*)$/u.test(token))) {
+      fail(`${label} has malformed ${name}: values`);
+    }
+    const values = tokens.map(Number);
+    if (values.some((value) => !Number.isSafeInteger(value) || value < 0)) {
+      fail(`${label} has out-of-range ${name}: values`);
+    }
+    return values;
+  };
+  const observedPid = parseIds("Pid", 1)[0];
+  if (observedPid !== pid) fail(`${label} belongs to a different process`);
+  const groupsText = field("Groups");
+  const groups = groupsText === "" ? [] : groupsText.split(/\s+/u).map((token) => {
+    if (!/^(?:0|[1-9][0-9]*)$/u.test(token)) fail(`${label} has malformed Groups: values`);
+    const gid = Number(token);
+    if (!Number.isSafeInteger(gid) || gid < 0) fail(`${label} has out-of-range Groups: values`);
+    return gid;
+  });
+  if (new Set(groups).size !== groups.length) fail(`${label} repeats a Groups: value`);
+  return {
+    gid: parseIds("Gid", 4),
+    groups: [...groups].sort((left, right) => left - right),
+    uid: parseIds("Uid", 4),
+  };
+}
+
+function inspectProcDirectory(pid) {
+  const path = `/proc/${pid}`;
+  const stat = lstatSync(path);
+  if (!stat.isDirectory() || stat.isSymbolicLink() || realpathSync(path) !== path) {
+    fail(`process directory is not a canonical procfs directory: ${path}`);
+  }
+  return { dev: stat.dev.toString(), ino: stat.ino.toString() };
+}
+
+function collectProcIdentitySnapshot(pid) {
+  const directoryBefore = inspectProcDirectory(pid);
+  const statBefore = parseProcStat(
+    readBoundedProcFile(`/proc/${pid}/stat`, `process ${pid} stat`, MAX_PROC_STAT_BYTES),
+    pid,
+  );
+  const identity = parseProcStatus(
+    readBoundedProcFile(`/proc/${pid}/status`, `process ${pid} status`, MAX_PROC_STATUS_BYTES),
+    pid,
+  );
+  const statAfter = parseProcStat(
+    readBoundedProcFile(`/proc/${pid}/stat`, `process ${pid} stat confirmation`, MAX_PROC_STAT_BYTES),
+    pid,
+  );
+  const directoryAfter = inspectProcDirectory(pid);
+  if (
+    canonicalJson(directoryBefore) !== canonicalJson(directoryAfter) ||
+    statBefore.startTimeTicks !== statAfter.startTimeTicks
+  ) {
+    fail(`process ${pid} restarted while its procfs identity was collected`);
+  }
+  return {
+    ...identity,
+    procDirectoryDev: directoryAfter.dev,
+    procDirectoryIno: directoryAfter.ino,
+    processState: statAfter.processState,
+    startTimeTicks: statAfter.startTimeTicks,
+  };
+}
+
+const EFFECTIVE_CRITICAL_KEYS = Object.freeze([
+  "AmbientCapabilities",
+  "CapabilityBoundingSet",
+  "Group",
+  "IPAddressAllow",
+  "IPAddressDeny",
+  "InaccessiblePaths",
+  "LockPersonality",
+  "MemoryDenyWriteExecute",
+  "NoNewPrivileges",
+  "PrivateDevices",
+  "PrivateTmp",
+  "ProtectClock",
+  "ProtectControlGroups",
+  "ProtectHome",
+  "ProtectHostname",
+  "ProtectKernelLogs",
+  "ProtectKernelModules",
+  "ProtectKernelTunables",
+  "ProtectSystem",
+  "ReadOnlyPaths",
+  "ReadWritePaths",
+  "RemainAfterExit",
+  "Restart",
+  "RestrictAddressFamilies",
+  "RestrictNamespaces",
+  "RestrictRealtime",
+  "RestrictSUIDSGID",
+  "SupplementaryGroups",
+  "SystemCallArchitectures",
+  "Type",
+  "UMask",
+  "User",
+  "WorkingDirectory",
+]);
+
+const EFFECTIVE_BASE_PROPERTIES = Object.freeze([
+  "ActiveEnterTimestampMonotonic",
+  "ActiveState",
+  "BindPaths",
+  "BindReadOnlyPaths",
+  "ConditionResult",
+  "Conditions",
+  "DropInPaths",
+  "Environment",
+  "EnvironmentFiles",
+  "ExecCondition",
+  "ExecMainCode",
+  "ExecMainStatus",
+  "ExecStart",
+  "ExecStartPost",
+  "ExecStartPre",
+  "FragmentPath",
+  "InvocationID",
+  "LoadCredential",
+  "LoadState",
+  "MainPID",
+  "Result",
+  "RootDirectory",
+  "RootImage",
+  "SetCredential",
+  "SubState",
+]);
+
+function effectivePropertyNames() {
+  const local = [...new Set([...EFFECTIVE_BASE_PROPERTIES, ...EFFECTIVE_CRITICAL_KEYS])].sort();
+  if (canonicalJson(local) !== canonicalJson(RUNTIME_SYSTEMCTL_SHOW_PROPERTIES)) {
+    fail("collector and rendered runtime systemctl property schemas diverged");
+  }
+  return [...RUNTIME_SYSTEMCTL_SHOW_PROPERTIES];
+}
+
+function splitLiteralWords(value) {
+  if (value === "") return [];
+  if (/[$%`;&|<>\r\n\0]/u.test(value)) fail("systemctl effective value contains dynamic syntax");
+  return value
+    .trim()
+    .split(/\s+/u)
+    .map((word) => word.replace(/^"(.*)"$/u, "$1"))
+    .sort();
+}
+
+function expectedWords(values) {
+  return values.flatMap((value) => value.split(/\s+/u)).sort();
+}
+
+function extractExecArgv(value, label) {
+  if (value === "") return [];
+  const result = [];
+  for (const match of value.matchAll(/(?:^|\s*;\s*)\{[^{}]*?argv\[\]=(.+?)\s*;\s*ignore_errors=/gu)) {
+    result.push(match[1].trim());
+  }
+  if (result.length === 0) fail(`${label} has an unreviewed systemctl Exec serialization`);
+  return result;
+}
+
+function parseUnsignedDecimal(value, label, { allowZero = true } = {}) {
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    fail(`${label} is not a canonical unsigned decimal`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0 || (!allowZero && parsed === 0)) {
+    fail(`${label} is outside the reviewed safe-integer range`);
+  }
+  return parsed;
+}
+
+function validateUnitLifecycle(unit, properties, uptimeFinishedMilliseconds) {
+  if (properties.ActiveState !== "active") fail(`unit is not active: ${unit.unit_name}`);
+  if (properties.ConditionResult !== "yes") fail(`unit conditions did not pass: ${unit.unit_name}`);
+  if (!/^[0-9a-f]{32}$/u.test(properties.InvocationID) || /^0{32}$/u.test(properties.InvocationID)) {
+    fail(`unit InvocationID is not a canonical non-zero generation id: ${unit.unit_name}`);
+  }
+  const activeEnterMicroseconds = parseUnsignedDecimal(
+    properties.ActiveEnterTimestampMonotonic,
+    `${unit.unit_name}.ActiveEnterTimestampMonotonic`,
+    { allowZero: false },
+  );
+  if (
+    uptimeFinishedMilliseconds !== undefined &&
+    activeEnterMicroseconds > uptimeFinishedMilliseconds * 1000
+  ) {
+    fail(`unit activation timestamp is not bound to this boot: ${unit.unit_name}`);
+  }
+  const mainPid = parseUnsignedDecimal(properties.MainPID, `${unit.unit_name}.MainPID`);
+  if (properties.Type === "oneshot") {
+    if (
+      unit.unit_name !== REVIEWED_ONESHOT_UNIT ||
+      unit.fragment_path !== REVIEWED_ONESHOT_FRAGMENT ||
+      canonicalJson(unit.hardening.Type ?? []) !== canonicalJson(["oneshot"]) ||
+      canonicalJson(unit.hardening.RemainAfterExit ?? []) !== canonicalJson(["yes"])
+    ) {
+      fail(`unit is not the uniquely reviewed successful oneshot: ${unit.unit_name}`);
+    }
+    if (
+      mainPid !== 0 ||
+      properties.SubState !== "exited" ||
+      properties.Result !== "success" ||
+      properties.ExecMainCode !== "1" ||
+      properties.ExecMainStatus !== "0"
+    ) {
+      fail(`reviewed oneshot completion proof failed: ${unit.unit_name}`);
+    }
+    return { kind: "successful-oneshot", mainPid };
+  }
+  if (!["simple", "notify"].includes(properties.Type)) {
+    fail(`unit has an unreviewed long-running Type: ${unit.unit_name}`);
+  }
+  if (mainPid === 0 || properties.SubState !== "running") {
+    fail(`long-running unit has no active MainPID: ${unit.unit_name}`);
+  }
+  return { kind: "long-running", mainPid };
+}
+
+function validateEffectiveUnitProperties(unit, properties, uptimeFinishedMilliseconds) {
+  exactKeys(properties, effectivePropertyNames(), `effective properties for ${unit.unit_name}`);
+  if (properties.FragmentPath !== unit.fragment_path) fail(`FragmentPath drift: ${unit.unit_name}`);
+  if (properties.DropInPaths !== "") fail(`systemd drop-ins are forbidden: ${unit.unit_name}`);
+  if (properties.LoadState !== "loaded") fail(`unit is not loaded: ${unit.unit_name}`);
+  if (unit.conditions.length > 0 && properties.Conditions === "") {
+    fail(`effective conditions are missing: ${unit.unit_name}`);
+  }
+  for (const condition of unit.conditions) {
+    const separator = condition.indexOf("=");
+    const key = condition.slice(0, separator);
+    const value = condition.slice(separator + 1);
+    if (!properties.Conditions.includes(key) || !properties.Conditions.includes(value)) {
+      fail(`effective condition drift: ${unit.unit_name}`);
+    }
+  }
+  for (const forbidden of [
+    "ExecStartPost",
+    "ExecCondition",
+    "EnvironmentFiles",
+    "RootDirectory",
+    "RootImage",
+    "BindPaths",
+    "BindReadOnlyPaths",
+    "LoadCredential",
+    "SetCredential",
+  ]) {
+    if (properties[forbidden] !== "") fail(`effective ${forbidden} is forbidden: ${unit.unit_name}`);
+  }
+  const actualStart = extractExecArgv(properties.ExecStart, `${unit.unit_name}.ExecStart`);
+  const actualPre = extractExecArgv(properties.ExecStartPre, `${unit.unit_name}.ExecStartPre`);
+  if (canonicalJson(actualStart) !== canonicalJson(unit.exec_start)) fail(`effective ExecStart drift: ${unit.unit_name}`);
+  if (canonicalJson(actualPre) !== canonicalJson(unit.exec_start_pre)) fail(`effective ExecStartPre drift: ${unit.unit_name}`);
+  if (canonicalJson(splitLiteralWords(properties.Environment)) !== canonicalJson([...unit.environment].sort())) {
+    fail(`effective Environment drift: ${unit.unit_name}`);
+  }
+  for (const key of EFFECTIVE_CRITICAL_KEYS) {
+    const expected = unit.hardening[key];
+    if (expected === undefined) {
+      continue;
+    }
+    if (expected.length === 1 && expected[0] === "true") {
+      if (!new Set(["yes", "true"]).has(properties[key])) fail(`effective ${key} drift: ${unit.unit_name}`);
+      continue;
+    }
+    if (expected.length === 1 && expected[0] === "") {
+      if (properties[key] !== "") fail(`effective ${key} drift: ${unit.unit_name}`);
+      continue;
+    }
+    if (canonicalJson(splitLiteralWords(properties[key])) !== canonicalJson(expectedWords(expected))) {
+      fail(`effective ${key} drift: ${unit.unit_name}`);
+    }
+  }
+  return validateUnitLifecycle(unit, properties, uptimeFinishedMilliseconds);
+}
+
+function collectSystemctlValue(unitName, property) {
+  const record = runAbsolute("/usr/bin/systemctl", ["show", unitName, `--property=${property}`, "--value"]);
+  if (record.exit_status !== 0 || record.stderr !== "") fail(`systemctl show failed for ${unitName}.${property}`);
+  return record.stdout.replace(/\n$/u, "");
+}
+
+function confirmUnitGeneration(unit, properties) {
+  const confirmation = {
+    active_enter_timestamp_monotonic: collectSystemctlValue(unit.unit_name, "ActiveEnterTimestampMonotonic"),
+    active_state: collectSystemctlValue(unit.unit_name, "ActiveState"),
+    invocation_id: collectSystemctlValue(unit.unit_name, "InvocationID"),
+    main_pid: collectSystemctlValue(unit.unit_name, "MainPID"),
+  };
+  if (
+    confirmation.active_state !== properties.ActiveState ||
+    confirmation.main_pid !== properties.MainPID ||
+    confirmation.invocation_id !== properties.InvocationID ||
+    confirmation.active_enter_timestamp_monotonic !== properties.ActiveEnterTimestampMonotonic
+  ) {
+    fail(`systemd unit generation changed during live collection: ${unit.unit_name}`);
+  }
+  return confirmation;
+}
+
+function assertSnapshotIdentity(snapshot, expected, unitName) {
+  if (
+    canonicalJson(snapshot.uid) !== canonicalJson([expected.uid, expected.uid, expected.uid, expected.uid]) ||
+    canonicalJson(snapshot.gid) !== canonicalJson([expected.gid, expected.gid, expected.gid, expected.gid]) ||
+    canonicalJson(snapshot.groups) !== canonicalJson(expected.groups)
+  ) {
+    fail(`running process identity differs from the reviewed unit identity: ${unitName}`);
+  }
+}
+
+function collectLongRunningProcessIdentity(unit, properties, nss, serviceIdentities) {
+  const pid = parseUnsignedDecimal(properties.MainPID, `${unit.unit_name}.MainPID`, { allowZero: false });
+  const expected = resolveExpectedUnitProcessIdentity(unit, nss, serviceIdentities);
+  const before = collectProcIdentitySnapshot(pid);
+  assertSnapshotIdentity(before, expected, unit.unit_name);
+  const firstConfirmation = confirmUnitGeneration(unit, properties);
+  const middle = collectProcIdentitySnapshot(pid);
+  assertSnapshotIdentity(middle, expected, unit.unit_name);
+  const secondConfirmation = confirmUnitGeneration(unit, properties);
+  const after = collectProcIdentitySnapshot(pid);
+  assertSnapshotIdentity(after, expected, unit.unit_name);
+  for (const snapshot of [middle, after]) {
+    if (
+      snapshot.procDirectoryDev !== before.procDirectoryDev ||
+      snapshot.procDirectoryIno !== before.procDirectoryIno ||
+      snapshot.startTimeTicks !== before.startTimeTicks ||
+      canonicalJson(snapshot.uid) !== canonicalJson(before.uid) ||
+      canonicalJson(snapshot.gid) !== canonicalJson(before.gid) ||
+      canonicalJson(snapshot.groups) !== canonicalJson(before.groups)
+    ) {
+      fail(`running process restarted or changed credentials during live collection: ${unit.unit_name}`);
+    }
+  }
+  return {
+    confirmations: [firstConfirmation, secondConfirmation],
+    evidence: {
+      gid_after: after.gid,
+      gid_before: before.gid,
+      groups_after: after.groups,
+      groups_before: before.groups,
+      main_pid: pid,
+      proc_directory_dev_after: after.procDirectoryDev,
+      proc_directory_dev_before: before.procDirectoryDev,
+      proc_directory_ino_after: after.procDirectoryIno,
+      proc_directory_ino_before: before.procDirectoryIno,
+      process_state_after: after.processState,
+      process_state_before: before.processState,
+      start_time_ticks_after: after.startTimeTicks,
+      start_time_ticks_before: before.startTimeTicks,
+      uid_after: after.uid,
+      uid_before: before.uid,
+    },
+  };
+}
+
+function collectUnit(unit, nss, serviceIdentities, uptimeFinishedMilliseconds) {
+  const properties = Object.create(null);
+  for (const property of effectivePropertyNames()) {
+    properties[property] = collectSystemctlValue(unit.unit_name, property);
+  }
+  const lifecycle = validateEffectiveUnitProperties(unit, properties, uptimeFinishedMilliseconds);
+  let generationConfirmations;
+  let processIdentity;
+  if (lifecycle.kind === "long-running") {
+    const collected = collectLongRunningProcessIdentity(unit, properties, nss, serviceIdentities);
+    generationConfirmations = collected.confirmations;
+    processIdentity = collected.evidence;
+  } else {
+    generationConfirmations = [confirmUnitGeneration(unit, properties), confirmUnitGeneration(unit, properties)];
+    processIdentity = null;
+  }
+  const fragmentBytes = readOneLinkRegular(unit.fragment_path, `systemd fragment ${unit.unit_name}`, 2 * 1024 * 1024);
+  return {
+    fragment_sha256: hashBytes(fragmentBytes),
+    generation_confirmations: generationConfirmations,
+    process_identity: processIdentity,
+    properties,
+    unit_name: unit.unit_name,
+  };
+}
+
+function readHostBinding() {
+  const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+  validateUuid(bootId, "Linux boot id");
+  const machineId = readFileSync("/etc/machine-id");
+  const uptimeText = readFileSync("/proc/uptime", "utf8").trim().split(/\s+/u)[0];
+  const uptimeMilliseconds = Math.floor(Number(uptimeText) * 1000);
+  if (!Number.isSafeInteger(uptimeMilliseconds) || uptimeMilliseconds < 0) fail("Linux uptime is malformed");
+  const kernel = runAbsolute("/usr/bin/uname", ["-r"]);
+  const systemd = runAbsolute("/usr/bin/systemctl", ["--version"]);
+  if (kernel.exit_status !== 0 || kernel.stderr !== "" || systemd.exit_status !== 0 || systemd.stderr !== "") {
+    fail("host version collection failed");
+  }
+  return {
+    boot_id: bootId,
+    kernel_release: kernel.stdout.trim(),
+    machine_id_sha256: hashBytes(machineId),
+    systemd_version: systemd.stdout.split("\n", 1)[0],
+    uptime_milliseconds: uptimeMilliseconds,
+  };
+}
+
+function validateGenerationConfirmations(confirmations, properties, unitName) {
+  if (!Array.isArray(confirmations) || confirmations.length !== 2) {
+    fail(`unit generation confirmations are incomplete: ${unitName}`);
+  }
+  for (const [index, confirmation] of confirmations.entries()) {
+    exactKeys(
+      confirmation,
+      ["active_enter_timestamp_monotonic", "active_state", "invocation_id", "main_pid"],
+      `${unitName} generation confirmation[${index}]`,
+    );
+    if (
+      confirmation.active_enter_timestamp_monotonic !== properties.ActiveEnterTimestampMonotonic ||
+      confirmation.active_state !== properties.ActiveState ||
+      confirmation.invocation_id !== properties.InvocationID ||
+      confirmation.main_pid !== properties.MainPID
+    ) {
+      fail(`unit MainPID or InvocationID changed during collection: ${unitName}`);
+    }
+  }
+}
+
+function validateIdVector(value, expected, label) {
+  if (
+    !Array.isArray(value) ||
+    value.length !== 4 ||
+    value.some((entry) => !Number.isSafeInteger(entry) || entry < 1) ||
+    value.some((entry) => entry !== expected)
+  ) {
+    fail(`${label} does not contain four copies of the expected service id`);
+  }
+}
+
+function validateProcessIdentityEvidence(processIdentity, lifecycle, expectedIdentity, unitName) {
+  if (lifecycle.kind === "successful-oneshot") {
+    if (processIdentity !== null) fail(`reviewed oneshot must not claim procfs process identity: ${unitName}`);
+    return;
+  }
+  exactKeys(
+    processIdentity,
+    [
+      "gid_after",
+      "gid_before",
+      "groups_after",
+      "groups_before",
+      "main_pid",
+      "proc_directory_dev_after",
+      "proc_directory_dev_before",
+      "proc_directory_ino_after",
+      "proc_directory_ino_before",
+      "process_state_after",
+      "process_state_before",
+      "start_time_ticks_after",
+      "start_time_ticks_before",
+      "uid_after",
+      "uid_before",
+    ],
+    `${unitName} procfs process identity`,
+  );
+  if (processIdentity.main_pid !== lifecycle.mainPid || processIdentity.main_pid < 1) {
+    fail(`procfs identity MainPID drift: ${unitName}`);
+  }
+  for (const key of [
+    "proc_directory_dev_before",
+    "proc_directory_dev_after",
+    "proc_directory_ino_before",
+    "proc_directory_ino_after",
+    "start_time_ticks_before",
+    "start_time_ticks_after",
+  ]) {
+    if (typeof processIdentity[key] !== "string" || !/^[1-9][0-9]*$/u.test(processIdentity[key])) {
+      fail(`procfs identity ${key} is malformed: ${unitName}`);
+    }
+  }
+  for (const [beforeKey, afterKey] of [
+    ["proc_directory_dev_before", "proc_directory_dev_after"],
+    ["proc_directory_ino_before", "proc_directory_ino_after"],
+    ["start_time_ticks_before", "start_time_ticks_after"],
+  ]) {
+    if (processIdentity[beforeKey] !== processIdentity[afterKey]) {
+      fail(`procfs process restart race detected: ${unitName}`);
+    }
+  }
+  for (const key of ["process_state_before", "process_state_after"]) {
+    if (typeof processIdentity[key] !== "string" || !/^[A-Za-z]$/u.test(processIdentity[key]) || ["X", "x", "Z"].includes(processIdentity[key])) {
+      fail(`procfs process state is dead or malformed: ${unitName}`);
+    }
+  }
+  validateIdVector(processIdentity.uid_before, expectedIdentity.uid, `${unitName} Uid before`);
+  validateIdVector(processIdentity.uid_after, expectedIdentity.uid, `${unitName} Uid after`);
+  validateIdVector(processIdentity.gid_before, expectedIdentity.gid, `${unitName} Gid before`);
+  validateIdVector(processIdentity.gid_after, expectedIdentity.gid, `${unitName} Gid after`);
+  for (const key of ["groups_before", "groups_after"]) {
+    if (
+      !Array.isArray(processIdentity[key]) ||
+      canonicalJson(processIdentity[key]) !== canonicalJson(expectedIdentity.groups)
+    ) {
+      fail(`procfs process Groups drift: ${unitName}`);
+    }
+  }
+  if (
+    canonicalJson(processIdentity.uid_before) !== canonicalJson(processIdentity.uid_after) ||
+    canonicalJson(processIdentity.gid_before) !== canonicalJson(processIdentity.gid_after) ||
+    canonicalJson(processIdentity.groups_before) !== canonicalJson(processIdentity.groups_after)
+  ) {
+    fail(`procfs process credentials changed during collection: ${unitName}`);
+  }
+}
+
+export function validateLiveRuntimeEvidence({
+  evidence,
+  request,
+  expectedMachineIdSha256,
+  expectedBootId,
+  nowUnixSeconds,
+  maxAgeSeconds = 120,
+}) {
+  exactKeys(
+    evidence,
+    [
+      "approved_plan_sha256",
+      "challenge_hex",
+      "collected_finished_unix_seconds",
+      "collected_started_unix_seconds",
+      "collector",
+      "collector_process",
+      "evidence_kind",
+      "host",
+      "installed_files",
+      "manifest_sha256",
+      "nss",
+      "runtime_directories",
+      "schema_version",
+      "secret_access_checks",
+      "secret_parent_directories",
+      "systemd_analyze_verify",
+      "trusted_commands",
+      "units",
+    ],
+    "live runtime evidence",
+  );
+  if (evidence.schema_version !== LIVE_SCHEMA_VERSION || evidence.evidence_kind !== LIVE_EVIDENCE_KIND) {
+    fail("live runtime evidence schema or kind is not reviewed");
+  }
+  if (evidence.collector !== RUNTIME_COLLECTOR) fail("live runtime collector identity mismatch");
+  if (canonicalJson(request.systemctl_show_properties) !== canonicalJson(RUNTIME_SYSTEMCTL_SHOW_PROPERTIES)) {
+    fail("runtime request systemctl property schema is not the reviewed closed set");
+  }
+  if (!Array.isArray(request.service_identities) || request.service_identities.length !== request.units.length) {
+    fail("runtime request service identity bindings are incomplete");
+  }
+  if (evidence.manifest_sha256 !== request.manifest_sha256 || evidence.approved_plan_sha256 !== request.approved_plan_sha256) {
+    fail("live evidence is not bound to the approved manifest and plan");
+  }
+  if (typeof evidence.challenge_hex !== "string" || !/^[0-9a-f]{64}$/u.test(evidence.challenge_hex) || /^0{64}$/u.test(evidence.challenge_hex)) {
+    fail("live evidence challenge must be an internally random 256-bit value");
+  }
+  const start = evidence.collected_started_unix_seconds;
+  const finish = evidence.collected_finished_unix_seconds;
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(finish) || finish < start || finish - start > MAX_COLLECTION_SECONDS) {
+    fail("live evidence collection window is invalid");
+  }
+  if (!Number.isSafeInteger(nowUnixSeconds) || nowUnixSeconds < finish || nowUnixSeconds - finish > maxAgeSeconds) {
+    fail("live evidence is stale or from the future");
+  }
+  exactKeys(evidence.collector_process, ["egid", "euid", "pid"], "collector process");
+  if (evidence.collector_process.euid !== 0 || evidence.collector_process.egid !== 0) {
+    fail("live collector was not root");
+  }
+  exactKeys(
+    evidence.host,
+    ["boot_id", "kernel_release", "machine_id_sha256", "systemd_version", "uptime_finished_milliseconds", "uptime_started_milliseconds"],
+    "live evidence host",
+  );
+  validateUuid(evidence.host.boot_id, "live evidence boot id");
+  if (evidence.host.machine_id_sha256 !== expectedMachineIdSha256) fail("live evidence came from another host");
+  if (expectedBootId !== undefined && evidence.host.boot_id !== expectedBootId) fail("live evidence came from another boot");
+  if (
+    !Number.isSafeInteger(evidence.host.uptime_started_milliseconds) ||
+    !Number.isSafeInteger(evidence.host.uptime_finished_milliseconds) ||
+    evidence.host.uptime_finished_milliseconds < evidence.host.uptime_started_milliseconds
+  ) fail("live evidence uptime binding is invalid");
+
+  if (!Array.isArray(evidence.trusted_commands) || evidence.trusted_commands.length !== REQUIRED_COMMANDS.length + 1) {
+    fail("live evidence does not bind the complete command TCB");
+  }
+  for (const command of evidence.trusted_commands) {
+    exactKeys(command, ["gid", "mode", "nlink", "path", "sha256", "uid"], "trusted command");
+    validateAbsolutePath(command.path, "trusted command path");
+    validateDigest(command.sha256, "trusted command digest");
+    if (command.uid !== 0 || command.nlink !== 1 || (Number.parseInt(command.mode, 8) & 0o022) !== 0) {
+      fail(`untrusted runtime command metadata: ${command.path}`);
+    }
+  }
+  const commandPaths = evidence.trusted_commands.map((entry) => entry.path).sort();
+  const expectedCommandPaths = [...REQUIRED_COMMANDS, "/usr/bin/node"].sort();
+  if (canonicalJson(commandPaths) !== canonicalJson(expectedCommandPaths)) {
+    fail("live evidence command TCB paths are not closed");
+  }
+
+  if (!Array.isArray(evidence.installed_files) || evidence.installed_files.length !== request.installed_files.length) {
+    fail("live installed-file evidence is incomplete");
+  }
+  for (let index = 0; index < request.installed_files.length; index += 1) {
+    const expected = request.installed_files[index];
+    const actual = evidence.installed_files[index];
+    exactKeys(
+      actual,
+      [
+        "acl_sha256",
+        "capability_sha256",
+        "dev",
+        "expected_type",
+        "file_type",
+        "gid",
+        "ino",
+        "mode",
+        "nlink",
+        "sha256",
+        "sha256_command_sha256",
+        "size",
+        "stat_command_sha256",
+        "target_path",
+        "uid",
+        "xattr_sha256",
+      ],
+      `live installed_files[${index}]`,
+    );
+    for (const key of ["file_type", "gid", "mode", "nlink", "sha256", "target_path", "uid"]) {
+      if (actual[key] !== expected[key]) fail(`live installed-file ${key} drift: ${expected.target_path}`);
+    }
+    for (const key of ["acl_sha256", "capability_sha256", "sha256_command_sha256", "stat_command_sha256", "xattr_sha256"]) {
+      validateDigest(actual[key], `live installed-file ${key}`);
+    }
+  }
+  const expectedSecretParentPaths = secretParentPaths(request.secret_files);
+  if (
+    !Array.isArray(evidence.secret_parent_directories) ||
+    evidence.secret_parent_directories.length !== expectedSecretParentPaths.length
+  ) {
+    fail("live secret parent directory evidence is incomplete");
+  }
+  for (let index = 0; index < expectedSecretParentPaths.length; index += 1) {
+    const actual = evidence.secret_parent_directories[index];
+    exactKeys(
+      actual,
+      [
+        "acl_sha256",
+        "capability_sha256",
+        "dev",
+        "expected_type",
+        "file_type",
+        "gid",
+        "ino",
+        "mode",
+        "nlink",
+        "size",
+        "stat_command_sha256",
+        "target_path",
+        "uid",
+        "xattr_sha256",
+      ],
+      `live secret_parent_directories[${index}]`,
+    );
+    if (actual.target_path !== expectedSecretParentPaths[index] || actual.file_type !== "directory" || actual.expected_type !== "directory") {
+      fail(`live secret parent directory path/type drift: ${expectedSecretParentPaths[index]}`);
+    }
+    for (const key of ["acl_sha256", "capability_sha256", "stat_command_sha256", "xattr_sha256"]) {
+      validateDigest(actual[key], `live secret parent ${key}`);
+    }
+  }
+  if (!Array.isArray(evidence.runtime_directories) || evidence.runtime_directories.length !== request.tmpfiles_directories.length) {
+    fail("live tmpfiles directory evidence is incomplete");
+  }
+  for (let index = 0; index < request.tmpfiles_directories.length; index += 1) {
+    const expected = request.tmpfiles_directories[index];
+    const actual = evidence.runtime_directories[index];
+    exactKeys(
+      actual,
+      [
+        "acl_sha256",
+        "capability_sha256",
+        "dev",
+        "expected_type",
+        "file_type",
+        "gid",
+        "group_name",
+        "ino",
+        "mode",
+        "nlink",
+        "size",
+        "stat_command_sha256",
+        "target_path",
+        "uid",
+        "user_name",
+        "xattr_sha256",
+      ],
+      `live runtime_directories[${index}]`,
+    );
+    if (
+      actual.target_path !== expected.target_path ||
+      actual.mode !== expected.mode ||
+      actual.user_name !== expected.user_name ||
+      actual.group_name !== expected.group_name ||
+      actual.file_type !== "directory"
+    ) fail(`live tmpfiles directory drift: ${expected.target_path}`);
+  }
+  if (!Array.isArray(evidence.units) || evidence.units.length !== request.units.length) {
+    fail("live systemd unit evidence is incomplete");
+  }
+  const lifecycleByUnit = new Map();
+  for (let index = 0; index < request.units.length; index += 1) {
+    const expected = request.units[index];
+    const actual = evidence.units[index];
+    exactKeys(
+      actual,
+      ["fragment_sha256", "generation_confirmations", "process_identity", "properties", "unit_name"],
+      `live units[${index}]`,
+    );
+    if (actual.unit_name !== expected.unit_name || actual.properties.FragmentPath !== expected.fragment_path) {
+      fail(`live systemd unit identity drift: ${expected.unit_name}`);
+    }
+    if (actual.properties.DropInPaths !== "") fail(`live systemd drop-in detected: ${expected.unit_name}`);
+    for (const key of ["ExecStartPost", "ExecCondition", "EnvironmentFiles", "RootDirectory", "RootImage", "BindPaths", "BindReadOnlyPaths", "LoadCredential", "SetCredential"]) {
+      if (actual.properties[key] !== "") fail(`live systemd ${key} is forbidden: ${expected.unit_name}`);
+    }
+    const fragment = request.installed_files.find((file) => file.target_path === expected.fragment_path);
+    if (!fragment || actual.fragment_sha256 !== fragment.sha256) {
+      fail(`live systemd fragment hash drift: ${expected.unit_name}`);
+    }
+    const lifecycle = validateEffectiveUnitProperties(
+      expected,
+      actual.properties,
+      evidence.host.uptime_finished_milliseconds,
+    );
+    validateGenerationConfirmations(actual.generation_confirmations, actual.properties, expected.unit_name);
+    lifecycleByUnit.set(expected.unit_name, lifecycle);
+  }
+  if (
+    evidence.systemd_analyze_verify.exit_status !== 0 ||
+    evidence.systemd_analyze_verify.stdout !== "" ||
+    evidence.systemd_analyze_verify.stderr !== "" ||
+    canonicalJson(evidence.systemd_analyze_verify.argv) !== canonicalJson(request.systemd_analyze_argv)
+  ) fail("live systemd-analyze verify evidence failed");
+  exactKeys(evidence.nss, ["groups", "users"], "live NSS evidence");
+  if (!Array.isArray(evidence.nss.groups) || !Array.isArray(evidence.nss.users)) {
+    fail("live NSS evidence arrays are missing");
+  }
+  const usersByName = new Map(evidence.nss.users.map((user) => [user.name, user]));
+  const groupsByName = new Map(evidence.nss.groups.map((group) => [group.name, group]));
+  if (usersByName.size !== evidence.nss.users.length || groupsByName.size !== evidence.nss.groups.length) {
+    fail("live NSS evidence repeats identities");
+  }
+  if (new Set(evidence.nss.users.map((user) => user.uid)).size !== evidence.nss.users.length) {
+    fail("live NSS evidence aliases service UIDs");
+  }
+  if (new Set(evidence.nss.groups.map((group) => group.gid)).size !== evidence.nss.groups.length) {
+    fail("live NSS evidence aliases service GIDs");
+  }
+  for (const group of evidence.nss.groups) {
+    exactKeys(group, ["gid", "members", "name"], `live NSS group ${group.name ?? "<unknown>"}`);
+    if (!Number.isSafeInteger(group.gid) || group.gid < 1 || !Array.isArray(group.members)) {
+      fail("live NSS group data is malformed");
+    }
+  }
+  for (const user of evidence.nss.users) {
+    exactKeys(user, ["name", "primary_gid", "supplementary_gids", "uid"], `live NSS user ${user.name ?? "<unknown>"}`);
+    if (
+      !Number.isSafeInteger(user.uid) || user.uid < 1 ||
+      !Number.isSafeInteger(user.primary_gid) || user.primary_gid < 1 ||
+      !Array.isArray(user.supplementary_gids)
+    ) fail("live NSS user data is malformed");
+  }
+  for (const group of evidence.nss.groups) {
+    for (const memberName of group.members) {
+      const member = usersByName.get(memberName);
+      if (!member || !member.supplementary_gids.includes(group.gid)) {
+        fail(`live NSS group membership is inconsistent: ${group.name}`);
+      }
+    }
+  }
+  for (const unit of request.units) {
+    const userName = unit.hardening.User?.[0];
+    const groupName = unit.hardening.Group?.[0];
+    const user = usersByName.get(userName);
+    const group = groupsByName.get(groupName);
+    const pinned = request.service_identities.find((identity) => identity.unit_name === unit.unit_name);
+    if (
+      !user ||
+      !group ||
+      !pinned ||
+      pinned.user_name !== userName ||
+      pinned.group_name !== groupName ||
+      pinned.uid !== user.uid ||
+      pinned.gid !== group.gid ||
+      user.uid < 1 ||
+      group.gid < 1 ||
+      user.primary_gid !== group.gid
+    ) {
+      fail(`live NSS primary identity drift: ${unit.unit_name}`);
+    }
+    const expectedGroups = new Set([group.gid]);
+    for (const directive of unit.hardening.SupplementaryGroups ?? []) {
+      for (const supplementaryName of directive.split(/\s+/u)) {
+        const supplementary = groupsByName.get(supplementaryName);
+        if (!supplementary) fail(`live NSS supplementary group missing: ${supplementaryName}`);
+      }
+    }
+    if (
+      canonicalJson([...new Set(user.supplementary_gids)].sort((left, right) => left - right)) !==
+      canonicalJson([...expectedGroups].sort((left, right) => left - right))
+    ) {
+      fail(`live NSS unexpected supplementary group: ${unit.unit_name}`);
+    }
+    const expectedProcessIdentity = resolveExpectedUnitProcessIdentity(
+      unit,
+      evidence.nss,
+      request.service_identities,
+    );
+    const actualUnit = evidence.units.find((entry) => entry.unit_name === unit.unit_name);
+    validateProcessIdentityEvidence(
+      actualUnit?.process_identity,
+      lifecycleByUnit.get(unit.unit_name),
+      expectedProcessIdentity,
+      unit.unit_name,
+    );
+  }
+  const expectedAccessCheckCount = request.secret_files.length * request.service_identities.length;
+  if (!Array.isArray(evidence.secret_access_checks) || evidence.secret_access_checks.length !== expectedAccessCheckCount) {
+    fail("live secret positive/negative access probes are incomplete");
+  }
+  let accessIndex = 0;
+  for (const secret of request.secret_files) {
+    for (const identity of request.service_identities) {
+      const unit = request.units.find((entry) => entry.unit_name === identity.unit_name);
+      const expectedIdentity = resolveExpectedUnitProcessIdentity(
+        unit,
+        evidence.nss,
+        request.service_identities,
+      );
+      const expectedReadable = identity.unit_name === secret.consumer_unit_name;
+      const actual = evidence.secret_access_checks[accessIndex];
+      exactKeys(
+        actual,
+        ["argv", "exit_status", "expected_readable", "stderr", "stdout", "target_path", "unit_name"],
+        `live secret_access_checks[${accessIndex}]`,
+      );
+      if (
+        actual.unit_name !== identity.unit_name ||
+        actual.target_path !== secret.target_path ||
+        actual.expected_readable !== expectedReadable ||
+        actual.exit_status !== (expectedReadable ? 0 : 1) ||
+        actual.stdout !== "" ||
+        actual.stderr !== "" ||
+        canonicalJson(actual.argv) !== canonicalJson(secretProbeArgv(expectedIdentity, secret.target_path))
+      ) {
+        fail(`live secret access isolation evidence failed: ${identity.unit_name} -> ${secret.target_path}`);
+      }
+      accessIndex += 1;
+    }
+  }
+  return true;
+}
+
+export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256, approvedPlanSha256, expectedMachineIdSha256 }) {
+  if (process.platform !== "linux") fail("collect-live is Linux-only");
+  if (
+    process.getuid?.() !== 0 ||
+    process.getgid?.() !== 0 ||
+    process.geteuid?.() !== 0 ||
+    process.getegid?.() !== 0
+  ) fail("collect-live requires real and effective root");
+  if (process.execPath !== "/usr/bin/node") fail("collect-live requires the reviewed absolute /usr/bin/node runtime");
+  validateDigest(approvedManifestSha256, "approved manifest SHA-256");
+  validateDigest(approvedPlanSha256, "approved plan SHA-256");
+  validateDigest(expectedMachineIdSha256, "expected machine-id SHA-256");
+  const { request } = readPinnedBundle(bundleRoot, approvedManifestSha256, approvedPlanSha256);
+  const trustedCommands = [...REQUIRED_COMMANDS, process.execPath].sort().map(inspectTrustedCommand);
+  const started = Math.floor(Date.now() / 1000);
+  const hostStarted = readHostBinding();
+  if (hostStarted.machine_id_sha256 !== expectedMachineIdSha256) fail("collector is running on an unapproved host");
+  const challengeHex = randomBytes(32).toString("hex");
+  const nss = collectNss(request);
+  const installedFiles = request.installed_files.map(collectInstalledFile);
+  const runtimeDirectories = request.tmpfiles_directories.map((entry) => collectTmpfilesDirectory(entry, nss));
+  const secretParentDirectories = secretParentPaths(request.secret_files).map(collectSecretParentDirectory);
+  const secretAccessChecks = collectSecretAccessChecks(request, nss);
+  for (const secret of request.secret_files) {
+    const before = installedFiles.find((entry) => entry.target_path === secret.target_path);
+    const expected = request.installed_files.find((entry) => entry.target_path === secret.target_path);
+    if (!before || !expected) fail(`secret is absent from installed-file closure: ${secret.target_path}`);
+    const after = collectInstalledFile(expected);
+    if (canonicalJson(before) !== canonicalJson(after)) {
+      fail(`secret metadata or content changed around access probes: ${secret.target_path}`);
+    }
+  }
+  const secretParentConfirmation = secretParentPaths(request.secret_files).map(collectSecretParentDirectory);
+  if (canonicalJson(secretParentDirectories) !== canonicalJson(secretParentConfirmation)) {
+    fail("secret parent directory metadata changed around access probes");
+  }
+  const units = request.units.map((unit) =>
+    collectUnit(unit, nss, request.service_identities, hostStarted.uptime_milliseconds),
+  );
+  const analyze = runAbsolute(request.systemd_analyze_argv[0], request.systemd_analyze_argv.slice(1), { allowOutput: false, timeout: 30_000 });
+  if (analyze.exit_status !== 0) fail("systemd-analyze verify failed");
+  const hostFinished = readHostBinding();
+  const finished = Math.floor(Date.now() / 1000);
+  if (hostFinished.boot_id !== hostStarted.boot_id || hostFinished.machine_id_sha256 !== hostStarted.machine_id_sha256) {
+    fail("host or boot identity changed during live collection");
+  }
+  const evidence = {
+    approved_plan_sha256: approvedPlanSha256,
+    challenge_hex: challengeHex,
+    collected_finished_unix_seconds: finished,
+    collected_started_unix_seconds: started,
+    collector: RUNTIME_COLLECTOR,
+    collector_process: { egid: process.getegid(), euid: process.geteuid(), pid: process.pid },
+    evidence_kind: LIVE_EVIDENCE_KIND,
+    host: {
+      boot_id: hostStarted.boot_id,
+      kernel_release: hostStarted.kernel_release,
+      machine_id_sha256: hostStarted.machine_id_sha256,
+      systemd_version: hostStarted.systemd_version,
+      uptime_finished_milliseconds: hostFinished.uptime_milliseconds,
+      uptime_started_milliseconds: hostStarted.uptime_milliseconds,
+    },
+    installed_files: installedFiles,
+    manifest_sha256: approvedManifestSha256,
+    nss,
+    runtime_directories: runtimeDirectories,
+    schema_version: LIVE_SCHEMA_VERSION,
+    secret_access_checks: secretAccessChecks,
+    secret_parent_directories: secretParentDirectories,
+    systemd_analyze_verify: analyze,
+    trusted_commands: trustedCommands,
+    units,
+  };
+  validateLiveRuntimeEvidence({
+    evidence,
+    expectedBootId: hostStarted.boot_id,
+    expectedMachineIdSha256,
+    maxAgeSeconds: 0,
+    nowUnixSeconds: finished,
+    request,
+  });
+  return evidence;
+}
+
+function parseCli(argv) {
+  const command = argv[0];
+  if (!["collect-live", "verify-offline"].includes(command)) {
+    fail("usage: payment-v1-linux-runtime-evidence.mjs <collect-live|verify-offline> --bundle ABS --approved-manifest-sha256 HEX --approved-plan-sha256 HEX --expected-machine-id-sha256 HEX --output ABS | --evidence ABS --trusted-evidence-sha256 HEX --expected-boot-id UUID");
+  }
+  const values = Object.create(null);
+  const allowed = new Set([
+    "--bundle",
+    "--approved-manifest-sha256",
+    "--approved-plan-sha256",
+    "--expected-machine-id-sha256",
+    "--expected-boot-id",
+    "--evidence",
+    "--trusted-evidence-sha256",
+    "--output",
+  ]);
+  for (let index = 1; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.has(flag) || value === undefined || values[flag] !== undefined) {
+      fail(`invalid, repeated, or missing CLI option: ${flag ?? "<missing>"}`);
+    }
+    values[flag] = value;
+  }
+  for (const required of ["--bundle", "--approved-manifest-sha256", "--approved-plan-sha256", "--expected-machine-id-sha256"]) {
+    if (values[required] === undefined) fail(`missing required CLI option ${required}`);
+  }
+  validateAbsolutePath(values["--bundle"], "CLI bundle path");
+  for (const flag of ["--approved-manifest-sha256", "--approved-plan-sha256", "--expected-machine-id-sha256"]) {
+    validateDigest(values[flag], flag);
+  }
+  if (command === "collect-live") {
+    if (values["--output"] === undefined) fail("collect-live requires --output");
+    validateAbsolutePath(values["--output"], "CLI output path");
+    for (const forbidden of ["--evidence", "--trusted-evidence-sha256", "--expected-boot-id"]) {
+      if (values[forbidden] !== undefined) fail(`collect-live forbids caller evidence option ${forbidden}`);
+    }
+  } else {
+    for (const required of ["--evidence", "--trusted-evidence-sha256", "--expected-boot-id"]) {
+      if (values[required] === undefined) fail(`verify-offline requires ${required}`);
+    }
+    if (values["--output"] !== undefined) fail("verify-offline forbids --output");
+    validateAbsolutePath(values["--evidence"], "CLI evidence path");
+    validateDigest(values["--trusted-evidence-sha256"], "trusted evidence SHA-256");
+    validateUuid(values["--expected-boot-id"], "expected boot id");
+  }
+  return { command, values };
+}
+
+function runCli(argv) {
+  const { command, values } = parseCli(argv);
+  const common = {
+    approvedManifestSha256: values["--approved-manifest-sha256"],
+    approvedPlanSha256: values["--approved-plan-sha256"],
+    bundleRoot: values["--bundle"],
+    expectedMachineIdSha256: values["--expected-machine-id-sha256"],
+  };
+  if (command === "collect-live") {
+    if (existsSync(values["--output"])) fail("collect-live refuses to overwrite evidence output");
+    if (realpathSync(dirname(values["--output"])) !== dirname(values["--output"])) {
+      fail("collect-live output parent must be canonical");
+    }
+    const evidence = collectLiveRuntimeEvidence(common);
+    writeFileSync(values["--output"], canonicalJson(evidence), { flag: "wx", mode: 0o600 });
+    process.stdout.write(`payment-v1-linux-runtime-evidence: live PASS challenge=${evidence.challenge_hex}\n`);
+    return;
+  }
+  const { request } = readPinnedBundle(common.bundleRoot, common.approvedManifestSha256, common.approvedPlanSha256);
+  const evidenceBytes = readOneLinkRegular(values["--evidence"], "offline live evidence");
+  if (hashBytes(evidenceBytes) !== values["--trusted-evidence-sha256"]) {
+    fail("offline evidence does not match the out-of-band trusted SHA-256 pin");
+  }
+  const evidence = strictJsonBytes(evidenceBytes, "offline live evidence");
+  validateLiveRuntimeEvidence({
+    evidence,
+    expectedBootId: values["--expected-boot-id"],
+    expectedMachineIdSha256: common.expectedMachineIdSha256,
+    maxAgeSeconds: Number.MAX_SAFE_INTEGER,
+    nowUnixSeconds: evidence.collected_finished_unix_seconds,
+    request,
+  });
+  process.stdout.write("payment-v1-linux-runtime-evidence: offline trusted-pin structure PASS\n");
+}
+
+const isMain = process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isMain) {
+  try {
+    runCli(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`payment-v1-linux-runtime-evidence: FAIL: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/payment-v1-linux-runtime-evidence.test.mjs
+++ b/scripts/payment-v1-linux-runtime-evidence.test.mjs
@@ -1,0 +1,580 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  LIVE_EVIDENCE_KIND,
+  validateLiveRuntimeEvidence,
+} from "./payment-v1-linux-runtime-evidence.mjs";
+import {
+  RUNTIME_COLLECTOR,
+  RUNTIME_SYSTEMCTL_SHOW_PROPERTIES,
+} from "./payment-v1-rendered-artifact-gate.mjs";
+
+const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const COLLECTOR = join(SCRIPT_DIRECTORY, "payment-v1-linux-runtime-evidence.mjs");
+const COMMANDS = [
+  "/usr/bin/getent",
+  "/usr/bin/getfacl",
+  "/usr/bin/getfattr",
+  "/usr/bin/id",
+  "/usr/bin/node",
+  "/usr/bin/setpriv",
+  "/usr/bin/sha256sum",
+  "/usr/bin/stat",
+  "/usr/bin/systemctl",
+  "/usr/bin/systemd-analyze",
+  "/usr/bin/test",
+  "/usr/bin/uname",
+  "/usr/sbin/getcap",
+];
+
+function hash(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function execValue(command) {
+  return `{ path=${command.split(" ", 1)[0]} ; argv[]=${command} ; ignore_errors=no ; start_time=[n/a] ; }`;
+}
+
+function fixture() {
+  const fragmentPath = "/etc/systemd/system/bitcoinpir-test.service";
+  const binaryPath = `/opt/bitcoinpir/test/${hash("binary")}/test`;
+  const unit = {
+    conditions: ["ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED"],
+    environment: ["RUST_LOG=error"],
+    environment_files: [],
+    exec_start: [`${binaryPath} serve --config /etc/bitcoinpir/payment-v1/test/config.toml`],
+    exec_start_pre: ["/usr/bin/test -x /opt/bitcoinpir/test/check"],
+    fragment_path: fragmentPath,
+    hardening: {
+      AmbientCapabilities: [""],
+      CapabilityBoundingSet: [""],
+      Group: ["bitcoinpir-test"],
+      LockPersonality: ["true"],
+      MemoryDenyWriteExecute: ["true"],
+      NoNewPrivileges: ["true"],
+      PrivateDevices: ["true"],
+      PrivateTmp: ["true"],
+      ProtectControlGroups: ["true"],
+      ProtectHome: ["true"],
+      ProtectKernelLogs: ["true"],
+      ProtectKernelModules: ["true"],
+      ProtectKernelTunables: ["true"],
+      ProtectSystem: ["strict"],
+      ReadOnlyPaths: ["/etc/bitcoinpir/payment-v1/test"],
+      Restart: ["no"],
+      RestrictAddressFamilies: ["AF_UNIX", "AF_INET"],
+      RestrictNamespaces: ["true"],
+      RestrictRealtime: ["true"],
+      RestrictSUIDSGID: ["true"],
+      SupplementaryGroups: ["bitcoinpir-shared"],
+      SystemCallArchitectures: ["native"],
+      Type: ["simple"],
+      UMask: ["0077"],
+      User: ["bitcoinpir-test"],
+      WorkingDirectory: ["/var/lib/bitcoinpir-test"],
+    },
+    unit_name: "bitcoinpir-test.service",
+  };
+  const installedFiles = [
+    { file_type: "regular", gid: 0, mode: "0644", nlink: 1, sha256: hash("fragment"), target_path: fragmentPath, uid: 0 },
+    { file_type: "regular", gid: 0, mode: "0555", nlink: 1, sha256: hash("binary"), target_path: binaryPath, uid: 0 },
+  ];
+  const request = {
+    approved_plan_sha256: hash("plan"),
+    collector: RUNTIME_COLLECTOR,
+    deployment_profile: "test",
+    installed_files: installedFiles,
+    manifest_sha256: hash("manifest"),
+    schema_version: 1,
+    secret_files: [],
+    service_identities: [{
+      gid: 731,
+      group_name: "bitcoinpir-test",
+      uid: 730,
+      unit_name: unit.unit_name,
+      user_name: "bitcoinpir-test",
+    }],
+    systemctl_show_properties: RUNTIME_SYSTEMCTL_SHOW_PROPERTIES,
+    systemd_analyze_argv: ["/usr/bin/systemd-analyze", "verify", fragmentPath],
+    tmpfiles_directories: [
+      { group_name: "bitcoinpir-shared", mode: "0710", target_path: "/run/bitcoinpir-test", user_name: "bitcoinpir-test" },
+    ],
+    units: [unit],
+  };
+  const properties = {
+    ActiveEnterTimestampMonotonic: "4000000",
+    ActiveState: "active",
+    AmbientCapabilities: "",
+    BindPaths: "",
+    BindReadOnlyPaths: "",
+    CapabilityBoundingSet: "",
+    ConditionResult: "yes",
+    Conditions: "ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+    DropInPaths: "",
+    Environment: "RUST_LOG=error",
+    EnvironmentFiles: "",
+    ExecCondition: "",
+    ExecMainCode: "0",
+    ExecMainStatus: "0",
+    ExecStart: execValue(unit.exec_start[0]),
+    ExecStartPost: "",
+    ExecStartPre: execValue(unit.exec_start_pre[0]),
+    FragmentPath: fragmentPath,
+    Group: "bitcoinpir-test",
+    IPAddressAllow: "",
+    IPAddressDeny: "",
+    InaccessiblePaths: "",
+    InvocationID: "a".repeat(32),
+    LoadCredential: "",
+    LoadState: "loaded",
+    LockPersonality: "yes",
+    MainPID: "4242",
+    MemoryDenyWriteExecute: "yes",
+    NoNewPrivileges: "yes",
+    PrivateDevices: "yes",
+    PrivateTmp: "yes",
+    ProtectClock: "",
+    ProtectControlGroups: "yes",
+    ProtectHome: "yes",
+    ProtectHostname: "",
+    ProtectKernelLogs: "yes",
+    ProtectKernelModules: "yes",
+    ProtectKernelTunables: "yes",
+    ProtectSystem: "strict",
+    ReadOnlyPaths: "/etc/bitcoinpir/payment-v1/test",
+    ReadWritePaths: "",
+    RemainAfterExit: "no",
+    Restart: "no",
+    Result: "success",
+    RestrictAddressFamilies: "AF_INET AF_UNIX",
+    RestrictNamespaces: "yes",
+    RestrictRealtime: "yes",
+    RestrictSUIDSGID: "yes",
+    RootDirectory: "",
+    RootImage: "",
+    SetCredential: "",
+    SubState: "running",
+    SupplementaryGroups: "bitcoinpir-shared",
+    SystemCallArchitectures: "native",
+    Type: "simple",
+    UMask: "0077",
+    User: "bitcoinpir-test",
+    WorkingDirectory: "/var/lib/bitcoinpir-test",
+  };
+  function richFile(expected, index) {
+    return {
+      acl_sha256: hash(`acl-${index}`),
+      capability_sha256: hash(""),
+      dev: "1",
+      expected_type: "regular",
+      ...expected,
+      ino: String(100 + index),
+      sha256_command_sha256: hash(`sha-command-${index}`),
+      size: 100 + index,
+      stat_command_sha256: hash(`stat-${index}`),
+      xattr_sha256: hash(`xattr-${index}`),
+    };
+  }
+  const machine = hash("machine");
+  const boot = "12345678-1234-4abc-8def-123456789abc";
+  const generationConfirmation = {
+    active_enter_timestamp_monotonic: properties.ActiveEnterTimestampMonotonic,
+    active_state: properties.ActiveState,
+    invocation_id: properties.InvocationID,
+    main_pid: properties.MainPID,
+  };
+  const processIdentity = {
+    gid_after: [731, 731, 731, 731],
+    gid_before: [731, 731, 731, 731],
+    groups_after: [731, 732],
+    groups_before: [731, 732],
+    main_pid: 4242,
+    proc_directory_dev_after: "9",
+    proc_directory_dev_before: "9",
+    proc_directory_ino_after: "99",
+    proc_directory_ino_before: "99",
+    process_state_after: "S",
+    process_state_before: "R",
+    start_time_ticks_after: "123456",
+    start_time_ticks_before: "123456",
+    uid_after: [730, 730, 730, 730],
+    uid_before: [730, 730, 730, 730],
+  };
+  const evidence = {
+    approved_plan_sha256: request.approved_plan_sha256,
+    challenge_hex: hash("internal-random-challenge"),
+    collected_finished_unix_seconds: 1_800_000_010,
+    collected_started_unix_seconds: 1_800_000_000,
+    collector: RUNTIME_COLLECTOR,
+    collector_process: { egid: 0, euid: 0, pid: 42 },
+    evidence_kind: LIVE_EVIDENCE_KIND,
+    host: {
+      boot_id: boot,
+      kernel_release: "6.8.0-test",
+      machine_id_sha256: machine,
+      systemd_version: "systemd 257",
+      uptime_finished_milliseconds: 5010,
+      uptime_started_milliseconds: 5000,
+    },
+    installed_files: installedFiles.map(richFile),
+    manifest_sha256: request.manifest_sha256,
+    nss: {
+      groups: [
+        { gid: 731, members: [], name: "bitcoinpir-test" },
+        { gid: 732, members: [], name: "bitcoinpir-shared" },
+      ],
+      users: [
+        { name: "bitcoinpir-test", primary_gid: 731, supplementary_gids: [731], uid: 730 },
+      ],
+    },
+    runtime_directories: [
+      {
+        acl_sha256: hash("dir-acl"),
+        capability_sha256: hash(""),
+        dev: "1",
+        expected_type: "directory",
+        file_type: "directory",
+        gid: 732,
+        group_name: "bitcoinpir-shared",
+        ino: "200",
+        mode: "0710",
+        nlink: 2,
+        size: 40,
+        stat_command_sha256: hash("dir-stat"),
+        target_path: "/run/bitcoinpir-test",
+        uid: 730,
+        user_name: "bitcoinpir-test",
+        xattr_sha256: hash("dir-xattr"),
+      },
+    ],
+    schema_version: 1,
+    secret_access_checks: [],
+    secret_parent_directories: [],
+    systemd_analyze_verify: {
+      argv: request.systemd_analyze_argv,
+      exit_status: 0,
+      stderr: "",
+      stdout: "",
+    },
+    trusted_commands: COMMANDS.map((path, index) => ({
+      gid: 0,
+      mode: "0755",
+      nlink: 1,
+      path,
+      sha256: hash(`command-${index}`),
+      uid: 0,
+    })),
+    units: [{
+      fragment_sha256: hash("fragment"),
+      generation_confirmations: [clone(generationConfirmation), clone(generationConfirmation)],
+      process_identity: processIdentity,
+      properties,
+      unit_name: unit.unit_name,
+    }],
+  };
+  return { boot, evidence, machine, request };
+}
+
+function validate(value) {
+  return validateLiveRuntimeEvidence({
+    evidence: value.evidence,
+    expectedBootId: value.boot,
+    expectedMachineIdSha256: value.machine,
+    maxAgeSeconds: 30,
+    nowUnixSeconds: 1_800_000_020,
+    request: value.request,
+  });
+}
+
+function oneshotFixture() {
+  const value = fixture();
+  const fragmentPath = "/etc/systemd/system/bitcoinpir-lightning-preflight.service";
+  const unit = value.request.units[0];
+  unit.fragment_path = fragmentPath;
+  unit.unit_name = "bitcoinpir-lightning-preflight.service";
+  unit.hardening.Type = ["oneshot"];
+  unit.hardening.RemainAfterExit = ["yes"];
+  value.request.service_identities[0].unit_name = unit.unit_name;
+  value.request.installed_files[0].target_path = fragmentPath;
+  value.request.systemd_analyze_argv[2] = fragmentPath;
+  value.evidence.installed_files[0].target_path = fragmentPath;
+  value.evidence.systemd_analyze_verify.argv[2] = fragmentPath;
+  const actual = value.evidence.units[0];
+  actual.unit_name = unit.unit_name;
+  actual.properties.FragmentPath = fragmentPath;
+  actual.properties.Type = "oneshot";
+  actual.properties.RemainAfterExit = "yes";
+  actual.properties.MainPID = "0";
+  actual.properties.SubState = "exited";
+  actual.properties.Result = "success";
+  actual.properties.ExecMainCode = "1";
+  actual.properties.ExecMainStatus = "0";
+  actual.generation_confirmations = actual.generation_confirmations.map((confirmation) => ({
+    ...confirmation,
+    main_pid: "0",
+  }));
+  actual.process_identity = null;
+  return value;
+}
+
+function testProbeArgv({ gid, groups, uid }, targetPath) {
+  return [
+    "/usr/bin/setpriv",
+    "--no-new-privs",
+    "--inh-caps=-all",
+    "--ambient-caps=-all",
+    "--bounding-set=-all",
+    "--reuid", String(uid),
+    "--regid", String(gid),
+    "--groups", groups.join(","),
+    "--",
+    "/usr/bin/test",
+    "-r",
+    targetPath,
+  ];
+}
+
+function secretIsolationFixture() {
+  const value = fixture();
+  const peerUnit = clone(value.request.units[0]);
+  peerUnit.unit_name = "bitcoinpir-z-peer.service";
+  peerUnit.fragment_path = "/etc/systemd/system/bitcoinpir-z-peer.service";
+  peerUnit.hardening.User = ["bitcoinpir-z-peer"];
+  peerUnit.hardening.Group = ["bitcoinpir-z-peer"];
+  peerUnit.hardening.SupplementaryGroups = ["bitcoinpir-test"];
+  value.request.units.push(peerUnit);
+  value.request.service_identities.push({
+    gid: 734,
+    group_name: "bitcoinpir-z-peer",
+    uid: 733,
+    unit_name: peerUnit.unit_name,
+    user_name: "bitcoinpir-z-peer",
+  });
+  value.evidence.nss.groups.push({ gid: 734, members: [], name: "bitcoinpir-z-peer" });
+  value.evidence.nss.users.push({ name: "bitcoinpir-z-peer", primary_gid: 734, supplementary_gids: [734], uid: 733 });
+
+  const peerFragment = { file_type: "regular", gid: 0, mode: "0644", nlink: 1, sha256: hash("peer-fragment"), target_path: peerUnit.fragment_path, uid: 0 };
+  value.request.installed_files.push(peerFragment);
+  value.evidence.installed_files.push({
+    ...clone(value.evidence.installed_files[0]),
+    ...peerFragment,
+    ino: "303",
+    sha256_command_sha256: hash("peer-sha-command"),
+    stat_command_sha256: hash("peer-stat"),
+  });
+  value.request.systemd_analyze_argv.push(peerUnit.fragment_path);
+  value.evidence.systemd_analyze_verify.argv.push(peerUnit.fragment_path);
+  const peerProperties = {
+    ...clone(value.evidence.units[0].properties),
+    FragmentPath: peerUnit.fragment_path,
+    Group: "bitcoinpir-z-peer",
+    InvocationID: "b".repeat(32),
+    MainPID: "4243",
+    SupplementaryGroups: "bitcoinpir-test",
+    User: "bitcoinpir-z-peer",
+  };
+  const peerConfirmation = {
+    active_enter_timestamp_monotonic: peerProperties.ActiveEnterTimestampMonotonic,
+    active_state: "active",
+    invocation_id: peerProperties.InvocationID,
+    main_pid: peerProperties.MainPID,
+  };
+  value.evidence.units.push({
+    fragment_sha256: peerFragment.sha256,
+    generation_confirmations: [clone(peerConfirmation), clone(peerConfirmation)],
+    process_identity: {
+      gid_after: [734, 734, 734, 734],
+      gid_before: [734, 734, 734, 734],
+      groups_after: [731, 734],
+      groups_before: [731, 734],
+      main_pid: 4243,
+      proc_directory_dev_after: "9",
+      proc_directory_dev_before: "9",
+      proc_directory_ino_after: "100",
+      proc_directory_ino_before: "100",
+      process_state_after: "S",
+      process_state_before: "S",
+      start_time_ticks_after: "123457",
+      start_time_ticks_before: "123457",
+      uid_after: [733, 733, 733, 733],
+      uid_before: [733, 733, 733, 733],
+    },
+    properties: peerProperties,
+    unit_name: peerUnit.unit_name,
+  });
+
+  const targetPath = "/etc/bitcoinpir/payment-v1/issuer/quote-signing.key";
+  const secret = { file_type: "regular", gid: 731, mode: "0400", nlink: 1, sha256: hash("issuer-secret"), target_path: targetPath, uid: 730 };
+  value.request.installed_files.push(secret);
+  value.request.secret_files = [{ consumer_unit_name: value.request.units[0].unit_name, gid: 731, mode: "0400", target_path: targetPath, uid: 730 }];
+  value.evidence.installed_files.push({
+    ...clone(value.evidence.installed_files[0]),
+    ...secret,
+    ino: "304",
+    sha256_command_sha256: hash("secret-sha-command"),
+    stat_command_sha256: hash("secret-stat"),
+  });
+  const parents = [
+    "/",
+    "/etc",
+    "/etc/bitcoinpir",
+    "/etc/bitcoinpir/payment-v1",
+    "/etc/bitcoinpir/payment-v1/issuer",
+  ];
+  value.evidence.secret_parent_directories = parents.map((target, index) => ({
+    acl_sha256: hash(`parent-acl-${index}`),
+    capability_sha256: hash(""),
+    dev: "1",
+    expected_type: "directory",
+    file_type: "directory",
+    gid: 0,
+    ino: String(400 + index),
+    mode: index === parents.length - 1 ? "0710" : "0755",
+    nlink: 2,
+    size: 40,
+    stat_command_sha256: hash(`parent-stat-${index}`),
+    target_path: target,
+    uid: 0,
+    xattr_sha256: hash(`parent-xattr-${index}`),
+  }));
+  value.evidence.secret_access_checks = [
+    {
+      argv: testProbeArgv({ gid: 731, groups: [731, 732], uid: 730 }, targetPath),
+      exit_status: 0,
+      expected_readable: true,
+      stderr: "",
+      stdout: "",
+      target_path: targetPath,
+      unit_name: value.request.units[0].unit_name,
+    },
+    {
+      argv: testProbeArgv({ gid: 734, groups: [731, 734], uid: 733 }, targetPath),
+      exit_status: 1,
+      expected_readable: false,
+      stderr: "",
+      stdout: "",
+      target_path: targetPath,
+      unit_name: peerUnit.unit_name,
+    },
+  ];
+  return value;
+}
+
+test("valid live evidence binds challenge, host, boot, files, NSS, units, and command TCB", () => {
+  assert.equal(validate(fixture()), true);
+});
+
+test("reviewed preflight oneshot uses active-exited boot-bound completion evidence without fake procfs identity", () => {
+  assert.equal(validate(oneshotFixture()), true);
+  for (const [mutate, expected] of [
+    [(value) => { value.evidence.units[0].properties.ExecMainCode = "0"; }, /oneshot completion proof/],
+    [(value) => { value.evidence.units[0].properties.ExecMainStatus = "1"; }, /oneshot completion proof/],
+    [(value) => { value.evidence.units[0].properties.SubState = "running"; }, /oneshot completion proof/],
+    [(value) => { value.evidence.units[0].properties.MainPID = "42"; }, /oneshot completion proof/],
+    [(value) => { value.evidence.units[0].properties.ActiveEnterTimestampMonotonic = "6000000"; }, /not bound to this boot/],
+    [(value) => { value.evidence.units[0].properties.InvocationID = "0".repeat(32); }, /InvocationID/],
+  ]) {
+    const value = oneshotFixture();
+    mutate(value);
+    assert.throws(() => validate(value), expected);
+  }
+});
+
+test("secret evidence binds parent metadata and positive owner/negative cross-role access probes", () => {
+  assert.equal(validate(secretIsolationFixture()), true);
+  const readableByPeer = secretIsolationFixture();
+  readableByPeer.evidence.secret_access_checks[1].exit_status = 0;
+  assert.throws(() => validate(readableByPeer), /secret access isolation/);
+  const missingParent = secretIsolationFixture();
+  missingParent.evidence.secret_parent_directories.pop();
+  assert.throws(() => validate(missingParent), /parent directory evidence is incomplete/);
+});
+
+for (const [label, mutate, expected] of [
+  ["drop-in", (f) => { f.evidence.units[0].properties.DropInPaths = "/etc/systemd/system/x.d/evil.conf"; }, /drop-in/],
+  ["ExecStart reset", (f) => { f.evidence.units[0].properties.ExecStart = execValue("/usr/bin/true"); }, /ExecStart drift/],
+  ["ExecStartPost", (f) => { f.evidence.units[0].properties.ExecStartPost = execValue("/usr/bin/true"); }, /ExecStartPost/],
+  ["EnvironmentFile", (f) => { f.evidence.units[0].properties.EnvironmentFiles = "/tmp/evil"; }, /EnvironmentFiles/],
+  ["credential", (f) => { f.evidence.units[0].properties.LoadCredential = "secret:/tmp/evil"; }, /LoadCredential/],
+  ["root image", (f) => { f.evidence.units[0].properties.RootImage = "/tmp/root.img"; }, /RootImage/],
+  ["file hash", (f) => { f.evidence.installed_files[0].sha256 = hash("evil"); }, /sha256 drift/],
+  ["tmpfiles mode", (f) => { f.evidence.runtime_directories[0].mode = "0777"; }, /tmpfiles directory drift/],
+  ["unexpected issuer group", (f) => { f.evidence.nss.users[0].supplementary_gids.push(999); }, /unexpected supplementary group/],
+  ["inactive unit", (f) => { f.evidence.units[0].properties.ActiveState = "inactive"; }, /not active/],
+  ["zero MainPID", (f) => { f.evidence.units[0].properties.MainPID = "0"; }, /no active MainPID/],
+  ["effective Restart drift", (f) => { f.evidence.units[0].properties.Restart = "on-failure"; }, /Restart drift/],
+  ["MainPID confirmation race", (f) => { f.evidence.units[0].generation_confirmations[1].main_pid = "4243"; }, /MainPID or InvocationID changed/],
+  ["InvocationID generation race", (f) => { f.evidence.units[0].generation_confirmations[1].invocation_id = "b".repeat(32); }, /MainPID or InvocationID changed/],
+  ["proc starttime race", (f) => { f.evidence.units[0].process_identity.start_time_ticks_after = "123457"; }, /restart race/],
+  ["proc inode race", (f) => { f.evidence.units[0].process_identity.proc_directory_ino_after = "100"; }, /restart race/],
+  ["old process retained supplementary group", (f) => {
+    f.evidence.units[0].process_identity.groups_before.push(999);
+    f.evidence.units[0].process_identity.groups_after.push(999);
+  }, /process Groups drift/],
+  ["running process UID drift", (f) => { f.evidence.units[0].process_identity.uid_after = [999, 999, 999, 999]; }, /Uid after/],
+  ["command replacement", (f) => { f.evidence.trusted_commands[0].mode = "0777"; }, /untrusted runtime command/],
+]) {
+  test(`live verifier rejects ${label}`, () => {
+    const value = fixture();
+    mutate(value);
+    assert.throws(() => validate(value), expected);
+  });
+}
+
+test("live verifier rejects replay, foreign host, foreign boot, and forged challenge", () => {
+  const stale = fixture();
+  assert.throws(
+    () => validateLiveRuntimeEvidence({ evidence: stale.evidence, expectedBootId: stale.boot, expectedMachineIdSha256: stale.machine, maxAgeSeconds: 5, nowUnixSeconds: 1_800_000_020, request: stale.request }),
+    /stale/,
+  );
+  const host = fixture();
+  host.machine = hash("another-machine");
+  assert.throws(() => validate(host), /another host/);
+  const boot = fixture();
+  boot.boot = "87654321-4321-4abc-8def-123456789abc";
+  assert.throws(() => validate(boot), /another boot/);
+  const challenge = fixture();
+  challenge.evidence.challenge_hex = "0".repeat(64);
+  assert.throws(() => validate(challenge), /internally random/);
+});
+
+test("collect-live rejects caller JSON, caller challenge, and offline verification without a digest pin", () => {
+  const base = [
+    "--bundle", "/tmp/bundle",
+    "--approved-manifest-sha256", hash("manifest"),
+    "--approved-plan-sha256", hash("plan"),
+    "--expected-machine-id-sha256", hash("machine"),
+  ];
+  const callerJson = spawnSync(process.execPath, [COLLECTOR, "collect-live", ...base, "--output", "/tmp/output", "--evidence", "/tmp/forged.json"], { encoding: "utf8" });
+  assert.notEqual(callerJson.status, 0);
+  assert.match(callerJson.stderr, /forbids caller evidence/);
+  const challenge = spawnSync(process.execPath, [COLLECTOR, "collect-live", ...base, "--output", "/tmp/output", "--challenge", hash("chosen")], { encoding: "utf8" });
+  assert.notEqual(challenge.status, 0);
+  assert.match(challenge.stderr, /invalid, repeated, or missing CLI option/);
+  const offline = spawnSync(process.execPath, [COLLECTOR, "verify-offline", ...base, "--evidence", "/tmp/forged.json", "--expected-boot-id", "12345678-1234-4abc-8def-123456789abc"], { encoding: "utf8" });
+  assert.notEqual(offline.status, 0);
+  assert.match(offline.stderr, /trusted-evidence-sha256/);
+});
+
+test("collect-live is Linux-only and root-only before any runtime evidence can be claimed", () => {
+  if (process.platform === "linux" && process.geteuid?.() === 0 && process.execPath === "/usr/bin/node") return;
+  const result = spawnSync(process.execPath, [
+    COLLECTOR,
+    "collect-live",
+    "--bundle", "/tmp/missing-bundle",
+    "--approved-manifest-sha256", hash("manifest"),
+    "--approved-plan-sha256", hash("plan"),
+    "--expected-machine-id-sha256", hash("machine"),
+    "--output", "/tmp/nonexistent-parent/evidence.json",
+  ], { encoding: "utf8" });
+  assert.notEqual(result.status, 0);
+});

--- a/scripts/payment-v1-local-check.sh
+++ b/scripts/payment-v1-local-check.sh
@@ -11,7 +11,8 @@ using real funds. Cargo is forced offline; full mode requires a preinstalled
 `wasm-pack`/`wasm-bindgen` toolchain and refuses to bootstrap it from the
 network.
 
-  --quick  Five-method × five-workload matrix plus focused persistence and fake-Lightning checks.
+  --quick  Five-method × five-workload matrix plus focused persistence,
+           directory-relay, deployment-template and fake-Lightning checks.
            It starts no service process; unit tests may briefly bind loopback
            TCP or Unix-domain listeners.
   --full   The default offline payment-platform Rust suite, operator tooling,
@@ -71,6 +72,8 @@ cargo test --locked --offline -p pir-cashu-custody
 cargo test --locked --offline -p pir-arc-adapter --features provider-store
 
 echo "[4/5] fake-Lightning, quote/claim lifecycle, and native/WASM client boundaries"
+cargo test --locked --offline -p bitcoinpir-directory-relay
+cargo test --locked --offline -p bitcoinpir-cln-rpc-guard
 cargo test --locked --offline -p pir-lightning-backend
 cargo test --locked --offline -p pir-issuer-core
 cargo test --locked --offline -p pir-issuer-service
@@ -80,6 +83,16 @@ cargo run --locked --offline -p payment-issuer \
   --features test-only-fake-lightning -- serve-fake --help >/dev/null
 cargo test --locked --offline -p pir-sdk-client --all-targets
 cargo test --locked --offline -p pir-sdk-wasm --lib
+node --check scripts/payment-v1-deployment-template-gate.mjs
+node --test scripts/payment-v1-deployment-template-gate.test.mjs
+node scripts/payment-v1-deployment-template-gate.mjs
+node --check scripts/payment-v1-rendered-artifact-gate.mjs
+node --check scripts/payment-v1-rendered-artifact-gate.test.mjs
+node --check scripts/payment-v1-linux-runtime-evidence.mjs
+node --check scripts/payment-v1-linux-runtime-evidence.test.mjs
+node --test \
+  scripts/payment-v1-rendered-artifact-gate.test.mjs \
+  scripts/payment-v1-linux-runtime-evidence.test.mjs
 
 if [[ "$mode" == "quick" ]]; then
   echo "[5/5] quick mode complete (no external network, no funds)"
@@ -108,6 +121,8 @@ cargo test --locked --offline \
   -p pir-cashu-custody \
   -p pir-arc-adapter \
   -p pir-directory-nostr \
+  -p bitcoinpir-directory-relay \
+  -p bitcoinpir-cln-rpc-guard \
   -p pir-runtime-core \
   -p pir-sdk-client \
   -p pir-sdk-wasm \
@@ -227,7 +242,7 @@ cargo clippy --locked --offline -p payment-issuer \
   -- -D warnings
 cargo check --locked --offline -p runtime --bin unified_server
 
-echo "[6/9] Standard Cashu signed-pin TLS and real-provider process boundary"
+echo "[6/9] Standard Cashu and shared-issuer signed-pin TLS process boundaries"
 cargo test --locked --offline -p runtime \
   --features standard-cashu-process-e2e \
   --test payment_v1_standard_cashu_process_e2e \
@@ -258,8 +273,35 @@ if cargo check --locked --offline --release -p runtime \
 fi
 grep -F 'test-only-webpki-root must never be compiled into a production release' \
   "$cashu_boundary_log" >/dev/null
+if cargo check --locked --offline --release -p runtime \
+  --features shared-issuer-process-e2e >"$cashu_boundary_log" 2>&1; then
+  echo "payment-v1-local-check: shared-issuer test-only root feature compiled in release mode" >&2
+  rm -f -- "$cashu_boundary_log"
+  exit 1
+fi
+grep -F 'test-only-webpki-root must never be compiled into a production release' \
+  "$cashu_boundary_log" >/dev/null
 rm -f -- "$cashu_boundary_log"
 trap - EXIT HUP INT TERM
+
+issuer_e2e_target_dir="$repo_root/target/payment-issuer-shared-e2e"
+cargo build --locked --offline \
+  -p payment-issuer \
+  --features test-only-fake-lightning \
+  --bin payment-issuer \
+  --target-dir "$issuer_e2e_target_dir"
+BITCOINPIR_PAYMENT_ISSUER_BIN="$issuer_e2e_target_dir/debug/payment-issuer" \
+  cargo test --locked --offline \
+    -p runtime \
+    --features shared-issuer-process-e2e \
+    --test payment_v1_shared_issuer_process_e2e \
+    shared_issuer_real_process_tls_e2e -- --exact
+cargo clippy --locked --offline \
+  -p runtime \
+  --features shared-issuer-process-e2e \
+  --bin unified_server \
+  --test payment_v1_shared_issuer_process_e2e \
+  --no-deps -- -D warnings
 
 fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/bpir-payment-v1-fixture.XXXXXX")"
 trap 'rm -rf -- "$fixture_root"' EXIT HUP INT TERM
@@ -275,6 +317,16 @@ node --test scripts/payment-v1-nostr-readback.test.mjs
 node scripts/payment-v1-nostr-readback.mjs --help >/dev/null
 node --check scripts/payment-v1-pages-deploy-gate.mjs
 node scripts/payment-v1-pages-deploy-gate.mjs
+node --check scripts/payment-v1-deployment-template-gate.mjs
+node --test scripts/payment-v1-deployment-template-gate.test.mjs
+node scripts/payment-v1-deployment-template-gate.mjs
+node --check scripts/payment-v1-rendered-artifact-gate.mjs
+node --check scripts/payment-v1-rendered-artifact-gate.test.mjs
+node --check scripts/payment-v1-linux-runtime-evidence.mjs
+node --check scripts/payment-v1-linux-runtime-evidence.test.mjs
+node --test \
+  scripts/payment-v1-rendered-artifact-gate.test.mjs \
+  scripts/payment-v1-linux-runtime-evidence.test.mjs
 
 echo "[7/9] warnings denied in dedicated Payment V1 crates and tools"
 cargo clippy --locked --offline --all-targets --no-deps \
@@ -297,6 +349,8 @@ cargo clippy --locked --offline --all-targets --no-deps \
   -p pir-cashu-custody \
   -p pir-arc-adapter \
   -p pir-directory-nostr \
+  -p bitcoinpir-directory-relay \
+  -p bitcoinpir-cln-rpc-guard \
   -p payment-issuer \
   -p rollback-authority \
   -p bpir-admin \

--- a/scripts/payment-v1-rendered-artifact-gate.mjs
+++ b/scripts/payment-v1-rendered-artifact-gate.mjs
@@ -1,0 +1,2367 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { isIP } from "node:net";
+import {
+  basename,
+  dirname,
+  join,
+  posix,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
+import { pathToFileURL } from "node:url";
+
+const PLAN_SCHEMA_VERSION = 1;
+const MANIFEST_SCHEMA_VERSION = 1;
+const EVIDENCE_SCHEMA_VERSION = 1;
+export const RUNTIME_COLLECTOR =
+  "bitcoinpir-payment-v1-linux-runtime-evidence-v1";
+
+const MAX_JSON_BYTES = 8 * 1024 * 1024;
+const MAX_TEMPLATE_BYTES = 2 * 1024 * 1024;
+const MAX_PAYLOAD_BYTES = 512 * 1024 * 1024;
+const MAX_BUNDLE_BYTES = 2 * 1024 * 1024 * 1024;
+const MAX_TREE_ENTRIES = 4096;
+const MAX_PATH_COMPONENTS = 24;
+const EMPTY_SHA256 =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+const SYSTEMD_HARDENING_KEYS = Object.freeze([
+  "AmbientCapabilities",
+  "CapabilityBoundingSet",
+  "Group",
+  "IPAddressAllow",
+  "IPAddressDeny",
+  "InaccessiblePaths",
+  "LimitNOFILE",
+  "LockPersonality",
+  "MemoryDenyWriteExecute",
+  "NoNewPrivileges",
+  "PrivateDevices",
+  "PrivateTmp",
+  "ProtectClock",
+  "ProtectControlGroups",
+  "ProtectHome",
+  "ProtectHostname",
+  "ProtectKernelLogs",
+  "ProtectKernelModules",
+  "ProtectKernelTunables",
+  "ProtectSystem",
+  "ReadOnlyPaths",
+  "ReadWritePaths",
+  "RemainAfterExit",
+  "Restart",
+  "RestartSec",
+  "RestrictAddressFamilies",
+  "RestrictNamespaces",
+  "RestrictRealtime",
+  "RestrictSUIDSGID",
+  "RuntimeDirectory",
+  "RuntimeDirectoryMode",
+  "StateDirectory",
+  "StateDirectoryMode",
+  "SupplementaryGroups",
+  "SystemCallArchitectures",
+  "TimeoutStartSec",
+  "TimeoutStopSec",
+  "Type",
+  "UMask",
+  "User",
+  "WorkingDirectory",
+]);
+
+const SYSTEMD_UNIT_KEYS = Object.freeze([
+  "After",
+  "Before",
+  "BindsTo",
+  "ConditionPathExists",
+  "Description",
+  "Requires",
+  "Wants",
+]);
+
+const SYSTEMD_SERVICE_KEYS = Object.freeze([
+  ...SYSTEMD_HARDENING_KEYS,
+  "Environment",
+  "ExecStart",
+  "ExecStartPre",
+]);
+
+const PROFILE_CATALOG = Object.freeze({
+  "edge-hetzner-v1": Object.freeze({
+    templates: Object.freeze([
+      "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
+      "deploy/payment-v1/systemd/payment-v1-edge.service.in",
+    ]),
+  }),
+  "edge-rollback-authority-v1": Object.freeze({
+    templates: Object.freeze([
+      "deploy/payment-v1/edge/rollback-authority.Caddyfile.in",
+      "deploy/payment-v1/systemd/payment-v1-edge.service.in",
+    ]),
+  }),
+  "issuer-lightning-signet-v1": Object.freeze({
+    templates: Object.freeze([
+      "deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in",
+      "deploy/payment-v1/lightning/lightningd.conf.in",
+      "deploy/payment-v1/lightning/verify-layout.sh.in",
+      "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in",
+      "deploy/payment-v1/systemd/hetzner-core-lightning.service.in",
+      "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in",
+      "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+    ]),
+  }),
+  "provider-v1": Object.freeze({
+    templates: Object.freeze([
+      "deploy/payment-v1/systemd/hetzner-provider.service.in",
+    ]),
+  }),
+  "rollback-authority-v1": Object.freeze({
+    templates: Object.freeze([
+      "deploy/payment-v1/systemd/rollback-authority.service.in",
+    ]),
+  }),
+});
+
+const MANAGED_FILE_PREFIXES = Object.freeze([
+  "/etc/bitcoinpir/payment-v1/",
+  "/opt/bitcoinpir/",
+  "/usr/local/libexec/bitcoinpir/",
+]);
+
+const REQUIRED_SYSTEMD_HARDENING = Object.freeze({
+  LockPersonality: ["true"],
+  MemoryDenyWriteExecute: ["true"],
+  NoNewPrivileges: ["true"],
+  PrivateTmp: ["true"],
+  ProtectControlGroups: ["true"],
+  ProtectHome: ["true"],
+  ProtectKernelLogs: ["true"],
+  ProtectKernelModules: ["true"],
+  ProtectKernelTunables: ["true"],
+  ProtectSystem: ["strict"],
+  RestrictNamespaces: ["true"],
+  RestrictRealtime: ["true"],
+  RestrictSUIDSGID: ["true"],
+  SystemCallArchitectures: ["native"],
+});
+
+export const RUNTIME_SYSTEMCTL_SHOW_PROPERTIES = Object.freeze([
+  "ActiveEnterTimestampMonotonic",
+  "ActiveState",
+  "AmbientCapabilities",
+  "BindPaths",
+  "BindReadOnlyPaths",
+  "CapabilityBoundingSet",
+  "ConditionResult",
+  "Conditions",
+  "DropInPaths",
+  "Environment",
+  "EnvironmentFiles",
+  "ExecCondition",
+  "ExecMainCode",
+  "ExecMainStatus",
+  "ExecStart",
+  "ExecStartPost",
+  "ExecStartPre",
+  "FragmentPath",
+  "Group",
+  "IPAddressAllow",
+  "IPAddressDeny",
+  "InaccessiblePaths",
+  "InvocationID",
+  "LoadCredential",
+  "LoadState",
+  "LockPersonality",
+  "MainPID",
+  "MemoryDenyWriteExecute",
+  "NoNewPrivileges",
+  "PrivateDevices",
+  "PrivateTmp",
+  "ProtectClock",
+  "ProtectControlGroups",
+  "ProtectHome",
+  "ProtectHostname",
+  "ProtectKernelLogs",
+  "ProtectKernelModules",
+  "ProtectKernelTunables",
+  "ProtectSystem",
+  "ReadOnlyPaths",
+  "ReadWritePaths",
+  "RemainAfterExit",
+  "Restart",
+  "RestrictAddressFamilies",
+  "RestrictNamespaces",
+  "RestrictRealtime",
+  "RestrictSUIDSGID",
+  "Result",
+  "RootDirectory",
+  "RootImage",
+  "SetCredential",
+  "SubState",
+  "SupplementaryGroups",
+  "SystemCallArchitectures",
+  "Type",
+  "UMask",
+  "User",
+  "WorkingDirectory",
+]);
+
+const TEMPLATE_CATALOG = Object.freeze({
+  "deploy/payment-v1/systemd/hetzner-core-lightning.service.in": {
+    artifactClass: "systemd-unit",
+    targetPath: "/etc/systemd/system/bitcoinpir-core-lightning.service",
+    modes: ["0644"],
+    rootOwned: true,
+  },
+  "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in": {
+    artifactClass: "systemd-unit",
+    targetPath: "/etc/systemd/system/bitcoinpir-cln-rpc-guard.service",
+    modes: ["0644"],
+    rootOwned: true,
+  },
+  "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in": {
+    artifactClass: "systemd-unit",
+    targetPath: "/etc/systemd/system/bitcoinpir-lightning-preflight.service",
+    modes: ["0644"],
+    rootOwned: true,
+  },
+  "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in": {
+    artifactClass: "systemd-unit",
+    targetPath: "/etc/systemd/system/bitcoinpir-payment-issuer.service",
+    modes: ["0644"],
+    rootOwned: true,
+  },
+  "deploy/payment-v1/systemd/hetzner-provider.service.in": {
+    artifactClass: "systemd-unit",
+    targetPath: "/etc/systemd/system/bitcoinpir-provider.service",
+    modes: ["0644"],
+    rootOwned: true,
+  },
+  "deploy/payment-v1/systemd/payment-v1-edge.service.in": {
+    artifactClass: "systemd-unit",
+    targetPath: "/etc/systemd/system/bitcoinpir-payment-v1-edge.service",
+    modes: ["0644"],
+    rootOwned: true,
+  },
+  "deploy/payment-v1/systemd/rollback-authority.service.in": {
+    artifactClass: "systemd-unit",
+    targetPath: "/etc/systemd/system/bitcoinpir-rollback-authority.service",
+    modes: ["0644"],
+    rootOwned: true,
+  },
+  "deploy/payment-v1/systemd/hetzner-directory-relay.service.in": {
+    artifactClass: "systemd-unit",
+    targetPath: "/etc/systemd/system/bitcoinpir-directory-relay.service",
+    modes: ["0644"],
+    rootOwned: true,
+  },
+  "deploy/payment-v1/edge/hetzner-public.Caddyfile.in": {
+    artifactClass: "config",
+    targetPath: "/etc/bitcoinpir/payment-v1/edge/hetzner-public.Caddyfile",
+    modes: ["0400", "0440", "0600", "0640"],
+    rootOwned: false,
+  },
+  "deploy/payment-v1/edge/rollback-authority.Caddyfile.in": {
+    artifactClass: "config",
+    targetPath: "/etc/bitcoinpir/payment-v1/edge/rollback-authority.Caddyfile",
+    modes: ["0400", "0440", "0600", "0640"],
+    rootOwned: false,
+  },
+  "deploy/payment-v1/lightning/lightningd.conf.in": {
+    artifactClass: "config",
+    targetPath: "/etc/bitcoinpir/payment-v1/lightning/lightningd.conf",
+    modes: ["0400", "0440", "0600", "0640"],
+    rootOwned: false,
+  },
+  "deploy/payment-v1/lightning/verify-layout.sh.in": {
+    artifactClass: "executable-config",
+    targetPath: "/usr/local/libexec/bitcoinpir/verify-lightning-layout",
+    modes: ["0755"],
+    rootOwned: true,
+  },
+  "deploy/payment-v1/lightning/issuer-cln.args.in": {
+    artifactClass: "argument-fragment",
+    targetPath: "/etc/bitcoinpir/payment-v1/issuer/issuer-cln.args",
+    modes: ["0400", "0440", "0600", "0640"],
+    rootOwned: false,
+  },
+  "deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in": {
+    artifactClass: "config",
+    targetPath: "/etc/tmpfiles.d/bitcoinpir-cln-rpc-guard.conf",
+    modes: ["0644"],
+    rootOwned: true,
+  },
+  "deploy/payment-v1/directory-relay.toml.example": {
+    artifactClass: "config",
+    targetPath: "/etc/bitcoinpir/payment-v1/directory-relay/config.toml",
+    modes: ["0400", "0440", "0600"],
+    rootOwned: false,
+  },
+});
+
+const HEX64_PLACEHOLDERS = new Set([
+  "AUTHORITY_PUBKEY_HEX",
+  "BITCOIN_CORE_BUNDLE_SHA256",
+  "BPIR_ADMIN_SHA256",
+  "CADDY_SHA256",
+  "CASHU_MINT_ID_HEX",
+  "CLN_BUNDLE_SHA256",
+  "CLN_RPC_GUARD_SHA256",
+  "DIRECTORY_PUBLISHER_PUBKEY_HEX",
+  "HETZNER_OPERATOR_PUBKEY_HEX",
+  "HETZNER_POLICY_PUBKEY_HEX",
+  "HETZNER_PROVIDER_ID_HEX",
+  "ISSUER_SETTLEMENT_PUBKEY_HEX",
+  "PAYMENT_ISSUER_SHA256",
+  "ROLLBACK_AUTHORITY_SHA256",
+  "UNIFIED_SERVER_SHA256",
+]);
+
+const DNS_HOST_PLACEHOLDERS = new Set([
+  "DIRECTORY_RELAY_WSS_HOST",
+  "PAYMENT_ISSUER_HTTPS_HOST",
+  "PROVIDER_WSS_HOST",
+  "ROLLBACK_AUTHORITY_HTTPS_HOST",
+]);
+
+const UID_GID_PLACEHOLDERS = new Set([
+  "ISSUER_GID",
+  "ISSUER_UID",
+  "LIGHTNING_GID",
+  "LIGHTNING_UID",
+  "CLN_GUARD_UID",
+  "PREFLIGHT_GID",
+  "PREFLIGHT_UID",
+]);
+
+const POSITIVE_SERVICE_VALUE_PLACEHOLDERS = new Set([
+  "CASHU_MAX_UNSETTLED_NOTES",
+  "CASHU_MAX_UNSETTLED_VALUE",
+  "SHARED_MINIMUM_AUTHORIZATION_EPOCH",
+]);
+
+const ALL_PLACEHOLDER_NAMES = new Set([
+  ...HEX64_PLACEHOLDERS,
+  ...DNS_HOST_PLACEHOLDERS,
+  ...UID_GID_PLACEHOLDERS,
+  ...POSITIVE_SERVICE_VALUE_PLACEHOLDERS,
+  "BITCOIND_SYSTEMD_UNIT",
+  "BITCOINPIR_WEB_ORIGIN",
+  "BITCOIN_RPC_PORT",
+  "CLN_GUARD_MAX_INVOICE_BURST",
+  "CLN_GUARD_MAX_INVOICE_MSAT",
+  "CLN_GUARD_MAX_INVOICES_PER_MINUTE",
+  "CLN_GUARD_MAX_INVOICES_PER_RUNTIME",
+  "CLN_P2P_ANNOUNCE_ADDR",
+  "CLN_P2P_BIND_ADDR",
+  "EDGE_CADDYFILE",
+  "HETZNER_PROVIDER_SERVER_ID",
+  "LIGHTNING_NETWORK",
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function asciiCompare(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function isPlainObject(value) {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (Object.getPrototypeOf(value) === null || Object.getPrototypeOf(value) === Object.prototype)
+  );
+}
+
+function exactKeys(value, expected, label) {
+  if (!isPlainObject(value)) fail(`${label} must be an object`);
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (
+    actual.length !== wanted.length ||
+    actual.some((key, index) => key !== wanted[index])
+  ) {
+    fail(
+      `${label} keys must equal ${JSON.stringify(wanted)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+class StrictJsonParser {
+  constructor(text, label) {
+    this.text = text;
+    this.label = label;
+    this.index = 0;
+  }
+
+  parse() {
+    if (Buffer.byteLength(this.text, "utf8") > MAX_JSON_BYTES) {
+      fail(`${this.label} exceeds ${MAX_JSON_BYTES} bytes`);
+    }
+    if (this.text.charCodeAt(0) === 0xfeff) fail(`${this.label} contains a BOM`);
+    const value = this.parseValue();
+    this.skipWhitespace();
+    if (this.index !== this.text.length) {
+      fail(`${this.label} has trailing JSON data at byte ${this.index}`);
+    }
+    return value;
+  }
+
+  skipWhitespace() {
+    while (/[\t\n\r ]/u.test(this.text[this.index] ?? "")) this.index += 1;
+  }
+
+  parseValue() {
+    this.skipWhitespace();
+    const character = this.text[this.index];
+    if (character === "{") return this.parseObject();
+    if (character === "[") return this.parseArray();
+    if (character === '"') return this.parseString();
+    if (character === "t" && this.consumeLiteral("true")) return true;
+    if (character === "f" && this.consumeLiteral("false")) return false;
+    if (character === "n" && this.consumeLiteral("null")) return null;
+    if (character === "-" || /[0-9]/u.test(character ?? "")) return this.parseNumber();
+    fail(`${this.label} has invalid JSON at byte ${this.index}`);
+  }
+
+  consumeLiteral(literal) {
+    if (this.text.slice(this.index, this.index + literal.length) !== literal) return false;
+    this.index += literal.length;
+    return true;
+  }
+
+  parseString() {
+    const start = this.index;
+    this.index += 1;
+    let escaped = false;
+    while (this.index < this.text.length) {
+      const code = this.text.charCodeAt(this.index);
+      const character = this.text[this.index];
+      if (!escaped && character === '"') {
+        this.index += 1;
+        try {
+          return JSON.parse(this.text.slice(start, this.index));
+        } catch {
+          fail(`${this.label} has an invalid JSON string at byte ${start}`);
+        }
+      }
+      if (!escaped && code < 0x20) {
+        fail(`${this.label} has a raw control character at byte ${this.index}`);
+      }
+      if (!escaped && character === "\\") {
+        escaped = true;
+      } else {
+        escaped = false;
+      }
+      this.index += 1;
+    }
+    fail(`${this.label} has an unterminated JSON string at byte ${start}`);
+  }
+
+  parseNumber() {
+    const match = /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?/u.exec(
+      this.text.slice(this.index),
+    );
+    if (!match) fail(`${this.label} has an invalid number at byte ${this.index}`);
+    this.index += match[0].length;
+    const value = Number(match[0]);
+    if (!Number.isFinite(value)) fail(`${this.label} contains a non-finite number`);
+    return value;
+  }
+
+  parseArray() {
+    const result = [];
+    this.index += 1;
+    this.skipWhitespace();
+    if (this.text[this.index] === "]") {
+      this.index += 1;
+      return result;
+    }
+    while (true) {
+      result.push(this.parseValue());
+      this.skipWhitespace();
+      if (this.text[this.index] === "]") {
+        this.index += 1;
+        return result;
+      }
+      if (this.text[this.index] !== ",") {
+        fail(`${this.label} array is missing a comma at byte ${this.index}`);
+      }
+      this.index += 1;
+    }
+  }
+
+  parseObject() {
+    const result = Object.create(null);
+    const seen = new Set();
+    this.index += 1;
+    this.skipWhitespace();
+    if (this.text[this.index] === "}") {
+      this.index += 1;
+      return result;
+    }
+    while (true) {
+      this.skipWhitespace();
+      if (this.text[this.index] !== '"') {
+        fail(`${this.label} object key must be a string at byte ${this.index}`);
+      }
+      const key = this.parseString();
+      if (seen.has(key)) fail(`${this.label} repeats JSON key ${JSON.stringify(key)}`);
+      seen.add(key);
+      this.skipWhitespace();
+      if (this.text[this.index] !== ":") {
+        fail(`${this.label} object key is missing ':' at byte ${this.index}`);
+      }
+      this.index += 1;
+      result[key] = this.parseValue();
+      this.skipWhitespace();
+      if (this.text[this.index] === "}") {
+        this.index += 1;
+        return result;
+      }
+      if (this.text[this.index] !== ",") {
+        fail(`${this.label} object is missing a comma at byte ${this.index}`);
+      }
+      this.index += 1;
+    }
+  }
+}
+
+export function parseStrictJson(text, label = "JSON document") {
+  if (typeof text !== "string") fail(`${label} must be UTF-8 text`);
+  return new StrictJsonParser(text, label).parse();
+}
+
+function canonicalize(value) {
+  if (value === null || typeof value === "boolean") return JSON.stringify(value);
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) fail("canonical JSON numbers must be safe integers");
+    return String(value);
+  }
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  if (isPlainObject(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`)
+      .join(",")}}`;
+  }
+  fail("canonical JSON contains an unsupported value");
+}
+
+export function canonicalJson(value) {
+  return `${canonicalize(value)}\n`;
+}
+
+export function computeApprovedPlanSha256(plan) {
+  return sha256(Buffer.from(canonicalJson(plan)));
+}
+
+function requireApprovedPlan(plan, approvedPlanSha256) {
+  validateSha256(approvedPlanSha256, "externally approved plan SHA-256");
+  const computed = computeApprovedPlanSha256(plan);
+  if (computed !== approvedPlanSha256) {
+    fail("render plan does not match the externally approved plan SHA-256");
+  }
+  return computed;
+}
+
+function readStrictJsonFile(path, label) {
+  const bytes = readRegularSingleLinkFile(path, label);
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    fail(`${label} is not valid UTF-8`);
+  }
+  return parseStrictJson(text, label);
+}
+
+function readRegularSingleLinkFile(path, label, maxBytes = MAX_JSON_BYTES) {
+  let stat;
+  try {
+    stat = lstatSync(path);
+  } catch {
+    fail(`${label} is missing: ${path}`);
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    fail(`${label} must be a regular non-symlink file: ${path}`);
+  }
+  if (stat.nlink !== 1) fail(`${label} must have exactly one hard link: ${path}`);
+  if (!Number.isSafeInteger(stat.size) || stat.size < 0 || stat.size > maxBytes) {
+    fail(`${label} exceeds the ${maxBytes}-byte size limit: ${path}`);
+  }
+  return readFileSync(path);
+}
+
+function requireCanonicalRoot(path, label) {
+  const absolute = resolve(path);
+  let stat;
+  try {
+    stat = lstatSync(absolute);
+  } catch {
+    fail(`${label} does not exist: ${absolute}`);
+  }
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    fail(`${label} must be a real directory: ${absolute}`);
+  }
+  // macOS intentionally exposes /var as an alias of /private/var. Canonicalize
+  // already-existing ancestors here, then require every selected descendant
+  // to resolve byte-for-byte below this real root in resolveUnder(). The root
+  // itself is still rejected when its final component is a symlink.
+  return realpathSync(absolute);
+}
+
+function safeRelativePath(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length < 1 ||
+    value.length > 512 ||
+    value.startsWith("/") ||
+    value.includes("\\") ||
+    !/^[A-Za-z0-9._/-]+$/u.test(value)
+  ) {
+    fail(`${label} must be a bounded portable relative path`);
+  }
+  const components = value.split("/");
+  if (components.some((component) => component === "" || component === "." || component === "..")) {
+    fail(`${label} contains an empty, dot, or parent component`);
+  }
+  if (components.length > MAX_PATH_COMPONENTS) {
+    fail(`${label} exceeds the ${MAX_PATH_COMPONENTS}-component depth limit`);
+  }
+  if (posix.normalize(value) !== value) fail(`${label} is not canonical`);
+  return value;
+}
+
+function safeTargetPath(value, label) {
+  if (
+    typeof value !== "string" ||
+    value.length < 2 ||
+    value.length > 512 ||
+    !value.startsWith("/") ||
+    value.endsWith("/") ||
+    value.includes("\\") ||
+    !/^\/[A-Za-z0-9._/-]+$/u.test(value)
+  ) {
+    fail(`${label} must be a canonical absolute ASCII target path`);
+  }
+  if (value.split("/").some((component, index) => index > 0 && ["", ".", ".."].includes(component))) {
+    fail(`${label} contains an empty, dot, or parent component`);
+  }
+  if (value.split("/").length - 1 > MAX_PATH_COMPONENTS) {
+    fail(`${label} exceeds the ${MAX_PATH_COMPONENTS}-component depth limit`);
+  }
+  if (posix.normalize(value) !== value) fail(`${label} is not canonical`);
+  return value;
+}
+
+function resolveUnder(root, relativePath, label) {
+  const path = join(root, ...relativePath.split("/"));
+  const rel = relative(root, path);
+  if (rel === "" || rel === ".." || rel.startsWith(`..${sep}`) || resolve(path) !== path) {
+    fail(`${label} escapes its root`);
+  }
+  let real;
+  try {
+    real = realpathSync(path);
+  } catch {
+    fail(`${label} is missing: ${relativePath}`);
+  }
+  if (real !== path) fail(`${label} resolves through a symlink: ${relativePath}`);
+  return path;
+}
+
+function validateSha256(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/u.test(value)) {
+    fail(`${label} must be a lowercase SHA-256 hex digest`);
+  }
+  if (/^0{64}$/u.test(value)) fail(`${label} must not be all zero`);
+  return value;
+}
+
+function validateMode(value, allowed, label) {
+  if (typeof value !== "string" || !/^[0-7]{4}$/u.test(value) || !allowed.includes(value)) {
+    fail(`${label} mode must be one of ${JSON.stringify(allowed)}`);
+  }
+}
+
+function validateUidGid(value, label, { allowRoot = true } = {}) {
+  if (!Number.isSafeInteger(value) || value < (allowRoot ? 0 : 1) || value > 4_294_967_294) {
+    fail(`${label} must be a bounded numeric uid/gid`);
+  }
+}
+
+function validateSafeAscii(value, label, maxLength = 256) {
+  if (
+    typeof value !== "string" ||
+    value.length < 1 ||
+    value.length > maxLength ||
+    !/^[\x21-\x7e]+$/u.test(value)
+  ) {
+    fail(`${label} must be bounded, non-empty printable ASCII without whitespace`);
+  }
+  if (/["'\\$%@]/u.test(value)) {
+    fail(`${label} contains a forbidden quote, backslash, dollar, percent, or at-sign`);
+  }
+}
+
+function validateDnsHost(value, label) {
+  validateSafeAscii(value, label, 253);
+  if (value !== value.toLowerCase() || value.endsWith(".") || !value.includes(".")) {
+    fail(`${label} must be a canonical lowercase DNS hostname with at least two labels`);
+  }
+  const labels = value.split(".");
+  if (
+    labels.some(
+      (part) =>
+        part.length < 1 ||
+        part.length > 63 ||
+        !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u.test(part),
+    )
+  ) {
+    fail(`${label} is not a canonical DNS hostname`);
+  }
+}
+
+function parseUnsignedDecimal(value, label, minimum, maximum) {
+  validateSafeAscii(value, label, 20);
+  if (!/^(?:0|[1-9][0-9]*)$/u.test(value)) fail(`${label} must be canonical decimal`);
+  const parsed = BigInt(value);
+  if (parsed < minimum || parsed > maximum) {
+    fail(`${label} must be in [${minimum}, ${maximum}]`);
+  }
+}
+
+function parseHostPort(value, label, { announce = false } = {}) {
+  validateSafeAscii(value, label, 320);
+  let host;
+  let portText;
+  const bracketed = /^\[([^\]]+)\]:([0-9]+)$/u.exec(value);
+  if (bracketed) {
+    host = bracketed[1];
+    portText = bracketed[2];
+    if (isIP(host) !== 6) fail(`${label} has an invalid bracketed IPv6 address`);
+  } else {
+    const match = /^([^:]+):([0-9]+)$/u.exec(value);
+    if (!match) fail(`${label} must be host:port or [IPv6]:port`);
+    host = match[1];
+    portText = match[2];
+    if (isIP(host) === 0) validateDnsHost(host, `${label} host`);
+  }
+  parseUnsignedDecimal(portText, `${label} port`, 1n, 65_535n);
+  if (announce && ["0.0.0.0", "127.0.0.1", "::", "::1"].includes(host)) {
+    fail(`${label} must not announce an unspecified or loopback address`);
+  }
+}
+
+function validatePlaceholderValue(name, value) {
+  const label = `placeholder ${name}`;
+  if (!ALL_PLACEHOLDER_NAMES.has(name)) fail(`${label} is not in the closed-world schema`);
+  validateSafeAscii(value, label, 512);
+  if (HEX64_PLACEHOLDERS.has(name)) {
+    validateSha256(value, label);
+    return;
+  }
+  if (DNS_HOST_PLACEHOLDERS.has(name)) {
+    validateDnsHost(value, label);
+    return;
+  }
+  if (UID_GID_PLACEHOLDERS.has(name)) {
+    parseUnsignedDecimal(value, label, 1n, 4_294_967_294n);
+    return;
+  }
+  if (POSITIVE_SERVICE_VALUE_PLACEHOLDERS.has(name)) {
+    parseUnsignedDecimal(value, label, 1n, 9_223_372_036_854_775_807n);
+    return;
+  }
+  switch (name) {
+    case "BITCOIND_SYSTEMD_UNIT":
+      if (!/^[A-Za-z0-9_.-]{1,128}\.service$/u.test(value)) {
+        fail(`${label} must be one literal systemd .service unit name`);
+      }
+      return;
+    case "BITCOINPIR_WEB_ORIGIN": {
+      const match = /^https:\/\/([^/]+)$/u.exec(value);
+      if (!match) fail(`${label} must be one canonical HTTPS origin without path or port`);
+      validateDnsHost(match[1], `${label} host`);
+      return;
+    }
+    case "BITCOIN_RPC_PORT":
+      parseUnsignedDecimal(value, label, 1n, 65_535n);
+      return;
+    case "CLN_GUARD_MAX_INVOICE_MSAT":
+      parseUnsignedDecimal(value, label, 1n, 2_100_000_000_000_000_000n);
+      return;
+    case "CLN_GUARD_MAX_INVOICES_PER_MINUTE":
+      parseUnsignedDecimal(value, label, 1n, 600n);
+      return;
+    case "CLN_GUARD_MAX_INVOICE_BURST":
+      parseUnsignedDecimal(value, label, 1n, 100n);
+      return;
+    case "CLN_GUARD_MAX_INVOICES_PER_RUNTIME":
+      parseUnsignedDecimal(value, label, 1n, 100_000n);
+      return;
+    case "CLN_P2P_ANNOUNCE_ADDR":
+      parseHostPort(value, label, { announce: true });
+      return;
+    case "CLN_P2P_BIND_ADDR":
+      parseHostPort(value, label);
+      return;
+    case "EDGE_CADDYFILE":
+      if (!["hetzner-public.Caddyfile", "rollback-authority.Caddyfile"].includes(value)) {
+        fail(`${label} is not a reviewed edge Caddyfile basename`);
+      }
+      return;
+    case "HETZNER_PROVIDER_SERVER_ID":
+      if (!/^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$/u.test(value)) {
+        fail(`${label} must be a bounded lowercase server-id slug`);
+      }
+      return;
+    case "LIGHTNING_NETWORK":
+      if (value !== "signet") fail(`${label} must equal signet for Payment V1 staging`);
+      return;
+    default:
+      fail(`${label} has no validator`);
+  }
+}
+
+function expectedPayloadClass(targetPath) {
+  if (
+    targetPath.startsWith("/opt/bitcoinpir/") ||
+    targetPath.startsWith("/usr/local/libexec/bitcoinpir/")
+  ) {
+    return "binary";
+  }
+  const name = basename(targetPath).toLowerCase();
+  if (name.endsWith(".sha256")) return "hash-manifest";
+  if (
+    name.endsWith(".key") ||
+    name.endsWith(".seed") ||
+    /(?:secret|derivation|signing|custody|idempotency)/u.test(name)
+  ) {
+    return "secret";
+  }
+  if (
+    name.endsWith(".bin") ||
+    /(?:policy|authorization|approval|delegation|receipt|metadata)/u.test(name)
+  ) {
+    return "policy";
+  }
+  return "config";
+}
+
+function validatePrivateReadableMetadata(artifact, label) {
+  const ownerPrivate = artifact.uid > 0 && artifact.gid >= 0 && artifact.mode === "0400";
+  const groupPrivate = artifact.uid === 0 && artifact.gid > 0 && artifact.mode === "0440";
+  const rootPrivate = artifact.uid === 0 && artifact.gid === 0 && artifact.mode === "0400";
+  if (!ownerPrivate && !groupPrivate && !rootPrivate) {
+    fail(
+      `${label} must be 0400 for one owner or 0440 for one non-root service group`,
+    );
+  }
+}
+
+function validatePayloadMetadata(artifact, label) {
+  const expectedClass = expectedPayloadClass(artifact.target_path);
+  if (artifact.class !== expectedClass) {
+    fail(`${label}.class must equal target-derived class ${expectedClass}`);
+  }
+  switch (artifact.class) {
+    case "binary":
+      if (artifact.uid !== 0 || artifact.gid !== 0 || artifact.mode !== "0555") {
+        fail(`${label} binary must be immutable root:root mode 0555`);
+      }
+      break;
+    case "hash-manifest":
+      if (artifact.uid !== 0 || artifact.gid !== 0 || artifact.mode !== "0444") {
+        fail(`${label} hash manifest must be immutable root:root mode 0444`);
+      }
+      break;
+    case "secret":
+    case "policy":
+      validatePrivateReadableMetadata(artifact, label);
+      break;
+    case "config":
+      if (artifact.mode === "0444" && artifact.uid === 0 && artifact.gid === 0) break;
+      validatePrivateReadableMetadata(artifact, label);
+      break;
+    default:
+      fail(`${label}.class is outside the closed payload class schema`);
+  }
+  if (artifact.class === "secret" && /4$/u.test(artifact.mode)) {
+    fail(`${label} secret must never be world-readable`);
+  }
+}
+
+function validateRenderedMetadata(artifact, catalog, label) {
+  validateMode(artifact.mode, catalog.modes, label);
+  if (catalog.rootOwned && (artifact.uid !== 0 || artifact.gid !== 0)) {
+    fail(`${label} must be root:root at its installation target`);
+  }
+  if (
+    !catalog.rootOwned &&
+    (catalog.artifactClass === "config" || catalog.artifactClass === "argument-fragment")
+  ) {
+    validatePrivateReadableMetadata(artifact, label);
+  }
+}
+
+function secretConsumerUnit(deploymentProfile, targetPath) {
+  const mappings = {
+    "edge-hetzner-v1": [["/etc/bitcoinpir/payment-v1/edge/", "bitcoinpir-payment-v1-edge.service"]],
+    "edge-rollback-authority-v1": [["/etc/bitcoinpir/payment-v1/edge/", "bitcoinpir-payment-v1-edge.service"]],
+    "issuer-lightning-signet-v1": [
+      ["/etc/bitcoinpir/payment-v1/issuer/", "bitcoinpir-payment-issuer.service"],
+      ["/etc/bitcoinpir/payment-v1/lightning/", "bitcoinpir-core-lightning.service"],
+    ],
+    "provider-v1": [["/etc/bitcoinpir/payment-v1/provider/", "bitcoinpir-provider.service"]],
+    "rollback-authority-v1": [["/etc/bitcoinpir/payment-v1/rollback-authority/", "bitcoinpir-rollback-authority.service"]],
+  };
+  return mappings[deploymentProfile]?.find(([prefix]) => targetPath.startsWith(prefix))?.[1];
+}
+
+function validateSecretOwnerBindings(plan) {
+  const identities = new Map(plan.service_identities.map((identity) => [identity.unit_name, identity]));
+  const artifacts = plan.payload_artifacts ?? plan.artifacts;
+  for (const artifact of artifacts) {
+    if ((artifact.class ?? artifact.artifact_class) !== "secret") continue;
+    const unitName = secretConsumerUnit(plan.deployment_profile, artifact.target_path);
+    const identity = identities.get(unitName);
+    if (!unitName || !identity) {
+      fail(`secret target has no exact service identity binding: ${artifact.target_path}`);
+    }
+    if (artifact.uid !== identity.uid || artifact.gid !== identity.gid || artifact.mode !== "0400") {
+      fail(
+        `secret must be owned exclusively by ${unitName} uid=${identity.uid} gid=${identity.gid} mode 0400: ${artifact.target_path}`,
+      );
+    }
+  }
+}
+
+function validatePlan(plan) {
+  exactKeys(
+    plan,
+    [
+      "deployment_id",
+      "deployment_profile",
+      "payload_artifacts",
+      "placeholders",
+      "rendered_artifacts",
+      "schema_version",
+      "service_identities",
+    ],
+    "render plan",
+  );
+  if (plan.schema_version !== PLAN_SCHEMA_VERSION) {
+    fail(`render plan schema_version must equal ${PLAN_SCHEMA_VERSION}`);
+  }
+  if (
+    typeof plan.deployment_id !== "string" ||
+    !/^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$/u.test(plan.deployment_id)
+  ) {
+    fail("render plan deployment_id must be a bounded lowercase slug");
+  }
+  if (typeof plan.deployment_profile !== "string" || !PROFILE_CATALOG[plan.deployment_profile]) {
+    fail(
+      `render plan deployment_profile must be one of ${JSON.stringify(Object.keys(PROFILE_CATALOG).sort(asciiCompare))}`,
+    );
+  }
+  if (!isPlainObject(plan.placeholders)) fail("render plan placeholders must be an object");
+  if (!Array.isArray(plan.rendered_artifacts) || plan.rendered_artifacts.length < 1) {
+    fail("render plan rendered_artifacts must be a non-empty array");
+  }
+  if (!Array.isArray(plan.payload_artifacts)) {
+    fail("render plan payload_artifacts must be an array");
+  }
+  if (!Array.isArray(plan.service_identities) || plan.service_identities.length < 1 || plan.service_identities.length > 32) {
+    fail("render plan service_identities must be a bounded non-empty array");
+  }
+  if (plan.rendered_artifacts.length > 64 || plan.payload_artifacts.length > 1024) {
+    fail("render plan contains too many artifacts");
+  }
+
+  for (const [index, identity] of plan.service_identities.entries()) {
+    const label = `service_identities[${index}]`;
+    exactKeys(identity, ["gid", "group_name", "uid", "unit_name", "user_name"], label);
+    if (!/^bitcoinpir-[a-z0-9-]+\.service$/u.test(identity.unit_name)) {
+      fail(`${label}.unit_name is not a reviewed BitcoinPIR service name`);
+    }
+    for (const key of ["group_name", "user_name"]) {
+      if (!/^bitcoinpir-[a-z0-9-]+$/u.test(identity[key])) {
+        fail(`${label}.${key} is not a reviewed BitcoinPIR NSS name`);
+      }
+    }
+    validateUidGid(identity.uid, `${label}.uid`);
+    validateUidGid(identity.gid, `${label}.gid`);
+    if (identity.uid === 0 || identity.gid === 0) fail(`${label} must bind a non-root service identity`);
+    if (index > 0 && asciiCompare(plan.service_identities[index - 1].unit_name, identity.unit_name) >= 0) {
+      fail("render plan service_identities must be unique and bytewise sorted by unit_name");
+    }
+  }
+  if (new Set(plan.service_identities.map((identity) => identity.uid)).size !== plan.service_identities.length) {
+    fail("render plan service identities must use distinct UIDs");
+  }
+
+  const renderedSources = new Set();
+  const targets = new Set();
+  for (const [index, artifact] of plan.rendered_artifacts.entries()) {
+    const label = `rendered_artifacts[${index}]`;
+    exactKeys(
+      artifact,
+      ["gid", "mode", "source_path", "source_sha256", "target_path", "uid"],
+      label,
+    );
+    const sourcePath = safeRelativePath(artifact.source_path, `${label}.source_path`);
+    const catalog = TEMPLATE_CATALOG[sourcePath];
+    if (!catalog) fail(`${label}.source_path is not in the reviewed template catalog`);
+    if (artifact.target_path !== catalog.targetPath) {
+      fail(`${label}.target_path must equal ${catalog.targetPath}`);
+    }
+    safeTargetPath(artifact.target_path, `${label}.target_path`);
+    validateSha256(artifact.source_sha256, `${label}.source_sha256`);
+    validateRenderedMetadata(artifact, catalog, label);
+    validateUidGid(artifact.uid, `${label}.uid`);
+    validateUidGid(artifact.gid, `${label}.gid`);
+    if (renderedSources.has(sourcePath)) fail(`${label} repeats a rendered source`);
+    renderedSources.add(sourcePath);
+    if (targets.has(artifact.target_path)) fail(`${label} repeats an installation target`);
+    targets.add(artifact.target_path);
+  }
+
+  for (const [index, artifact] of plan.payload_artifacts.entries()) {
+    const label = `payload_artifacts[${index}]`;
+    exactKeys(
+      artifact,
+      ["class", "expected_sha256", "gid", "mode", "source_path", "target_path", "uid"],
+      label,
+    );
+    safeRelativePath(artifact.source_path, `${label}.source_path`);
+    safeTargetPath(artifact.target_path, `${label}.target_path`);
+    validateSha256(artifact.expected_sha256, `${label}.expected_sha256`);
+    if (!["binary", "config", "policy", "secret", "hash-manifest"].includes(artifact.class)) {
+      fail(`${label}.class is outside the closed payload class schema`);
+    }
+    const prefixes =
+      artifact.class === "binary"
+        ? ["/opt/bitcoinpir/", "/usr/local/libexec/bitcoinpir/"]
+        : artifact.class === "policy"
+          ? ["/etc/bitcoinpir/payment-v1/", "/home/pir/data/payment-v1/"]
+          : ["/etc/bitcoinpir/payment-v1/"];
+    if (!prefixes.some((prefix) => artifact.target_path.startsWith(prefix))) {
+      fail(`${label}.target_path is outside the reviewed ${artifact.class} prefixes`);
+    }
+    validateUidGid(artifact.uid, `${label}.uid`);
+    validateUidGid(artifact.gid, `${label}.gid`);
+    validatePayloadMetadata(artifact, label);
+    if (targets.has(artifact.target_path)) fail(`${label} repeats an installation target`);
+    targets.add(artifact.target_path);
+  }
+
+  validateSecretOwnerBindings(plan);
+
+
+  const expectedTemplates = PROFILE_CATALOG[plan.deployment_profile].templates;
+  assertSameStringSet(renderedSources, expectedTemplates, "deployment profile templates");
+}
+
+function extractPlaceholders(text) {
+  return new Set(text.match(/@[A-Z][A-Z0-9_]{0,63}@/gu)?.map((token) => token.slice(1, -1)) ?? []);
+}
+
+function renderTemplate(text, placeholders, label) {
+  let rendered = text;
+  for (const name of [...extractPlaceholders(text)].sort()) {
+    rendered = rendered.split(`@${name}@`).join(placeholders[name]);
+  }
+  if (/@[A-Z][A-Z0-9_]{0,63}@/u.test(rendered)) {
+    fail(`${label} retains an unresolved @PLACEHOLDER@ token`);
+  }
+  if (/\bUNRESOLVED\b/u.test(rendered)) fail(`${label} retains an UNRESOLVED marker`);
+  if (/\r|\0/u.test(rendered)) fail(`${label} contains a carriage return or NUL byte`);
+  return rendered;
+}
+
+function managedReferencesFromCommand(command, label) {
+  if (/[$%`;&|<>\n\r\0]/u.test(command)) {
+    fail(`${label} contains variable expansion, a specifier, or shell metacharacter`);
+  }
+  if (/['"]/u.test(command)) fail(`${label} must not rely on quoting semantics`);
+  const first = command.trim().split(/\s+/u)[0] ?? "";
+  if (!first.startsWith("/") || /^[!+@:-]/u.test(first)) {
+    fail(`${label} command must start with one literal absolute executable path`);
+  }
+  const references = new Set();
+  for (const match of command.matchAll(/\/(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+/gu)) {
+    const candidate = match[0];
+    if (MANAGED_FILE_PREFIXES.some((prefix) => candidate.startsWith(prefix))) {
+      safeTargetPath(candidate, `${label} managed path`);
+      references.add(candidate);
+    }
+  }
+  return references;
+}
+
+function parseSystemdUnit(text, label) {
+  if (/^\s*\[Install\]\s*$/imu.test(text)) fail(`${label} contains forbidden [Install]`);
+  if (/%/u.test(text)) fail(`${label} contains a forbidden systemd percent specifier`);
+  if (/\$/u.test(text)) fail(`${label} contains forbidden systemd variable expansion`);
+  if (!/^[\x00-\x7f]*$/u.test(text)) fail(`${label} must be stable ASCII text`);
+  const logicalLines = [];
+  let pending = "";
+  for (const original of text.split("\n")) {
+    const trimmed = original.trim();
+    if (trimmed === "" || trimmed.startsWith("#") || trimmed.startsWith(";")) continue;
+    const continued = original.trimEnd().endsWith("\\");
+    const fragment = continued ? original.trimEnd().slice(0, -1).trim() : trimmed;
+    pending = pending === "" ? fragment : `${pending} ${fragment}`;
+    if (!continued) {
+      logicalLines.push(pending);
+      pending = "";
+    }
+  }
+  if (pending !== "") fail(`${label} has an unterminated continuation`);
+
+  const sections = new Map();
+  let section;
+  for (const line of logicalLines) {
+    const sectionMatch = /^\[([A-Za-z][A-Za-z0-9]*)\]$/u.exec(line);
+    if (sectionMatch) {
+      section = sectionMatch[1];
+      if (!["Unit", "Service"].includes(section)) fail(`${label} has forbidden [${section}]`);
+      if (sections.has(section)) fail(`${label} repeats [${section}]`);
+      sections.set(section, new Map());
+      continue;
+    }
+    if (!section) fail(`${label} has a directive outside a section`);
+    const match = /^([A-Za-z][A-Za-z0-9]*)=(.*)$/u.exec(line);
+    if (!match) fail(`${label} has a malformed directive: ${line}`);
+    const key = match[1];
+    const value = match[2].trim();
+    const allowedKeys = section === "Unit" ? SYSTEMD_UNIT_KEYS : SYSTEMD_SERVICE_KEYS;
+    if (!allowedKeys.includes(key)) {
+      fail(`${label} contains closed-world forbidden directive ${section}.${key}=`);
+    }
+    if (value === "" && !["AmbientCapabilities", "CapabilityBoundingSet"].includes(key)) {
+      fail(`${label} contains a forbidden empty ${key}= reset`);
+    }
+    const values = sections.get(section).get(key) ?? [];
+    if (
+      values.length > 0 &&
+      !(
+        (section === "Unit" && key === "ConditionPathExists") ||
+        (section === "Service" && key === "ExecStartPre")
+      )
+    ) {
+      fail(`${label} repeats single-valued directive ${section}.${key}=`);
+    }
+    values.push(value);
+    sections.get(section).set(key, values);
+  }
+  if (!sections.has("Unit") || !sections.has("Service")) {
+    fail(`${label} must contain exactly [Unit] and [Service]`);
+  }
+  const service = sections.get("Service");
+  const unit = sections.get("Unit");
+  const execStart = service.get("ExecStart") ?? [];
+  if (execStart.length !== 1) fail(`${label} must have exactly one effective ExecStart`);
+  const conditions = [...unit.entries()]
+    .filter(([key]) => key.startsWith("Condition"))
+    .flatMap(([key, values]) => values.map((value) => `${key}=${value}`))
+    .sort();
+  if (conditions.length < 1) fail(`${label} must retain at least one fail-closed condition`);
+
+  const environment = [];
+  for (const directive of service.get("Environment") ?? []) {
+    if (/["'\\$%]/u.test(directive)) fail(`${label} Environment= must use literal assignments`);
+    for (const assignment of directive.split(/\s+/u)) {
+      if (!/^[A-Za-z_][A-Za-z0-9_]*=[^\s]+$/u.test(assignment)) {
+        fail(`${label} has a malformed Environment= assignment`);
+      }
+      environment.push(assignment);
+    }
+  }
+  environment.sort();
+  if (new Set(environment.map((value) => value.split("=", 1)[0])).size !== environment.length) {
+    fail(`${label} repeats an Environment= variable`);
+  }
+
+  const hardening = Object.create(null);
+  for (const key of SYSTEMD_HARDENING_KEYS) {
+    const values = service.get(key);
+    if (values) hardening[key] = [...values];
+  }
+  for (const [key, expected] of Object.entries(REQUIRED_SYSTEMD_HARDENING)) {
+    if (canonicalize(hardening[key] ?? []) !== canonicalize(expected)) {
+      fail(`${label} ${key} must equal ${JSON.stringify(expected)}`);
+    }
+  }
+  for (const key of ["AmbientCapabilities", "CapabilityBoundingSet"]) {
+    const values = hardening[key];
+    if (!values || values.length !== 1) fail(`${label} must explicitly set ${key}`);
+    if (values[0] !== "" && values[0] !== "CAP_NET_BIND_SERVICE") {
+      fail(`${label} ${key} contains an unreviewed capability`);
+    }
+  }
+  const managedReferences = new Set();
+  for (const [key, commands] of [
+    ["ExecStart", execStart],
+    ["ExecStartPre", service.get("ExecStartPre") ?? []],
+  ]) {
+    for (const [index, command] of commands.entries()) {
+      for (const reference of managedReferencesFromCommand(
+        command,
+        `${label} ${key}[${index}]`,
+      )) {
+        managedReferences.add(reference);
+      }
+    }
+  }
+  return {
+    conditions,
+    environment,
+    environment_files: [],
+    exec_start: [...execStart],
+    exec_start_pre: [...(service.get("ExecStartPre") ?? [])],
+    hardening,
+    managed_references: [...managedReferences].sort(asciiCompare),
+  };
+}
+
+function validateProfileUnitPolicy(deploymentProfile, fragmentPath, hardening, label) {
+  if (
+    deploymentProfile === "issuer-lightning-signet-v1" &&
+    fragmentPath === "/etc/systemd/system/bitcoinpir-cln-rpc-guard.service"
+  ) {
+    if (canonicalize(hardening.Restart ?? []) !== canonicalize(["no"])) {
+      fail(`${label} must keep the CLN guard deadman Restart=no`);
+    }
+    if (hardening.RestartSec !== undefined) {
+      fail(`${label} must not configure RestartSec for the non-restarting CLN guard`);
+    }
+  }
+  if (
+    deploymentProfile === "provider-v1" &&
+    fragmentPath === "/etc/systemd/system/bitcoinpir-provider.service"
+  ) {
+    for (const key of ["PrivateDevices", "ProtectClock", "ProtectHostname"]) {
+      if (canonicalize(hardening[key] ?? []) !== canonicalize(["true"])) {
+        fail(`${label} must keep provider ${key}=true`);
+      }
+    }
+  }
+}
+
+function validateRuntimeServiceIdentities(plan, runtimeUnits) {
+  if (
+    canonicalize(plan.service_identities.map((identity) => identity.unit_name)) !==
+    canonicalize(runtimeUnits.map((unit) => unit.unit_name))
+  ) {
+    fail("render plan service_identities must exactly cover the rendered runtime units");
+  }
+  const issuerPins = {
+    "bitcoinpir-cln-rpc-guard.service": ["CLN_GUARD_UID", "LIGHTNING_GID"],
+    "bitcoinpir-core-lightning.service": ["LIGHTNING_UID", "LIGHTNING_GID"],
+    "bitcoinpir-lightning-preflight.service": ["PREFLIGHT_UID", "PREFLIGHT_GID"],
+    "bitcoinpir-payment-issuer.service": ["ISSUER_UID", "ISSUER_GID"],
+  };
+  for (const unit of runtimeUnits) {
+    const identity = plan.service_identities.find((entry) => entry.unit_name === unit.unit_name);
+    if (
+      !identity ||
+      canonicalize(unit.hardening.User ?? []) !== canonicalize([identity.user_name]) ||
+      canonicalize(unit.hardening.Group ?? []) !== canonicalize([identity.group_name])
+    ) {
+      fail(`service identity does not match rendered User=/Group=: ${unit.unit_name}`);
+    }
+    const pins = issuerPins[unit.unit_name];
+    if (plan.deployment_profile === "issuer-lightning-signet-v1" && pins) {
+      if (
+        identity.uid !== Number(plan.placeholders[pins[0]]) ||
+        identity.gid !== Number(plan.placeholders[pins[1]])
+      ) {
+        fail(`issuer service identity does not match its externally approved UID/GID placeholders: ${unit.unit_name}`);
+      }
+    }
+  }
+}
+
+function artifactBundlePath(targetPath) {
+  return `files/${targetPath.slice(1)}`;
+}
+
+function hashBindingClass(artifactClass) {
+  if (artifactClass === "binary") return "binary";
+  if (artifactClass === "policy") return "policy";
+  if (artifactClass === "secret") return "secret";
+  if (artifactClass === "hash-manifest") return "hash_manifest";
+  return "config";
+}
+
+function configManagedReferences(sourcePath, text) {
+  if (sourcePath !== "deploy/payment-v1/lightning/lightningd.conf.in") return [];
+  const references = new Set();
+  for (const original of text.split("\n")) {
+    const line = original.trim();
+    if (line === "" || line.startsWith("#") || !line.includes("=")) continue;
+    const value = line.slice(line.indexOf("=") + 1);
+    if (/[$%`;&|<>\r\0]/u.test(value)) {
+      fail(`rendered ${sourcePath} contains a dynamic or shell-like value`);
+    }
+    for (const match of value.matchAll(/\/(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+/gu)) {
+      if (MANAGED_FILE_PREFIXES.some((prefix) => match[0].startsWith(prefix))) {
+        references.add(match[0]);
+      }
+    }
+  }
+  return [...references].sort(asciiCompare);
+}
+
+function parseTmpfilesDirectories(sourcePath, text) {
+  if (sourcePath !== "deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in") return [];
+  const directories = [];
+  for (const [index, original] of text.split("\n").entries()) {
+    const line = original.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const fields = line.split(/\s+/u);
+    if (
+      fields.length !== 7 ||
+      fields[0] !== "d" ||
+      fields[5] !== "-" ||
+      fields[6] !== "-"
+    ) {
+      fail(`rendered ${sourcePath} line ${index + 1} is outside the closed tmpfiles schema`);
+    }
+    const targetPath = safeTargetPath(fields[1], `rendered ${sourcePath} directory`);
+    if (!targetPath.startsWith("/run/bitcoinpir-cln-rpc-guard")) {
+      fail(`rendered ${sourcePath} has an unreviewed runtime directory`);
+    }
+    validateMode(fields[2], ["0710"], `rendered ${sourcePath} directory`);
+    for (const [field, label] of [[fields[3], "user"], [fields[4], "group"]]) {
+      if (!/^[a-z_][a-z0-9_-]{0,31}$/u.test(field)) {
+        fail(`rendered ${sourcePath} tmpfiles ${label} is not one literal NSS name`);
+      }
+    }
+    directories.push({
+      group_name: fields[4],
+      mode: fields[2],
+      target_path: targetPath,
+      user_name: fields[3],
+    });
+  }
+  directories.sort((left, right) => asciiCompare(left.target_path, right.target_path));
+  if (directories.length !== 2) fail(`rendered ${sourcePath} must define exactly two directories`);
+  return directories;
+}
+
+function parseHashManifest(bytes, label) {
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    fail(`${label} must be UTF-8`);
+  }
+  if (!/^[\x00-\x7f]*$/u.test(text) || text.length < 1 || !text.endsWith("\n")) {
+    fail(`${label} must be non-empty canonical ASCII ending in newline`);
+  }
+  const entries = [];
+  const seen = new Set();
+  for (const [index, line] of text.slice(0, -1).split("\n").entries()) {
+    const match = /^([0-9a-f]{64})  (\/[A-Za-z0-9._/-]+)$/u.exec(line);
+    if (!match) fail(`${label} line ${index + 1} is not strict sha256sum syntax`);
+    const targetPath = safeTargetPath(match[2], `${label} line ${index + 1} path`);
+    if (!MANAGED_FILE_PREFIXES.some((prefix) => targetPath.startsWith(prefix))) {
+      fail(`${label} line ${index + 1} is outside managed deployment prefixes`);
+    }
+    if (seen.has(targetPath)) fail(`${label} repeats ${targetPath}`);
+    seen.add(targetPath);
+    entries.push({ sha256: match[1], target_path: targetPath });
+  }
+  const sorted = [...entries].sort((left, right) => asciiCompare(left.target_path, right.target_path));
+  if (canonicalize(entries) !== canonicalize(sorted)) {
+    fail(`${label} entries must be bytewise ASCII sorted by absolute target path`);
+  }
+  return entries;
+}
+
+function validateHashManifestScope(manifestPath, entries, plan) {
+  const oneExact = (targetPath) => {
+    if (entries.length !== 1 || entries[0].target_path !== targetPath) {
+      fail(`hash manifest ${manifestPath} must bind only ${targetPath}`);
+    }
+  };
+  switch (manifestPath) {
+    case "/etc/bitcoinpir/payment-v1/edge/caddy.sha256":
+      oneExact(`/opt/bitcoinpir/caddy/${plan.placeholders.CADDY_SHA256}/caddy`);
+      return;
+    case "/etc/bitcoinpir/payment-v1/edge/edge-config.sha256":
+      oneExact(`/etc/bitcoinpir/payment-v1/edge/${plan.placeholders.EDGE_CADDYFILE}`);
+      return;
+    case "/etc/bitcoinpir/payment-v1/issuer/payment-issuer.sha256":
+      oneExact(`/opt/bitcoinpir/payment-issuer/${plan.placeholders.PAYMENT_ISSUER_SHA256}/payment-issuer`);
+      return;
+    case "/etc/bitcoinpir/payment-v1/lightning/bpir-admin.sha256":
+      oneExact(`/opt/bitcoinpir/bpir-admin/${plan.placeholders.BPIR_ADMIN_SHA256}/bpir-admin`);
+      return;
+    case "/etc/bitcoinpir/payment-v1/lightning/cln-rpc-guard.sha256":
+      oneExact(`/opt/bitcoinpir/cln-rpc-guard/${plan.placeholders.CLN_RPC_GUARD_SHA256}/bitcoinpir-cln-rpc-guard`);
+      return;
+    case "/etc/bitcoinpir/payment-v1/lightning/layout-verifier.sha256":
+      oneExact("/usr/local/libexec/bitcoinpir/verify-lightning-layout");
+      return;
+    case "/etc/bitcoinpir/payment-v1/lightning/lightningd-config.sha256":
+      oneExact("/etc/bitcoinpir/payment-v1/lightning/lightningd.conf");
+      return;
+    case "/etc/bitcoinpir/payment-v1/lightning/preflight-config.sha256":
+      oneExact("/etc/bitcoinpir/payment-v1/lightning/preflight.toml");
+      return;
+    case "/etc/bitcoinpir/payment-v1/lightning/backup-receipt.sha256":
+      if (
+        entries.length !== 1 ||
+        !/^\/etc\/bitcoinpir\/payment-v1\/lightning\/backup-receipt\.(?:bin|json|toml)$/u.test(
+          entries[0].target_path,
+        )
+      ) {
+        fail(`hash manifest ${manifestPath} must bind one reviewed backup-receipt artifact`);
+      }
+      return;
+    case "/etc/bitcoinpir/payment-v1/lightning/cln-bundle.sha256": {
+      const prefix = `/opt/bitcoinpir/core-lightning/${plan.placeholders.CLN_BUNDLE_SHA256}/`;
+      if (entries.length < 3 || entries.some((entry) => !entry.target_path.startsWith(prefix))) {
+        fail(`hash manifest ${manifestPath} must remain inside the selected CLN bundle`);
+      }
+      for (const required of ["bin/lightningd", "plugins/bcli", "plugins/chanbackup"]) {
+        if (!entries.some((entry) => entry.target_path === `${prefix}${required}`)) {
+          fail(`hash manifest ${manifestPath} is missing ${required}`);
+        }
+      }
+      return;
+    }
+    case "/etc/bitcoinpir/payment-v1/lightning/bitcoin-core-bundle.sha256": {
+      const prefix = `/opt/bitcoinpir/bitcoin-core/${plan.placeholders.BITCOIN_CORE_BUNDLE_SHA256}/`;
+      if (entries.length < 1 || entries.some((entry) => !entry.target_path.startsWith(prefix))) {
+        fail(`hash manifest ${manifestPath} must remain inside the selected Bitcoin Core bundle`);
+      }
+      if (!entries.some((entry) => entry.target_path === `${prefix}bin/bitcoin-cli`)) {
+        fail(`hash manifest ${manifestPath} is missing bin/bitcoin-cli`);
+      }
+      return;
+    }
+    case "/etc/bitcoinpir/payment-v1/provider/unified-server.sha256":
+      oneExact(`/opt/bitcoinpir/unified-server/${plan.placeholders.UNIFIED_SERVER_SHA256}/unified_server`);
+      return;
+    case "/etc/bitcoinpir/payment-v1/rollback-authority/rollback-authority.sha256":
+      oneExact(`/opt/bitcoinpir/rollback-authority/${plan.placeholders.ROLLBACK_AUTHORITY_SHA256}/rollback-authority`);
+      return;
+    default:
+      fail(`hash manifest target is not in the closed deployment schema: ${manifestPath}`);
+  }
+}
+
+function enforceDependencyClosure({ artifacts, fileBytes, initialReferences, plan }) {
+  const byTarget = new Map(artifacts.map((artifact) => [artifact.target_path, artifact]));
+  const reachable = new Set(initialReferences);
+  const queue = [...initialReferences].sort(asciiCompare);
+  while (queue.length > 0) {
+    const targetPath = queue.shift();
+    const artifact = byTarget.get(targetPath);
+    if (!artifact) {
+      if ([...byTarget.keys()].some((candidate) => candidate.startsWith(`${targetPath}/`))) {
+        continue;
+      }
+      fail(`deployment dependency is missing from the manifest: ${targetPath}`);
+    }
+    if (artifact.artifact_class !== "hash-manifest") continue;
+    const bytes = fileBytes.get(artifact.bundle_path);
+    const manifestEntries = parseHashManifest(bytes, `hash manifest ${targetPath}`);
+    validateHashManifestScope(targetPath, manifestEntries, plan);
+    for (const entry of manifestEntries) {
+      const dependency = byTarget.get(entry.target_path);
+      if (!dependency) {
+        fail(`hash manifest ${targetPath} references missing artifact ${entry.target_path}`);
+      }
+      if (dependency.rendered_sha256 !== entry.sha256) {
+        fail(`hash manifest ${targetPath} has the wrong digest for ${entry.target_path}`);
+      }
+      if (!reachable.has(entry.target_path)) {
+        reachable.add(entry.target_path);
+        queue.push(entry.target_path);
+        queue.sort(asciiCompare);
+      }
+    }
+  }
+  for (const artifact of artifacts) {
+    if (artifact.source_kind === "payload" && !reachable.has(artifact.target_path)) {
+      fail(`payload artifact is not reachable from the closed deployment profile: ${artifact.target_path}`);
+    }
+  }
+
+  const pathChecks = [
+    ["CADDY_SHA256", "/opt/bitcoinpir/caddy/", "/caddy", true],
+    ["CLN_RPC_GUARD_SHA256", "/opt/bitcoinpir/cln-rpc-guard/", "/bitcoinpir-cln-rpc-guard", true],
+    ["BPIR_ADMIN_SHA256", "/opt/bitcoinpir/bpir-admin/", "/bpir-admin", true],
+    ["PAYMENT_ISSUER_SHA256", "/opt/bitcoinpir/payment-issuer/", "/payment-issuer", true],
+    ["UNIFIED_SERVER_SHA256", "/opt/bitcoinpir/unified-server/", "/unified_server", true],
+    ["ROLLBACK_AUTHORITY_SHA256", "/opt/bitcoinpir/rollback-authority/", "/rollback-authority", true],
+  ];
+  for (const [placeholder, prefix, suffix, digestIsBinary] of pathChecks) {
+    const digest = plan.placeholders[placeholder];
+    if (digest === undefined) continue;
+    const target = `${prefix}${digest}${suffix}`;
+    const artifact = byTarget.get(target);
+    if (!artifact || artifact.artifact_class !== "binary") {
+      fail(`${placeholder} must select the exact binary target ${target}`);
+    }
+    if (digestIsBinary && artifact.rendered_sha256 !== digest) {
+      fail(`${placeholder} must equal the selected single-file binary digest`);
+    }
+  }
+}
+
+function buildBundleModel({ sourceRoot, inputRoot, plan, approvedPlanSha256 }) {
+  const canonicalSourceRoot = requireCanonicalRoot(sourceRoot, "source root");
+  const canonicalInputRoot = requireCanonicalRoot(inputRoot, "payload input root");
+  validatePlan(plan);
+  const approvedPlanDigest = requireApprovedPlan(plan, approvedPlanSha256);
+
+  const selectedTemplates = [];
+  const requiredPlaceholders = new Set();
+  for (const specification of plan.rendered_artifacts) {
+    const sourcePath = resolveUnder(
+      canonicalSourceRoot,
+      specification.source_path,
+      `template source ${specification.source_path}`,
+    );
+    const sourceBytes = readRegularSingleLinkFile(
+      sourcePath,
+      `template source ${specification.source_path}`,
+      MAX_TEMPLATE_BYTES,
+    );
+    const sourceSha256 = sha256(sourceBytes);
+    if (sourceSha256 !== specification.source_sha256) {
+      fail(`template source hash mismatch for ${specification.source_path}`);
+    }
+    let sourceText;
+    try {
+      sourceText = new TextDecoder("utf-8", { fatal: true }).decode(sourceBytes);
+    } catch {
+      fail(`template source is not valid UTF-8: ${specification.source_path}`);
+    }
+    for (const name of extractPlaceholders(sourceText)) {
+      if (!ALL_PLACEHOLDER_NAMES.has(name)) {
+        fail(`template ${specification.source_path} uses unknown placeholder ${name}`);
+      }
+      requiredPlaceholders.add(name);
+    }
+    selectedTemplates.push({ specification, sourceBytes, sourceSha256, sourceText });
+  }
+
+  exactKeys(plan.placeholders, [...requiredPlaceholders], "render plan placeholders");
+  for (const name of requiredPlaceholders) validatePlaceholderValue(name, plan.placeholders[name]);
+  if (
+    plan.deployment_profile === "edge-hetzner-v1" &&
+    plan.placeholders.EDGE_CADDYFILE !== "hetzner-public.Caddyfile"
+  ) {
+    fail("edge-hetzner-v1 must select hetzner-public.Caddyfile");
+  }
+  if (
+    plan.deployment_profile === "edge-rollback-authority-v1" &&
+    plan.placeholders.EDGE_CADDYFILE !== "rollback-authority.Caddyfile"
+  ) {
+    fail("edge-rollback-authority-v1 must select rollback-authority.Caddyfile");
+  }
+  if (plan.deployment_profile === "issuer-lightning-signet-v1") {
+    const uidValues = ["ISSUER_UID", "LIGHTNING_UID", "CLN_GUARD_UID", "PREFLIGHT_UID"].map(
+      (name) => plan.placeholders[name],
+    );
+    const gidValues = ["ISSUER_GID", "LIGHTNING_GID", "PREFLIGHT_GID"].map(
+      (name) => plan.placeholders[name],
+    );
+    if (new Set(uidValues).size !== uidValues.length || new Set(gidValues).size !== gidValues.length) {
+      fail("issuer Lightning profile service UIDs and service GIDs must be distinct per namespace");
+    }
+  }
+  if (
+    requiredPlaceholders.has("CLN_GUARD_MAX_INVOICE_BURST") &&
+    BigInt(plan.placeholders.CLN_GUARD_MAX_INVOICE_BURST) >
+      BigInt(plan.placeholders.CLN_GUARD_MAX_INVOICES_PER_MINUTE)
+  ) {
+    fail("CLN guard invoice burst must not exceed its per-minute rate");
+  }
+
+  const artifacts = [];
+  const fileBytes = new Map();
+  const runtimeUnits = [];
+  const tmpfilesDirectories = [];
+  const initialReferences = new Set();
+  for (const selected of selectedTemplates) {
+    const { specification, sourceSha256, sourceText } = selected;
+    const catalog = TEMPLATE_CATALOG[specification.source_path];
+    const renderedText = renderTemplate(
+      sourceText,
+      plan.placeholders,
+      `rendered ${specification.source_path}`,
+    );
+    const renderedBytes = Buffer.from(renderedText, "utf8");
+    const renderedSha256 = sha256(renderedBytes);
+    const bundlePath = artifactBundlePath(specification.target_path);
+    fileBytes.set(bundlePath, renderedBytes);
+    artifacts.push({
+      artifact_class: catalog.artifactClass,
+      bundle_path: bundlePath,
+      gid: specification.gid,
+      mode: specification.mode,
+      rendered_sha256: renderedSha256,
+      source_kind: "template",
+      source_path: specification.source_path,
+      source_sha256: sourceSha256,
+      target_path: specification.target_path,
+      uid: specification.uid,
+    });
+    if (catalog.artifactClass === "systemd-unit") {
+      const parsed = parseSystemdUnit(renderedText, `rendered unit ${specification.target_path}`);
+      validateProfileUnitPolicy(
+        plan.deployment_profile,
+        specification.target_path,
+        parsed.hardening,
+        `rendered unit ${specification.target_path}`,
+      );
+      for (const reference of parsed.managed_references) initialReferences.add(reference);
+      const { managed_references: _managedReferences, ...runtimeUnit } = parsed;
+      runtimeUnits.push({
+        ...runtimeUnit,
+        fragment_path: specification.target_path,
+        unit_name: basename(specification.target_path),
+      });
+    }
+    for (const reference of configManagedReferences(specification.source_path, renderedText)) {
+      initialReferences.add(reference);
+    }
+    tmpfilesDirectories.push(...parseTmpfilesDirectories(specification.source_path, renderedText));
+  }
+
+  for (const specification of plan.payload_artifacts) {
+    const sourcePath = resolveUnder(
+      canonicalInputRoot,
+      specification.source_path,
+      `payload source ${specification.source_path}`,
+    );
+    const sourceBytes = readRegularSingleLinkFile(
+      sourcePath,
+      `payload source ${specification.source_path}`,
+      MAX_PAYLOAD_BYTES,
+    );
+    const sourceSha256 = sha256(sourceBytes);
+    if (sourceSha256 !== specification.expected_sha256) {
+      fail(`payload source hash mismatch for ${specification.source_path}`);
+    }
+    const bundlePath = artifactBundlePath(specification.target_path);
+    fileBytes.set(bundlePath, sourceBytes);
+    artifacts.push({
+      artifact_class: specification.class,
+      bundle_path: bundlePath,
+      gid: specification.gid,
+      mode: specification.mode,
+      rendered_sha256: sourceSha256,
+      source_kind: "payload",
+      source_path: specification.source_path,
+      source_sha256: sourceSha256,
+      target_path: specification.target_path,
+      uid: specification.uid,
+    });
+  }
+
+  artifacts.sort((left, right) => asciiCompare(left.target_path, right.target_path));
+  runtimeUnits.sort((left, right) => asciiCompare(left.unit_name, right.unit_name));
+  validateRuntimeServiceIdentities(plan, runtimeUnits);
+  enforceDependencyClosure({ artifacts, fileBytes, initialReferences, plan });
+  const hashBindings = { binary: [], config: [], hash_manifest: [], policy: [], secret: [] };
+  for (const artifact of artifacts) {
+    hashBindings[hashBindingClass(artifact.artifact_class)].push({
+      sha256: artifact.rendered_sha256,
+      target_path: artifact.target_path,
+    });
+  }
+
+  const canonicalPlan = canonicalJson(plan);
+  const manifest = {
+    artifacts,
+    approved_plan_sha256: approvedPlanDigest,
+    deployment_id: plan.deployment_id,
+    deployment_profile: plan.deployment_profile,
+    hash_bindings: hashBindings,
+    placeholder_commitment_sha256: sha256(Buffer.from(canonicalJson(plan.placeholders))),
+    plan_sha256: approvedPlanDigest,
+    runtime_units: runtimeUnits,
+    schema_version: MANIFEST_SCHEMA_VERSION,
+    service_identities: plan.service_identities,
+    tmpfiles_directories: tmpfilesDirectories,
+  };
+  const manifestBytes = Buffer.from(canonicalJson(manifest));
+  const manifestSha256 = sha256(manifestBytes);
+  const request = runtimeRequestFromManifest(manifest, manifestSha256);
+  const requestBytes = Buffer.from(canonicalJson(request));
+  fileBytes.set("payment-v1-manifest.json", manifestBytes);
+  fileBytes.set("runtime-evidence-request.json", requestBytes);
+  return {
+    artifacts,
+    fileBytes,
+    manifest,
+    manifestBytes,
+    manifestSha256,
+    request,
+    requestBytes,
+  };
+}
+
+export function runtimeRequestFromManifest(manifest, manifestSha256) {
+  validateSha256(manifestSha256, "manifest SHA-256");
+  exactKeys(
+    manifest,
+    [
+      "approved_plan_sha256",
+      "artifacts",
+      "deployment_id",
+      "deployment_profile",
+      "hash_bindings",
+      "placeholder_commitment_sha256",
+      "plan_sha256",
+      "runtime_units",
+      "schema_version",
+      "service_identities",
+      "tmpfiles_directories",
+    ],
+    "rendered manifest",
+  );
+  if (manifest.schema_version !== MANIFEST_SCHEMA_VERSION) {
+    fail(`rendered manifest schema_version must equal ${MANIFEST_SCHEMA_VERSION}`);
+  }
+  validateSha256(manifest.approved_plan_sha256, "rendered manifest approved plan SHA-256");
+  if (manifest.plan_sha256 !== manifest.approved_plan_sha256) {
+    fail("rendered manifest plan digest is not the externally approved digest");
+  }
+  if (!PROFILE_CATALOG[manifest.deployment_profile]) {
+    fail("rendered manifest deployment profile is not reviewed");
+  }
+  if (!Array.isArray(manifest.service_identities) || manifest.service_identities.length < 1 || manifest.service_identities.length > 32) {
+    fail("rendered manifest service_identities must be a bounded non-empty array");
+  }
+  for (const [index, identity] of manifest.service_identities.entries()) {
+    const label = `rendered manifest service_identities[${index}]`;
+    exactKeys(identity, ["gid", "group_name", "uid", "unit_name", "user_name"], label);
+    if (!/^bitcoinpir-[a-z0-9-]+\.service$/u.test(identity.unit_name)) fail(`${label}.unit_name is malformed`);
+    for (const key of ["group_name", "user_name"]) {
+      if (!/^bitcoinpir-[a-z0-9-]+$/u.test(identity[key])) fail(`${label}.${key} is malformed`);
+    }
+    validateUidGid(identity.uid, `${label}.uid`);
+    validateUidGid(identity.gid, `${label}.gid`);
+    if (identity.uid === 0 || identity.gid === 0) fail(`${label} must be non-root`);
+    if (index > 0 && asciiCompare(manifest.service_identities[index - 1].unit_name, identity.unit_name) >= 0) {
+      fail("rendered manifest service_identities must be unique and bytewise sorted");
+    }
+  }
+  if (new Set(manifest.service_identities.map((identity) => identity.uid)).size !== manifest.service_identities.length) {
+    fail("rendered manifest service identities must use distinct UIDs");
+  }
+  if (
+    typeof manifest.deployment_id !== "string" ||
+    !/^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$/u.test(manifest.deployment_id)
+  ) {
+    fail("rendered manifest deployment_id is malformed");
+  }
+  validateSha256(manifest.placeholder_commitment_sha256, "rendered manifest placeholder commitment");
+  if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length < 1 || manifest.artifacts.length > MAX_TREE_ENTRIES) {
+    fail("rendered manifest artifacts must be a bounded non-empty array");
+  }
+  const installedFiles = manifest.artifacts.map((artifact, index) => {
+    const label = `rendered manifest artifacts[${index}]`;
+    exactKeys(
+      artifact,
+      [
+        "artifact_class",
+        "bundle_path",
+        "gid",
+        "mode",
+        "rendered_sha256",
+        "source_kind",
+        "source_path",
+        "source_sha256",
+        "target_path",
+        "uid",
+      ],
+      label,
+    );
+    safeTargetPath(artifact.target_path, `${label}.target_path`);
+    if (artifact.bundle_path !== artifactBundlePath(artifact.target_path)) {
+      fail(`${label}.bundle_path is not derived from target_path`);
+    }
+    safeRelativePath(artifact.source_path, `${label}.source_path`);
+    validateSha256(artifact.source_sha256, `${label}.source_sha256`);
+    validateSha256(artifact.rendered_sha256, `${label}.rendered_sha256`);
+    if (![
+      "argument-fragment",
+      "binary",
+      "config",
+      "executable-config",
+      "hash-manifest",
+      "policy",
+      "secret",
+      "systemd-unit",
+    ].includes(artifact.artifact_class)) {
+      fail(`${label}.artifact_class is not reviewed`);
+    }
+    if (!["payload", "template"].includes(artifact.source_kind)) {
+      fail(`${label}.source_kind is not reviewed`);
+    }
+    validateMode(artifact.mode, ["0400", "0440", "0444", "0555", "0644", "0710", "0755"], label);
+    validateUidGid(artifact.uid, `${label}.uid`);
+    validateUidGid(artifact.gid, `${label}.gid`);
+    return {
+      file_type: "regular",
+      gid: artifact.gid,
+      mode: artifact.mode,
+      nlink: 1,
+      sha256: artifact.rendered_sha256,
+      target_path: artifact.target_path,
+      uid: artifact.uid,
+    };
+  });
+  for (let index = 1; index < installedFiles.length; index += 1) {
+    if (asciiCompare(installedFiles[index - 1].target_path, installedFiles[index].target_path) >= 0) {
+      fail("rendered manifest artifacts must be unique bytewise ASCII sorted targets");
+    }
+  }
+  const expectedHashBindings = { binary: [], config: [], hash_manifest: [], policy: [], secret: [] };
+  for (const artifact of manifest.artifacts) {
+    expectedHashBindings[hashBindingClass(artifact.artifact_class)].push({
+      sha256: artifact.rendered_sha256,
+      target_path: artifact.target_path,
+    });
+  }
+  exactKeys(manifest.hash_bindings, Object.keys(expectedHashBindings), "rendered manifest hash_bindings");
+  if (canonicalize(manifest.hash_bindings) !== canonicalize(expectedHashBindings)) {
+    fail("rendered manifest hash_bindings do not exactly cover its artifacts");
+  }
+  if (!Array.isArray(manifest.runtime_units) || manifest.runtime_units.length > 32) {
+    fail("rendered manifest runtime_units must be bounded");
+  }
+  const artifactByTarget = new Map(manifest.artifacts.map((artifact) => [artifact.target_path, artifact]));
+  for (const [index, unit] of manifest.runtime_units.entries()) {
+    const label = `rendered manifest runtime_units[${index}]`;
+    exactKeys(
+      unit,
+      [
+        "conditions",
+        "environment",
+        "environment_files",
+        "exec_start",
+        "exec_start_pre",
+        "fragment_path",
+        "hardening",
+        "unit_name",
+      ],
+      label,
+    );
+    safeTargetPath(unit.fragment_path, `${label}.fragment_path`);
+    if (
+      !unit.fragment_path.startsWith("/etc/systemd/system/bitcoinpir-") ||
+      !unit.fragment_path.endsWith(".service") ||
+      unit.unit_name !== basename(unit.fragment_path)
+    ) {
+      fail(`${label} is not one reviewed bitcoinpir systemd unit`);
+    }
+    if (artifactByTarget.get(unit.fragment_path)?.artifact_class !== "systemd-unit") {
+      fail(`${label}.fragment_path is not a rendered systemd artifact`);
+    }
+    for (const [key, minimum] of [["conditions", 1], ["exec_start", 1]]) {
+      validateStringArray(unit[key], `${label}.${key}`, { maxItems: 64, maxLength: 8192 });
+      if (unit[key].length < minimum) fail(`${label}.${key} is incomplete`);
+    }
+    if (unit.exec_start.length !== 1) fail(`${label}.exec_start must contain exactly one command`);
+    for (const key of ["environment", "environment_files", "exec_start_pre"]) {
+      validateStringArray(unit[key], `${label}.${key}`, { maxItems: 64, maxLength: 8192 });
+    }
+    if (unit.environment_files.length !== 0) fail(`${label}.environment_files must be empty`);
+    if (!isPlainObject(unit.hardening)) fail(`${label}.hardening must be an object`);
+    for (const [key, values] of Object.entries(unit.hardening)) {
+      if (!SYSTEMD_HARDENING_KEYS.includes(key)) fail(`${label}.hardening has unknown key ${key}`);
+      validateStringArray(values, `${label}.hardening.${key}`, { maxItems: 8, maxLength: 4096 });
+    }
+    for (const [key, expected] of Object.entries(REQUIRED_SYSTEMD_HARDENING)) {
+      if (canonicalize(unit.hardening[key] ?? []) !== canonicalize(expected)) {
+        fail(`${label}.hardening.${key} is weaker than the reviewed baseline`);
+      }
+    }
+    validateProfileUnitPolicy(
+      manifest.deployment_profile,
+      unit.fragment_path,
+      unit.hardening,
+      label,
+    );
+  }
+  if (
+    canonicalize(manifest.service_identities.map((identity) => identity.unit_name)) !==
+    canonicalize(manifest.runtime_units.map((unit) => unit.unit_name))
+  ) {
+    fail("rendered manifest service_identities must exactly cover runtime_units");
+  }
+  for (const unit of manifest.runtime_units) {
+    const identity = manifest.service_identities.find((entry) => entry.unit_name === unit.unit_name);
+    if (
+      !identity ||
+      canonicalize(unit.hardening.User ?? []) !== canonicalize([identity.user_name]) ||
+      canonicalize(unit.hardening.Group ?? []) !== canonicalize([identity.group_name])
+    ) {
+      fail(`rendered manifest service identity does not match User=/Group=: ${unit.unit_name}`);
+    }
+  }
+  validateSecretOwnerBindings(manifest);
+  const systemdArtifactTargets = manifest.artifacts
+    .filter((artifact) => artifact.artifact_class === "systemd-unit")
+    .map((artifact) => artifact.target_path);
+  const runtimeFragmentPaths = manifest.runtime_units.map((unit) => unit.fragment_path);
+  if (canonicalize(runtimeFragmentPaths) !== canonicalize(systemdArtifactTargets)) {
+    fail("rendered manifest runtime_units must exactly cover its systemd-unit artifacts in bytewise order");
+  }
+  if (!Array.isArray(manifest.tmpfiles_directories) || manifest.tmpfiles_directories.length > 16) {
+    fail("rendered manifest tmpfiles_directories must be bounded");
+  }
+  for (const [index, directory] of manifest.tmpfiles_directories.entries()) {
+    const label = `rendered manifest tmpfiles_directories[${index}]`;
+    exactKeys(directory, ["group_name", "mode", "target_path", "user_name"], label);
+    safeTargetPath(directory.target_path, `${label}.target_path`);
+    validateMode(directory.mode, ["0710"], label);
+    for (const key of ["group_name", "user_name"]) {
+      if (!/^[a-z_][a-z0-9_-]{0,31}$/u.test(directory[key])) {
+        fail(`${label}.${key} is not a literal NSS name`);
+      }
+    }
+  }
+  const systemdAnalyzeArgv = [
+    "/usr/bin/systemd-analyze",
+    "verify",
+    ...manifest.runtime_units.map((unit) => unit.fragment_path),
+  ];
+  const secretFiles = manifest.artifacts
+    .filter((artifact) => artifact.artifact_class === "secret")
+    .map((artifact) => ({
+      consumer_unit_name: secretConsumerUnit(manifest.deployment_profile, artifact.target_path),
+      gid: artifact.gid,
+      mode: artifact.mode,
+      target_path: artifact.target_path,
+      uid: artifact.uid,
+    }));
+  return {
+    approved_plan_sha256: manifest.approved_plan_sha256,
+    collector: RUNTIME_COLLECTOR,
+    deployment_profile: manifest.deployment_profile,
+    installed_files: installedFiles,
+    manifest_sha256: manifestSha256,
+    schema_version: EVIDENCE_SCHEMA_VERSION,
+    secret_files: secretFiles,
+    service_identities: manifest.service_identities,
+    systemctl_show_properties: RUNTIME_SYSTEMCTL_SHOW_PROPERTIES,
+    systemd_analyze_argv: systemdAnalyzeArgv,
+    tmpfiles_directories: manifest.tmpfiles_directories,
+    units: manifest.runtime_units,
+  };
+}
+
+function requireAbsent(path, label) {
+  if (existsSync(path)) fail(`${label} already exists: ${path}`);
+}
+
+function ensurePrivateParent(path) {
+  const requestedAbsolute = resolve(path);
+  const requestedParent = dirname(requestedAbsolute);
+  const parent = requireCanonicalRoot(requestedParent, "bundle output parent");
+  const absolute = join(parent, basename(requestedAbsolute));
+  requireAbsent(absolute, "bundle output");
+  return { absolute, parent };
+}
+
+function writePrivateFile(root, relativePath, bytes) {
+  const target = join(root, ...relativePath.split("/"));
+  const rel = relative(root, target);
+  if (rel === "" || rel === ".." || rel.startsWith(`..${sep}`)) {
+    fail(`internal bundle path escapes root: ${relativePath}`);
+  }
+  const components = relativePath.split("/");
+  let cursor = root;
+  for (const component of components.slice(0, -1)) {
+    cursor = join(cursor, component);
+    if (!existsSync(cursor)) mkdirSync(cursor, { mode: 0o700 });
+    const stat = lstatSync(cursor);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      fail(`bundle parent is not a real directory: ${cursor}`);
+    }
+    chmodSync(cursor, 0o700);
+  }
+  writeFileSync(target, bytes, { flag: "wx", mode: 0o600 });
+  chmodSync(target, 0o600);
+}
+
+export function renderBundle({ sourceRoot, inputRoot, plan, approvedPlanSha256, outputRoot }) {
+  const model = buildBundleModel({ sourceRoot, inputRoot, plan, approvedPlanSha256 });
+  const { absolute, parent } = ensurePrivateParent(outputRoot);
+  const temporary = mkdtempSync(join(parent, `.${basename(absolute)}.tmp-`));
+  chmodSync(temporary, 0o700);
+  try {
+    for (const [relativePath, bytes] of [...model.fileBytes.entries()].sort(([left], [right]) =>
+      asciiCompare(left, right),
+    )) {
+      writePrivateFile(temporary, relativePath, bytes);
+    }
+    renameSync(temporary, absolute);
+  } catch (error) {
+    if (existsSync(temporary)) rmSync(temporary, { recursive: true, force: true });
+    throw error;
+  }
+  return model;
+}
+
+function expectedBundleEntries(fileBytes) {
+  const files = new Set(fileBytes.keys());
+  const directories = new Set();
+  for (const file of files) {
+    const components = file.split("/");
+    for (let index = 1; index < components.length; index += 1) {
+      directories.add(components.slice(0, index).join("/"));
+    }
+  }
+  return { directories, files };
+}
+
+function inspectBundleTree(root) {
+  const rootStat = lstatSync(root);
+  if ((rootStat.mode & 0o777) !== 0o700) {
+    fail("rendered bundle root must remain mode 0700");
+  }
+  const files = new Map();
+  const directories = new Set();
+  let entryCount = 0;
+  let totalBytes = 0;
+  function walk(directory, prefix) {
+    for (const entry of readdirSync(directory).sort(asciiCompare)) {
+      entryCount += 1;
+      if (entryCount > MAX_TREE_ENTRIES) fail(`bundle exceeds ${MAX_TREE_ENTRIES} tree entries`);
+      const path = join(directory, entry);
+      const relativePath = prefix === "" ? entry : `${prefix}/${entry}`;
+      if (relativePath.split("/").length > MAX_PATH_COMPONENTS + 2) {
+        fail(`bundle entry exceeds the depth limit: ${relativePath}`);
+      }
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) fail(`bundle contains symlink: ${relativePath}`);
+      if (stat.isDirectory()) {
+        if ((stat.mode & 0o777) !== 0o700) {
+          fail(`bundle staging directory must be mode 0700: ${relativePath}`);
+        }
+        directories.add(relativePath);
+        walk(path, relativePath);
+      } else if (stat.isFile()) {
+        if (stat.nlink !== 1) fail(`bundle file has multiple hard links: ${relativePath}`);
+        if ((stat.mode & 0o777) !== 0o600) {
+          fail(`bundle staging file must be mode 0600: ${relativePath}`);
+        }
+        totalBytes += stat.size;
+        if (!Number.isSafeInteger(totalBytes) || totalBytes > MAX_BUNDLE_BYTES) {
+          fail(`bundle exceeds ${MAX_BUNDLE_BYTES} bytes`);
+        }
+        files.set(relativePath, readFileSync(path));
+      } else {
+        fail(`bundle contains a non-regular special file: ${relativePath}`);
+      }
+    }
+  }
+  walk(root, "");
+  return { directories, files };
+}
+
+function assertSameStringSet(actual, expected, label) {
+  const left = [...actual].sort();
+  const right = [...expected].sort();
+  if (canonicalize(left) !== canonicalize(right)) {
+    fail(`${label} must equal the closed-world set ${JSON.stringify(right)}, got ${JSON.stringify(left)}`);
+  }
+}
+
+export function verifyBundle({ sourceRoot, inputRoot, plan, approvedPlanSha256, bundleRoot }) {
+  const model = buildBundleModel({ sourceRoot, inputRoot, plan, approvedPlanSha256 });
+  const canonicalBundleRoot = requireCanonicalRoot(bundleRoot, "rendered bundle root");
+  const actual = inspectBundleTree(canonicalBundleRoot);
+  const expected = expectedBundleEntries(model.fileBytes);
+  assertSameStringSet(actual.directories, expected.directories, "bundle directories");
+  assertSameStringSet(actual.files.keys(), expected.files, "bundle files");
+  for (const [relativePath, expectedBytes] of model.fileBytes) {
+    const actualBytes = actual.files.get(relativePath);
+    if (!actualBytes || !actualBytes.equals(expectedBytes)) {
+      fail(`rendered bundle byte mismatch: ${relativePath}`);
+    }
+  }
+  return model;
+}
+
+function validateStringArray(value, label, { maxItems = 2048, maxLength = 4096 } = {}) {
+  if (!Array.isArray(value) || value.length > maxItems) fail(`${label} must be a bounded array`);
+  for (const [index, entry] of value.entries()) {
+    if (
+      typeof entry !== "string" ||
+      entry.length > maxLength ||
+      /[\0\r\n]/u.test(entry)
+    ) {
+      fail(`${label}[${index}] must be a bounded single-line string`);
+    }
+  }
+}
+
+function canonicalEqual(actual, expected, label) {
+  if (canonicalize(actual) !== canonicalize(expected)) {
+    fail(`${label} does not match the rendered manifest expectation`);
+  }
+}
+
+export function validateRuntimeEvidence({ model, evidence }) {
+  exactKeys(
+    evidence,
+    [
+      "collected_at_unix_seconds",
+      "collector",
+      "host",
+      "installed_files",
+      "manifest_sha256",
+      "schema_version",
+      "systemd_analyze_verify",
+      "units",
+    ],
+    "runtime evidence",
+  );
+  if (evidence.schema_version !== EVIDENCE_SCHEMA_VERSION) {
+    fail(`runtime evidence schema_version must equal ${EVIDENCE_SCHEMA_VERSION}`);
+  }
+  if (evidence.collector !== RUNTIME_COLLECTOR) fail("runtime evidence collector is not reviewed");
+  if (evidence.manifest_sha256 !== model.manifestSha256) {
+    fail("runtime evidence manifest_sha256 does not bind the rendered manifest");
+  }
+  if (
+    !Number.isSafeInteger(evidence.collected_at_unix_seconds) ||
+    evidence.collected_at_unix_seconds < 1
+  ) {
+    fail("runtime evidence collected_at_unix_seconds must be a positive safe integer");
+  }
+  exactKeys(
+    evidence.host,
+    ["boot_id", "kernel_release", "machine_id_sha256", "systemd_version"],
+    "runtime evidence host",
+  );
+  validateSha256(evidence.host.machine_id_sha256, "runtime evidence host.machine_id_sha256");
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u.test(evidence.host.boot_id)) {
+    fail("runtime evidence host.boot_id must be a lowercase UUID");
+  }
+  for (const key of ["kernel_release", "systemd_version"]) {
+    validateSafeAscii(evidence.host[key], `runtime evidence host.${key}`, 128);
+  }
+
+  exactKeys(
+    evidence.systemd_analyze_verify,
+    ["argv", "exit_status", "stderr", "stdout"],
+    "runtime evidence systemd_analyze_verify",
+  );
+  validateStringArray(evidence.systemd_analyze_verify.argv, "systemd-analyze argv");
+  canonicalEqual(
+    evidence.systemd_analyze_verify.argv,
+    model.request.systemd_analyze_argv,
+    "systemd-analyze argv",
+  );
+  if (evidence.systemd_analyze_verify.exit_status !== 0) {
+    fail("systemd-analyze verify did not exit successfully");
+  }
+  if (evidence.systemd_analyze_verify.stdout !== "" || evidence.systemd_analyze_verify.stderr !== "") {
+    fail("systemd-analyze verify must produce no warnings or output");
+  }
+  if (sha256(Buffer.from(evidence.systemd_analyze_verify.stdout)) !== EMPTY_SHA256) {
+    fail("systemd-analyze stdout hash is not empty");
+  }
+
+  canonicalEqual(evidence.installed_files, model.request.installed_files, "installed file evidence");
+  if (!Array.isArray(evidence.units) || evidence.units.length !== model.request.units.length) {
+    fail("runtime unit evidence count does not match the rendered manifest");
+  }
+  for (let index = 0; index < evidence.units.length; index += 1) {
+    const actual = evidence.units[index];
+    const expected = model.request.units[index];
+    const label = `runtime evidence units[${index}]`;
+    exactKeys(
+      actual,
+      [
+        "active_state",
+        "conditions",
+        "drop_in_paths",
+        "environment",
+        "environment_files",
+        "exec_start",
+        "exec_start_pre",
+        "fragment_path",
+        "hardening",
+        "load_state",
+        "unit_name",
+      ],
+      label,
+    );
+    if (actual.load_state !== "loaded") fail(`${label}.load_state must equal loaded`);
+    if (!["active", "inactive"].includes(actual.active_state)) {
+      fail(`${label}.active_state must be active or inactive, never failed/unknown`);
+    }
+    if (!Array.isArray(actual.drop_in_paths) || actual.drop_in_paths.length !== 0) {
+      fail(`${label}.drop_in_paths must be empty`);
+    }
+    for (const key of [
+      "conditions",
+      "environment",
+      "environment_files",
+      "exec_start",
+      "exec_start_pre",
+    ]) {
+      validateStringArray(actual[key], `${label}.${key}`);
+    }
+    if (actual.environment_files.length !== 0) {
+      fail(`${label}.environment_files must be empty`);
+    }
+    canonicalEqual(actual.unit_name, expected.unit_name, `${label}.unit_name`);
+    canonicalEqual(actual.fragment_path, expected.fragment_path, `${label}.fragment_path`);
+    canonicalEqual(actual.exec_start, expected.exec_start, `${label}.exec_start`);
+    canonicalEqual(actual.exec_start_pre, expected.exec_start_pre, `${label}.exec_start_pre`);
+    canonicalEqual(actual.environment, expected.environment, `${label}.environment`);
+    canonicalEqual(actual.environment_files, expected.environment_files, `${label}.environment_files`);
+    canonicalEqual(actual.conditions, expected.conditions, `${label}.conditions`);
+    canonicalEqual(actual.hardening, expected.hardening, `${label}.hardening`);
+  }
+  return true;
+}
+
+function parseCli(argv) {
+  const command = argv[0];
+  if (!["render", "verify", "verify-runtime"].includes(command)) {
+    fail("usage: payment-v1-rendered-artifact-gate.mjs <render|verify|verify-runtime> --source-root ABS --input-root ABS --plan ABS --approved-plan-sha256 HEX --bundle ABS [--evidence ABS --trusted-evidence-sha256 HEX]");
+  }
+  const values = Object.create(null);
+  const allowed = new Set([
+    "--source-root",
+    "--input-root",
+    "--plan",
+    "--approved-plan-sha256",
+    "--bundle",
+    "--evidence",
+    "--trusted-evidence-sha256",
+  ]);
+  for (let index = 1; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.has(flag) || value === undefined || values[flag] !== undefined) {
+      fail(`invalid, repeated, or missing CLI option: ${flag ?? "<missing>"}`);
+    }
+    if (!["--approved-plan-sha256", "--trusted-evidence-sha256"].includes(flag) && !value.startsWith("/")) {
+      fail(`${flag} must be an absolute path`);
+    }
+    values[flag] = value;
+  }
+  for (const required of [
+    "--source-root",
+    "--input-root",
+    "--plan",
+    "--approved-plan-sha256",
+    "--bundle",
+  ]) {
+    if (values[required] === undefined) fail(`missing required CLI option ${required}`);
+  }
+  if (command === "verify-runtime" && values["--evidence"] === undefined) {
+    fail("verify-runtime requires --evidence");
+  }
+  if (command === "verify-runtime" && values["--trusted-evidence-sha256"] === undefined) {
+    fail("offline verify-runtime requires an externally trusted evidence SHA-256 pin");
+  }
+  if (command !== "verify-runtime" && values["--evidence"] !== undefined) {
+    fail("--evidence is valid only for verify-runtime");
+  }
+  if (command !== "verify-runtime" && values["--trusted-evidence-sha256"] !== undefined) {
+    fail("--trusted-evidence-sha256 is valid only for verify-runtime");
+  }
+  validateSha256(values["--approved-plan-sha256"], "CLI approved plan SHA-256");
+  if (values["--trusted-evidence-sha256"] !== undefined) {
+    validateSha256(values["--trusted-evidence-sha256"], "CLI trusted evidence SHA-256");
+  }
+  return { command, values };
+}
+
+function runCli(argv) {
+  const { command, values } = parseCli(argv);
+  const plan = readStrictJsonFile(values["--plan"], "render plan");
+  const common = {
+    bundleRoot: values["--bundle"],
+    inputRoot: values["--input-root"],
+    plan,
+    approvedPlanSha256: values["--approved-plan-sha256"],
+    sourceRoot: values["--source-root"],
+  };
+  if (command === "render") {
+    renderBundle({ ...common, outputRoot: common.bundleRoot });
+    process.stdout.write("payment-v1-rendered-artifact-gate: render PASS\n");
+    return;
+  }
+  const model = verifyBundle(common);
+  if (command === "verify-runtime") {
+    const evidenceBytes = readRegularSingleLinkFile(
+      values["--evidence"],
+      "runtime evidence",
+      MAX_JSON_BYTES,
+    );
+    if (sha256(evidenceBytes) !== values["--trusted-evidence-sha256"]) {
+      fail("runtime evidence does not match the externally trusted evidence SHA-256 pin");
+    }
+    let evidenceText;
+    try {
+      evidenceText = new TextDecoder("utf-8", { fatal: true }).decode(evidenceBytes);
+    } catch {
+      fail("runtime evidence is not valid UTF-8");
+    }
+    const evidence = parseStrictJson(evidenceText, "runtime evidence");
+    validateRuntimeEvidence({ model, evidence });
+    process.stdout.write("payment-v1-rendered-artifact-gate: offline pinned runtime structure PASS\n");
+    return;
+  }
+  process.stdout.write("payment-v1-rendered-artifact-gate: verify PASS\n");
+}
+
+const isMain =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isMain) {
+  try {
+    runCli(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`payment-v1-rendered-artifact-gate: FAIL: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/payment-v1-rendered-artifact-gate.test.mjs
+++ b/scripts/payment-v1-rendered-artifact-gate.test.mjs
@@ -1,0 +1,961 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  appendFileSync,
+  chmodSync,
+  copyFileSync,
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  truncateSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  RUNTIME_COLLECTOR,
+  canonicalJson,
+  computeApprovedPlanSha256,
+  parseStrictJson,
+  renderBundle,
+  validateRuntimeEvidence,
+  verifyBundle,
+} from "./payment-v1-rendered-artifact-gate.mjs";
+
+const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const REPOSITORY = resolve(SCRIPT_DIRECTORY, "..");
+const GATE = join(SCRIPT_DIRECTORY, "payment-v1-rendered-artifact-gate.mjs");
+const EDGE_UNIT = "deploy/payment-v1/systemd/payment-v1-edge.service.in";
+const EDGE_CONFIG = "deploy/payment-v1/edge/hetzner-public.Caddyfile.in";
+const GUARD_UNIT = "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in";
+const PROVIDER_UNIT = "deploy/payment-v1/systemd/hetzner-provider.service.in";
+const ISSUER_TEMPLATES = [
+  "deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in",
+  "deploy/payment-v1/lightning/lightningd.conf.in",
+  "deploy/payment-v1/lightning/verify-layout.sh.in",
+  "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in",
+  "deploy/payment-v1/systemd/hetzner-core-lightning.service.in",
+  "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in",
+  "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+];
+
+function hashBytes(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function hashFile(path) {
+  return hashBytes(readFileSync(path));
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function writeParent(path, bytes, mode = 0o600) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, bytes, { mode });
+}
+
+function copySource(sourceRoot, sourcePath) {
+  const destination = join(sourceRoot, ...sourcePath.split("/"));
+  mkdirSync(dirname(destination), { recursive: true });
+  copyFileSync(join(REPOSITORY, ...sourcePath.split("/")), destination);
+}
+
+function temporaryRoots(t) {
+  const root = mkdtempSync(join(tmpdir(), "bpir-rendered-v2-"));
+  t.after(() => rmSync(root, { force: true, recursive: true }));
+  const sourceRoot = join(root, "source");
+  const inputRoot = join(root, "input");
+  mkdirSync(sourceRoot, { mode: 0o700 });
+  mkdirSync(inputRoot, { mode: 0o700 });
+  return { bundleRoot: join(root, "bundle"), inputRoot, root, sourceRoot };
+}
+
+function payloadClass(targetPath) {
+  const name = basename(targetPath).toLowerCase();
+  if (targetPath.startsWith("/opt/bitcoinpir/")) return "binary";
+  if (name.endsWith(".sha256")) return "hash-manifest";
+  if (
+    name.endsWith(".key") ||
+    name.endsWith(".seed") ||
+    /(?:secret|derivation|signing|custody|idempotency)/u.test(name)
+  ) return "secret";
+  if (name.endsWith(".bin") || /(?:policy|authorization|approval|delegation|receipt|metadata)/u.test(name)) {
+    return "policy";
+  }
+  return "config";
+}
+
+function payloadMetadata(targetPath, issuerGid = 732, preflightGid = 736) {
+  const artifactClass = payloadClass(targetPath);
+  if (artifactClass === "binary") return { class: artifactClass, gid: 0, mode: "0555", uid: 0 };
+  if (artifactClass === "hash-manifest") {
+    return { class: artifactClass, gid: 0, mode: "0444", uid: 0 };
+  }
+  const gid = targetPath.startsWith("/etc/bitcoinpir/payment-v1/lightning/")
+    ? preflightGid
+    : issuerGid;
+  return { class: artifactClass, gid, mode: "0440", uid: 0 };
+}
+
+function renderText(sourceRoot, sourcePath, placeholders) {
+  let text = readFileSync(join(sourceRoot, sourcePath), "utf8");
+  for (const [name, value] of Object.entries(placeholders)) {
+    text = text.split(`@${name}@`).join(value);
+  }
+  assert.doesNotMatch(text, /@[A-Z][A-Z0-9_]+@/u);
+  return text;
+}
+
+function addPayload(fixture, targetPath, bytes, index) {
+  const sourcePath = `payload/${String(index).padStart(3, "0")}-${basename(targetPath)}`;
+  writeParent(join(fixture.inputRoot, sourcePath), bytes);
+  return {
+    ...payloadMetadata(targetPath),
+    expected_sha256: hashBytes(bytes),
+    source_path: sourcePath,
+    target_path: targetPath,
+  };
+}
+
+function makeEdgeFixture(t) {
+  const fixture = temporaryRoots(t);
+  copySource(fixture.sourceRoot, EDGE_UNIT);
+  copySource(fixture.sourceRoot, EDGE_CONFIG);
+  const caddyBytes = Buffer.from("reviewed-caddy-v2\n");
+  const caddySha = hashBytes(caddyBytes);
+  const placeholders = {
+    CADDY_SHA256: caddySha,
+    DIRECTORY_RELAY_WSS_HOST: "directory.example.net",
+    EDGE_CADDYFILE: "hetzner-public.Caddyfile",
+    PAYMENT_ISSUER_HTTPS_HOST: "pay.example.net",
+    PROVIDER_WSS_HOST: "pir.example.net",
+  };
+  const renderedConfig = Buffer.from(renderText(fixture.sourceRoot, EDGE_CONFIG, placeholders));
+  const targets = {
+    binary: `/opt/bitcoinpir/caddy/${caddySha}/caddy`,
+    binaryManifest: "/etc/bitcoinpir/payment-v1/edge/caddy.sha256",
+    config: "/etc/bitcoinpir/payment-v1/edge/hetzner-public.Caddyfile",
+    configManifest: "/etc/bitcoinpir/payment-v1/edge/edge-config.sha256",
+  };
+  const payloads = [
+    [targets.binary, caddyBytes],
+    [targets.binaryManifest, Buffer.from(`${caddySha}  ${targets.binary}\n`)],
+    [
+      targets.configManifest,
+      Buffer.from(`${hashBytes(renderedConfig)}  ${targets.config}\n`),
+    ],
+  ];
+  const plan = {
+    deployment_id: "hetzner-edge-v1-test",
+    deployment_profile: "edge-hetzner-v1",
+    payload_artifacts: payloads.map(([target, bytes], index) => addPayload(fixture, target, bytes, index)),
+    placeholders,
+    rendered_artifacts: [
+      {
+        gid: 730,
+        mode: "0440",
+        source_path: EDGE_CONFIG,
+        source_sha256: hashFile(join(fixture.sourceRoot, EDGE_CONFIG)),
+        target_path: targets.config,
+        uid: 0,
+      },
+      {
+        gid: 0,
+        mode: "0644",
+        source_path: EDGE_UNIT,
+        source_sha256: hashFile(join(fixture.sourceRoot, EDGE_UNIT)),
+        target_path: "/etc/systemd/system/bitcoinpir-payment-v1-edge.service",
+        uid: 0,
+      },
+    ],
+    schema_version: 1,
+    service_identities: [{
+      gid: 730,
+      group_name: "bitcoinpir-payment-edge",
+      uid: 729,
+      unit_name: "bitcoinpir-payment-v1-edge.service",
+      user_name: "bitcoinpir-payment-edge",
+    }],
+  };
+  return { ...fixture, plan, targets };
+}
+
+function issuerPlaceholders(binaryDigests) {
+  return {
+    BITCOIND_SYSTEMD_UNIT: "bitcoind.service",
+    BITCOINPIR_WEB_ORIGIN: "https://app.example.net",
+    BITCOIN_CORE_BUNDLE_SHA256: hashBytes("bitcoin-core-bundle"),
+    BITCOIN_RPC_PORT: "38332",
+    BPIR_ADMIN_SHA256: binaryDigests.admin,
+    CLN_BUNDLE_SHA256: hashBytes("cln-bundle"),
+    CLN_GUARD_MAX_INVOICE_BURST: "8",
+    CLN_GUARD_MAX_INVOICE_MSAT: "10000000",
+    CLN_GUARD_MAX_INVOICES_PER_MINUTE: "60",
+    CLN_GUARD_MAX_INVOICES_PER_RUNTIME: "10000",
+    CLN_GUARD_UID: "735",
+    CLN_P2P_ANNOUNCE_ADDR: "lightning.example.net:9735",
+    CLN_P2P_BIND_ADDR: "0.0.0.0:9735",
+    CLN_RPC_GUARD_SHA256: binaryDigests.guard,
+    HETZNER_POLICY_PUBKEY_HEX: "e".repeat(64),
+    ISSUER_GID: "732",
+    ISSUER_UID: "731",
+    LIGHTNING_GID: "734",
+    LIGHTNING_NETWORK: "signet",
+    LIGHTNING_UID: "733",
+    PAYMENT_ISSUER_SHA256: binaryDigests.issuer,
+    PREFLIGHT_GID: "736",
+    PREFLIGHT_UID: "737",
+  };
+}
+
+function makeIssuerFixture(t) {
+  const fixture = temporaryRoots(t);
+  for (const source of ISSUER_TEMPLATES) copySource(fixture.sourceRoot, source);
+  const binaryBytes = {
+    admin: Buffer.from("reviewed-bpir-admin\n"),
+    bitcoinCli: Buffer.from("reviewed-bitcoin-cli\n"),
+    bcli: Buffer.from("reviewed-bcli\n"),
+    chanbackup: Buffer.from("reviewed-chanbackup\n"),
+    guard: Buffer.from("reviewed-cln-guard\n"),
+    issuer: Buffer.from("reviewed-payment-issuer\n"),
+    lightningd: Buffer.from("reviewed-lightningd\n"),
+  };
+  const binaryDigests = Object.fromEntries(
+    Object.entries(binaryBytes).map(([name, bytes]) => [name, hashBytes(bytes)]),
+  );
+  const placeholders = issuerPlaceholders(binaryDigests);
+  const clnRoot = `/opt/bitcoinpir/core-lightning/${placeholders.CLN_BUNDLE_SHA256}`;
+  const bitcoinRoot = `/opt/bitcoinpir/bitcoin-core/${placeholders.BITCOIN_CORE_BUNDLE_SHA256}`;
+  const targets = {
+    admin: `/opt/bitcoinpir/bpir-admin/${binaryDigests.admin}/bpir-admin`,
+    bitcoinCli: `${bitcoinRoot}/bin/bitcoin-cli`,
+    bcli: `${clnRoot}/plugins/bcli`,
+    chanbackup: `${clnRoot}/plugins/chanbackup`,
+    guard: `/opt/bitcoinpir/cln-rpc-guard/${binaryDigests.guard}/bitcoinpir-cln-rpc-guard`,
+    issuer: `/opt/bitcoinpir/payment-issuer/${binaryDigests.issuer}/payment-issuer`,
+    lightningd: `${clnRoot}/bin/lightningd`,
+  };
+  const renderedTargets = {
+    config: "/etc/bitcoinpir/payment-v1/lightning/lightningd.conf",
+    verifier: "/usr/local/libexec/bitcoinpir/verify-lightning-layout",
+  };
+  const renderedHashes = {
+    config: hashBytes(renderText(fixture.sourceRoot, "deploy/payment-v1/lightning/lightningd.conf.in", placeholders)),
+    verifier: hashBytes(renderText(fixture.sourceRoot, "deploy/payment-v1/lightning/verify-layout.sh.in", placeholders)),
+  };
+  const directFiles = {
+    "/etc/bitcoinpir/payment-v1/issuer/cashu-bat.key": "bat-key\n",
+    "/etc/bitcoinpir/payment-v1/issuer/credential-derivation.key": "credential-key\n",
+    "/etc/bitcoinpir/payment-v1/issuer/direct-receipt-signing.key": "receipt-key\n",
+    "/etc/bitcoinpir/payment-v1/issuer/issuer-settlement-signing.key": "settlement-key\n",
+    "/etc/bitcoinpir/payment-v1/issuer/provider-clearing-approval.bin": "approval\n",
+    "/etc/bitcoinpir/payment-v1/issuer/provider-clearing-authorization.bin": "authorization\n",
+    "/etc/bitcoinpir/payment-v1/issuer/quote-delegation.bin": "delegation\n",
+    "/etc/bitcoinpir/payment-v1/issuer/quote-signing.key": "quote-key\n",
+    "/etc/bitcoinpir/payment-v1/issuer/redeem-response-derivation.key": "redeem-key\n",
+    "/etc/bitcoinpir/payment-v1/issuer/remote-rollback-authority.toml": "profile = \"remote-v1\"\n",
+    "/etc/bitcoinpir/payment-v1/issuer/service-policy.bin": "policy\n",
+    "/etc/bitcoinpir/payment-v1/lightning/backup-receipt.json": "{}\n",
+    "/etc/bitcoinpir/payment-v1/lightning/preflight.toml": "profile = \"signet-v1\"\n",
+  };
+  const digestFor = new Map([
+    ...Object.entries(targets).map(([name, target]) => [target, binaryDigests[name]]),
+    [renderedTargets.config, renderedHashes.config],
+    [renderedTargets.verifier, renderedHashes.verifier],
+    ...Object.entries(directFiles).map(([target, bytes]) => [target, hashBytes(bytes)]),
+  ]);
+  const manifestEntries = {
+    "/etc/bitcoinpir/payment-v1/issuer/payment-issuer.sha256": [targets.issuer],
+    "/etc/bitcoinpir/payment-v1/lightning/backup-receipt.sha256": [
+      "/etc/bitcoinpir/payment-v1/lightning/backup-receipt.json",
+    ],
+    "/etc/bitcoinpir/payment-v1/lightning/bitcoin-core-bundle.sha256": [targets.bitcoinCli],
+    "/etc/bitcoinpir/payment-v1/lightning/bpir-admin.sha256": [targets.admin],
+    "/etc/bitcoinpir/payment-v1/lightning/cln-bundle.sha256": [targets.lightningd, targets.bcli, targets.chanbackup],
+    "/etc/bitcoinpir/payment-v1/lightning/cln-rpc-guard.sha256": [targets.guard],
+    "/etc/bitcoinpir/payment-v1/lightning/layout-verifier.sha256": [renderedTargets.verifier],
+    "/etc/bitcoinpir/payment-v1/lightning/lightningd-config.sha256": [renderedTargets.config],
+    "/etc/bitcoinpir/payment-v1/lightning/preflight-config.sha256": [
+      "/etc/bitcoinpir/payment-v1/lightning/preflight.toml",
+    ],
+  };
+  const manifestFiles = Object.fromEntries(
+    Object.entries(manifestEntries).map(([target, dependencies]) => [
+      target,
+      `${dependencies
+        .sort()
+        .map((dependency) => `${digestFor.get(dependency)}  ${dependency}`)
+        .join("\n")}\n`,
+    ]),
+  );
+  const payloadContents = [
+    ...Object.entries(targets).map(([name, target]) => [target, binaryBytes[name]]),
+    ...Object.entries(directFiles),
+    ...Object.entries(manifestFiles),
+  ].sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+  const plan = {
+    deployment_id: "issuer-lightning-signet-v1-test",
+    deployment_profile: "issuer-lightning-signet-v1",
+    payload_artifacts: payloadContents.map(([target, bytes], index) => {
+      const artifact = addPayload(fixture, target, bytes, index);
+      return artifact.class === "secret"
+        ? { ...artifact, gid: Number(placeholders.ISSUER_GID), mode: "0400", uid: Number(placeholders.ISSUER_UID) }
+        : artifact;
+    }),
+    placeholders,
+    rendered_artifacts: ISSUER_TEMPLATES.map((sourcePath) => {
+      const targetsBySource = {
+        "deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in": "/etc/tmpfiles.d/bitcoinpir-cln-rpc-guard.conf",
+        "deploy/payment-v1/lightning/lightningd.conf.in": renderedTargets.config,
+        "deploy/payment-v1/lightning/verify-layout.sh.in": renderedTargets.verifier,
+        "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in": "/etc/systemd/system/bitcoinpir-cln-rpc-guard.service",
+        "deploy/payment-v1/systemd/hetzner-core-lightning.service.in": "/etc/systemd/system/bitcoinpir-core-lightning.service",
+        "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in": "/etc/systemd/system/bitcoinpir-lightning-preflight.service",
+        "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in": "/etc/systemd/system/bitcoinpir-payment-issuer.service",
+      };
+      const nonRootConfig = sourcePath.endsWith("lightningd.conf.in");
+      return {
+        gid: nonRootConfig ? Number(placeholders.LIGHTNING_GID) : 0,
+        mode: sourcePath.endsWith("lightningd.conf.in")
+          ? "0440"
+          : sourcePath.endsWith("verify-layout.sh.in")
+            ? "0755"
+            : "0644",
+        source_path: sourcePath,
+        source_sha256: hashFile(join(fixture.sourceRoot, sourcePath)),
+        target_path: targetsBySource[sourcePath],
+        uid: 0,
+      };
+    }),
+    schema_version: 1,
+    service_identities: [
+      { gid: 734, group_name: "bitcoinpir-cln-guard", uid: 735, unit_name: "bitcoinpir-cln-rpc-guard.service", user_name: "bitcoinpir-cln-rpc-guard" },
+      { gid: 734, group_name: "bitcoinpir-cln-guard", uid: 733, unit_name: "bitcoinpir-core-lightning.service", user_name: "bitcoinpir-lightning" },
+      { gid: 736, group_name: "bitcoinpir-lightning-preflight", uid: 737, unit_name: "bitcoinpir-lightning-preflight.service", user_name: "bitcoinpir-lightning-preflight" },
+      { gid: 732, group_name: "bitcoinpir-issuer", uid: 731, unit_name: "bitcoinpir-payment-issuer.service", user_name: "bitcoinpir-issuer" },
+    ],
+  };
+  return { ...fixture, plan };
+}
+
+function makeProviderFixture(t) {
+  const fixture = temporaryRoots(t);
+  const source = PROVIDER_UNIT;
+  copySource(fixture.sourceRoot, source);
+  const binaryBytes = Buffer.from("reviewed-unified-server\n");
+  const binarySha = hashBytes(binaryBytes);
+  const binaryTarget = `/opt/bitcoinpir/unified-server/${binarySha}/unified_server`;
+  const directFiles = {
+    "/etc/bitcoinpir/payment-v1/provider/cashu-bat.key": "bat\n",
+    "/etc/bitcoinpir/payment-v1/provider/cashu-custody-epoch-1.key": "custody\n",
+    "/etc/bitcoinpir/payment-v1/provider/cashu-recovery-epoch-1.key": "recovery\n",
+    "/etc/bitcoinpir/payment-v1/provider/databases.toml": "profile = \"provider-v1\"\n",
+    "/etc/bitcoinpir/payment-v1/provider/provider-clearing-signing.key": "clearing\n",
+    "/etc/bitcoinpir/payment-v1/provider/provider-identity.cert": "certificate\n",
+    "/etc/bitcoinpir/payment-v1/provider/provider-identity.key": "identity\n",
+    "/etc/bitcoinpir/payment-v1/provider/remote-rollback-authority.toml": "profile = \"remote-v1\"\n",
+    "/etc/bitcoinpir/payment-v1/provider/service-policy.bin": "policy\n",
+    "/etc/bitcoinpir/payment-v1/provider/shared-clearing-approval.bin": "approval\n",
+    "/etc/bitcoinpir/payment-v1/provider/shared-clearing-authorization.bin": "authorization\n",
+    "/etc/bitcoinpir/payment-v1/provider/shared-redeem-idempotency.key": "idempotency\n",
+  };
+  const manifestTarget = "/etc/bitcoinpir/payment-v1/provider/unified-server.sha256";
+  const contents = [
+    [binaryTarget, binaryBytes],
+    [manifestTarget, `${binarySha}  ${binaryTarget}\n`],
+    ...Object.entries(directFiles),
+  ].sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+  const placeholders = {
+    CASHU_MAX_UNSETTLED_NOTES: "1000",
+    CASHU_MAX_UNSETTLED_VALUE: "100000",
+    CASHU_MINT_ID_HEX: "3".repeat(64),
+    HETZNER_OPERATOR_PUBKEY_HEX: "4".repeat(64),
+    HETZNER_POLICY_PUBKEY_HEX: "e".repeat(64),
+    HETZNER_PROVIDER_ID_HEX: "f".repeat(64),
+    HETZNER_PROVIDER_SERVER_ID: "hetzner-pir-0",
+    ISSUER_SETTLEMENT_PUBKEY_HEX: "5".repeat(64),
+    SHARED_MINIMUM_AUTHORIZATION_EPOCH: "1",
+    UNIFIED_SERVER_SHA256: binarySha,
+  };
+  const plan = {
+    deployment_id: "provider-v1-test",
+    deployment_profile: "provider-v1",
+    payload_artifacts: contents.map(([target, bytes], index) => {
+      const artifact = addPayload(fixture, target, bytes, index);
+      return artifact.class === "secret" ? { ...artifact, gid: 741, mode: "0400", uid: 740 } : artifact;
+    }),
+    placeholders,
+    rendered_artifacts: [{
+      gid: 0,
+      mode: "0644",
+      source_path: source,
+      source_sha256: hashFile(join(fixture.sourceRoot, source)),
+      target_path: "/etc/systemd/system/bitcoinpir-provider.service",
+      uid: 0,
+    }],
+    schema_version: 1,
+    service_identities: [{ gid: 741, group_name: "bitcoinpir-provider", uid: 740, unit_name: "bitcoinpir-provider.service", user_name: "bitcoinpir-provider" }],
+  };
+  return { ...fixture, plan };
+}
+
+function makeRollbackFixture(t) {
+  const fixture = temporaryRoots(t);
+  const source = "deploy/payment-v1/systemd/rollback-authority.service.in";
+  copySource(fixture.sourceRoot, source);
+  const binaryBytes = Buffer.from("reviewed-rollback-authority\n");
+  const binarySha = hashBytes(binaryBytes);
+  const binaryTarget = `/opt/bitcoinpir/rollback-authority/${binarySha}/rollback-authority`;
+  const contents = [
+    [binaryTarget, binaryBytes],
+    ["/etc/bitcoinpir/payment-v1/rollback-authority/authority-public.txt", "public metadata\n"],
+    ["/etc/bitcoinpir/payment-v1/rollback-authority/authority.seed", "secret seed\n"],
+    [
+      "/etc/bitcoinpir/payment-v1/rollback-authority/rollback-authority.sha256",
+      `${binarySha}  ${binaryTarget}\n`,
+    ],
+  ].sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+  const plan = {
+    deployment_id: "rollback-authority-v1-test",
+    deployment_profile: "rollback-authority-v1",
+    payload_artifacts: contents.map(([target, bytes], index) => {
+      const artifact = addPayload(fixture, target, bytes, index);
+      return artifact.class === "secret" ? { ...artifact, gid: 743, mode: "0400", uid: 742 } : artifact;
+    }),
+    placeholders: {
+      AUTHORITY_PUBKEY_HEX: "7".repeat(64),
+      ROLLBACK_AUTHORITY_SHA256: binarySha,
+    },
+    rendered_artifacts: [{
+      gid: 0,
+      mode: "0644",
+      source_path: source,
+      source_sha256: hashFile(join(fixture.sourceRoot, source)),
+      target_path: "/etc/systemd/system/bitcoinpir-rollback-authority.service",
+      uid: 0,
+    }],
+    schema_version: 1,
+    service_identities: [{ gid: 743, group_name: "bitcoinpir-rollback-authority", uid: 742, unit_name: "bitcoinpir-rollback-authority.service", user_name: "bitcoinpir-rollback-authority" }],
+  };
+  return { ...fixture, plan };
+}
+
+function makeRollbackEdgeFixture(t) {
+  const fixture = temporaryRoots(t);
+  const source = "deploy/payment-v1/edge/rollback-authority.Caddyfile.in";
+  copySource(fixture.sourceRoot, source);
+  copySource(fixture.sourceRoot, EDGE_UNIT);
+  const binaryBytes = Buffer.from("reviewed-caddy-rollback\n");
+  const binarySha = hashBytes(binaryBytes);
+  const binaryTarget = `/opt/bitcoinpir/caddy/${binarySha}/caddy`;
+  const configTarget = "/etc/bitcoinpir/payment-v1/edge/rollback-authority.Caddyfile";
+  const placeholders = {
+    CADDY_SHA256: binarySha,
+    EDGE_CADDYFILE: "rollback-authority.Caddyfile",
+    ROLLBACK_AUTHORITY_HTTPS_HOST: "authority.example.net",
+  };
+  const configSha = hashBytes(renderText(fixture.sourceRoot, source, placeholders));
+  const contents = [
+    [binaryTarget, binaryBytes],
+    ["/etc/bitcoinpir/payment-v1/edge/caddy.sha256", `${binarySha}  ${binaryTarget}\n`],
+    ["/etc/bitcoinpir/payment-v1/edge/edge-config.sha256", `${configSha}  ${configTarget}\n`],
+  ];
+  const plan = {
+    deployment_id: "rollback-edge-v1-test",
+    deployment_profile: "edge-rollback-authority-v1",
+    payload_artifacts: contents.map(([target, bytes], index) => addPayload(fixture, target, bytes, index)),
+    placeholders,
+    rendered_artifacts: [
+      {
+        gid: 730,
+        mode: "0440",
+        source_path: source,
+        source_sha256: hashFile(join(fixture.sourceRoot, source)),
+        target_path: configTarget,
+        uid: 0,
+      },
+      {
+        gid: 0,
+        mode: "0644",
+        source_path: EDGE_UNIT,
+        source_sha256: hashFile(join(fixture.sourceRoot, EDGE_UNIT)),
+        target_path: "/etc/systemd/system/bitcoinpir-payment-v1-edge.service",
+        uid: 0,
+      },
+    ],
+    schema_version: 1,
+    service_identities: [{
+      gid: 730,
+      group_name: "bitcoinpir-payment-edge",
+      uid: 729,
+      unit_name: "bitcoinpir-payment-v1-edge.service",
+      user_name: "bitcoinpir-payment-edge",
+    }],
+  };
+  return { ...fixture, plan };
+}
+
+function approved(plan) {
+  return computeApprovedPlanSha256(plan);
+}
+
+function renderFixture(fixture, outputRoot = fixture.bundleRoot) {
+  return renderBundle({
+    approvedPlanSha256: approved(fixture.plan),
+    inputRoot: fixture.inputRoot,
+    outputRoot,
+    plan: fixture.plan,
+    sourceRoot: fixture.sourceRoot,
+  });
+}
+
+function verifyFixture(fixture, bundleRoot = fixture.bundleRoot) {
+  return verifyBundle({
+    approvedPlanSha256: approved(fixture.plan),
+    bundleRoot,
+    inputRoot: fixture.inputRoot,
+    plan: fixture.plan,
+    sourceRoot: fixture.sourceRoot,
+  });
+}
+
+function updateTemplate(fixture, sourcePath, mutate) {
+  const path = join(fixture.sourceRoot, sourcePath);
+  const before = readFileSync(path, "utf8");
+  const after = mutate(before);
+  assert.notEqual(after, before);
+  writeFileSync(path, after);
+  fixture.plan.rendered_artifacts.find((entry) => entry.source_path === sourcePath).source_sha256 = hashFile(path);
+}
+
+function makeRuntimeEvidence(model) {
+  return {
+    collected_at_unix_seconds: 1_800_000_000,
+    collector: RUNTIME_COLLECTOR,
+    host: {
+      boot_id: "12345678-1234-4abc-8def-123456789abc",
+      kernel_release: "6.8.0-bitcoinpir",
+      machine_id_sha256: hashBytes("test-machine"),
+      systemd_version: "systemd-257.7",
+    },
+    installed_files: clone(model.request.installed_files),
+    manifest_sha256: model.manifestSha256,
+    schema_version: 1,
+    systemd_analyze_verify: {
+      argv: clone(model.request.systemd_analyze_argv),
+      exit_status: 0,
+      stderr: "",
+      stdout: "",
+    },
+    units: model.request.units.map((unit) => ({
+      active_state: "inactive",
+      conditions: clone(unit.conditions),
+      drop_in_paths: [],
+      environment: clone(unit.environment),
+      environment_files: clone(unit.environment_files),
+      exec_start: clone(unit.exec_start),
+      exec_start_pre: clone(unit.exec_start_pre),
+      fragment_path: unit.fragment_path,
+      hardening: clone(unit.hardening),
+      load_state: "loaded",
+      unit_name: unit.unit_name,
+    })),
+  };
+}
+
+test("edge bundle is deterministic, externally plan-pinned, and closed", (t) => {
+  const fixture = makeEdgeFixture(t);
+  const first = renderFixture(fixture);
+  assert.equal(first.manifest.approved_plan_sha256, approved(fixture.plan));
+  assert.equal(first.manifest.deployment_profile, "edge-hetzner-v1");
+  assert.deepEqual(
+    first.manifest.artifacts.map((artifact) => artifact.target_path),
+    first.manifest.artifacts.map((artifact) => artifact.target_path).sort(),
+  );
+  assert.deepEqual(Object.keys(first.manifest.hash_bindings).sort(), [
+    "binary", "config", "hash_manifest", "policy", "secret",
+  ]);
+  assert.equal(verifyFixture(fixture).manifestSha256, first.manifestSha256);
+  const secondRoot = join(fixture.root, "second");
+  const second = renderFixture(fixture, secondRoot);
+  assert.equal(second.manifestSha256, first.manifestSha256);
+  assert.deepEqual(
+    readdirSync(fixture.bundleRoot, { recursive: true }).sort(),
+    readdirSync(secondRoot, { recursive: true }).sort(),
+  );
+});
+
+test("complete issuer profile closes core, guard, tmpfiles, preflight, issuer, and referenced files", (t) => {
+  const fixture = makeIssuerFixture(t);
+  const model = renderFixture(fixture);
+  assert.equal(model.request.units.length, 4);
+  assert.equal(model.request.tmpfiles_directories.length, 2);
+  assert.equal(model.manifest.deployment_profile, "issuer-lightning-signet-v1");
+  assert.equal(verifyFixture(fixture).manifestSha256, model.manifestSha256);
+});
+
+test("issuer profile keeps the CLN guard deadman non-restarting", (t) => {
+  const fixture = makeIssuerFixture(t);
+  updateTemplate(fixture, GUARD_UNIT, (text) =>
+    text.replace("Restart=no", "Restart=on-failure\nRestartSec=5"),
+  );
+  assert.throws(() => renderFixture(fixture), /CLN guard deadman Restart=no/);
+});
+
+for (const directive of ["PrivateDevices", "ProtectClock", "ProtectHostname"]) {
+  test(`provider profile keeps ${directive}=true`, (t) => {
+    const fixture = makeProviderFixture(t);
+    updateTemplate(fixture, PROVIDER_UNIT, (text) =>
+      text.replace(`${directive}=true`, `${directive}=false`),
+    );
+    assert.throws(() => renderFixture(fixture), new RegExp(`provider ${directive}=true`));
+  });
+}
+
+for (const [label, factory, profile] of [
+  ["provider", makeProviderFixture, "provider-v1"],
+  ["rollback authority", makeRollbackFixture, "rollback-authority-v1"],
+  ["rollback edge", makeRollbackEdgeFixture, "edge-rollback-authority-v1"],
+]) {
+  test(`${label} deployment profile is renderable and dependency-closed`, (t) => {
+    const fixture = factory(t);
+    const model = renderFixture(fixture);
+    assert.equal(model.manifest.deployment_profile, profile);
+    assert.equal(verifyFixture(fixture).manifestSha256, model.manifestSha256);
+    for (const artifact of fixture.plan.payload_artifacts) {
+      const changed = clone(fixture.plan);
+      changed.payload_artifacts = changed.payload_artifacts.filter(
+        (entry) => entry.target_path !== artifact.target_path,
+      );
+      assert.throws(
+        () => renderBundle({
+          approvedPlanSha256: approved(changed),
+          inputRoot: fixture.inputRoot,
+          outputRoot: join(fixture.root, `missing-${hashBytes(artifact.target_path).slice(0, 10)}`),
+          plan: changed,
+          sourceRoot: fixture.sourceRoot,
+        }),
+        /dependency is missing|references missing artifact/,
+        artifact.target_path,
+      );
+    }
+  });
+}
+
+test("Hetzner edge rejects deletion of every template and payload dependency", (t) => {
+  const fixture = makeEdgeFixture(t);
+  for (const sourcePath of [EDGE_UNIT, EDGE_CONFIG]) {
+    const changed = clone(fixture.plan);
+    changed.rendered_artifacts = changed.rendered_artifacts.filter(
+      (entry) => entry.source_path !== sourcePath,
+    );
+    assert.throws(
+      () => renderBundle({ approvedPlanSha256: approved(changed), inputRoot: fixture.inputRoot, outputRoot: join(fixture.root, `missing-${basename(sourcePath)}`), plan: changed, sourceRoot: fixture.sourceRoot }),
+      /deployment profile templates/,
+    );
+  }
+  for (const artifact of fixture.plan.payload_artifacts) {
+    const changed = clone(fixture.plan);
+    changed.payload_artifacts = changed.payload_artifacts.filter(
+      (entry) => entry.target_path !== artifact.target_path,
+    );
+    assert.throws(
+      () => renderBundle({ approvedPlanSha256: approved(changed), inputRoot: fixture.inputRoot, outputRoot: join(fixture.root, `missing-${hashBytes(artifact.target_path).slice(0, 10)}`), plan: changed, sourceRoot: fixture.sourceRoot }),
+      /dependency is missing|references missing artifact/,
+    );
+  }
+});
+
+test("issuer profile rejects deletion of every template dependency", (t) => {
+  const fixture = makeIssuerFixture(t);
+  for (const sourcePath of ISSUER_TEMPLATES) {
+    const changed = clone(fixture.plan);
+    changed.rendered_artifacts = changed.rendered_artifacts.filter((entry) => entry.source_path !== sourcePath);
+    assert.throws(
+      () => renderBundle({ approvedPlanSha256: approved(changed), inputRoot: fixture.inputRoot, outputRoot: join(fixture.root, `missing-template-${basename(sourcePath)}`), plan: changed, sourceRoot: fixture.sourceRoot }),
+      /deployment profile templates/,
+      sourcePath,
+    );
+  }
+});
+
+test("issuer profile rejects deletion of every referenced payload dependency", (t) => {
+  const fixture = makeIssuerFixture(t);
+  for (const artifact of fixture.plan.payload_artifacts) {
+    const changed = clone(fixture.plan);
+    changed.payload_artifacts = changed.payload_artifacts.filter((entry) => entry.target_path !== artifact.target_path);
+    assert.throws(
+      () => renderBundle({ approvedPlanSha256: approved(changed), inputRoot: fixture.inputRoot, outputRoot: join(fixture.root, `missing-payload-${hashBytes(artifact.target_path).slice(0, 12)}`), plan: changed, sourceRoot: fixture.sourceRoot }),
+      /dependency is missing|references missing artifact/,
+      artifact.target_path,
+    );
+  }
+});
+
+test("profile rejects extra, stale, and cross-profile targets", (t) => {
+  const extra = makeEdgeFixture(t);
+  extra.plan.payload_artifacts.push(addPayload(extra, "/etc/bitcoinpir/payment-v1/edge/old.conf", "old\n", 99));
+  assert.throws(() => renderFixture(extra), /not reachable from the closed deployment profile/);
+
+  const stale = makeEdgeFixture(t);
+  stale.plan.payload_artifacts[0].target_path = "/opt/bitcoinpir/caddy/old/caddy";
+  assert.throws(() => renderFixture(stale), /CADDY_SHA256 must select|dependency is missing|references missing artifact/);
+
+  const crossed = makeEdgeFixture(t);
+  crossed.plan.deployment_profile = "edge-rollback-authority-v1";
+  assert.throws(() => renderFixture(crossed), /deployment profile templates|must select rollback/);
+});
+
+test("approved plan digest is external, mandatory, and cannot self-authorize", (t) => {
+  const fixture = makeEdgeFixture(t);
+  assert.throws(
+    () => renderBundle({ inputRoot: fixture.inputRoot, outputRoot: fixture.bundleRoot, plan: fixture.plan, sourceRoot: fixture.sourceRoot }),
+    /externally approved plan SHA-256/,
+  );
+  assert.throws(
+    () => renderBundle({ approvedPlanSha256: "1".repeat(64), inputRoot: fixture.inputRoot, outputRoot: fixture.bundleRoot, plan: fixture.plan, sourceRoot: fixture.sourceRoot }),
+    /does not match the externally approved/,
+  );
+  fixture.plan.approved_plan_sha256 = approved(fixture.plan);
+  assert.throws(() => renderFixture(fixture), /render plan keys must equal/);
+});
+
+for (const [directive, value] of [
+  ["ExecStartPost", "/usr/bin/true"],
+  ["ExecCondition", "/usr/bin/true"],
+  ["EnvironmentFile", "/tmp/evil.env"],
+  ["LoadCredential", "secret:/tmp/secret"],
+  ["SetCredential", "secret:evil"],
+  ["BindPaths", "/tmp:/etc"],
+  ["BindReadOnlyPaths", "/tmp:/etc"],
+  ["RootDirectory", "/tmp/root"],
+  ["RootImage", "/tmp/root.img"],
+  ["RootHash", "abc"],
+  ["RootHashSignature", "/tmp/sig"],
+  ["ExecStartPre", "+/usr/bin/true"],
+]) {
+  test(`systemd closed directive schema rejects ${directive}`, (t) => {
+    const fixture = makeEdgeFixture(t);
+    updateTemplate(fixture, EDGE_UNIT, (text) => text.replace("[Service]\n", `[Service]\n${directive}=${value}\n`));
+    assert.throws(() => renderFixture(fixture), /closed-world forbidden directive|literal absolute executable/);
+  });
+}
+
+for (const [label, mutation, expected] of [
+  ["dollar expansion", (text) => text.replace("ExecStart=", "ExecStart=/usr/bin/echo $HOME\nExecStart="), /variable expansion/],
+  ["percent expansion", (text) => text.replace("Description=", "Description=%n "), /percent specifier/],
+  ["ExecStart reset", (text) => text.replace("\nExecStart=", "\nExecStart=\nExecStart="), /empty ExecStart= reset/],
+  ["condition reset", (text) => text.replace("ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED", "ConditionPathExists=\nConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED"), /empty ConditionPathExists= reset/],
+]) {
+  test(`systemd rejects ${label}`, (t) => {
+    const fixture = makeEdgeFixture(t);
+    updateTemplate(fixture, EDGE_UNIT, mutation);
+    assert.throws(() => renderFixture(fixture), expected);
+  });
+}
+
+test("payload class and target metadata are target-derived and secrets cannot be 0644", (t) => {
+  const fixture = makeIssuerFixture(t);
+  const secret = fixture.plan.payload_artifacts.find((entry) => entry.class === "secret");
+  secret.mode = "0644";
+  assert.throws(() => renderFixture(fixture), /0400 for one owner|secret must never/);
+
+  const groupReadable = makeIssuerFixture(t);
+  const issuerSecret = groupReadable.plan.payload_artifacts.find((entry) => entry.class === "secret");
+  Object.assign(issuerSecret, { gid: 732, mode: "0440", uid: 0 });
+  assert.throws(() => renderFixture(groupReadable), /owned exclusively by bitcoinpir-payment-issuer/);
+
+  const crossRoleOwner = makeIssuerFixture(t);
+  const guardOwnedSecret = crossRoleOwner.plan.payload_artifacts.find((entry) => entry.class === "secret");
+  Object.assign(guardOwnedSecret, { gid: 734, mode: "0400", uid: 735 });
+  assert.throws(() => renderFixture(crossRoleOwner), /owned exclusively by bitcoinpir-payment-issuer/);
+
+  const wrongProviderOwner = makeProviderFixture(t);
+  wrongProviderOwner.plan.payload_artifacts.find((entry) => entry.class === "secret").uid = 999;
+  assert.throws(() => renderFixture(wrongProviderOwner), /owned exclusively by bitcoinpir-provider/);
+
+  const wrongClass = makeEdgeFixture(t);
+  wrongClass.plan.payload_artifacts[0].class = "config";
+  assert.throws(() => renderFixture(wrongClass), /target-derived class binary|outside the reviewed config prefixes/);
+
+  const wrongBinaryOwner = makeEdgeFixture(t);
+  wrongBinaryOwner.plan.payload_artifacts[0].uid = 730;
+  assert.throws(() => renderFixture(wrongBinaryOwner), /binary must be immutable root:root mode 0555/);
+
+  const wrongManifestMode = makeEdgeFixture(t);
+  wrongManifestMode.plan.payload_artifacts.find((entry) => entry.class === "hash-manifest").mode = "0644";
+  assert.throws(() => renderFixture(wrongManifestMode), /hash manifest must be immutable root:root mode 0444/);
+});
+
+test("hash manifests are strict, sorted, complete, and bind actual artifacts", (t) => {
+  const wrong = makeEdgeFixture(t);
+  const manifest = wrong.plan.payload_artifacts.find((entry) => entry.target_path.endsWith("caddy.sha256"));
+  writeFileSync(join(wrong.inputRoot, manifest.source_path), `${"1".repeat(64)}  ${wrong.targets.binary}\n`);
+  manifest.expected_sha256 = hashFile(join(wrong.inputRoot, manifest.source_path));
+  assert.throws(() => renderFixture(wrong), /wrong digest/);
+
+  const malformed = makeEdgeFixture(t);
+  const second = malformed.plan.payload_artifacts.find((entry) => entry.target_path.endsWith("caddy.sha256"));
+  writeFileSync(join(malformed.inputRoot, second.source_path), `${hashBytes("x")} *${malformed.targets.binary}\n`);
+  second.expected_sha256 = hashFile(join(malformed.inputRoot, second.source_path));
+  assert.throws(() => renderFixture(malformed), /strict sha256sum syntax/);
+
+  const smuggled = makeEdgeFixture(t);
+  const smuggledTarget = "/etc/bitcoinpir/payment-v1/edge/old.conf";
+  const smuggledPayload = addPayload(smuggled, smuggledTarget, "old\n", 99);
+  smuggled.plan.payload_artifacts.push(smuggledPayload);
+  const scoped = smuggled.plan.payload_artifacts.find((entry) => entry.target_path.endsWith("caddy.sha256"));
+  const original = readFileSync(join(smuggled.inputRoot, scoped.source_path), "utf8").trimEnd();
+  writeFileSync(
+    join(smuggled.inputRoot, scoped.source_path),
+    `${hashBytes("old\n")}  ${smuggledTarget}\n${original}\n`,
+  );
+  scoped.expected_sha256 = hashFile(join(smuggled.inputRoot, scoped.source_path));
+  assert.throws(() => renderFixture(smuggled), /must bind only/);
+
+  const unsorted = makeIssuerFixture(t);
+  const clnManifest = unsorted.plan.payload_artifacts.find((entry) =>
+    entry.target_path.endsWith("/cln-bundle.sha256"),
+  );
+  const clnPath = join(unsorted.inputRoot, clnManifest.source_path);
+  const reversed = readFileSync(clnPath, "utf8").trimEnd().split("\n").reverse().join("\n");
+  writeFileSync(clnPath, `${reversed}\n`);
+  clnManifest.expected_sha256 = hashFile(clnPath);
+  assert.throws(() => renderFixture(unsorted), /bytewise ASCII sorted/);
+});
+
+test("systemd rejects duplicate single-valued directives even without an empty reset", (t) => {
+  const fixture = makeEdgeFixture(t);
+  updateTemplate(fixture, EDGE_UNIT, (text) =>
+    text.replace("User=bitcoinpir-payment-edge", "User=bitcoinpir-payment-edge\nUser=root"),
+  );
+  assert.throws(() => renderFixture(fixture), /repeats single-valued directive Service.User/);
+});
+
+test("size, depth, ASCII path, source symlink, and hardlink limits fail closed", (t) => {
+  const deep = makeEdgeFixture(t);
+  deep.plan.payload_artifacts[0].source_path = `${"a/".repeat(25)}caddy`;
+  assert.throws(() => renderFixture(deep), /depth limit/);
+
+  const nonAscii = makeEdgeFixture(t);
+  nonAscii.plan.payload_artifacts[0].source_path = "payload/caddÿ";
+  assert.throws(() => renderFixture(nonAscii), /portable relative path/);
+
+  const huge = makeEdgeFixture(t);
+  const binary = huge.plan.payload_artifacts.find((entry) => entry.class === "binary");
+  truncateSync(join(huge.inputRoot, binary.source_path), 512 * 1024 * 1024 + 1);
+  assert.throws(() => renderFixture(huge), /size limit/);
+
+  const symlink = makeEdgeFixture(t);
+  const sourcePath = join(symlink.sourceRoot, EDGE_CONFIG);
+  rmSync(sourcePath);
+  symlinkSync(join(REPOSITORY, EDGE_CONFIG), sourcePath);
+  assert.throws(() => renderFixture(symlink), /symlink|resolves through/);
+
+  const hardlink = makeEdgeFixture(t);
+  linkSync(join(hardlink.inputRoot, hardlink.plan.payload_artifacts[0].source_path), join(hardlink.root, "alias"));
+  assert.throws(() => renderFixture(hardlink), /exactly one hard link/);
+});
+
+test("bundle tree rejects tamper, extra file, extra directory, symlink, hardlink, and deep tree", (t) => {
+  const tamper = makeEdgeFixture(t);
+  renderFixture(tamper);
+  appendFileSync(join(tamper.bundleRoot, "payment-v1-manifest.json"), " ");
+  assert.throws(() => verifyFixture(tamper), /byte mismatch/);
+
+  const extra = makeEdgeFixture(t);
+  renderFixture(extra);
+  writeFileSync(join(extra.bundleRoot, "extra"), "x", { mode: 0o600 });
+  assert.throws(() => verifyFixture(extra), /bundle files must equal/);
+
+  const directory = makeEdgeFixture(t);
+  renderFixture(directory);
+  mkdirSync(join(directory.bundleRoot, "extra"), { mode: 0o700 });
+  assert.throws(() => verifyFixture(directory), /bundle directories must equal/);
+
+  const symlink = makeEdgeFixture(t);
+  renderFixture(symlink);
+  symlinkSync("payment-v1-manifest.json", join(symlink.bundleRoot, "alias"));
+  assert.throws(() => verifyFixture(symlink), /contains symlink/);
+
+  const hardlink = makeEdgeFixture(t);
+  renderFixture(hardlink);
+  linkSync(join(hardlink.bundleRoot, "payment-v1-manifest.json"), join(hardlink.bundleRoot, "alias"));
+  assert.throws(() => verifyFixture(hardlink), /multiple hard links/);
+
+  const deep = makeEdgeFixture(t);
+  renderFixture(deep);
+  let cursor = deep.bundleRoot;
+  for (let index = 0; index < 28; index += 1) {
+    cursor = join(cursor, "d");
+    mkdirSync(cursor, { mode: 0o700 });
+  }
+  assert.throws(() => verifyFixture(deep), /depth limit/);
+});
+
+test("runtime structure remains manifest-bound and rejects drop-ins, reset effects, and drift", (t) => {
+  const fixture = makeEdgeFixture(t);
+  const model = renderFixture(fixture);
+  const valid = makeRuntimeEvidence(model);
+  assert.equal(validateRuntimeEvidence({ evidence: valid, model }), true);
+
+  for (const [label, mutate, expected] of [
+    ["drop-in", (e) => e.units[0].drop_in_paths.push("/etc/systemd/system/x.d/evil.conf"), /drop_in_paths must be empty/],
+    ["ExecStart reset", (e) => { e.units[0].exec_start = ["/usr/bin/true"]; }, /exec_start does not match/],
+    ["ExecStartPre reset", (e) => { e.units[0].exec_start_pre = []; }, /exec_start_pre does not match/],
+    ["environment", (e) => e.units[0].environment.push("LD_PRELOAD=/tmp/evil"), /environment does not match/],
+    ["fragment", (e) => { e.units[0].fragment_path = "/run/systemd/transient/evil.service"; }, /fragment_path does not match/],
+    ["file hash", (e) => { e.installed_files[0].sha256 = "3".repeat(64); }, /installed file evidence does not match/],
+    ["host state", (e) => { e.units[0].active_state = "failed"; }, /active_state must be/],
+  ]) {
+    const evidence = makeRuntimeEvidence(model);
+    mutate(evidence);
+    assert.throws(() => validateRuntimeEvidence({ evidence, model }), expected, label);
+  }
+});
+
+test("CLI requires external plan and evidence pins; forged or unpinned runtime JSON fails", (t) => {
+  const fixture = makeEdgeFixture(t);
+  const planPath = join(fixture.root, "plan.json");
+  writeFileSync(planPath, canonicalJson(fixture.plan));
+  const common = [
+    "--source-root", fixture.sourceRoot,
+    "--input-root", fixture.inputRoot,
+    "--plan", planPath,
+    "--approved-plan-sha256", approved(fixture.plan),
+    "--bundle", fixture.bundleRoot,
+  ];
+  const missingPin = spawnSync(process.execPath, [GATE, "render", ...common.filter((_, index) => index < 6 || index > 7)], { encoding: "utf8" });
+  assert.notEqual(missingPin.status, 0);
+  const rendered = spawnSync(process.execPath, [GATE, "render", ...common], { encoding: "utf8" });
+  assert.equal(rendered.status, 0, rendered.stderr);
+  const model = verifyFixture(fixture);
+  const evidencePath = join(fixture.root, "evidence.json");
+  const evidenceBytes = Buffer.from(canonicalJson(makeRuntimeEvidence(model)));
+  writeFileSync(evidencePath, evidenceBytes);
+  const unpinned = spawnSync(process.execPath, [GATE, "verify-runtime", ...common, "--evidence", evidencePath], { encoding: "utf8" });
+  assert.notEqual(unpinned.status, 0);
+  assert.match(unpinned.stderr, /externally trusted evidence/);
+  const wrong = spawnSync(process.execPath, [GATE, "verify-runtime", ...common, "--evidence", evidencePath, "--trusted-evidence-sha256", "1".repeat(64)], { encoding: "utf8" });
+  assert.notEqual(wrong.status, 0);
+  const pinned = spawnSync(process.execPath, [GATE, "verify-runtime", ...common, "--evidence", evidencePath, "--trusted-evidence-sha256", hashBytes(evidenceBytes)], { encoding: "utf8" });
+  assert.equal(pinned.status, 0, pinned.stderr);
+  assert.match(pinned.stdout, /offline pinned runtime structure PASS/);
+});
+
+test("strict JSON rejects duplicates and renderer never overwrites output", (t) => {
+  assert.throws(() => parseStrictJson('{"a":1,"a":2}\n'), /repeats JSON key/);
+  const fixture = makeEdgeFixture(t);
+  mkdirSync(fixture.bundleRoot, { mode: 0o700 });
+  assert.throws(() => renderFixture(fixture), /already exists/);
+});


### PR DESCRIPTION
## Summary

- add a directory-only Nostr relay with pinned publisher/kind, canonical EVENT/REQ handling, immutable SQLite archive/head state, bounded work/egress, and fail-closed duplicate/replacement semantics
- add a method-scoped Core Lightning Unix RPC guard, split-UID preflight support, key-generation roles, Signet staging checks, and non-activating Hetzner/VPSBG deployment templates
- make the first production shared-issuer surface ledger-only: expose redeem/balance only, remove payout target/fee/TTL configuration, and retain payout state machines only behind test/library boundaries
- add a real provider -> TLS edge -> payment-issuer process E2E with an independent Free peer, restart/replay assertions, wrong-CA/pin/offline failures, ledger accounting, and privacy-log checks
- add source-template, rendered-bundle, and live-Linux evidence gates; wire new crates, gates, E2E, clippy, and release-feature rejection into Payment Platform CI
- document the Hetzner-new-services / VPSBG-minimal-change topology, explicit trust boundaries, production blockers, and rollback/activation ceremonies

## Why

Payment V1 already supports Free, direct BOLT11 receipt, Standard Cashu, BitcoinPIR BAT, and experimental ARC at the protocol/provider/browser boundaries. This change prepares the missing production service and deployment seams while preserving two-server independence and keeping invoices, payment hashes, preimages, payer data, and cross-provider pair identifiers out of PIR authorization.

It also narrows the first shared-clearing product to authenticated ledger accrual. Automated payout remains intentionally disabled until a separate custody and operations design is reviewed.

## Validation performed locally

- deployment source gate: 16/16 tests and CLI gate passed
- rendered/live evidence gates: 63/63 tests passed
- all four Node gate/test files passed `node --check`
- `rustfmt --edition 2021 --check` passed for every changed Rust file
- `cargo metadata --locked --offline` passed after verifying the lockfile changed only for the expected new packages/dependency edges
- `bash -n` and ShellCheck passed for the local check; the deployment layout template passed `sh -n`
- Pages semantic deployment gate passed
- staged diff/worktree closure, source hashes, secret scan, file modes, and `git diff --cached --check` passed
- two independent read-only reviews found no P0/P1 source blocker

No Cargo compilation/test process was run on this macOS host because the local Rust test runner is affected by a system policy hang. Exact-commit Linux CI is required before merge.

## Required before merge

- all Payment Platform Linux jobs, including the new shared-issuer process E2E, warnings-denied clippy, and test-only release guards, must pass
- review any CI failures on this exact commit; do not treat local static checks as executable Rust evidence

## Not authorized or activated by this PR

This PR does not deploy or mutate any remote host, publish the production Nostr key/catalog, create a Lightning wallet/channel, or use real funds.

Public activation still requires:

- ephemeral source-fair ingress without persistent IP/request logging
- independent rollback-authority hosts/admin/failure domains and a second independently operated relay
- a decision on attestation-gated VPSBG state/key release versus explicitly expanding the VPSBG host trust boundary
- measured cgroup/resource limits and a real root-only Linux `collect-live` drill
- separately approved Signet/remote deployment and final manual browser acceptance

ARC remains experimental and production-disabled pending independent cryptographic review.

## Follow-up test hardening

A later focused change should add a real-process shared-issuer response-loss seam plus issuer same-store restart. Existing store/service tests cover exact replay and outcome-unknown recovery, while this new process cell currently restarts only the provider.
