### PR TITLE
Test Payment V1 fault isolation and response-loss recovery

### DIFF
--- a/.github/workflows/payment-platform.yml
+++ b/.github/workflows/payment-platform.yml
@@ -219,10 +219,15 @@ jobs:
           cargo test --locked --offline -p runtime --test payment_v1_process_e2e
           cargo test --locked --offline -p runtime --test payment_v1_methods_process_e2e
           cargo test --locked --offline -p runtime --test payment_v1_harmony_pool_process_e2e
+      - name: Exercise two independent directory-relay process stores and views
+        run: |
+          cargo test --locked --offline -p bitcoinpir-directory-relay --test payment_v1_two_relay_process_e2e two_relay_real_process_catalog_e2e -- --exact --ignored
+          cargo clippy --locked --offline -p bitcoinpir-directory-relay --test payment_v1_two_relay_process_e2e --no-deps -- -D warnings
       - name: Exercise provider and issuer remote rollback authorities over pinned WebPKI TLS
         run: |
           cargo test --locked --offline -p pir-rollback-authority-client --features test-only-webpki-root test_only_webpki_root_requires_owner_only_regular_file
           cargo test --locked --offline -p runtime --features remote-authority-process-e2e --test payment_v1_process_e2e remote_authority_process::remote_authority_real_process_tls_provider_e2e -- --exact
+          cargo test --locked --offline -p runtime --features remote-authority-process-e2e --test payment_v1_process_e2e three_authority_process::three_authority_real_process_topology_e2e -- --exact
           cargo clippy --locked --offline -p runtime --features remote-authority-process-e2e --bin unified_server --test payment_v1_process_e2e --no-deps -- -D warnings
           cargo test --locked --offline -p payment-issuer --features remote-authority-process-e2e --test remote_authority_process_e2e payment_issuer_remote_authority_real_process_tls_e2e -- --exact
           cargo clippy --locked --offline -p payment-issuer --features remote-authority-process-e2e --all-targets --no-deps -- -D warnings

--- a/apps/directory-relay/tests/payment_v1_two_relay_process_e2e.rs
+++ b/apps/directory-relay/tests/payment_v1_two_relay_process_e2e.rs
@@ -1,0 +1,651 @@
+//! Local process-topology coverage for two BitcoinPIR directory relays.
+//!
+//! This test launches two copies of the repository's production
+//! `bitcoinpir-directory-relay` binary and proves process, listener,
+//! configuration, and SQLite separation on one CI host. It does not prove
+//! different operators, networks, machines, or administrative trust domains.
+
+#![cfg(unix)]
+
+use std::fs::{self, File};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use futures_util::{SinkExt, StreamExt};
+use pir_directory_nostr::{
+    full_catalog_req_json_v1, verify_directory_checkpoint_event_v1,
+    verify_directory_entry_event_v1, DirectoryCatalogCheckpointV1, DirectoryCheckpointEntryV1,
+    DirectoryEntryV1, DirectoryHealthClassV1, DirectoryHealthV1, DirectoryPublisherKeyV1,
+    NostrEventV1, DIRECTORY_SHARD_COUNT_V1,
+};
+use serde_json::Value;
+use tokio::net::TcpStream as TokioTcpStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+
+const START_TIMEOUT: Duration = Duration::from_secs(30);
+const IO_TIMEOUT: Duration = Duration::from_secs(10);
+
+type RelayClient = WebSocketStream<MaybeTlsStream<TokioTcpStream>>;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ShardHead {
+    entry_event_id: [u8; 32],
+    directory_sequence: u64,
+    checkpoint_event_id: [u8; 32],
+    checkpoint_epoch: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct CatalogSnapshot(Vec<ShardHead>);
+
+#[derive(Debug, Eq, PartialEq)]
+enum DualRelayReadError {
+    Relay0(String),
+    Relay1(String),
+    SplitView,
+}
+
+struct RelayMaterial {
+    label: &'static str,
+    port: u16,
+    config: PathBuf,
+    database: PathBuf,
+}
+
+struct RelayProcess {
+    label: &'static str,
+    child: Option<Child>,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+}
+
+impl RelayProcess {
+    fn spawn(root: &Path, material: &RelayMaterial, generation: u8) -> Self {
+        let stdout_path = root.join(format!(
+            "{}-generation-{generation}-stdout.log",
+            material.label
+        ));
+        let stderr_path = root.join(format!(
+            "{}-generation-{generation}-stderr.log",
+            material.label
+        ));
+        let stdout = File::create(&stdout_path).expect("create relay stdout log");
+        let stderr = File::create(&stderr_path).expect("create relay stderr log");
+        let child = Command::new(env!("CARGO_BIN_EXE_bitcoinpir-directory-relay"))
+            .args([
+                "--config",
+                material.config.to_str().expect("UTF-8 relay config path"),
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .spawn()
+            .expect("spawn directory relay process");
+        let mut process = Self {
+            label: material.label,
+            child: Some(child),
+            stdout_path,
+            stderr_path,
+        };
+        process.wait_until_listening(material.port);
+        process
+    }
+
+    fn id(&self) -> u32 {
+        self.child.as_ref().expect("relay process is running").id()
+    }
+
+    fn wait_until_listening(&mut self, port: u16) {
+        let deadline = Instant::now() + START_TIMEOUT;
+        loop {
+            let child = self.child.as_mut().expect("relay process is running");
+            if let Some(status) = child.try_wait().expect("poll relay process") {
+                panic!(
+                    "{} exited before listening ({status})\nstdout:\n{}\nstderr:\n{}",
+                    self.label,
+                    read_log(&self.stdout_path),
+                    read_log(&self.stderr_path),
+                );
+            }
+            if TcpStream::connect_timeout(
+                &format!("127.0.0.1:{port}")
+                    .parse()
+                    .expect("loopback address"),
+                Duration::from_millis(100),
+            )
+            .is_ok()
+            {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {}\nstdout:\n{}\nstderr:\n{}",
+                self.label,
+                read_log(&self.stdout_path),
+                read_log(&self.stderr_path),
+            );
+            thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    fn stop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+impl Drop for RelayProcess {
+    fn drop(&mut self) {
+        self.stop();
+        if thread::panicking() {
+            eprintln!(
+                "{} logs after test failure\nstdout:\n{}\nstderr:\n{}",
+                self.label,
+                read_log(&self.stdout_path),
+                read_log(&self.stderr_path),
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "run explicitly by payment-platform CI/full local acceptance"]
+async fn two_relay_real_process_catalog_e2e() {
+    let root = tempfile::tempdir().expect("two-relay process test root");
+    chmod(root.path(), 0o700);
+    let publisher = DirectoryPublisherKeyV1::from_secret_bytes([0x61; 32])
+        .expect("deterministic test directory key");
+    let now = unix_now();
+    let relay0_port = distinct_unused_port(&[]);
+    let relay1_port = distinct_unused_port(&[relay0_port]);
+    let relay0 = prepare_relay(root.path(), "relay0", relay0_port, publisher.public_key());
+    let relay1 = prepare_relay(root.path(), "relay1", relay1_port, publisher.public_key());
+    assert_ne!(relay0.config, relay1.config);
+    assert_ne!(relay0.database, relay1.database);
+    assert_ne!(relay0.port, relay1.port);
+
+    let mut process0 = RelayProcess::spawn(root.path(), &relay0, 0);
+    let mut process1 = RelayProcess::spawn(root.path(), &relay1, 0);
+    assert_ne!(process0.id(), process1.id());
+    assert_ne!(
+        fs::metadata(&relay0.database)
+            .expect("relay0 database")
+            .ino(),
+        fs::metadata(&relay1.database)
+            .expect("relay1 database")
+            .ino(),
+        "the two relay processes must not alias one SQLite file"
+    );
+
+    let initial = signed_catalog(&publisher, now, now.saturating_sub(2), 1, 1);
+
+    // Relay 0 durably commits the first event, but the socket carrying its OK
+    // disappears. ID readback is the commit barrier; retrying the same signed
+    // event must be accepted as an idempotent duplicate.
+    publish_without_reading_ack(relay0.port, &initial[0]).await;
+    wait_for_event_id(relay0.port, initial[0].id()).await;
+    let (accepted, reason) = publish(relay0.port, &initial[0]).await;
+    assert!(accepted);
+    assert!(
+        reason.starts_with("duplicate:"),
+        "unexpected retry reason: {reason}"
+    );
+
+    publish_many(relay0.port, &initial[1..]).await;
+    publish_many(relay1.port, &initial).await;
+    let baseline = read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now)
+        .await
+        .expect("identical complete catalog");
+    assert_eq!(baseline.0.len(), usize::from(DIRECTORY_SHARD_COUNT_V1));
+
+    // A newer shard-0 head on only one relay is a split view. The client must
+    // reject the pair and must never merge the newer entry with the older
+    // checkpoint (or vice versa).
+    let shard0_update = signed_shard(&publisher, now, now.saturating_sub(1), 0, 2, 2, 0xb0);
+    publish_many(relay0.port, &shard0_update).await;
+    let relay0_split_head = read_catalog(relay0.port, publisher.public_key(), now)
+        .await
+        .expect("relay0 split-view head remains independently valid");
+    let relay1_split_head = read_catalog(relay1.port, publisher.public_key(), now)
+        .await
+        .expect("relay1 split-view head remains independently valid");
+    assert_ne!(
+        relay0_split_head, relay1_split_head,
+        "the two independently verified catalog heads must conflict"
+    );
+    assert_eq!(
+        read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now).await,
+        Err(DualRelayReadError::SplitView),
+        "stale relay head must fail closed with the exact split-view error"
+    );
+    publish_many(relay1.port, &shard0_update).await;
+    let converged = read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now)
+        .await
+        .expect("relays converge after the same signed update");
+    assert_ne!(converged, baseline);
+    assert_eq!(converged.0[0].directory_sequence, 2);
+    assert_eq!(converged.0[0].checkpoint_epoch, 2);
+
+    // One offline relay is not silently replaced by the other relay's view.
+    process1.stop();
+    read_catalog(relay0.port, publisher.public_key(), now)
+        .await
+        .expect("relay0 remains independently readable");
+    let offline_error =
+        read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now)
+            .await
+            .expect_err("dual-relay policy must fail closed while one relay is offline");
+    assert!(
+        matches!(
+            offline_error,
+            DualRelayReadError::Relay1(reason)
+                if reason.starts_with(&format!("connect relay {} failed:", relay1.port))
+        ),
+        "offline relay1 must be attributed to the relay1 transport boundary"
+    );
+
+    process1 = RelayProcess::spawn(root.path(), &relay1, 1);
+    assert_eq!(
+        read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now)
+            .await
+            .expect("relay1 durable restart restores the catalog"),
+        converged
+    );
+
+    process0.stop();
+    process0 = RelayProcess::spawn(root.path(), &relay0, 1);
+    assert_ne!(process0.id(), process1.id());
+    assert_eq!(
+        read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now)
+            .await
+            .expect("both durable stores survive independent process restart"),
+        converged
+    );
+}
+
+fn prepare_relay(
+    root: &Path,
+    label: &'static str,
+    port: u16,
+    directory_pubkey: &[u8; 32],
+) -> RelayMaterial {
+    let directory = root.join(label);
+    fs::create_dir(&directory).expect("create relay domain directory");
+    chmod(&directory, 0o700);
+    let config = directory.join("relay.toml");
+    let database = directory.join("relay.sqlite3");
+    let text = format!(
+        r#"profile = "bitcoinpir-directory-relay-v1"
+listen = "127.0.0.1:{port}"
+database = "{}"
+directory_pubkey_hex = "{}"
+max_connections = 32
+max_in_flight_operations = 4
+max_operations_per_second = 1000000
+max_egress_bytes_per_second = 1073741824
+max_egress_bytes_per_connection = 67108864
+max_archive_events = 20000
+max_archive_bytes = 67108864
+handshake_timeout_seconds = 5
+idle_timeout_seconds = 10
+connection_timeout_seconds = 60
+operation_timeout_seconds = 10
+egress_timeout_seconds = 10
+"#,
+        database.display(),
+        hex::encode(directory_pubkey),
+    );
+    fs::write(&config, text).expect("write relay config");
+    chmod(&config, 0o600);
+    RelayMaterial {
+        label,
+        port,
+        config,
+        database,
+    }
+}
+
+fn signed_catalog(
+    publisher: &DirectoryPublisherKeyV1,
+    now: u64,
+    created_at: u64,
+    sequence: u64,
+    checkpoint_epoch: u64,
+) -> Vec<NostrEventV1> {
+    let mut events = Vec::with_capacity(usize::from(DIRECTORY_SHARD_COUNT_V1) * 2);
+    for shard in 0..DIRECTORY_SHARD_COUNT_V1 {
+        events.extend(signed_shard(
+            publisher,
+            now,
+            created_at,
+            shard,
+            sequence,
+            checkpoint_epoch,
+            shard,
+        ));
+    }
+    events
+}
+
+fn signed_shard(
+    publisher: &DirectoryPublisherKeyV1,
+    now: u64,
+    created_at: u64,
+    shard: u8,
+    sequence: u64,
+    checkpoint_epoch: u64,
+    randomness: u8,
+) -> [NostrEventV1; 2] {
+    let mut provider_id = [0x41; 32];
+    provider_id[0] = (shard << 4) | 1;
+    provider_id[31] = shard.saturating_add(1);
+    let entry = DirectoryEntryV1::new_tombstone(
+        provider_id,
+        sequence,
+        now + 3_600,
+        DirectoryHealthV1 {
+            class: DirectoryHealthClassV1::Unknown,
+            observed_bucket: now - (now % 300),
+        },
+        now,
+    )
+    .expect("valid directory tombstone");
+    let entry_event = publisher
+        .sign_entry_event(&entry, created_at, &[randomness.wrapping_add(1); 32])
+        .expect("sign directory entry");
+    let checkpoint = DirectoryCatalogCheckpointV1::new(
+        shard,
+        checkpoint_epoch,
+        created_at,
+        now + 3_600,
+        vec![DirectoryCheckpointEntryV1 {
+            provider_id,
+            directory_sequence: sequence,
+            event_id: *entry_event.id(),
+        }],
+        now,
+    )
+    .expect("valid directory checkpoint");
+    let checkpoint_event = publisher
+        .sign_checkpoint_event(
+            &checkpoint,
+            created_at,
+            &[randomness.wrapping_add(0x41); 32],
+        )
+        .expect("sign directory checkpoint");
+    [entry_event, checkpoint_event]
+}
+
+async fn relay_client(port: u16) -> Result<RelayClient, String> {
+    connect_async(format!("ws://127.0.0.1:{port}"))
+        .await
+        .map(|(client, _)| client)
+        .map_err(|error| format!("connect relay {port} failed: {error}"))
+}
+
+async fn receive_text(client: &mut RelayClient) -> Result<String, String> {
+    let message = tokio::time::timeout(IO_TIMEOUT, client.next())
+        .await
+        .map_err(|_| "relay response timeout".to_owned())?
+        .ok_or_else(|| "relay closed before response".to_owned())?
+        .map_err(|error| format!("relay WebSocket response failed: {error}"))?;
+    match message {
+        Message::Text(text) => Ok(text.to_string()),
+        other => Err(format!("unexpected relay message: {other:?}")),
+    }
+}
+
+async fn publish(port: u16, event: &NostrEventV1) -> (bool, String) {
+    let mut client = relay_client(port).await.expect("connect publish client");
+    client
+        .send(Message::Text(
+            String::from_utf8(
+                event
+                    .to_event_message_json_bytes()
+                    .expect("publish envelope"),
+            )
+            .expect("UTF-8 publish envelope")
+            .into(),
+        ))
+        .await
+        .expect("send event");
+    let response: Value = serde_json::from_str(
+        &receive_text(&mut client)
+            .await
+            .expect("receive publish acknowledgement"),
+    )
+    .expect("parse publish acknowledgement");
+    assert_eq!(response[0], "OK");
+    assert_eq!(response[1], hex::encode(event.id()));
+    let _ = client.send(Message::Close(None)).await;
+    (
+        response[2].as_bool().expect("OK acceptance flag"),
+        response[3].as_str().expect("OK reason").to_owned(),
+    )
+}
+
+async fn publish_many(port: u16, events: &[NostrEventV1]) {
+    for event in events {
+        let (accepted, reason) = publish(port, event).await;
+        assert!(accepted, "relay {port} rejected event: {reason}");
+    }
+}
+
+async fn publish_without_reading_ack(port: u16, event: &NostrEventV1) {
+    let mut client = relay_client(port).await.expect("connect lost-ACK client");
+    client
+        .send(Message::Text(
+            String::from_utf8(
+                event
+                    .to_event_message_json_bytes()
+                    .expect("publish envelope"),
+            )
+            .expect("UTF-8 publish envelope")
+            .into(),
+        ))
+        .await
+        .expect("send event before losing ACK");
+    drop(client);
+}
+
+async fn wait_for_event_id(port: u16, event_id: &[u8; 32]) {
+    let committed = tokio::time::timeout(Duration::from_secs(10), async {
+        for attempt in 0u64..40 {
+            let mut client = relay_client(port).await.expect("connect readback probe");
+            let subscription = format!("lost-ack-readback-{attempt}");
+            let request = serde_json::json!([
+                "REQ",
+                subscription,
+                {"ids": [hex::encode(event_id)]}
+            ]);
+            client
+                .send(Message::Text(request.to_string().into()))
+                .await
+                .expect("send readback probe");
+            let mut found = false;
+            loop {
+                let response: Value = serde_json::from_str(
+                    &receive_text(&mut client)
+                        .await
+                        .expect("receive readback probe"),
+                )
+                .expect("parse readback response");
+                match response[0].as_str().expect("readback response kind") {
+                    "EVENT" => {
+                        found |= response[2]["id"] == hex::encode(event_id);
+                    }
+                    "EOSE" => break,
+                    other => panic!("unexpected readback response: {other}"),
+                }
+            }
+            let _ = client.send(Message::Close(None)).await;
+            if found {
+                return true;
+            }
+            let backoff_ms = 25 + attempt.min(15) * 10;
+            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+        }
+        false
+    })
+    .await
+    .expect("lost-ACK event never crossed the durable readback barrier");
+    assert!(
+        committed,
+        "lost-ACK event was not readable after 40 bounded probes"
+    );
+}
+
+async fn read_consistent_catalog(
+    relay0_port: u16,
+    relay1_port: u16,
+    directory_pubkey: &[u8; 32],
+    now: u64,
+) -> Result<CatalogSnapshot, DualRelayReadError> {
+    let (left, right) = tokio::join!(
+        read_catalog(relay0_port, directory_pubkey, now),
+        read_catalog(relay1_port, directory_pubkey, now),
+    );
+    let left = left.map_err(DualRelayReadError::Relay0)?;
+    let right = right.map_err(DualRelayReadError::Relay1)?;
+    if left != right {
+        return Err(DualRelayReadError::SplitView);
+    }
+    Ok(left)
+}
+
+async fn read_catalog(
+    port: u16,
+    directory_pubkey: &[u8; 32],
+    now: u64,
+) -> Result<CatalogSnapshot, String> {
+    let mut client = relay_client(port).await?;
+    let requests = full_catalog_req_json_v1(directory_pubkey)
+        .map_err(|error| format!("build catalog requests failed: {error}"))?;
+    let mut heads = Vec::with_capacity(usize::from(DIRECTORY_SHARD_COUNT_V1));
+    for (shard, request) in requests.into_iter().enumerate() {
+        let request_text = String::from_utf8(request)
+            .map_err(|error| format!("generated catalog request is not UTF-8: {error}"))?;
+        let parsed_request: Value = serde_json::from_str(&request_text)
+            .map_err(|error| format!("parse generated catalog request failed: {error}"))?;
+        let subscription = parsed_request[1]
+            .as_str()
+            .ok_or_else(|| "generated request has no subscription".to_owned())?
+            .to_owned();
+        client
+            .send(Message::Text(request_text.into()))
+            .await
+            .map_err(|error| format!("send catalog request failed: {error}"))?;
+        let mut entry = None;
+        let mut checkpoint = None;
+        loop {
+            let response: Value = serde_json::from_str(&receive_text(&mut client).await?)
+                .map_err(|error| format!("parse catalog response failed: {error}"))?;
+            match response[0]
+                .as_str()
+                .ok_or_else(|| "catalog response has no kind".to_owned())?
+            {
+                "EVENT" => {
+                    if response[1] != subscription {
+                        return Err("catalog subscription mismatch".to_owned());
+                    }
+                    let event_json = serde_json::to_vec(&response[2])
+                        .map_err(|error| format!("serialize returned event failed: {error}"))?;
+                    if let Ok(verified) =
+                        verify_directory_entry_event_v1(&event_json, directory_pubkey, now)
+                    {
+                        if usize::from(verified.shard()) != shard || entry.is_some() {
+                            return Err("catalog entry head is ambiguous".to_owned());
+                        }
+                        entry = Some((
+                            *verified.discovery_entry().provider_id(),
+                            *verified.event().id(),
+                            verified.discovery_entry().directory_sequence(),
+                        ));
+                    } else {
+                        let verified = verify_directory_checkpoint_event_v1(
+                            &event_json,
+                            directory_pubkey,
+                            now,
+                        )
+                        .map_err(|error| format!("invalid returned catalog event: {error}"))?;
+                        if usize::from(verified.checkpoint().shard()) != shard
+                            || checkpoint.is_some()
+                        {
+                            return Err("catalog checkpoint head is ambiguous".to_owned());
+                        }
+                        checkpoint = Some((
+                            *verified.event().id(),
+                            verified.checkpoint().checkpoint_epoch(),
+                            verified.checkpoint().entries().to_vec(),
+                        ));
+                    }
+                }
+                "EOSE" => {
+                    if response[1] != subscription {
+                        return Err("catalog EOSE subscription mismatch".to_owned());
+                    }
+                    break;
+                }
+                "CLOSED" => return Err("relay refused catalog snapshot".to_owned()),
+                other => return Err(format!("unexpected catalog response: {other}")),
+            }
+        }
+        let (provider_id, entry_event_id, directory_sequence) =
+            entry.ok_or_else(|| format!("shard {shard} has no entry head"))?;
+        let (checkpoint_event_id, checkpoint_epoch, checkpoint_entries) =
+            checkpoint.ok_or_else(|| format!("shard {shard} has no checkpoint head"))?;
+        if checkpoint_entries.as_slice()
+            != &[DirectoryCheckpointEntryV1 {
+                provider_id,
+                directory_sequence,
+                event_id: entry_event_id,
+            }]
+        {
+            return Err("catalog checkpoint does not bind the returned entry head".to_owned());
+        }
+        heads.push(ShardHead {
+            entry_event_id,
+            directory_sequence,
+            checkpoint_event_id,
+            checkpoint_epoch,
+        });
+    }
+    let _ = client.send(Message::Close(None)).await;
+    Ok(CatalogSnapshot(heads))
+}
+
+fn distinct_unused_port(excluded: &[u16]) -> u16 {
+    loop {
+        let port = TcpListener::bind("127.0.0.1:0")
+            .expect("bind ephemeral port")
+            .local_addr()
+            .expect("ephemeral local address")
+            .port();
+        if !excluded.contains(&port) {
+            return port;
+        }
+    }
+}
+
+fn chmod(path: &Path, mode: u32) {
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).expect("set private permissions");
+}
+
+fn read_log(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|error| format!("<read log failed: {error}>"))
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_secs()
+}

--- a/apps/directory-relay/tests/payment_v1_two_relay_process_e2e.rs
+++ b/apps/directory-relay/tests/payment_v1_two_relay_process_e2e.rs
@@ -603,7 +603,7 @@ async fn read_catalog(
         let (checkpoint_event_id, checkpoint_epoch, checkpoint_entries) =
             checkpoint.ok_or_else(|| format!("shard {shard} has no checkpoint head"))?;
         if checkpoint_entries.as_slice()
-            != &[DirectoryCheckpointEntryV1 {
+            != [DirectoryCheckpointEntryV1 {
                 provider_id,
                 directory_sequence,
                 event_id: entry_event_id,

--- a/apps/server/tests/payment_v1_process_e2e.rs
+++ b/apps/server/tests/payment_v1_process_e2e.rs
@@ -712,3 +712,7 @@ fn unix_now() -> u64 {
 #[cfg(feature = "remote-authority-process-e2e")]
 #[path = "support/payment_v1_remote_authority_process.rs"]
 mod remote_authority_process;
+
+#[cfg(feature = "remote-authority-process-e2e")]
+#[path = "support/payment_v1_three_authority_process.rs"]
+mod three_authority_process;

--- a/apps/server/tests/payment_v1_shared_issuer_process_e2e.rs
+++ b/apps/server/tests/payment_v1_shared_issuer_process_e2e.rs
@@ -7,6 +7,11 @@
 //! backend is used only to satisfy no-funds startup; this test never creates or
 //! settles an invoice. The peer provider independently selects Free/Open.
 //!
+//! The TLS edge also drops one complete, successful redeem response after the
+//! issuer commits it. The provider must fail closed without a delivery claim,
+//! then recover by replaying the exact request after the issuer and provider
+//! restart against their original stores and rollback floors.
+//!
 //! The private test CA hook is inherited from `standard-cashu-process-e2e`, so
 //! there is one test-only WebPKI injection surface and `pir-strict-https` keeps
 //! its release compile guard. All bearer/key fixtures are deterministic public
@@ -39,9 +44,9 @@ use pir_service_protocol::{
     CredentialUnitV1, DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1,
     FreeAuthorizationProofV1, FreeModeV1, IssuerClearingApprovalV1, LightningNetworkV1,
     OperationStartV1, PriceV1, PrivacyLeakageV1, ProviderClearingAuthorizationClaimsV1,
-    ProviderClearingAuthorizationV1, ServiceOfferV1, ServicePolicyV1, ServiceScopePolicyV1,
-    ServiceScopeV1, SettlementModesV1, SettlementRuleV1, SettlementUnitV1, VerificationMode,
-    WorkloadId,
+    ProviderClearingAuthorizationV1, ProviderRedeemEnvelopeV1, ProviderRedeemResponseV1,
+    ServiceOfferV1, ServicePolicyV1, ServiceScopePolicyV1, ServiceScopeV1, SettlementModesV1,
+    SettlementRuleV1, SettlementUnitV1, VerificationMode, WorkloadId,
 };
 use pir_service_store::{
     ProviderStore, SqliteRollbackFloorAuthorityV1, StoreOptions as ProviderStoreOptions,
@@ -61,6 +66,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use zeroize::Zeroizing;
 
 const SHARED_OFFER_ID: u32 = 61;
 const FREE_OFFER_ID: u32 = 62;
@@ -70,6 +76,11 @@ const TINY_BINS_PER_TABLE: usize = 128;
 const TEST_LEAF_SPKI_SHA256_HEX: &str =
     "e91550521f8e17b21d99f7e00b99c08be1b1f31fe57772ac8f904ea50c6a609b";
 const TLS_EDGE_HELPER_MARKER: &str = "BITCOINPIR_TEST_ONLY_SHARED_ISSUER_TLS_EDGE_V1";
+const TLS_EDGE_TRANSCRIPT_PATH: &str = "BITCOINPIR_TEST_SHARED_ISSUER_TRANSCRIPTS";
+const TLS_EDGE_DROP_SUCCESS_ONCE_PATH: &str = "BITCOINPIR_TEST_SHARED_ISSUER_DROP_SUCCESS_ONCE";
+const REDEEM_CONTENT_TYPE: &str = "application/vnd.bitcoinpir.redeem-v1";
+const REDEEM_RESULT_CONTENT_TYPE: &str = "application/vnd.bitcoinpir.redeem-result-v1";
+const REDEEM_TRANSCRIPT_DIGEST_BYTES: usize = 3 * 32;
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(30);
 const TLS_IO_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_PROXY_HTTP_BYTES: usize = 128 * 1024;
@@ -214,6 +225,25 @@ struct TlsMaterial {
     private_key: PathBuf,
 }
 
+/// Fixed-size, test-local replay evidence. No envelope, credential, raw
+/// idempotency key, HTTP metadata, peer address, or timing is persisted.
+#[derive(Clone, Copy)]
+struct RedeemTranscriptDigests {
+    canonical_body: [u8; 32],
+    request_digest: [u8; 32],
+    idempotency_key_digest: [u8; 32],
+}
+
+impl RedeemTranscriptDigests {
+    fn encode(self) -> [u8; REDEEM_TRANSCRIPT_DIGEST_BYTES] {
+        let mut encoded = [0u8; REDEEM_TRANSCRIPT_DIGEST_BYTES];
+        encoded[..32].copy_from_slice(&self.canonical_body);
+        encoded[32..64].copy_from_slice(&self.request_digest);
+        encoded[64..].copy_from_slice(&self.idempotency_key_digest);
+        encoded
+    }
+}
+
 #[test]
 #[ignore = "spawned only by shared_issuer_real_process_tls_e2e"]
 fn shared_issuer_tls_edge_subprocess() {
@@ -233,8 +263,18 @@ fn shared_issuer_tls_edge_subprocess() {
     let counter_path = PathBuf::from(required_env(
         "BITCOINPIR_TEST_SHARED_ISSUER_FORWARD_COUNTER",
     ));
-    serve_tls_edge(bind, upstream, &certificate, &private_key, &counter_path)
-        .expect("serve shared-issuer TLS edge");
+    let transcript_path = PathBuf::from(required_env(TLS_EDGE_TRANSCRIPT_PATH));
+    let drop_success_once_path = env::var_os(TLS_EDGE_DROP_SUCCESS_ONCE_PATH).map(PathBuf::from);
+    serve_tls_edge(
+        bind,
+        upstream,
+        &certificate,
+        &private_key,
+        &counter_path,
+        &transcript_path,
+        drop_success_once_path.as_deref(),
+    )
+    .expect("serve shared-issuer TLS edge");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -310,8 +350,20 @@ async fn shared_issuer_real_process_tls_e2e() {
     init_issuer_store(&issuer);
     let payment_issuer = spawn_payment_issuer(root.path(), issuer_port, &issuer, &shared_providers);
     let forward_counter = root.path().join("tls-edge-forwarded.log");
+    let transcript_path = root.path().join("tls-edge-transcript-digests.bin");
+    let drop_success_once_path = root.path().join("tls-edge-drop-success-once.marker");
     write_private_file(&forward_counter, b"");
-    let tls_edge = spawn_tls_edge(root.path(), edge_port, issuer_port, &tls, &forward_counter);
+    write_private_file(&transcript_path, b"");
+    assert!(!drop_success_once_path.exists());
+    let tls_edge = spawn_tls_edge(
+        root.path(),
+        edge_port,
+        issuer_port,
+        &tls,
+        &forward_counter,
+        &transcript_path,
+        Some(&drop_success_once_path),
+    );
 
     assert_ne!(paid.provider_id, free.provider_id);
     assert_ne!(paid.store_path, free.store_path);
@@ -320,9 +372,40 @@ async fn shared_issuer_real_process_tls_e2e() {
     let paid_server = spawn_provider(root.path(), &db_path, &paid, paid_port, 0, Some(&tls.root));
     let free_server = spawn_provider(root.path(), &db_path, &free, free_port, 0, None);
 
+    // The edge reads a complete HTTP 200 from the real issuer, proving that the
+    // ledger commit completed, then drops that one downstream response. The
+    // provider must fail closed and must not create a local delivery claim.
+    let lost_response = authorize_only(paid_port, &paid, manifest_root)
+        .await
+        .expect_err("committed issuer response loss must not grant locally");
+    assert!(
+        lost_response.contains("internal-after-spend"),
+        "unexpected outcome-unknown rejection: {lost_response}"
+    );
+    assert_payment_material_absent(&lost_response, "", &[&paid]);
+    let (paid_loss_stdout, paid_loss_stderr) = paid_server.stop();
+    assert_server_log(&paid_loss_stdout, &paid_loss_stderr, paid_port, &paid);
+    assert_provider_spend_inventory(&paid, 0);
+    assert_eq!(forwarded_request_count(&forward_counter), 1);
+    assert_private_regular_file(&drop_success_once_path);
+    let response_loss_marker =
+        fs::read(&drop_success_once_path).expect("read response-loss marker");
+    assert_eq!(
+        response_loss_marker.as_slice(),
+        b"committed-response-dropped\n"
+    );
+
+    // Kill and reopen the actual issuer against the same detailed store and
+    // rollback floor. The provider is also reopened to prove recovery does not
+    // depend on volatile client state.
+    let (issuer_loss_stdout, issuer_loss_stderr) = payment_issuer.stop();
+    assert_issuer_log(&issuer_loss_stdout, &issuer_loss_stderr, &paid);
+    assert_issuer_ledger(&issuer, &paid, &[&wrong_ca, &wrong_pin, &offline]);
+    let payment_issuer = spawn_payment_issuer(root.path(), issuer_port, &issuer, &shared_providers);
+    let paid_server = spawn_provider(root.path(), &db_path, &paid, paid_port, 1, Some(&tls.root));
     exercise_grant_and_dpf(paid_port, &paid, manifest_root)
         .await
-        .expect("shared-issuer BAT must redeem and authorize");
+        .expect("exact redeem replay after issuer restart must recover one grant");
     exercise_grant_and_dpf(free_port, &free, manifest_root)
         .await
         .expect("peer provider must independently accept Free/Open");
@@ -331,11 +414,15 @@ async fn shared_issuer_real_process_tls_e2e() {
     let (free_stdout, free_stderr) = free_server.stop();
     assert_server_log(&paid_stdout_first, &paid_stderr_first, paid_port, &paid);
     assert_server_log(&free_stdout, &free_stderr, free_port, &free);
+    assert_provider_spend_inventory(&paid, 1);
+    assert_eq!(forwarded_request_count(&forward_counter), 2);
+    assert_private_regular_file(&transcript_path);
+    assert_first_two_forwarded_requests_are_identical(&transcript_path);
 
     // Reopen the paid provider against the same local store. The issuer may
     // return its exact durable redeem response, but the provider-local claim is
     // already committed and a second connection grant is forbidden.
-    let paid_server = spawn_provider(root.path(), &db_path, &paid, paid_port, 1, Some(&tls.root));
+    let paid_server = spawn_provider(root.path(), &db_path, &paid, paid_port, 2, Some(&tls.root));
     let replay = authorize_only(paid_port, &paid, manifest_root)
         .await
         .expect_err("replayed shared-issuer proof must not grant after restart");
@@ -345,12 +432,12 @@ async fn shared_issuer_real_process_tls_e2e() {
     );
     let (paid_stdout, paid_stderr) = paid_server.stop();
     assert_server_log(&paid_stdout, &paid_stderr, paid_port, &paid);
-    assert_eq!(provider_local_claim_count(&paid), 1);
+    assert_provider_spend_inventory(&paid, 1);
 
     let forwarded_after_replay = forwarded_request_count(&forward_counter);
     assert!(
-        (1..=2).contains(&forwarded_after_replay),
-        "initial redeem must be forwarded once; exact replay may be rejected locally or replayed at the issuer"
+        (2..=3).contains(&forwarded_after_replay),
+        "loss recovery must forward twice; a later spent replay may be rejected locally or replayed at the issuer"
     );
 
     // Every trust failure uses a fresh provider process/store. The signed
@@ -369,7 +456,7 @@ async fn shared_issuer_real_process_tls_e2e() {
             .expect_err("wrong CA/pin/offline issuer must fail closed");
         let (stdout, stderr) = server.stop();
         assert_server_log(&stdout, &stderr, port, fixture);
-        assert_eq!(provider_local_claim_count(fixture), 0);
+        assert_provider_spend_inventory(fixture, 0);
         assert_eq!(
             forwarded_request_count(&forward_counter),
             forwarded_after_replay,
@@ -379,16 +466,8 @@ async fn shared_issuer_real_process_tls_e2e() {
 
     let (edge_stdout, edge_stderr) = tls_edge.stop();
     let (issuer_stdout, issuer_stderr) = payment_issuer.stop();
-    for forbidden in ["payment_hash", "preimage", "invoice", "secret_raw"] {
-        assert!(!edge_stdout.contains(forbidden));
-        assert!(!edge_stderr.contains(forbidden));
-    }
-    assert!(issuer_stdout.contains("payment-issuer fake service listening"));
-    assert!(issuer_stdout.contains("issuer_store_startup_check=ok"));
-    for forbidden in ["payment_hash", "preimage", "invoice", "secret_raw"] {
-        assert!(!issuer_stdout.contains(forbidden));
-        assert!(!issuer_stderr.contains(forbidden));
-    }
+    assert_payment_material_absent(&edge_stdout, &edge_stderr, &[&paid]);
+    assert_issuer_log(&issuer_stdout, &issuer_stderr, &paid);
 
     assert_issuer_ledger(&issuer, &paid, &[&wrong_ca, &wrong_pin, &offline]);
 }
@@ -969,13 +1048,17 @@ fn spawn_tls_edge(
     issuer_port: u16,
     material: &TlsMaterial,
     counter_path: &Path,
+    transcript_path: &Path,
+    drop_success_once_path: Option<&Path>,
 ) -> ChildProcess {
     let label = "shared-issuer-tls-edge".to_owned();
     let stdout_path = root.join("shared-issuer-tls-edge-stdout.log");
     let stderr_path = root.join("shared-issuer-tls-edge-stderr.log");
     let stdout = File::create(&stdout_path).expect("create TLS edge stdout log");
     let stderr = File::create(&stderr_path).expect("create TLS edge stderr log");
-    let child = Command::new(env::current_exe().expect("current integration test executable"))
+    let mut command =
+        Command::new(env::current_exe().expect("current integration test executable"));
+    command
         .args([
             "--ignored",
             "--exact",
@@ -997,9 +1080,14 @@ fn spawn_tls_edge(
             "BITCOINPIR_TEST_SHARED_ISSUER_FORWARD_COUNTER",
             counter_path,
         )
+        .env(TLS_EDGE_TRANSCRIPT_PATH, transcript_path)
         .stdin(Stdio::null())
         .stdout(Stdio::from(stdout))
-        .stderr(Stdio::from(stderr))
+        .stderr(Stdio::from(stderr));
+    if let Some(path) = drop_success_once_path {
+        command.env(TLS_EDGE_DROP_SUCCESS_ONCE_PATH, path);
+    }
+    let child = command
         .spawn()
         .expect("spawn shared-issuer TLS edge process");
     let mut process = ChildProcess {
@@ -1204,7 +1292,7 @@ fn write_tiny_table(path: &Path, params: &pir_core::params::TableParams, tag_see
     fs::write(path, bytes).unwrap();
 }
 
-fn provider_local_claim_count(fixture: &ProviderFixture) -> u64 {
+fn assert_provider_spend_inventory(fixture: &ProviderFixture, expected: u64) {
     let rollback = SqliteRollbackFloorAuthorityV1::open_existing(
         &fixture.rollback_path,
         ProviderStoreOptions::default().busy_timeout,
@@ -1217,10 +1305,11 @@ fn provider_local_claim_count(fixture: &ProviderFixture) -> u64 {
         Arc::new(rollback),
     )
     .expect("open provider store for audit");
-    store
+    let inventory = store
         .operational_inventory()
-        .expect("provider operational inventory")
-        .spent_capability_rows
+        .expect("provider operational inventory");
+    assert_eq!(inventory.spent_capability_rows, expected);
+    assert_eq!(inventory.observed_spend_commit_seq, expected);
 }
 
 fn assert_issuer_ledger(
@@ -1250,6 +1339,7 @@ fn assert_issuer_ledger(
         paid.shared.as_ref().unwrap().account_id
     );
     assert_eq!(paid_balance.unit, SettlementUnitV1::AuthCredit);
+    assert_eq!(paid_balance.ledger_sequence, 1);
     assert_eq!(
         (paid_balance.available_value, paid_balance.reserved_value),
         (9, 0)
@@ -1271,13 +1361,47 @@ fn assert_server_log(stdout: &str, stderr: &str, port: u16, fixture: &ProviderFi
     assert!(stdout.contains(&format!("Listening on ws://127.0.0.1:{port}")));
     assert!(stdout.contains("Service admission V1: enforced"));
     assert!(!stderr.contains("UNSAFE DEBUG QUERY LOGGING ENABLED"));
-    for forbidden in ["payment_hash", "preimage", "invoice", "secret_raw"] {
-        assert!(!stdout.contains(forbidden));
-        assert!(!stderr.contains(forbidden));
+    assert_payment_material_absent(stdout, stderr, &[fixture]);
+}
+
+fn assert_issuer_log(stdout: &str, stderr: &str, fixture: &ProviderFixture) {
+    assert!(stdout.contains("payment-issuer fake service listening"));
+    assert!(stdout.contains("issuer_store_startup_check=ok"));
+    assert_payment_material_absent(stdout, stderr, &[fixture]);
+}
+
+fn assert_payment_material_absent(stdout: &str, stderr: &str, fixtures: &[&ProviderFixture]) {
+    let stdout_lower = stdout.to_ascii_lowercase();
+    let stderr_lower = stderr.to_ascii_lowercase();
+    for forbidden in [
+        "payment_hash",
+        "payment hash",
+        "paymenthash",
+        "preimage",
+        "invoice",
+        "secret_raw",
+    ] {
+        assert!(!stdout_lower.contains(forbidden));
+        assert!(!stderr_lower.contains(forbidden));
     }
-    if let Some(shared) = &fixture.shared {
-        assert!(!stdout.contains(&hex::encode(shared.proof.secret_raw)));
-        assert!(!stderr.contains(&hex::encode(shared.proof.secret_raw)));
+    for fixture in fixtures {
+        let Some(shared) = &fixture.shared else {
+            continue;
+        };
+        let proof = shared
+            .proof
+            .encode()
+            .expect("encode BAT proof for log audit");
+        for forbidden in [
+            hex::encode(shared.proof.secret_raw),
+            hex::encode(shared.proof.c),
+            hex::encode(proof),
+            format!("{:?}", shared.proof.secret_raw),
+            format!("{:?}", shared.proof.c),
+        ] {
+            assert!(!stdout_lower.contains(forbidden.as_str()));
+            assert!(!stderr_lower.contains(forbidden.as_str()));
+        }
     }
 }
 
@@ -1319,6 +1443,8 @@ fn serve_tls_edge(
     certificate_pem: &[u8],
     private_key_pem: &[u8],
     counter_path: &Path,
+    transcript_path: &Path,
+    drop_success_once_path: Option<&Path>,
 ) -> io::Result<()> {
     if !bind.ip().is_loopback() || !upstream.ip().is_loopback() {
         return Err(io::Error::new(
@@ -1341,7 +1467,15 @@ fn serve_tls_edge(
     let listener = TcpListener::bind(bind)?;
     loop {
         let (socket, _) = listener.accept()?;
-        if serve_one_tls_edge_request(socket, upstream, Arc::clone(&config), counter_path).is_err()
+        if serve_one_tls_edge_request(
+            socket,
+            upstream,
+            Arc::clone(&config),
+            counter_path,
+            transcript_path,
+            drop_success_once_path,
+        )
+        .is_err()
         {
             // Readiness probes and malformed TLS/HTTP are deliberately silent.
             // Never log peer addresses, credential bytes, timing, or responses.
@@ -1354,18 +1488,15 @@ fn serve_one_tls_edge_request(
     upstream_address: SocketAddr,
     config: Arc<ServerConfig>,
     counter_path: &Path,
+    transcript_path: &Path,
+    drop_success_once_path: Option<&Path>,
 ) -> io::Result<()> {
     socket.set_read_timeout(Some(TLS_IO_TIMEOUT))?;
     socket.set_write_timeout(Some(TLS_IO_TIMEOUT))?;
     let connection = ServerConnection::new(config).map_err(io::Error::other)?;
     let mut tls = StreamOwned::new(connection, socket);
     let request = read_bounded_http_request(&mut tls)?;
-    if !request.starts_with(b"POST /v1/redeems HTTP/1.1\r\n") {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "TLS edge accepts only the issuer redeem route",
-        ));
-    }
+    let transcript = validate_canonical_redeem_request(&request)?;
 
     let mut upstream = TcpStream::connect_timeout(&upstream_address, TLS_IO_TIMEOUT)?;
     upstream.set_read_timeout(Some(TLS_IO_TIMEOUT))?;
@@ -1385,11 +1516,180 @@ fn serve_one_tls_edge_request(
             "issuer response is empty or exceeded the proxy bound",
         ));
     }
+    let canonical_success =
+        validate_canonical_redeem_success_response(&response, &transcript.request_digest)?;
+    append_redeem_transcript_digests(transcript_path, transcript)?;
+    if canonical_success && mark_drop_success_response_once(drop_success_once_path)? {
+        // The complete issuer success response proves the redeem commit escaped
+        // the application boundary. Drop the downstream TLS stream without
+        // forwarding one response, modeling an outcome-unknown network loss.
+        return Err(io::Error::new(
+            io::ErrorKind::ConnectionAborted,
+            "test-only committed issuer response loss",
+        ));
+    }
     tls.write_all(&response)?;
     tls.flush()?;
     tls.conn.send_close_notify();
     let _ = tls.flush();
     Ok(())
+}
+
+fn validate_canonical_redeem_request(wire: &[u8]) -> io::Result<RedeemTranscriptDigests> {
+    let body =
+        exact_content_length_http_body(wire, "POST /v1/redeems HTTP/1.1", REDEEM_CONTENT_TYPE)?;
+    let envelope = ProviderRedeemEnvelopeV1::decode(body).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "issuer request body is not a redeem envelope",
+        )
+    })?;
+    let canonical = Zeroizing::new(envelope.encode().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "issuer redeem envelope cannot be canonically encoded",
+        )
+    })?);
+    if canonical.as_slice() != body {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "issuer redeem envelope is not canonical",
+        ));
+    }
+    let request_digest = envelope.request.request_digest().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "issuer redeem request digest is invalid",
+        )
+    })?;
+    Ok(RedeemTranscriptDigests {
+        canonical_body: sha256(body),
+        request_digest,
+        idempotency_key_digest: sha256(&envelope.request.idempotency_key),
+    })
+}
+
+fn validate_canonical_redeem_success_response(
+    wire: &[u8],
+    expected_request_digest: &[u8; 32],
+) -> io::Result<bool> {
+    let (head, _) = split_http_wire(wire)?;
+    if head.split("\r\n").next() != Some("HTTP/1.1 200 OK") {
+        return Ok(false);
+    }
+    let body = exact_content_length_http_body(wire, "HTTP/1.1 200 OK", REDEEM_RESULT_CONTENT_TYPE)?;
+    let response = ProviderRedeemResponseV1::decode(body).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "issuer success body is not a redeem response",
+        )
+    })?;
+    let canonical = response.encode().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "issuer redeem response cannot be canonically encoded",
+        )
+    })?;
+    if canonical.as_slice() != body || &response.request_digest != expected_request_digest {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "issuer redeem response is non-canonical or bound to another request",
+        ));
+    }
+    Ok(true)
+}
+
+fn exact_content_length_http_body<'a>(
+    wire: &'a [u8],
+    expected_start_line: &str,
+    expected_content_type: &str,
+) -> io::Result<&'a [u8]> {
+    let (head, body) = split_http_wire(wire)?;
+    let mut lines = head.split("\r\n");
+    if lines.next() != Some(expected_start_line) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "unexpected HTTP start line",
+        ));
+    }
+    let mut content_type = None;
+    let mut content_length = None;
+    for line in lines {
+        if !line.is_ascii() || line.bytes().any(|byte| matches!(byte, b'\r' | b'\n')) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "non-ASCII or folded HTTP header",
+            ));
+        }
+        let (name, raw_value) = line
+            .split_once(':')
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "malformed HTTP header"))?;
+        if name.is_empty()
+            || !name
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "malformed HTTP header name",
+            ));
+        }
+        let value = raw_value.trim_matches(|character| matches!(character, ' ' | '\t'));
+        if name.eq_ignore_ascii_case("content-type") {
+            if content_type.replace(value).is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "duplicate HTTP content type",
+                ));
+            }
+        } else if name.eq_ignore_ascii_case("content-length") {
+            if content_length.is_some()
+                || value.is_empty()
+                || !value.bytes().all(|byte| byte.is_ascii_digit())
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid or duplicate HTTP content length",
+                ));
+            }
+            content_length = Some(value.parse::<usize>().map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "HTTP content length overflow")
+            })?);
+        } else if name.eq_ignore_ascii_case("transfer-encoding")
+            || (name.eq_ignore_ascii_case("content-encoding")
+                && !value.eq_ignore_ascii_case("identity"))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "encoded HTTP body is forbidden",
+            ));
+        }
+    }
+    if content_type != Some(expected_content_type) || content_length != Some(body.len()) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "HTTP content type or body length is not exact",
+        ));
+    }
+    Ok(body)
+}
+
+fn split_http_wire(wire: &[u8]) -> io::Result<(&str, &[u8])> {
+    let head_end = wire
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "missing HTTP header terminator")
+        })?;
+    let head = std::str::from_utf8(&wire[..head_end])
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "non-ASCII HTTP headers"))?;
+    if head.is_empty() || !head.is_ascii() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "empty HTTP header block",
+        ));
+    }
+    Ok((head, &wire[head_end + 4..]))
 }
 
 fn read_bounded_http_request(reader: &mut impl Read) -> io::Result<Vec<u8>> {
@@ -1462,6 +1762,35 @@ fn append_forward_counter(path: &Path) -> io::Result<()> {
     file.sync_data()
 }
 
+fn append_redeem_transcript_digests(
+    path: &Path,
+    transcript: RedeemTranscriptDigests,
+) -> io::Result<()> {
+    let mut file = fs::OpenOptions::new().append(true).open(path)?;
+    file.write_all(&transcript.encode())?;
+    file.sync_data()
+}
+
+fn mark_drop_success_response_once(path: Option<&Path>) -> io::Result<bool> {
+    let Some(path) = path else {
+        return Ok(false);
+    };
+    match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+    {
+        Ok(mut file) => {
+            file.write_all(b"committed-response-dropped\n")?;
+            file.sync_all()?;
+            Ok(true)
+        }
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
 fn forwarded_request_count(path: &Path) -> u64 {
     u64::try_from(
         fs::read(path)
@@ -1471,6 +1800,26 @@ fn forwarded_request_count(path: &Path) -> u64 {
             .count(),
     )
     .expect("forward counter fits u64")
+}
+
+fn assert_first_two_forwarded_requests_are_identical(path: &Path) {
+    let digests = fs::read(path).expect("read TLS edge transcript digests");
+    assert_eq!(
+        digests.len(),
+        2 * REDEEM_TRANSCRIPT_DIGEST_BYTES,
+        "response-loss recovery must make exactly two completed issuer requests"
+    );
+    for (label, start, end) in [
+        ("canonical redeem envelope", 0, 32),
+        ("request digest", 32, 64),
+        ("idempotency key digest", 64, 96),
+    ] {
+        assert_eq!(
+            &digests[start..end],
+            &digests[REDEEM_TRANSCRIPT_DIGEST_BYTES + start..REDEEM_TRANSCRIPT_DIGEST_BYTES + end],
+            "issuer restart recovery changed the {label}"
+        );
+    }
 }
 
 fn test_leaf_spki_sha256() -> [u8; 32] {

--- a/apps/server/tests/support/payment_v1_remote_authority_process.rs
+++ b/apps/server/tests/support/payment_v1_remote_authority_process.rs
@@ -44,7 +44,7 @@ struct AuthorityMaterial {
     client_verifying_key_hex: String,
 }
 
-struct HelperProcess {
+pub(super) struct HelperProcess {
     label: &'static str,
     child: Child,
     stdout_path: PathBuf,
@@ -81,7 +81,7 @@ impl HelperProcess {
         }
     }
 
-    fn wait_until_listening(&mut self, port: u16) {
+    pub(super) fn wait_until_listening(&mut self, port: u16) {
         let deadline = Instant::now() + PROCESS_START_TIMEOUT;
         loop {
             if let Some(status) = self.child.try_wait().expect("poll helper process") {
@@ -111,7 +111,11 @@ impl HelperProcess {
         }
     }
 
-    fn stop(mut self) -> (String, String) {
+    pub(super) fn id(&self) -> u32 {
+        self.child.id()
+    }
+
+    pub(super) fn stop(mut self) -> (String, String) {
         let _ = self.child.kill();
         let _ = self.child.wait();
         (read_log(&self.stdout_path), read_log(&self.stderr_path))
@@ -134,7 +138,7 @@ impl Drop for HelperProcess {
 }
 
 #[test]
-#[ignore = "spawned only by remote_authority_real_process_tls_provider_e2e"]
+#[ignore = "spawned only by remote-authority process E2Es"]
 fn rollback_authority_subprocess() {
     if env::var_os(AUTHORITY_HELPER_MARKER).is_none() {
         return;
@@ -169,7 +173,7 @@ fn rollback_authority_subprocess() {
 }
 
 #[test]
-#[ignore = "spawned only by remote_authority_real_process_tls_provider_e2e"]
+#[ignore = "spawned only by remote-authority process E2Es"]
 fn rollback_authority_tls_edge_subprocess() {
     if env::var_os(TLS_HELPER_MARKER).is_none() {
         return;
@@ -599,9 +603,31 @@ fn spawn_authority(
     port: u16,
     generation: u8,
 ) -> HelperProcess {
-    HelperProcess::spawn(
+    spawn_authority_helper(
         root,
         "rollback-authority-process",
+        generation,
+        port,
+        &material.authority_store,
+        &material.authority_secret,
+        &material.authority_metadata,
+        &material.authority_verifying_key_hex,
+    )
+}
+
+pub(super) fn spawn_authority_helper(
+    root: &Path,
+    label: &'static str,
+    generation: u8,
+    port: u16,
+    authority_store: &Path,
+    authority_secret: &Path,
+    authority_metadata: &Path,
+    authority_verifying_key_hex: &str,
+) -> HelperProcess {
+    HelperProcess::spawn(
+        root,
+        label,
         generation,
         "remote_authority_process::rollback_authority_subprocess",
         &[
@@ -612,19 +638,19 @@ fn spawn_authority(
             ),
             (
                 "BITCOINPIR_TEST_AUTHORITY_STORE",
-                material.authority_store.display().to_string(),
+                authority_store.display().to_string(),
             ),
             (
                 "BITCOINPIR_TEST_AUTHORITY_SECRET",
-                material.authority_secret.display().to_string(),
+                authority_secret.display().to_string(),
             ),
             (
                 "BITCOINPIR_TEST_AUTHORITY_METADATA",
-                material.authority_metadata.display().to_string(),
+                authority_metadata.display().to_string(),
             ),
             (
                 "BITCOINPIR_TEST_AUTHORITY_PUBLIC_KEY",
-                material.authority_verifying_key_hex.clone(),
+                authority_verifying_key_hex.to_owned(),
             ),
         ],
     )
@@ -637,9 +663,29 @@ fn spawn_tls_edge(
     authority_port: u16,
     generation: u8,
 ) -> HelperProcess {
-    HelperProcess::spawn(
+    spawn_tls_edge_helper(
         root,
         "rollback-authority-tls-edge-process",
+        generation,
+        tls_port,
+        authority_port,
+        &material.leaf_certificate,
+        &material.leaf_private_key,
+    )
+}
+
+pub(super) fn spawn_tls_edge_helper(
+    root: &Path,
+    label: &'static str,
+    generation: u8,
+    tls_port: u16,
+    authority_port: u16,
+    leaf_certificate: &Path,
+    leaf_private_key: &Path,
+) -> HelperProcess {
+    HelperProcess::spawn(
+        root,
+        label,
         generation,
         "remote_authority_process::rollback_authority_tls_edge_subprocess",
         &[
@@ -651,11 +697,11 @@ fn spawn_tls_edge(
             ),
             (
                 "BITCOINPIR_TEST_TLS_CERT",
-                material.leaf_certificate.display().to_string(),
+                leaf_certificate.display().to_string(),
             ),
             (
                 "BITCOINPIR_TEST_TLS_KEY",
-                material.leaf_private_key.display().to_string(),
+                leaf_private_key.display().to_string(),
             ),
         ],
     )

--- a/apps/server/tests/support/payment_v1_remote_authority_process.rs
+++ b/apps/server/tests/support/payment_v1_remote_authority_process.rs
@@ -608,11 +608,20 @@ fn spawn_authority(
         "rollback-authority-process",
         generation,
         port,
-        &material.authority_store,
-        &material.authority_secret,
-        &material.authority_metadata,
-        &material.authority_verifying_key_hex,
+        AuthorityHelperFiles {
+            store: &material.authority_store,
+            secret: &material.authority_secret,
+            metadata: &material.authority_metadata,
+            verifying_key_hex: &material.authority_verifying_key_hex,
+        },
     )
+}
+
+pub(super) struct AuthorityHelperFiles<'a> {
+    pub(super) store: &'a Path,
+    pub(super) secret: &'a Path,
+    pub(super) metadata: &'a Path,
+    pub(super) verifying_key_hex: &'a str,
 }
 
 pub(super) fn spawn_authority_helper(
@@ -620,10 +629,7 @@ pub(super) fn spawn_authority_helper(
     label: &'static str,
     generation: u8,
     port: u16,
-    authority_store: &Path,
-    authority_secret: &Path,
-    authority_metadata: &Path,
-    authority_verifying_key_hex: &str,
+    files: AuthorityHelperFiles<'_>,
 ) -> HelperProcess {
     HelperProcess::spawn(
         root,
@@ -638,19 +644,19 @@ pub(super) fn spawn_authority_helper(
             ),
             (
                 "BITCOINPIR_TEST_AUTHORITY_STORE",
-                authority_store.display().to_string(),
+                files.store.display().to_string(),
             ),
             (
                 "BITCOINPIR_TEST_AUTHORITY_SECRET",
-                authority_secret.display().to_string(),
+                files.secret.display().to_string(),
             ),
             (
                 "BITCOINPIR_TEST_AUTHORITY_METADATA",
-                authority_metadata.display().to_string(),
+                files.metadata.display().to_string(),
             ),
             (
                 "BITCOINPIR_TEST_AUTHORITY_PUBLIC_KEY",
-                authority_verifying_key_hex.to_owned(),
+                files.verifying_key_hex.to_owned(),
             ),
         ],
     )

--- a/apps/server/tests/support/payment_v1_three_authority_process.rs
+++ b/apps/server/tests/support/payment_v1_three_authority_process.rs
@@ -32,7 +32,7 @@ use pir_service_store::{RemoteProviderRollbackFloorAuthorityV1, StoreError as Pr
 use rollback_authority::{run as run_rollback_authority, Cli as RollbackAuthorityCli};
 
 use super::remote_authority_process::{
-    spawn_authority_helper, spawn_tls_edge_helper, HelperProcess,
+    spawn_authority_helper, spawn_tls_edge_helper, AuthorityHelperFiles, HelperProcess,
 };
 
 const TEST_ROOT_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----
@@ -743,10 +743,12 @@ fn spawn_authority(domain: &AuthorityDomain, root: &Path, generation: u8) -> Hel
         domain.label,
         generation,
         domain.authority_port,
-        &domain.authority_store,
-        &domain.authority_secret,
-        &domain.authority_metadata,
-        &domain.authority_verifying_key_hex,
+        AuthorityHelperFiles {
+            store: &domain.authority_store,
+            secret: &domain.authority_secret,
+            metadata: &domain.authority_metadata,
+            verifying_key_hex: &domain.authority_verifying_key_hex,
+        },
     );
     process.wait_until_listening(domain.authority_port);
     process

--- a/apps/server/tests/support/payment_v1_three_authority_process.rs
+++ b/apps/server/tests/support/payment_v1_three_authority_process.rs
@@ -5,6 +5,8 @@
 //! endpoint, authority child-test-harness process, and TLS-edge child process.
 //! Each authority harness invokes production `rollback_authority::run`; the
 //! parent test calls the production provider/issuer Store adapters directly.
+//! Provider and issuer authority backends are stopped independently while the
+//! other two business domains remain usable, then recovered from original state.
 //! It does not launch `unified_server`, `payment-issuer`, or an installed
 //! binary. This proves only local process/file separation, not separate
 //! operators, hosts, networks, or backups.
@@ -321,7 +323,10 @@ fn three_authority_real_process_topology_e2e() {
     // while provider 1 fails closed even though its TLS edge still listens.
     let _ = authority1.stop();
     open_provider_store(&provider0, &provider0_store).expect("provider0 remains available");
-    open_issuer_store(&issuer, &issuer_store).expect("issuer remains available");
+    let issuer_identity_before_outage = open_issuer_store(&issuer, &issuer_store)
+        .expect("issuer remains available")
+        .identity()
+        .expect("read issuer identity before its authority outage");
     assert_remote_read_error(
         &provider1.remote_config,
         provider1.business_id,
@@ -338,6 +343,37 @@ fn three_authority_real_process_topology_e2e() {
     let authority1 = spawn_authority(&provider1, root.path(), 1);
     open_provider_store(&provider1, &provider1_store)
         .expect("provider1 recovers against its durable authority database");
+
+    // Stop only the issuer's authority backend while its TLS edge continues to
+    // listen. Both provider authority domains remain usable, while the issuer
+    // fails closed instead of trusting only its detailed SQLite database.
+    let _ = authority_issuer.stop();
+    open_provider_store(&provider0, &provider0_store)
+        .expect("provider0 remains available during issuer authority outage");
+    open_provider_store(&provider1, &provider1_store)
+        .expect("provider1 remains available during issuer authority outage");
+    assert_remote_read_error(
+        &issuer.remote_config,
+        issuer.business_id,
+        "offline issuer authority backend",
+        RemoteAuthorityCallErrorV1::OutcomeUnknown,
+    );
+    assert!(
+        matches!(
+            open_issuer_store(&issuer, &issuer_store),
+            Err(pir_issuer_store::StoreError::RollbackAuthorityUnavailable(_))
+        ),
+        "offline issuer authority must return RollbackAuthorityUnavailable, not fall back to local SQLite"
+    );
+    let authority_issuer = spawn_authority(&issuer, root.path(), 1);
+    let issuer_identity_after_recovery = open_issuer_store(&issuer, &issuer_store)
+        .expect("issuer recovers against its durable authority database")
+        .identity()
+        .expect("read issuer identity after authority recovery");
+    assert_eq!(
+        issuer_identity_after_recovery, issuer_identity_before_outage,
+        "issuer authority restart must recover the exact same store generation and commitment"
+    );
 
     // Restore provider 0's pre-initialization authority backup. The detailed
     // provider store requires a current remote floor and rejects Empty. Then

--- a/apps/server/tests/support/payment_v1_three_authority_process.rs
+++ b/apps/server/tests/support/payment_v1_three_authority_process.rs
@@ -1,0 +1,938 @@
+//! Local three-domain rollback-authority process topology.
+//!
+//! Provider 0, provider 1, and the issuer each receive a separate authority
+//! database, authority/client/value-root keys, namespace, TLS leaf/SPKI pin,
+//! endpoint, authority child-test-harness process, and TLS-edge child process.
+//! Each authority harness invokes production `rollback_authority::run`; the
+//! parent test calls the production provider/issuer Store adapters directly.
+//! It does not launch `unified_server`, `payment-issuer`, or an installed
+//! binary. This proves only local process/file separation, not separate
+//! operators, hosts, networks, or backups.
+
+use super::*;
+
+use std::collections::BTreeSet;
+use std::io::Write as _;
+use std::os::unix::fs::MetadataExt as _;
+
+use clap::Parser as _;
+use pir_issuer_store::{
+    IssuerStore, RemoteIssuerRollbackFloorAuthorityV1, StoreOptions as IssuerStoreOptions,
+};
+use pir_rollback_authority_client::{
+    load_remote_rollback_authority_deployment_descriptor_v1,
+    load_remote_rollback_authority_deployment_for_business_domain_v1,
+    validate_independent_remote_rollback_authority_deployments_v1, RemoteAuthorityCallErrorV1,
+    RemoteAuthorityDeploymentConfigErrorV1,
+};
+use pir_service_protocol::LightningNetworkV1;
+use pir_service_store::{RemoteProviderRollbackFloorAuthorityV1, StoreError as ProviderStoreError};
+use rollback_authority::{run as run_rollback_authority, Cli as RollbackAuthorityCli};
+
+use super::remote_authority_process::{
+    spawn_authority_helper, spawn_tls_edge_helper, HelperProcess,
+};
+
+const TEST_ROOT_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----
+MIIBojCCAUmgAwIBAgIUDmhpSrwUCoL3GQBhgYYMnNq4WZYwCgYIKoZIzj0EAwIw
+JzElMCMGA1UEAwwcQml0Y29pblBJUiB0b3BvbG9neSBFMkUgcm9vdDAeFw0yNjA3
+MjgyMDE0MTBaFw0zNjA3MjUyMDE0MTBaMCcxJTAjBgNVBAMMHEJpdGNvaW5QSVIg
+dG9wb2xvZ3kgRTJFIHJvb3QwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQTh8tM
+3PnGB85Dxdo9VbfNkp9wXscDGZH3ZXjS142DDyjPbOWl/Pl8ekkaLeMZ0WInlkYw
+ujd/iaImWOreKAgoo1MwUTAdBgNVHQ4EFgQUed6EAm1avFb/Tp5SMpmxgGX2loYw
+HwYDVR0jBBgwFoAUed6EAm1avFb/Tp5SMpmxgGX2loYwDwYDVR0TAQH/BAUwAwEB
+/zAKBggqhkjOPQQDAgNHADBEAiBFxl452MU5tTvWh6E+ph4XnftKp79IN8fsoYcK
+etCH5QIgAtbGHY9c1Z7uxZZVCkFgxpqQi64ISNhlIMjXcNLyTKs=
+-----END CERTIFICATE-----
+"#;
+
+const PROVIDER0_LEAF_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----
+MIIBtzCCAV2gAwIBAgIBATAKBggqhkjOPQQDAjAnMSUwIwYDVQQDDBxCaXRjb2lu
+UElSIHRvcG9sb2d5IEUyRSByb290MB4XDTI2MDcyODIwMTQxMFoXDTM2MDcyNTIw
+MTQxMFowFDESMBAGA1UEAwwJbG9jYWxob3N0MFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAE7UeLAYIUMeJDca/zLZWtFxH6dzhWpPyS+CgPQvYCkGzvIuuIfrdrM8pr
+H3Dje1xENLLVSl2Ck8yFjDwiRRj24aOBjDCBiTAUBgNVHREEDTALgglsb2NhbGhv
+c3QwDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYB
+BQUHAwEwHQYDVR0OBBYEFKBDj6+FYVMFL8RF2W619kBXO7VYMB8GA1UdIwQYMBaA
+FHnehAJtWrxW/06eUjKZsYBl9paGMAoGCCqGSM49BAMCA0gAMEUCIGg8owxWr7ly
+vrvoZkTNAbuci9ZwMjcn3QtUSJlLz/vMAiEAqeFQK9tdBfdCTAhvG4zUSoJJXnD3
+2xLusYyyJTBN5L0=
+-----END CERTIFICATE-----
+"#;
+
+const PROVIDER0_LEAF_PRIVATE_KEY_PEM: &str = r#"-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgC5ND3rX+Puq/p5l9
+53NPygjKdrH6GILVQYCHWvtgZ2ChRANCAATtR4sBghQx4kNxr/Mtla0XEfp3OFak
+/JL4KA9C9gKQbO8i64h+t2szymsfcON7XEQ0stVKXYKTzIWMPCJFGPbh
+-----END PRIVATE KEY-----
+"#;
+
+const PROVIDER1_LEAF_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----
+MIIBtjCCAV2gAwIBAgIBAjAKBggqhkjOPQQDAjAnMSUwIwYDVQQDDBxCaXRjb2lu
+UElSIHRvcG9sb2d5IEUyRSByb290MB4XDTI2MDcyODIwMTQxMFoXDTM2MDcyNTIw
+MTQxMFowFDESMBAGA1UEAwwJbG9jYWxob3N0MFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAEuOFIgKA2ahtr02XzAd4sp8mTsN31XaLJowLom020gkxEs3AQmn8vj5Tl
+vhTXGqU+vZgBWi96QE6aVOo1nBHSN6OBjDCBiTAUBgNVHREEDTALgglsb2NhbGhv
+c3QwDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYB
+BQUHAwEwHQYDVR0OBBYEFBvOJIDFToL5DyK6JDNhzMPDBIi1MB8GA1UdIwQYMBaA
+FHnehAJtWrxW/06eUjKZsYBl9paGMAoGCCqGSM49BAMCA0cAMEQCIEIFkqjyRSFo
+k+jMdv+D7k2bcOi5CZ46+fbPa7v/7+YnAiBBJDpnAdUVsaFPTgR5PeKf2pYaLXto
+TN8yY0cRPRaHbg==
+-----END CERTIFICATE-----
+"#;
+
+const PROVIDER1_LEAF_PRIVATE_KEY_PEM: &str = r#"-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQghQhVTaRMCyWuiqA0
+sPe9V2WacUuLhpKS6GfWTGtgkAKhRANCAAS44UiAoDZqG2vTZfMB3iynyZOw3fVd
+osmjAuibTbSCTESzcBCafy+PlOW+FNcapT69mAFaL3pATppU6jWcEdI3
+-----END PRIVATE KEY-----
+"#;
+
+const ISSUER_LEAF_CERTIFICATE_PEM: &str = r#"-----BEGIN CERTIFICATE-----
+MIIBtzCCAV2gAwIBAgIBAzAKBggqhkjOPQQDAjAnMSUwIwYDVQQDDBxCaXRjb2lu
+UElSIHRvcG9sb2d5IEUyRSByb290MB4XDTI2MDcyODIwMTQxMFoXDTM2MDcyNTIw
+MTQxMFowFDESMBAGA1UEAwwJbG9jYWxob3N0MFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAEA73VGG8ACOa5sMMqUFC/xZCEjnFpI9KCRKhd6ynu7fOPtiURK3KQSavw
+VZI9EoWJZDNqzE5xNLnlAt5QOwDmmqOBjDCBiTAUBgNVHREEDTALgglsb2NhbGhv
+c3QwDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYB
+BQUHAwEwHQYDVR0OBBYEFIi8wEI3HN4H7mEoX4AwqZ/IJb8DMB8GA1UdIwQYMBaA
+FHnehAJtWrxW/06eUjKZsYBl9paGMAoGCCqGSM49BAMCA0gAMEUCIB1En6R45/Eq
+M4H30hs7/PGcmWMtN3cOWr0Bfh/joY5GAiEAn1iEcwHbiu/oSZWyOYVOMOcuPeIT
+nYACGXIp4ODtCM8=
+-----END CERTIFICATE-----
+"#;
+
+const ISSUER_LEAF_PRIVATE_KEY_PEM: &str = r#"-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgjbiMTEJDIkcbHyxn
+QeAfpsV1tKWRquJAnAEhK8O+hyyhRANCAAQDvdUYbwAI5rmwwypQUL/FkISOcWkj
+0oJEqF3rKe7t84+2JRErcpBJq/BVkj0ShYlkM2rMTnE0ueUC3lA7AOaa
+-----END PRIVATE KEY-----
+"#;
+
+const PROVIDER0_PIN: &str = "23886aaf971540bd4cc609ef81f22afb1f4038a9cd2c92f4bdbea8640b70bf90";
+const PROVIDER1_PIN: &str = "39860b1070e088e403cc7e84845572f54ff36e4e585356858fa91c3654a50663";
+const ISSUER_PIN: &str = "20adc745ee5765b73fdc69cd7d4b4df6c56cae1081047306e37045c24b24c911";
+
+struct AuthorityDomain {
+    label: &'static str,
+    business_id: [u8; 32],
+    authority_port: u16,
+    tls_port: u16,
+    authority_secret: PathBuf,
+    authority_metadata: PathBuf,
+    authority_store: PathBuf,
+    client_secret: PathBuf,
+    value_root: PathBuf,
+    remote_config: PathBuf,
+    test_root: PathBuf,
+    leaf_certificate: PathBuf,
+    leaf_private_key: PathBuf,
+    authority_instance_id_hex: String,
+    authority_verifying_key_hex: String,
+    namespace_hex: String,
+    client_verifying_key_hex: String,
+    pin: &'static str,
+}
+
+#[test]
+fn three_authority_real_process_topology_e2e() {
+    let root = tempfile::tempdir().expect("three-authority process test root");
+    chmod(root.path(), 0o700);
+    let authority_ports = distinct_ports(6);
+    let provider0 = prepare_domain(
+        root.path(),
+        "provider0-authority",
+        [0xa0; 32],
+        authority_ports[0],
+        authority_ports[1],
+        PROVIDER0_LEAF_CERTIFICATE_PEM,
+        PROVIDER0_LEAF_PRIVATE_KEY_PEM,
+        PROVIDER0_PIN,
+    );
+    let provider1 = prepare_domain(
+        root.path(),
+        "provider1-authority",
+        [0xa1; 32],
+        authority_ports[2],
+        authority_ports[3],
+        PROVIDER1_LEAF_CERTIFICATE_PEM,
+        PROVIDER1_LEAF_PRIVATE_KEY_PEM,
+        PROVIDER1_PIN,
+    );
+    let issuer = prepare_domain(
+        root.path(),
+        "issuer-authority",
+        [0xa2; 32],
+        authority_ports[4],
+        authority_ports[5],
+        ISSUER_LEAF_CERTIFICATE_PEM,
+        ISSUER_LEAF_PRIVATE_KEY_PEM,
+        ISSUER_PIN,
+    );
+    let domains = [&provider0, &provider1, &issuer];
+    assert_domain_material_is_independent(&domains);
+
+    let descriptors = load_descriptors(&domains.map(|domain| domain.remote_config.as_path()));
+    validate_independent_remote_rollback_authority_deployments_v1(&descriptors)
+        .expect("three public authority deployments are independent");
+
+    let same_pin_config = root.path().join("provider1-same-pin.toml");
+    write_remote_config(
+        &same_pin_config,
+        &provider1,
+        &provider1.namespace_hex,
+        &provider1.client_verifying_key_hex,
+        &provider1.client_secret,
+        &provider1.value_root,
+        provider0.pin,
+    );
+    let same_namespace_config = root.path().join("provider1-same-namespace.toml");
+    write_remote_config(
+        &same_namespace_config,
+        &provider1,
+        &provider0.namespace_hex,
+        &provider1.client_verifying_key_hex,
+        &provider1.client_secret,
+        &provider1.value_root,
+        provider1.pin,
+    );
+    let wrong_client_config = root.path().join("provider0-wrong-client.toml");
+    write_remote_config(
+        &wrong_client_config,
+        &provider0,
+        &provider0.namespace_hex,
+        &provider1.client_verifying_key_hex,
+        &provider1.client_secret,
+        &provider1.value_root,
+        provider0.pin,
+    );
+    let crossed_config = root.path().join("provider1-crossed-client-domain.toml");
+    write_remote_config(
+        &crossed_config,
+        &provider1,
+        &provider0.namespace_hex,
+        &provider0.client_verifying_key_hex,
+        &provider0.client_secret,
+        &provider0.value_root,
+        provider1.pin,
+    );
+
+    assert_deployment_set_rejected(
+        [
+            &provider0.remote_config,
+            &same_pin_config,
+            &issuer.remote_config,
+        ],
+        "same TLS pin",
+    );
+    assert_deployment_set_rejected(
+        [
+            &provider0.remote_config,
+            &same_namespace_config,
+            &issuer.remote_config,
+        ],
+        "same namespace",
+    );
+
+    // Capture a provisioned-but-uninitialized provider-0 authority database.
+    // Restoring this snapshot later must not be accepted over the detailed
+    // provider store which has already anchored generation zero.
+    let stale_provider0_backup = root.path().join("provider0-authority-stale-snapshot");
+    snapshot_database(&provider0.authority_store, &stale_provider0_backup);
+
+    let mut authority0 = spawn_authority(&provider0, root.path(), 0);
+    let authority1 = spawn_authority(&provider1, root.path(), 0);
+    let authority_issuer = spawn_authority(&issuer, root.path(), 0);
+    let tls0 = spawn_tls(&provider0, root.path(), 0);
+    let tls1 = spawn_tls(&provider1, root.path(), 0);
+    let tls_issuer = spawn_tls(&issuer, root.path(), 0);
+    let process_ids = [
+        authority0.id(),
+        authority1.id(),
+        authority_issuer.id(),
+        tls0.id(),
+        tls1.id(),
+        tls_issuer.id(),
+    ];
+    assert_eq!(
+        process_ids.into_iter().collect::<BTreeSet<_>>().len(),
+        process_ids.len(),
+        "each authority and TLS edge must be a separate OS process"
+    );
+
+    // Every case reaches a TCP/TLS write attempt. The strict client therefore
+    // conservatively classifies a pin/handshake failure, an authority HTTP
+    // rejection, or a response failure as OutcomeUnknown rather than claiming
+    // that no application request could have been sent.
+    for (config, business_id, label, expected_error) in [
+        (
+            &same_pin_config,
+            provider1.business_id,
+            "same pin",
+            RemoteAuthorityCallErrorV1::OutcomeUnknown,
+        ),
+        (
+            &same_namespace_config,
+            provider1.business_id,
+            "same namespace",
+            RemoteAuthorityCallErrorV1::OutcomeUnknown,
+        ),
+        (
+            &wrong_client_config,
+            provider0.business_id,
+            "wrong client",
+            RemoteAuthorityCallErrorV1::OutcomeUnknown,
+        ),
+        (
+            &crossed_config,
+            provider0.business_id,
+            "crossed domain",
+            RemoteAuthorityCallErrorV1::OutcomeUnknown,
+        ),
+    ] {
+        assert_remote_read_error(config, business_id, label, expected_error);
+    }
+
+    let provider0_store = root.path().join("provider0-store.sqlite3");
+    let provider1_store = root.path().join("provider1-store.sqlite3");
+    let issuer_store = root.path().join("issuer-store.sqlite3");
+    create_provider_store(&provider0, &provider0_store, [0x30; 16]);
+    create_provider_store(&provider1, &provider1_store, [0x31; 16]);
+    create_issuer_store(&issuer, &issuer_store, [0x32; 16]);
+
+    // A syntactically valid provider-1 configuration cannot authenticate the
+    // provider-0 store: its opaque current record decodes to provider 1 and
+    // the production adapter rejects the business binding.
+    let crossed_authority = provider_authority(&provider1, provider0.business_id);
+    assert!(
+        matches!(
+            ProviderStore::open_existing(
+                &provider0_store,
+                provider0.business_id,
+                provider_store_options(),
+                Arc::new(crossed_authority),
+            ),
+            Err(ProviderStoreError::RollbackAuthorityUnavailable(_))
+        ),
+        "cross-authority provider configuration must fail with RollbackAuthorityUnavailable"
+    );
+
+    // Stop only provider 1's backend. The other two domains remain usable,
+    // while provider 1 fails closed even though its TLS edge still listens.
+    let _ = authority1.stop();
+    open_provider_store(&provider0, &provider0_store).expect("provider0 remains available");
+    open_issuer_store(&issuer, &issuer_store).expect("issuer remains available");
+    assert_remote_read_error(
+        &provider1.remote_config,
+        provider1.business_id,
+        "offline provider1 authority backend",
+        RemoteAuthorityCallErrorV1::OutcomeUnknown,
+    );
+    assert!(
+        matches!(
+            open_provider_store(&provider1, &provider1_store),
+            Err(ProviderStoreError::RollbackAuthorityUnavailable(_))
+        ),
+        "offline provider1 authority must return RollbackAuthorityUnavailable, not fall back to local SQLite"
+    );
+    let authority1 = spawn_authority(&provider1, root.path(), 1);
+    open_provider_store(&provider1, &provider1_store)
+        .expect("provider1 recovers against its durable authority database");
+
+    // Restore provider 0's pre-initialization authority backup. The detailed
+    // provider store requires a current remote floor and rejects Empty. Then
+    // put back the fresh authority database and prove explicit recovery.
+    let _ = authority0.stop();
+    let fresh_provider0_backup = root.path().join("provider0-authority-fresh-snapshot");
+    snapshot_database(&provider0.authority_store, &fresh_provider0_backup);
+    restore_database(&provider0.authority_store, &stale_provider0_backup);
+    let stale_authority0 = spawn_authority(&provider0, root.path(), 1);
+    let stale_configured = load_remote_rollback_authority_deployment_for_business_domain_v1(
+        &provider0.remote_config,
+        provider0.business_id,
+    )
+    .expect("load provider0 stale authority deployment");
+    let (stale_client, _stale_codec, stale_timeout) = stale_configured.into_parts();
+    let stale_read = stale_client
+        .read_until(Instant::now() + stale_timeout)
+        .expect("authenticated raw read from restored stale authority");
+    assert!(
+        stale_read.current().is_none(),
+        "the restored pre-initialization authority must return Ok(None)"
+    );
+    assert!(
+        matches!(
+            open_provider_store(&provider0, &provider0_store),
+            Err(ProviderStoreError::RollbackFloorMissing)
+        ),
+        "stale authority backup must fail with RollbackFloorMissing against the detailed store"
+    );
+    open_provider_store(&provider1, &provider1_store)
+        .expect("provider1 is unaffected by provider0 stale restore");
+    open_issuer_store(&issuer, &issuer_store)
+        .expect("issuer is unaffected by provider0 stale restore");
+    let _ = stale_authority0.stop();
+    restore_database(&provider0.authority_store, &fresh_provider0_backup);
+    authority0 = spawn_authority(&provider0, root.path(), 2);
+    open_provider_store(&provider0, &provider0_store)
+        .expect("provider0 recovers only after the current authority DB is restored");
+
+    // Keep all recovered processes alive until every final cross-domain check
+    // has completed, then kill/wait every local helper and inspect the complete
+    // helper log set for payment or authority-binding material.
+    assert_ne!(authority0.id(), authority1.id());
+    assert_ne!(authority0.id(), authority_issuer.id());
+    let _ = authority0.stop();
+    let _ = authority1.stop();
+    let _ = authority_issuer.stop();
+    let _ = tls0.stop();
+    let _ = tls1.stop();
+    let _ = tls_issuer.stop();
+    assert_topology_logs_are_coarse(root.path(), &domains);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_domain(
+    root: &Path,
+    label: &'static str,
+    business_id: [u8; 32],
+    authority_port: u16,
+    tls_port: u16,
+    leaf_certificate_pem: &str,
+    leaf_private_key_pem: &str,
+    pin: &'static str,
+) -> AuthorityDomain {
+    let domain = root.join(label);
+    let authority_directory = domain.join("authority");
+    let client_directory = domain.join("client");
+    let edge_directory = domain.join("tls-edge");
+    for directory in [
+        &domain,
+        &authority_directory,
+        &client_directory,
+        &edge_directory,
+    ] {
+        fs::create_dir(directory).expect("create authority topology directory");
+        chmod(directory, 0o700);
+    }
+    let authority_secret = authority_directory.join("authority.seed");
+    let authority_metadata = authority_directory.join("authority-public.txt");
+    let authority_store = authority_directory.join("authority.sqlite3");
+    let client_secret = client_directory.join("client.seed");
+    let value_root = client_directory.join("value-root.raw");
+    let client_metadata = client_directory.join("client-public.txt");
+    run_authority_cli(vec![
+        "rollback-authority".to_owned(),
+        "generate-authority".to_owned(),
+        "--secret-out".to_owned(),
+        authority_secret.display().to_string(),
+        "--metadata-out".to_owned(),
+        authority_metadata.display().to_string(),
+    ]);
+    run_authority_cli(vec![
+        "rollback-authority".to_owned(),
+        "generate-client".to_owned(),
+        "--secret-out".to_owned(),
+        client_secret.display().to_string(),
+        "--value-root-key-out".to_owned(),
+        value_root.display().to_string(),
+        "--metadata-out".to_owned(),
+        client_metadata.display().to_string(),
+    ]);
+    run_authority_cli(vec![
+        "rollback-authority".to_owned(),
+        "init-store".to_owned(),
+        "--store".to_owned(),
+        authority_store.display().to_string(),
+        "--authority-metadata".to_owned(),
+        authority_metadata.display().to_string(),
+        "--busy-timeout-ms".to_owned(),
+        "1000".to_owned(),
+    ]);
+    run_authority_cli(vec![
+        "rollback-authority".to_owned(),
+        "provision".to_owned(),
+        "--store".to_owned(),
+        authority_store.display().to_string(),
+        "--authority-metadata".to_owned(),
+        authority_metadata.display().to_string(),
+        "--client-metadata".to_owned(),
+        client_metadata.display().to_string(),
+        "--max-operation-rows".to_owned(),
+        "128".to_owned(),
+        "--max-call-rows".to_owned(),
+        "2048".to_owned(),
+    ]);
+
+    let test_root = client_directory.join("test-root.pem");
+    let leaf_certificate = edge_directory.join("localhost-leaf.pem");
+    let leaf_private_key = edge_directory.join("localhost-leaf.key");
+    write_private_file(&test_root, TEST_ROOT_CERTIFICATE_PEM.as_bytes());
+    write_private_file(&leaf_certificate, leaf_certificate_pem.as_bytes());
+    write_private_file(&leaf_private_key, leaf_private_key_pem.as_bytes());
+
+    let authority_instance_id_hex = metadata_field(&authority_metadata, "authority_instance_id");
+    let authority_verifying_key_hex =
+        metadata_field(&authority_metadata, "authority_verifying_key");
+    let namespace_hex = metadata_field(&client_metadata, "namespace");
+    let client_verifying_key_hex = metadata_field(&client_metadata, "client_verifying_key");
+    let material = AuthorityDomain {
+        label,
+        business_id,
+        authority_port,
+        tls_port,
+        authority_secret,
+        authority_metadata,
+        authority_store,
+        client_secret,
+        value_root,
+        remote_config: client_directory.join("remote-authority.toml"),
+        test_root,
+        leaf_certificate,
+        leaf_private_key,
+        authority_instance_id_hex,
+        authority_verifying_key_hex,
+        namespace_hex,
+        client_verifying_key_hex,
+        pin,
+    };
+    write_remote_config(
+        &material.remote_config,
+        &material,
+        &material.namespace_hex,
+        &material.client_verifying_key_hex,
+        &material.client_secret,
+        &material.value_root,
+        material.pin,
+    );
+    material
+}
+
+fn write_remote_config(
+    path: &Path,
+    authority: &AuthorityDomain,
+    namespace_hex: &str,
+    client_verifying_key_hex: &str,
+    client_secret: &Path,
+    value_root: &Path,
+    pin: &str,
+) {
+    let text = format!(
+        "schema = \"bitcoinpir_remote_rollback_authority_v1\"\nendpoint = {:?}\nauthority_instance_id_hex = {:?}\nauthority_verifying_key_hex = {:?}\nnamespace_hex = {:?}\nclient_verifying_key_hex = {:?}\nclient_signing_seed_path = {:?}\nvalue_root_key_path = {:?}\nleaf_spki_sha256_pins_hex = [{pin:?}]\nconnect_timeout_ms = 500\nio_timeout_ms = 1000\nattempt_timeout_ms = 1500\noperation_timeout_ms = 4500\ntest_only_webpki_root_pem_path = {:?}\n",
+        format!("https://localhost:{}", authority.tls_port),
+        authority.authority_instance_id_hex,
+        authority.authority_verifying_key_hex,
+        namespace_hex,
+        client_verifying_key_hex,
+        client_secret.display().to_string(),
+        value_root.display().to_string(),
+        authority.test_root.display().to_string(),
+    );
+    write_private_file(path, text.as_bytes());
+}
+
+fn assert_domain_material_is_independent(domains: &[&AuthorityDomain; 3]) {
+    for select in [
+        domains
+            .iter()
+            .map(|domain| domain.authority_instance_id_hex.as_str())
+            .collect::<Vec<_>>(),
+        domains
+            .iter()
+            .map(|domain| domain.authority_verifying_key_hex.as_str())
+            .collect(),
+        domains
+            .iter()
+            .map(|domain| domain.namespace_hex.as_str())
+            .collect(),
+        domains
+            .iter()
+            .map(|domain| domain.client_verifying_key_hex.as_str())
+            .collect(),
+        domains.iter().map(|domain| domain.pin).collect(),
+    ] {
+        assert_eq!(select.iter().copied().collect::<BTreeSet<_>>().len(), 3);
+    }
+    assert_distinct_file_contents(&domains.map(|domain| domain.authority_secret.as_path()));
+    assert_distinct_file_contents(&domains.map(|domain| domain.client_secret.as_path()));
+    assert_distinct_file_contents(&domains.map(|domain| domain.value_root.as_path()));
+    assert_distinct_file_contents(&domains.map(|domain| domain.authority_store.as_path()));
+    assert_distinct_file_contents(&domains.map(|domain| domain.leaf_certificate.as_path()));
+    for paths in [
+        domains.map(|domain| domain.authority_store.as_path()),
+        domains.map(|domain| domain.leaf_certificate.as_path()),
+        domains.map(|domain| domain.remote_config.as_path()),
+    ] {
+        let inodes = paths
+            .iter()
+            .map(|path| fs::metadata(path).expect("topology file metadata").ino())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(inodes.len(), 3, "authority topology paths must not alias");
+    }
+}
+
+fn assert_distinct_file_contents(paths: &[&Path; 3]) {
+    let values = paths
+        .iter()
+        .map(|path| fs::read(path).expect("read private topology fixture"))
+        .collect::<Vec<_>>();
+    assert!(values[0] != values[1] && values[0] != values[2] && values[1] != values[2]);
+}
+
+fn assert_topology_logs_are_coarse(root: &Path, domains: &[&AuthorityDomain; 3]) {
+    let mut forbidden = [
+        "invoice",
+        "invoice_id",
+        "invoice-id",
+        "invoice id",
+        "lightning invoice",
+        "payment_hash",
+        "payment-hash",
+        "payment hash",
+        "paymenthash",
+        "payment_preimage",
+        "payment-preimage",
+        "preimage",
+        "bolt11",
+        "lnbc",
+        "lnbcrt",
+    ]
+    .into_iter()
+    .map(str::to_owned)
+    .collect::<Vec<_>>();
+    for domain in domains {
+        forbidden.extend(
+            [
+                domain.authority_instance_id_hex.as_str(),
+                domain.authority_verifying_key_hex.as_str(),
+                domain.namespace_hex.as_str(),
+                domain.client_verifying_key_hex.as_str(),
+                domain.pin,
+            ]
+            .into_iter()
+            .map(|value| value.to_ascii_lowercase()),
+        );
+        forbidden.push(hex::encode(domain.business_id));
+        for path in [
+            &domain.authority_secret,
+            &domain.authority_metadata,
+            &domain.authority_store,
+            &domain.client_secret,
+            &domain.value_root,
+            &domain.remote_config,
+            &domain.test_root,
+            &domain.leaf_certificate,
+            &domain.leaf_private_key,
+        ] {
+            forbidden.push(path.to_string_lossy().to_ascii_lowercase());
+        }
+        forbidden.push(
+            sqlite_sidecar(&domain.authority_store, "-wal")
+                .to_string_lossy()
+                .to_ascii_lowercase(),
+        );
+        forbidden.push(
+            sqlite_sidecar(&domain.authority_store, "-shm")
+                .to_string_lossy()
+                .to_ascii_lowercase(),
+        );
+        for secret_path in [
+            &domain.authority_secret,
+            &domain.client_secret,
+            &domain.value_root,
+            &domain.leaf_private_key,
+        ] {
+            append_secret_log_oracles(&mut forbidden, secret_path);
+        }
+    }
+    for entry in fs::read_dir(root).expect("read topology helper logs") {
+        let path = entry.expect("topology log entry").path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("log") {
+            continue;
+        }
+        let log = fs::read_to_string(&path)
+            .expect("read topology helper log")
+            .to_ascii_lowercase();
+        for (forbidden_index, value) in forbidden.iter().enumerate() {
+            assert!(
+                !log.contains(value),
+                "topology helper log {} exposed forbidden private material category {forbidden_index}",
+                path.display(),
+            );
+        }
+    }
+}
+
+fn append_secret_log_oracles(forbidden: &mut Vec<String>, path: &Path) {
+    let secret = fs::read(path).expect("read topology secret for log oracle");
+    forbidden.push(hex::encode(&secret));
+    if let Ok(text) = std::str::from_utf8(&secret) {
+        let trimmed = text.trim();
+        if trimmed.len() >= 16 {
+            forbidden.push(trimmed.to_ascii_lowercase());
+        }
+        forbidden.extend(
+            text.lines()
+                .map(str::trim)
+                .filter(|line| line.len() >= 16 && !line.starts_with("-----"))
+                .map(str::to_ascii_lowercase),
+        );
+    }
+}
+
+fn load_descriptors(
+    configs: &[&Path; 3],
+) -> Vec<pir_rollback_authority_client::RemoteRollbackAuthorityDeploymentDescriptorV1> {
+    configs
+        .iter()
+        .map(|config| {
+            load_remote_rollback_authority_deployment_descriptor_v1(config)
+                .expect("load public authority deployment descriptor")
+        })
+        .collect()
+}
+
+fn assert_deployment_set_rejected(configs: [&PathBuf; 3], label: &str) {
+    let descriptors = load_descriptors(&configs.map(PathBuf::as_path));
+    assert_eq!(
+        validate_independent_remote_rollback_authority_deployments_v1(&descriptors),
+        Err(RemoteAuthorityDeploymentConfigErrorV1::DeploymentSetNotIndependent),
+        "{label} must invalidate the three-authority deployment set"
+    );
+}
+
+fn spawn_authority(domain: &AuthorityDomain, root: &Path, generation: u8) -> HelperProcess {
+    let mut process = spawn_authority_helper(
+        root,
+        domain.label,
+        generation,
+        domain.authority_port,
+        &domain.authority_store,
+        &domain.authority_secret,
+        &domain.authority_metadata,
+        &domain.authority_verifying_key_hex,
+    );
+    process.wait_until_listening(domain.authority_port);
+    process
+}
+
+fn spawn_tls(domain: &AuthorityDomain, root: &Path, generation: u8) -> HelperProcess {
+    let label = match domain.label {
+        "provider0-authority" => "provider0-authority-tls",
+        "provider1-authority" => "provider1-authority-tls",
+        "issuer-authority" => "issuer-authority-tls",
+        _ => panic!("unexpected topology domain"),
+    };
+    let mut process = spawn_tls_edge_helper(
+        root,
+        label,
+        generation,
+        domain.tls_port,
+        domain.authority_port,
+        &domain.leaf_certificate,
+        &domain.leaf_private_key,
+    );
+    process.wait_until_listening(domain.tls_port);
+    process
+}
+
+fn assert_remote_read_error(
+    config: &Path,
+    business_id: [u8; 32],
+    label: &str,
+    expected_error: RemoteAuthorityCallErrorV1,
+) {
+    let configured =
+        load_remote_rollback_authority_deployment_for_business_domain_v1(config, business_id)
+            .unwrap_or_else(|error| {
+                panic!("{label} config did not reach remote boundary: {error}")
+            });
+    let (client, _codec, timeout) = configured.into_parts();
+    assert_eq!(
+        client
+            .read_until(Instant::now() + timeout)
+            .expect_err("remote authority configuration unexpectedly authenticated"),
+        expected_error,
+        "{label} returned the wrong remote-call classification"
+    );
+}
+
+fn provider_authority(
+    domain: &AuthorityDomain,
+    expected_provider_id: [u8; 32],
+) -> RemoteProviderRollbackFloorAuthorityV1 {
+    let configured = load_remote_rollback_authority_deployment_for_business_domain_v1(
+        &domain.remote_config,
+        expected_provider_id,
+    )
+    .expect("load provider authority deployment");
+    let (client, codec, timeout) = configured.into_parts();
+    RemoteProviderRollbackFloorAuthorityV1::new(expected_provider_id, client, codec, timeout)
+        .expect("bind provider rollback authority")
+}
+
+fn issuer_authority(domain: &AuthorityDomain) -> RemoteIssuerRollbackFloorAuthorityV1 {
+    let configured = load_remote_rollback_authority_deployment_for_business_domain_v1(
+        &domain.remote_config,
+        domain.business_id,
+    )
+    .expect("load issuer authority deployment");
+    let (client, codec, timeout) = configured.into_parts();
+    RemoteIssuerRollbackFloorAuthorityV1::new(
+        domain.business_id,
+        LightningNetworkV1::Regtest,
+        client,
+        codec,
+        timeout,
+    )
+    .expect("bind issuer rollback authority")
+}
+
+fn create_provider_store(domain: &AuthorityDomain, path: &Path, store_instance_id: [u8; 16]) {
+    ProviderStore::create(
+        path,
+        store_instance_id,
+        domain.business_id,
+        provider_store_options(),
+        Arc::new(provider_authority(domain, domain.business_id)),
+    )
+    .expect("create provider store through its remote authority");
+}
+
+fn open_provider_store(
+    domain: &AuthorityDomain,
+    path: &Path,
+) -> pir_service_store::StoreResult<ProviderStore> {
+    ProviderStore::open_existing(
+        path,
+        domain.business_id,
+        provider_store_options(),
+        Arc::new(provider_authority(domain, domain.business_id)),
+    )
+}
+
+fn provider_store_options() -> StoreOptions {
+    StoreOptions {
+        busy_timeout: Duration::from_secs(1),
+    }
+}
+
+fn create_issuer_store(domain: &AuthorityDomain, path: &Path, store_instance_id: [u8; 16]) {
+    IssuerStore::create(
+        path,
+        store_instance_id,
+        domain.business_id,
+        LightningNetworkV1::Regtest,
+        IssuerStoreOptions {
+            busy_timeout: Duration::from_secs(1),
+        },
+        Arc::new(issuer_authority(domain)),
+    )
+    .expect("create issuer store through its remote authority");
+}
+
+fn open_issuer_store(
+    domain: &AuthorityDomain,
+    path: &Path,
+) -> pir_issuer_store::StoreResult<IssuerStore> {
+    IssuerStore::open_existing(
+        path,
+        domain.business_id,
+        LightningNetworkV1::Regtest,
+        IssuerStoreOptions {
+            busy_timeout: Duration::from_secs(1),
+        },
+        Arc::new(issuer_authority(domain)),
+    )
+}
+
+fn run_authority_cli(arguments: Vec<String>) {
+    let cli = RollbackAuthorityCli::try_parse_from(arguments).expect("parse authority ceremony");
+    run_rollback_authority(cli).expect("complete authority ceremony");
+}
+
+fn metadata_field(path: &Path, name: &str) -> String {
+    fs::read_to_string(path)
+        .expect("read public authority metadata")
+        .lines()
+        .find_map(|line| line.strip_prefix(&format!("{name}=")))
+        .unwrap_or_else(|| panic!("missing authority metadata field {name}"))
+        .to_owned()
+}
+
+fn write_private_file(path: &Path, bytes: &[u8]) {
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .expect("create private topology file");
+    file.write_all(bytes).expect("write private topology file");
+    file.sync_all().expect("sync private topology file");
+    chmod(path, 0o600);
+}
+
+fn snapshot_database(database: &Path, snapshot_directory: &Path) {
+    fs::create_dir(snapshot_directory).expect("create authority snapshot directory");
+    chmod(snapshot_directory, 0o700);
+    // A stopped WAL database is the main file plus an optional WAL. The SHM
+    // file is transient coordination state and must be rebuilt on reopen.
+    for source in [database.to_path_buf(), sqlite_sidecar(database, "-wal")] {
+        if source.exists() {
+            let name = source.file_name().expect("authority snapshot file name");
+            let destination = snapshot_directory.join(name);
+            fs::copy(&source, &destination).expect("copy authority database snapshot file");
+            chmod(&destination, 0o600);
+        }
+    }
+}
+
+fn restore_database(destination: &Path, snapshot_directory: &Path) {
+    for path in [
+        destination.to_path_buf(),
+        sqlite_sidecar(destination, "-wal"),
+        sqlite_sidecar(destination, "-shm"),
+    ] {
+        if path.exists() {
+            fs::remove_file(path).expect("remove temporary authority database generation");
+        }
+    }
+    let database_name = destination
+        .file_name()
+        .expect("authority destination file name");
+    for source in fs::read_dir(snapshot_directory)
+        .expect("read authority snapshot directory")
+        .map(|entry| entry.expect("authority snapshot directory entry").path())
+    {
+        let source_name = source.file_name().expect("authority snapshot file name");
+        let destination_path = if source_name == database_name {
+            destination.to_path_buf()
+        } else if source_name.to_string_lossy().ends_with("-wal") {
+            sqlite_sidecar(destination, "-wal")
+        } else {
+            panic!("unexpected authority snapshot file")
+        };
+        fs::copy(&source, &destination_path).expect("restore authority database snapshot file");
+        chmod(&destination_path, 0o600);
+    }
+    assert!(
+        destination.is_file(),
+        "authority snapshot has no main database"
+    );
+}
+
+fn sqlite_sidecar(database: &Path, suffix: &str) -> PathBuf {
+    let mut path = database.as_os_str().to_os_string();
+    path.push(suffix);
+    PathBuf::from(path)
+}
+
+fn distinct_ports(count: usize) -> Vec<u16> {
+    let mut ports = Vec::with_capacity(count);
+    while ports.len() < count {
+        let port = unused_loopback_port();
+        if !ports.contains(&port) {
+            ports.push(port);
+        }
+    }
+    ports
+}

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -379,6 +379,22 @@ operator has activated the path with real money or public infrastructure.
       logging. Its current macOS library and binary unit suites passed 23/23;
       Linux clippy, installed shutdown/backup drills and public WSS behavior
       remain exact-commit/deployment evidence rather than source claims.
+- [x] A CI-wired, explicitly selected process test starts two copies of the
+      repository's production `bitcoinpir-directory-relay` binary with
+      independent config/SQLite/port/runtime state, publishes one signed
+      16-shard catalog to both and uses real WebSocket readback to fail closed
+      on offline/exact split-view errors, recover lost ACK by bounded-backoff
+      durable ID probe plus idempotent retry, and preserve heads across
+      independent restarts. A companion three-authority test separates provider
+      0, provider 1 and issuer DB/key/namespace/TLS material. It starts authority
+      and TLS-edge child test harnesses; each authority harness invokes
+      production `rollback_authority::run`, while the parent directly calls the
+      production ProviderStore/IssuerStore adapters. Deployment-set validation,
+      raw-client rejection and Store-adapter rejection are asserted at their
+      respective boundaries. It does not launch `unified_server`,
+      `payment-issuer`, or installed binaries. These are local topology tests,
+      not claims of operational independence; their first Linux CI execution
+      remains candidate-commit evidence.
 - [x] Browser relay fetching and encrypted IndexedDB directory state.
 - [x] A no-account, process-local NIP-01 fake-relay integration test closes the
       signed publisher-artifact to two-relay read path through all 16 shards,

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -391,10 +391,14 @@ operator has activated the path with real money or public infrastructure.
       production `rollback_authority::run`, while the parent directly calls the
       production ProviderStore/IssuerStore adapters. Deployment-set validation,
       raw-client rejection and Store-adapter rejection are asserted at their
-      respective boundaries. It does not launch `unified_server`,
-      `payment-issuer`, or installed binaries. These are local topology tests,
-      not claims of operational independence; their first Linux CI execution
-      remains candidate-commit evidence.
+      respective boundaries. Provider- and issuer-authority backends are stopped
+      independently while their TLS edges remain online; only the affected Store
+      fails closed, the other two domains remain usable, and the issuer recovers
+      the exact same generation and commitment from its original authority
+      database. It does not launch `unified_server`, `payment-issuer`, or
+      installed binaries. These are local topology tests, not claims of
+      operational independence; their first Linux CI execution remains
+      candidate-commit evidence.
 - [x] Browser relay fetching and encrypted IndexedDB directory state.
 - [x] A no-account, process-local NIP-01 fake-relay integration test closes the
       signed publisher-artifact to two-relay read path through all 16 shards,
@@ -538,17 +542,23 @@ operator has activated the path with real money or public infrastructure.
       `payment-issuer`, places a private WebPKI TLS edge with a signed leaf-SPKI
       pin in front of its redeem-only route, and launches a real paid
       `unified_server` plus an independently selected Free/Open peer. A BAT
-      redemption credits the authenticated provider's shared ledger exactly
-      once and creates exactly one provider-local delivery claim; provider
-      restart/replay cannot create a second grant. Wrong CA, wrong signed pin
-      and offline issuer all fail closed before issuer application handling and
-      create neither a local claim nor a provider account. The test also checks
-      that payout rows remain zero and server logs contain no invoice, payment
-      hash, preimage or raw BAT secret. The fake-Lightning issuer binary is
-      supplied only by an absolute, non-symlink path and the shared test feature
-      inherits the release-rejected WebPKI hook. This branch's first executable
-      proof is intentionally pending the Linux Payment CI run; implementation
-      and static formatting alone are not recorded as a pass.
+      redemption reaches a complete canonical issuer success, after which the
+      test edge drops one response. The provider fails closed without a local
+      delivery claim; restarting issuer and provider against their original
+      stores/floors and replaying the identical proof reproduces the same
+      canonical-body, request and idempotency-key digests, credits ledger
+      sequence one exactly once and creates exactly one local claim. A later
+      replay cannot create a second grant. The fixed-size digest transcript is
+      test-local and retains no raw envelope, credential, idempotency key, HTTP
+      metadata, peer address or timing. Wrong CA, wrong signed pin and offline
+      issuer all fail closed before issuer application handling and create
+      neither a local claim nor a provider account. The test also checks that
+      payout rows remain zero and server logs contain no invoice, payment hash,
+      preimage or raw BAT secret. The fake-Lightning issuer binary is supplied
+      only by an absolute, non-symlink path and the shared test feature inherits
+      the release-rejected WebPKI hook. This branch's first executable proof is
+      intentionally pending the Linux Payment CI run; implementation and static
+      formatting alone are not recorded as a pass.
 - [x] Web unit tests cover acquisition recovery, directory storage, vault
       locking and local pair-selection boundaries.
 - [x] A dedicated Playwright job runs the production browser vault and

--- a/docs/payment/LOCAL_ACCEPTANCE.md
+++ b/docs/payment/LOCAL_ACCEPTANCE.md
@@ -673,13 +673,18 @@ BITCOINPIR_PAYMENT_ISSUER_BIN="$issuer_e2e_target_dir/debug/payment-issuer" \
 
 This is the executable provider-to-shared-clearing seam: a real issuer behind
 a private signed-pin TLS edge, a real paid provider and an independent Free
-peer. It proves one issuer redemption/ledger credit, one provider-local grant,
-restart/replay at-most-once behavior, and fail-closed wrong-CA/wrong-pin/offline
-dependencies without invoice creation or real funds. It does not prove public
-source-fair ingress, independent production rollback domains, real Lightning,
-automated payout, or target-host systemd state. The source is wired into CI,
-but this preparation branch must not record a pass until the Linux cell has run
-on the exact candidate commit.
+peer. The edge reads one complete canonical issuer success, then drops that
+response after the issuer commit while retaining only three test-local SHA-256
+digests. The provider fails closed without a local claim. Restarting both issuer
+and provider against their original stores/floors and replaying the exact proof
+must reproduce all three digests, recover exactly one provider-local grant and
+leave exactly one issuer ledger credit/sequence; a later replay cannot create a
+second grant. Wrong-CA, wrong-pin and offline dependencies fail closed without
+invoice creation or real funds. It does not prove public source-fair ingress,
+independent production rollback domains, real Lightning, automated payout, or
+target-host systemd state. The source is wired into CI, but this preparation
+branch must not record a pass until the Linux cell has run on the exact candidate
+commit.
 
 ## Standard Cashu custody boundary
 
@@ -900,10 +905,12 @@ spawns three authority child test harnesses which invoke production
 calls production ProviderStore/IssuerStore adapters directly. The
 deployment-set validator owns duplicate-pin/namespace rejection, raw clients
 own wrong-pin/client/cross-domain transport assertions, and the production
-adapters own crossed-provider, single-domain outage and stale-floor assertions.
-It does not launch `unified_server`, `payment-issuer`, or installed binaries.
-These new commands require their first Linux CI run on the candidate commit; no
-passing result is claimed here, and same-host processes do not prove
+adapters own crossed-provider, independently isolated provider- and
+issuer-authority outages, exact same-generation issuer recovery and stale-floor
+assertions. During each authority outage the other two business domains remain
+usable. It does not launch `unified_server`, `payment-issuer`, or installed
+binaries. These new commands require their first Linux CI run on the candidate
+commit; no passing result is claimed here, and same-host processes do not prove
 operational independence.
 
 The staging-only readback script resolves the lockfile-pinned `ws` dependency

--- a/docs/payment/LOCAL_ACCEPTANCE.md
+++ b/docs/payment/LOCAL_ACCEPTANCE.md
@@ -878,6 +878,34 @@ duplicate/unexpected/missing, non-text and oversized replies. They deliberately
 do not prove WebPKI, public relay policy, operator independence, or compatibility
 with relays that inject Ping/Pong control frames during the publish exchange.
 
+The full local script and Payment CI additionally select the real two-relay
+process topology explicitly (the test is ignored by ordinary package runs so
+`--quick` still starts no service process):
+
+```sh
+cargo test --locked --offline -p bitcoinpir-directory-relay \
+  --test payment_v1_two_relay_process_e2e \
+  two_relay_real_process_catalog_e2e -- --exact --ignored
+```
+
+It launches two copies of the repository's production
+`bitcoinpir-directory-relay` binary and covers separate
+config/SQLite/ports/runtimes, complete 16-shard signed readback, one relay
+offline, two independently valid but conflicting stale-head views with an exact
+split-view error, bounded-backoff lost-ACK readback plus idempotent retry, and
+independent restart recovery. The remote-authority full-mode cell also selects
+`three_authority_process::three_authority_real_process_topology_e2e`. That test
+spawns three authority child test harnesses which invoke production
+`rollback_authority::run` and three TLS-edge child harnesses; the parent process
+calls production ProviderStore/IssuerStore adapters directly. The
+deployment-set validator owns duplicate-pin/namespace rejection, raw clients
+own wrong-pin/client/cross-domain transport assertions, and the production
+adapters own crossed-provider, single-domain outage and stale-floor assertions.
+It does not launch `unified_server`, `payment-issuer`, or installed binaries.
+These new commands require their first Linux CI run on the candidate commit; no
+passing result is claimed here, and same-host processes do not prove
+operational independence.
+
 The staging-only readback script resolves the lockfile-pinned `ws` dependency
 from `web/node_modules`, disables compression and redirects, and applies a
 transport-level `maxPayload` before parsing relay data. It never reads a key or

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -106,6 +106,34 @@ wrong CA, wrong pin and offline authority all fail before the provider listens.
 Authority process logs are checked not to contain its instance, namespace,
 keys, invoice, payment hash or preimage.
 
+The same feature also contains a three-business-domain topology test:
+
+```sh
+cargo test --locked --offline -p runtime \
+  --features remote-authority-process-e2e \
+  --test payment_v1_process_e2e \
+  three_authority_process::three_authority_real_process_topology_e2e \
+  -- --exact
+```
+
+It starts three independent child copies of the current test harness, each of
+which invokes production `rollback_authority::run`, plus three independent TLS
+edge child harnesses. Provider 0, provider 1 and issuer authority domains have
+separate authority SQLite databases, authority/client/value-root keys,
+namespaces, ports and distinct localhost TLS leaf/SPKI pins. The public
+deployment-set validator rejects repeated pins or namespaces; raw remote
+clients prove wrong-pin, unprovisioned-client and cross-domain configurations
+fail with their exact remote-call classifications. The parent test directly
+calls the production provider/issuer Store adapters to exercise correct-domain
+opens, a crossed provider authority, one offline authority and a stale authority
+backup; the raw client first proves that the restored stale authority returns
+an authenticated empty floor, and the provider adapter then requires the exact
+`RollbackFloorMissing` result. Restoring the current database is required for
+recovery. This test does **not** launch `unified_server`, `payment-issuer`, or an
+installed authority binary. It is a single-host process/file topology test and
+does not establish different operators, machines, administrative domains or
+backup custody.
+
 The corresponding issuer-binary boundary is exercised separately:
 
 ```sh
@@ -135,8 +163,8 @@ enable either test feature, and a non-debug provider or payment-issuer build
 with it fails at compile time. The crate's build script separately rejects a
 Cargo release profile even if that profile manually enables Rust debug
 assertions; `debug_assertions` is not treated as the production boundary. The
-checked-in leaf private key has no production trust or secrecy value, and the
-E2Es require no OpenSSL command or network access.
+checked-in test leaf private keys have no production trust or secrecy value,
+and the E2Es require no OpenSSL command or network access.
 
 Fake Lightning has a separate artifact boundary. Default `payment-issuer`
 builds contain neither `serve-fake` nor `/__test/fake/settle`; local no-funds
@@ -150,6 +178,24 @@ issuer case covers store initialization/open rather than acquisition or query
 wiring. They do not satisfy production identity/binary pin, hardware proof,
 database proof/trusted-root, Merkle preflight/inclusion, real issuer/browser,
 external dependency, or non-DPF process-level cells.
+
+The repository relay has a separate real-process two-relay test:
+
+```sh
+cargo test --locked --offline -p bitcoinpir-directory-relay \
+  --test payment_v1_two_relay_process_e2e \
+  two_relay_real_process_catalog_e2e -- --exact --ignored
+```
+
+Two copies of the repository's production `bitcoinpir-directory-relay` binary
+use different owner-only configs, loopback ports, SQLite files and runtimes. A
+real WebSocket client publishes and cryptographically verifies the same complete
+16-shard catalog from both, proves both stale-head views remain independently
+valid before requiring the exact split-view rejection, rejects one-relay-offline,
+resolves a lost positive ACK with bounded-backoff ID readback plus idempotent
+same-event retry, and verifies independent restart recovery. The test
+deliberately does not infer relay-operator or host independence from local
+process separation.
 
 A separate non-default Standard Cashu process test is implemented and wired
 into Payment CI:

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -125,14 +125,18 @@ deployment-set validator rejects repeated pins or namespaces; raw remote
 clients prove wrong-pin, unprovisioned-client and cross-domain configurations
 fail with their exact remote-call classifications. The parent test directly
 calls the production provider/issuer Store adapters to exercise correct-domain
-opens, a crossed provider authority, one offline authority and a stale authority
-backup; the raw client first proves that the restored stale authority returns
-an authenticated empty floor, and the provider adapter then requires the exact
-`RollbackFloorMissing` result. Restoring the current database is required for
-recovery. This test does **not** launch `unified_server`, `payment-issuer`, or an
-installed authority binary. It is a single-host process/file topology test and
-does not establish different operators, machines, administrative domains or
-backup custody.
+opens and a crossed provider authority. It independently stops one provider
+authority backend and then the issuer authority backend while each TLS edge
+continues listening: the affected Store returns
+`RollbackAuthorityUnavailable`, the other two business domains remain usable,
+and restart against the original authority database recovers the exact issuer
+store generation and commitment. A separate stale-provider-authority case first
+proves that the restored backup returns an authenticated empty floor, and the
+provider adapter then requires the exact `RollbackFloorMissing` result.
+Restoring the current database is required for recovery. This test does **not**
+launch `unified_server`, `payment-issuer`, or an installed authority binary. It
+is a single-host process/file topology test and does not establish different
+operators, machines, administrative domains or backup custody.
 
 The corresponding issuer-binary boundary is exercised separately:
 
@@ -271,15 +275,23 @@ BITCOINPIR_PAYMENT_ISSUER_BIN="$issuer_e2e_target_dir/debug/payment-issuer" \
 
 It launches a real `payment-issuer`, a redeem-only private WebPKI TLS edge, one
 real shared-BAT `unified_server`, and an independently selected Free/Open peer.
-The paid provider must verify the signed issuer origin and leaf-SPKI pin,
-redeem exactly once, accrue one ledger credit, and durably claim one local
-grant. Restart/replay cannot create a second grant. Wrong CA, wrong signed pin
-and offline issuer fail before issuer HTTP application handling and create no
-local claim or ledger account. CI additionally denies warnings for the exact
-runtime/test targets and proves the test-only WebPKI feature cannot compile in
-a release profile. The current preparation branch has static source evidence
-only until that Linux CI cell passes; it is not public ingress, production
-rollback-authority, real Lightning or payout-executor evidence.
+After reading one complete canonical issuer HTTP 200 bound to the redeem request
+digest, the test edge persists a one-shot test marker and deliberately drops
+that downstream response. This proves the issuer commit escaped its application
+boundary while the provider must fail closed with no local delivery claim. The
+issuer and provider then restart against their original stores and rollback
+floors. Replaying the identical proof must reproduce the same canonical-body,
+request and idempotency-key SHA-256 digests, recover exactly one local grant and
+leave the issuer ledger at one credit/sequence; a later replay cannot create a
+second grant. The digest transcript is a fixed-size, test-local oracle and does
+not persist the raw envelope, credential, idempotency key, HTTP metadata, peer
+address or timing. Wrong CA, wrong signed pin and offline issuer fail before
+issuer HTTP application handling and create no local claim or ledger account.
+CI additionally denies warnings for the exact runtime/test targets and proves
+the test-only WebPKI feature cannot compile in a release profile. The current
+preparation branch has static source evidence only until that Linux CI cell
+passes; it is not public ingress, production rollback-authority, real Lightning
+or payout-executor evidence.
 
 ### First-version executable path ledger
 

--- a/scripts/payment-v1-local-check.sh
+++ b/scripts/payment-v1-local-check.sh
@@ -22,14 +22,14 @@ network.
            acquisition test, and a browser -> two independent issuers -> two
            real provider-gate test. This is the default.
 
-Full mode starts only temporary unified-server, rollback-authority,
-deterministic test-only TLS/NUT-03 mint, Vite and fake issuer listeners
+Full mode starts only temporary directory-relay, unified-server,
+rollback-authority, test-only TLS/NUT-03 mint, Vite and fake issuer listeners
 explicitly bound to 127.0.0.1; the tests kill and wait for every child. Neither
-mode contacts an external Lightning node or Cashu mint, publishes to a Nostr
-relay, deploys a server, uses real funds, or modifies source files. Quick mode
-starts no persistent service process. Cargo, the JavaScript package manager,
-and tests may update their normal local build caches (for example target/ and
-web/node_modules cache metadata).
+mode contacts an external Lightning node or Cashu mint, publishes to a public
+Nostr relay, deploys a server, uses real funds, or modifies source files. Quick
+mode starts no persistent service process. Cargo, the JavaScript package
+manager, and tests may update their normal local build caches (for example
+target/ and web/node_modules cache metadata).
 EOF
 }
 
@@ -139,6 +139,10 @@ cargo test --locked --offline -p runtime \
 cargo test --locked --offline -p runtime --test payment_v1_process_e2e
 cargo test --locked --offline -p runtime --test payment_v1_methods_process_e2e
 cargo test --locked --offline -p runtime --test payment_v1_harmony_pool_process_e2e
+cargo test --locked --offline -p bitcoinpir-directory-relay \
+  --test payment_v1_two_relay_process_e2e \
+  two_relay_real_process_catalog_e2e \
+  -- --exact --ignored
 cargo test --locked --offline -p pir-rollback-authority-client \
   --features test-only-webpki-root \
   test_only_webpki_root_requires_owner_only_regular_file
@@ -218,6 +222,11 @@ cargo test --locked --offline -p runtime \
   --features remote-authority-process-e2e \
   --test payment_v1_process_e2e \
   remote_authority_process::remote_authority_real_process_tls_provider_e2e \
+  -- --exact
+cargo test --locked --offline -p runtime \
+  --features remote-authority-process-e2e \
+  --test payment_v1_process_e2e \
+  three_authority_process::three_authority_real_process_topology_e2e \
   -- --exact
 cargo clippy --locked --offline -p runtime \
   --features remote-authority-process-e2e \


### PR DESCRIPTION
## Summary

- exercise a committed shared-issuer redeem whose HTTP success response is lost, then prove exact replay returns one ledger entry and one provider claim
- launch two independent directory-relay processes with separate public/publisher listeners and durable stores, and fail closed on offline or split views
- launch three independent rollback-authority domains and prove provider 0, provider 1, and issuer outages are isolated and recover their original authenticated state
- wire the process tests into Payment CI and the full local acceptance path

## Why

Payment V1 needs executable evidence for ambiguous response recovery and for the failure boundaries that must remain independent across relays and rollback authorities. These tests use production stores, adapters, relay processes, and authority servers rather than document-only topology claims.

## Validation

- `rustfmt --edition 2021 --check` on all changed Rust tests/support modules
- `bash -n scripts/payment-v1-local-check.sh`
- `git diff --check origin/main...HEAD`
- independent read-only review found no P0/P1 in the fault-isolation changes
- full Linux Payment CI is required before ready/merge