### PR TITLE
Exercise paid Harmony queries across providers

### DIFF
--- a/.github/workflows/payment-platform.yml
+++ b/.github/workflows/payment-platform.yml
@@ -37,6 +37,7 @@ on:
       - 'scripts/payment-v1-rendered-artifact-gate.test.mjs'
       - 'scripts/payment-v1-linux-runtime-evidence.mjs'
       - 'scripts/payment-v1-linux-runtime-evidence.test.mjs'
+      - 'scripts/payment-v1-source-fair-edge.test.mjs'
       - 'scripts/payment-v1-local-check.sh'
       - 'scripts/payment-v1-cdk-regtest-e2e.sh'
       - 'scripts/payment-v1-cln-regtest-e2e.sh'
@@ -81,6 +82,7 @@ on:
       - 'scripts/payment-v1-rendered-artifact-gate.test.mjs'
       - 'scripts/payment-v1-linux-runtime-evidence.mjs'
       - 'scripts/payment-v1-linux-runtime-evidence.test.mjs'
+      - 'scripts/payment-v1-source-fair-edge.test.mjs'
       - 'scripts/payment-v1-local-check.sh'
       - 'scripts/payment-v1-cdk-regtest-e2e.sh'
       - 'scripts/payment-v1-cln-regtest-e2e.sh'
@@ -407,6 +409,19 @@ jobs:
         run: npm ci
       - name: Enforce manual main-only production Pages deployment
         run: node scripts/payment-v1-pages-deploy-gate.mjs
+      - name: Install source-fair edge compatibility test binaries
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends haproxy
+          /usr/sbin/haproxy -vv | grep -E '^HAProxy version 2\.8\.'
+          /usr/sbin/haproxy -vv | grep -E '(\+SYSTEMD)([[:space:]]|$)'
+          caddy_container="$(docker create caddy@sha256:86deaf5e3d3408a6ccec08fbb79989783dd26e206ae10bcf78a801dc8c9ab794)"
+          docker cp "$caddy_container:/usr/bin/caddy" "$RUNNER_TEMP/caddy"
+          docker rm "$caddy_container"
+          chmod 0555 "$RUNNER_TEMP/caddy"
+          test "$("$RUNNER_TEMP/caddy" version | awk '{print $1}')" = 'v2.11.3'
+          echo 'BPIR_HAPROXY_BIN=/usr/sbin/haproxy' >> "$GITHUB_ENV"
+          echo "BPIR_CADDY_BIN=$RUNNER_TEMP/caddy" >> "$GITHUB_ENV"
       - name: Validate non-activating Payment V1 deployment templates
         run: |
           node --check scripts/payment-v1-deployment-template-gate.mjs
@@ -416,9 +431,11 @@ jobs:
           node --check scripts/payment-v1-rendered-artifact-gate.test.mjs
           node --check scripts/payment-v1-linux-runtime-evidence.mjs
           node --check scripts/payment-v1-linux-runtime-evidence.test.mjs
+          node --check scripts/payment-v1-source-fair-edge.test.mjs
           node --test \
             scripts/payment-v1-rendered-artifact-gate.test.mjs \
-            scripts/payment-v1-linux-runtime-evidence.test.mjs
+            scripts/payment-v1-linux-runtime-evidence.test.mjs \
+            scripts/payment-v1-source-fair-edge.test.mjs
       - name: Typecheck the opt-in CDK browser interoperability harness
         working-directory: web
         run: npx --no-install tsc -p tsconfig.payment-cdk-cashu-e2e.json --pretty false

--- a/apps/directory-relay/src/lib.rs
+++ b/apps/directory-relay/src/lib.rs
@@ -32,13 +32,22 @@ pub struct Cli {
 #[serde(deny_unknown_fields)]
 struct RelayFileConfig {
     profile: String,
-    listen: SocketAddr,
+    public_listen: SocketAddr,
+    publisher_listen: SocketAddr,
     database: PathBuf,
     directory_pubkey_hex: String,
     max_connections: usize,
+    max_public_connections: usize,
+    max_publisher_connections: usize,
     max_in_flight_operations: usize,
+    max_public_in_flight_operations: usize,
+    max_publisher_in_flight_operations: usize,
     max_operations_per_second: u32,
+    max_public_operations_per_second: u32,
+    max_publisher_operations_per_second: u32,
     max_egress_bytes_per_second: u64,
+    max_public_egress_bytes_per_second: u64,
+    max_publisher_egress_bytes_per_second: u64,
     max_egress_bytes_per_connection: u64,
     max_archive_events: u64,
     max_archive_bytes: u64,
@@ -51,13 +60,22 @@ struct RelayFileConfig {
 
 #[derive(Clone, Debug)]
 pub struct RelayConfig {
-    pub listen: SocketAddr,
+    pub public_listen: SocketAddr,
+    pub publisher_listen: SocketAddr,
     pub database: PathBuf,
     pub directory_pubkey: [u8; 32],
     pub max_connections: usize,
+    pub max_public_connections: usize,
+    pub max_publisher_connections: usize,
     pub max_in_flight_operations: usize,
+    pub max_public_in_flight_operations: usize,
+    pub max_publisher_in_flight_operations: usize,
     pub max_operations_per_second: u32,
+    pub max_public_operations_per_second: u32,
+    pub max_publisher_operations_per_second: u32,
     pub max_egress_bytes_per_second: u64,
+    pub max_public_egress_bytes_per_second: u64,
+    pub max_publisher_egress_bytes_per_second: u64,
     pub max_egress_bytes_per_connection: u64,
     pub max_archive_events: u64,
     pub max_archive_bytes: u64,
@@ -88,8 +106,14 @@ impl TryFrom<Cli> for RelayConfig {
         if file.profile != "bitcoinpir-directory-relay-v1" {
             return Err("directory relay configuration profile is unsupported".to_owned());
         }
-        if !file.listen.ip().is_loopback() {
-            return Err("directory relay must bind to a numeric loopback address".to_owned());
+        if !file.public_listen.ip().is_loopback()
+            || !file.publisher_listen.ip().is_loopback()
+            || file.public_listen == file.publisher_listen
+        {
+            return Err(
+                "directory relay requires distinct numeric loopback public and publisher binds"
+                    .to_owned(),
+            );
         }
         if !file.database.is_absolute() {
             return Err("directory relay database path must be absolute".to_owned());
@@ -97,12 +121,28 @@ impl TryFrom<Cli> for RelayConfig {
         let directory_pubkey = decode_public_key(&file.directory_pubkey_hex)?;
         if file.max_connections == 0
             || file.max_connections > 4_096
+            || file.max_public_connections == 0
+            || file.max_publisher_connections == 0
+            || file.max_public_connections > file.max_connections
+            || file.max_publisher_connections > file.max_connections
             || file.max_in_flight_operations == 0
             || file.max_in_flight_operations > 256
+            || file.max_public_in_flight_operations == 0
+            || file.max_publisher_in_flight_operations == 0
+            || file.max_public_in_flight_operations > file.max_in_flight_operations
+            || file.max_publisher_in_flight_operations > file.max_in_flight_operations
             || file.max_operations_per_second == 0
             || file.max_operations_per_second > 1_000_000
+            || file.max_public_operations_per_second == 0
+            || file.max_publisher_operations_per_second == 0
+            || file.max_public_operations_per_second > file.max_operations_per_second
+            || file.max_publisher_operations_per_second > file.max_operations_per_second
             || file.max_egress_bytes_per_second < 1024 * 1024
             || file.max_egress_bytes_per_second > 1024 * 1024 * 1024
+            || file.max_public_egress_bytes_per_second < 1024 * 1024
+            || file.max_publisher_egress_bytes_per_second < 1024 * 1024
+            || file.max_public_egress_bytes_per_second > file.max_egress_bytes_per_second
+            || file.max_publisher_egress_bytes_per_second > file.max_egress_bytes_per_second
             || file.max_egress_bytes_per_connection < 2 * 1024 * 1024
             || file.max_egress_bytes_per_connection > 8 * 1024 * 1024 * 1024
             || file.max_archive_events < 16_400
@@ -112,6 +152,28 @@ impl TryFrom<Cli> for RelayConfig {
         {
             return Err(
                 "directory relay concurrency/rate limits are outside safe bounds".to_owned(),
+            );
+        }
+        if file
+            .max_public_connections
+            .checked_add(file.max_publisher_connections)
+            != Some(file.max_connections)
+            || file
+                .max_public_in_flight_operations
+                .checked_add(file.max_publisher_in_flight_operations)
+                != Some(file.max_in_flight_operations)
+            || file
+                .max_public_operations_per_second
+                .checked_add(file.max_publisher_operations_per_second)
+                != Some(file.max_operations_per_second)
+            || file
+                .max_public_egress_bytes_per_second
+                .checked_add(file.max_publisher_egress_bytes_per_second)
+                != Some(file.max_egress_bytes_per_second)
+        {
+            return Err(
+                "directory relay lane reservations must exactly partition each global limit"
+                    .to_owned(),
             );
         }
         for (label, value, maximum) in [
@@ -126,13 +188,22 @@ impl TryFrom<Cli> for RelayConfig {
             }
         }
         Ok(Self {
-            listen: file.listen,
+            public_listen: file.public_listen,
+            publisher_listen: file.publisher_listen,
             database: file.database,
             directory_pubkey,
             max_connections: file.max_connections,
+            max_public_connections: file.max_public_connections,
+            max_publisher_connections: file.max_publisher_connections,
             max_in_flight_operations: file.max_in_flight_operations,
+            max_public_in_flight_operations: file.max_public_in_flight_operations,
+            max_publisher_in_flight_operations: file.max_publisher_in_flight_operations,
             max_operations_per_second: file.max_operations_per_second,
+            max_public_operations_per_second: file.max_public_operations_per_second,
+            max_publisher_operations_per_second: file.max_publisher_operations_per_second,
             max_egress_bytes_per_second: file.max_egress_bytes_per_second,
+            max_public_egress_bytes_per_second: file.max_public_egress_bytes_per_second,
+            max_publisher_egress_bytes_per_second: file.max_publisher_egress_bytes_per_second,
             max_egress_bytes_per_connection: file.max_egress_bytes_per_connection,
             max_archive_events: file.max_archive_events,
             max_archive_bytes: file.max_archive_bytes,
@@ -175,17 +246,26 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).unwrap();
         let path = directory.path().join("relay.toml");
-        let render = |listen: &str, key: &str| {
+        let render = |public_listen: &str, publisher_listen: &str, key: &str| {
             format!(
                 r#"
 profile = "bitcoinpir-directory-relay-v1"
-listen = "{listen}"
+public_listen = "{public_listen}"
+publisher_listen = "{publisher_listen}"
 database = "/tmp/bitcoinpir-directory-test.sqlite"
 directory_pubkey_hex = "{key}"
-max_connections = 1
-max_in_flight_operations = 1
-max_operations_per_second = 1
-max_egress_bytes_per_second = 1048576
+max_connections = 2
+max_public_connections = 1
+max_publisher_connections = 1
+max_in_flight_operations = 2
+max_public_in_flight_operations = 1
+max_publisher_in_flight_operations = 1
+max_operations_per_second = 2
+max_public_operations_per_second = 1
+max_publisher_operations_per_second = 1
+max_egress_bytes_per_second = 2097152
+max_public_egress_bytes_per_second = 1048576
+max_publisher_egress_bytes_per_second = 1048576
 max_egress_bytes_per_connection = 2097152
 max_archive_events = 16400
 max_archive_bytes = 16777216
@@ -197,18 +277,30 @@ egress_timeout_seconds = 1
 "#
             )
         };
-        fs::write(&path, render("127.0.0.1:8080", &"01".repeat(32))).unwrap();
+        fs::write(
+            &path,
+            render("127.0.0.1:8080", "127.0.0.1:8081", &"01".repeat(32)),
+        )
+        .unwrap();
         fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
         assert!(RelayConfig::try_from(Cli {
             config: path.clone()
         })
         .is_ok());
-        fs::write(&path, render("0.0.0.0:8080", &"01".repeat(32))).unwrap();
+        fs::write(
+            &path,
+            render("0.0.0.0:8080", "127.0.0.1:8081", &"01".repeat(32)),
+        )
+        .unwrap();
         assert!(RelayConfig::try_from(Cli {
             config: path.clone()
         })
         .is_err());
-        fs::write(&path, render("127.0.0.1:8080", &"AA".repeat(32))).unwrap();
+        fs::write(
+            &path,
+            render("127.0.0.1:8080", "127.0.0.1:8081", &"AA".repeat(32)),
+        )
+        .unwrap();
         assert!(RelayConfig::try_from(Cli { config: path }).is_err());
     }
 }

--- a/apps/directory-relay/src/server.rs
+++ b/apps/directory-relay/src/server.rs
@@ -33,12 +33,22 @@ pub const MAX_LEGAL_READBACK_EGRESS_BYTES: u64 =
 struct ServerState {
     store: Arc<Mutex<DirectoryStore>>,
     directory_pubkey: [u8; 32],
+    lane: RelayLane,
     operation_slots: Arc<Semaphore>,
+    global_operation_slots: Arc<Semaphore>,
     operation_timeout: Duration,
     egress_timeout: Duration,
     max_egress_bytes_per_connection: u64,
     rate_gate: RateGate,
+    global_rate_gate: Arc<RateGate>,
     egress_rate_gate: ByteRateGate,
+    global_egress_rate_gate: Arc<ByteRateGate>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RelayLane {
+    Public,
+    Publisher,
 }
 
 struct RateGate {
@@ -187,16 +197,27 @@ fn request_work_units(filter: &RequestFilter) -> u32 {
     }
 }
 
+fn admit_rate(state: &ServerState, cost: u32) -> bool {
+    // Lane admission is deliberately first. A public reader cannot consume a
+    // global unit until it has stayed within the public reservation.
+    state.rate_gate.admit(cost) && state.global_rate_gate.admit(cost)
+}
+
 pub struct RelayHandle {
-    local_addr: SocketAddr,
+    public_addr: SocketAddr,
+    publisher_addr: SocketAddr,
     shutdown: watch::Sender<bool>,
     store_interrupt: Arc<InterruptHandle>,
     task: JoinHandle<Result<(), String>>,
 }
 
 impl RelayHandle {
-    pub fn local_addr(&self) -> SocketAddr {
-        self.local_addr
+    pub fn public_addr(&self) -> SocketAddr {
+        self.public_addr
+    }
+
+    pub fn publisher_addr(&self) -> SocketAddr {
+        self.publisher_addr
     }
 
     pub async fn shutdown(self) -> Result<(), String> {
@@ -220,8 +241,11 @@ pub async fn run(config: RelayConfig) -> Result<(), String> {
 }
 
 pub async fn start(config: RelayConfig) -> Result<RelayHandle, String> {
-    if !config.listen.ip().is_loopback() {
-        return Err("directory relay refused a non-loopback bind".to_owned());
+    if !config.public_listen.ip().is_loopback()
+        || !config.publisher_listen.ip().is_loopback()
+        || config.public_listen == config.publisher_listen
+    {
+        return Err("directory relay refused invalid public/publisher binds".to_owned());
     }
     let now = now_unix()?;
     let path = config.database.clone();
@@ -236,38 +260,106 @@ pub async fn start(config: RelayConfig) -> Result<RelayHandle, String> {
     .await
     .map_err(|error| format!("directory relay startup worker failed: {error}"))??;
     let store_interrupt = Arc::new(store.interrupt_handle());
-    let listener = TcpListener::bind(config.listen)
+    let public_listener = TcpListener::bind(config.public_listen)
         .await
-        .map_err(|error| format!("bind directory relay loopback socket failed: {error}"))?;
-    let local_addr = listener
+        .map_err(|error| format!("bind directory public loopback socket failed: {error}"))?;
+    let public_addr = public_listener
         .local_addr()
-        .map_err(|error| format!("read directory relay socket address failed: {error}"))?;
-    if !local_addr.ip().is_loopback() {
-        return Err("bound directory relay socket is not loopback".to_owned());
+        .map_err(|error| format!("read directory public socket address failed: {error}"))?;
+    let publisher_listener = TcpListener::bind(config.publisher_listen)
+        .await
+        .map_err(|error| format!("bind directory publisher loopback socket failed: {error}"))?;
+    let publisher_addr = publisher_listener
+        .local_addr()
+        .map_err(|error| format!("read directory publisher socket address failed: {error}"))?;
+    if !public_addr.ip().is_loopback()
+        || !publisher_addr.ip().is_loopback()
+        || public_addr == publisher_addr
+    {
+        return Err("bound directory relay sockets are not distinct loopback addresses".to_owned());
     }
-    let state = Arc::new(ServerState {
-        store: Arc::new(Mutex::new(store)),
+    let store = Arc::new(Mutex::new(store));
+    let global_operation_slots = Arc::new(Semaphore::new(config.max_in_flight_operations));
+    let global_rate_gate = Arc::new(RateGate::new(config.max_operations_per_second));
+    let global_egress_rate_gate = Arc::new(ByteRateGate::new(config.max_egress_bytes_per_second));
+    let public_state = Arc::new(ServerState {
+        store: store.clone(),
         directory_pubkey: config.directory_pubkey,
-        operation_slots: Arc::new(Semaphore::new(config.max_in_flight_operations)),
+        lane: RelayLane::Public,
+        operation_slots: Arc::new(Semaphore::new(config.max_public_in_flight_operations)),
+        global_operation_slots: global_operation_slots.clone(),
         operation_timeout: config.operation_timeout,
         egress_timeout: config.egress_timeout,
         max_egress_bytes_per_connection: config.max_egress_bytes_per_connection,
-        rate_gate: RateGate::new(config.max_operations_per_second),
-        egress_rate_gate: ByteRateGate::new(config.max_egress_bytes_per_second),
+        rate_gate: RateGate::new(config.max_public_operations_per_second),
+        global_rate_gate: global_rate_gate.clone(),
+        egress_rate_gate: ByteRateGate::new(config.max_public_egress_bytes_per_second),
+        global_egress_rate_gate: global_egress_rate_gate.clone(),
     });
-    let connection_slots = Arc::new(Semaphore::new(config.max_connections));
+    let publisher_state = Arc::new(ServerState {
+        store,
+        directory_pubkey: config.directory_pubkey,
+        lane: RelayLane::Publisher,
+        operation_slots: Arc::new(Semaphore::new(config.max_publisher_in_flight_operations)),
+        global_operation_slots,
+        operation_timeout: config.operation_timeout,
+        egress_timeout: config.egress_timeout,
+        max_egress_bytes_per_connection: config.max_egress_bytes_per_connection,
+        rate_gate: RateGate::new(config.max_publisher_operations_per_second),
+        global_rate_gate,
+        egress_rate_gate: ByteRateGate::new(config.max_publisher_egress_bytes_per_second),
+        global_egress_rate_gate,
+    });
+    let global_connection_slots = Arc::new(Semaphore::new(config.max_connections));
+    let public_connection_slots = Arc::new(Semaphore::new(config.max_public_connections));
+    let publisher_connection_slots = Arc::new(Semaphore::new(config.max_publisher_connections));
     let (shutdown, shutdown_rx) = watch::channel(false);
-    let task = tokio::spawn(serve(
-        listener,
-        state,
-        connection_slots,
-        config.handshake_timeout,
-        config.idle_timeout,
-        config.connection_timeout,
-        shutdown_rx,
-    ));
+    let task_shutdown = shutdown.clone();
+    let task = tokio::spawn(async move {
+        let mut listeners = JoinSet::new();
+        listeners.spawn(serve(
+            public_listener,
+            public_state,
+            public_connection_slots,
+            global_connection_slots.clone(),
+            config.handshake_timeout,
+            config.idle_timeout,
+            config.connection_timeout,
+            shutdown_rx.clone(),
+        ));
+        listeners.spawn(serve(
+            publisher_listener,
+            publisher_state,
+            publisher_connection_slots,
+            global_connection_slots,
+            config.handshake_timeout,
+            config.idle_timeout,
+            config.connection_timeout,
+            shutdown_rx,
+        ));
+        let mut first_error = None;
+        while let Some(result) = listeners.join_next().await {
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                    let _ = task_shutdown.send(true);
+                }
+                Err(error) => {
+                    if first_error.is_none() {
+                        first_error = Some(format!("directory listener task failed: {error}"));
+                    }
+                    let _ = task_shutdown.send(true);
+                }
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    });
     Ok(RelayHandle {
-        local_addr,
+        public_addr,
+        publisher_addr,
         shutdown,
         store_interrupt,
         task,
@@ -277,7 +369,8 @@ pub async fn start(config: RelayConfig) -> Result<RelayHandle, String> {
 async fn serve(
     listener: TcpListener,
     state: Arc<ServerState>,
-    connection_slots: Arc<Semaphore>,
+    lane_connection_slots: Arc<Semaphore>,
+    global_connection_slots: Arc<Semaphore>,
     handshake_timeout: Duration,
     idle_timeout: Duration,
     connection_timeout: Duration,
@@ -304,8 +397,16 @@ async fn serve(
                     drop(stream);
                     continue;
                 }
-                let Ok(permit) = connection_slots.clone().try_acquire_owned() else {
+                // Acquire the lane reservation before the global slot. Since
+                // configured lane maxima exactly partition the global maximum,
+                // one lane can never wait on the other while holding global work.
+                let Ok(lane_permit) = lane_connection_slots.clone().try_acquire_owned() else {
                     log::warn!("directory_relay_connection_capacity_rejected");
+                    drop(stream);
+                    continue;
+                };
+                let Ok(global_permit) = global_connection_slots.clone().try_acquire_owned() else {
+                    log::warn!("directory_relay_global_connection_capacity_rejected");
                     drop(stream);
                     continue;
                 };
@@ -315,7 +416,8 @@ async fn serve(
                     if handle_connection(
                         stream,
                         state,
-                        permit,
+                        lane_permit,
+                        global_permit,
                         handshake_timeout,
                         idle_timeout,
                         connection_timeout,
@@ -343,7 +445,8 @@ async fn serve(
 async fn handle_connection(
     stream: TcpStream,
     state: Arc<ServerState>,
-    _connection_permit: OwnedSemaphorePermit,
+    _lane_connection_permit: OwnedSemaphorePermit,
+    _global_connection_permit: OwnedSemaphorePermit,
     handshake_timeout: Duration,
     idle_timeout: Duration,
     connection_timeout: Duration,
@@ -398,8 +501,20 @@ async fn handle_connection(
             return Err("connection message bound exceeded".to_owned());
         }
         let bytes = text.as_str().as_bytes();
+        match state.lane {
+            RelayLane::Public if best_effort_event_id(bytes).is_some() => {
+                // This signed event may already be durable from a private
+                // publish whose ACK was lost. Do not contradict it with a
+                // negative acknowledgement from the public lane.
+                return Err("EVENT rejected on public directory lane".to_owned());
+            }
+            RelayLane::Publisher if best_effort_event_id(bytes).is_none() => {
+                return Err("non-EVENT rejected on directory publisher lane".to_owned());
+            }
+            RelayLane::Public | RelayLane::Publisher => {}
+        }
         work_budget.reserve(1)?;
-        if !state.rate_gate.admit(1) {
+        if !admit_rate(&state, 1) {
             // A syntactically recognizable EVENT may be a retry whose durable
             // positive OK was lost. Without consulting the archive, a negative
             // ACK would contradict that committed state. Close without any ACK
@@ -438,6 +553,14 @@ async fn handle_connection(
                 continue;
             }
         };
+        if !matches!(
+            (state.lane, &message),
+            (RelayLane::Public, ClientMessage::Req { .. })
+                | (RelayLane::Public, ClientMessage::Close { .. })
+                | (RelayLane::Publisher, ClientMessage::Event(_))
+        ) {
+            return Err("message rejected on wrong directory lane".to_owned());
+        }
         match message {
             ClientMessage::Event(event) => {
                 let event_id = *event.event.id();
@@ -488,7 +611,7 @@ async fn handle_connection(
             } => {
                 let additional_work = request_work_units(&filter).saturating_sub(1);
                 if work_budget.reserve(additional_work).is_err()
-                    || !state.rate_gate.admit(additional_work)
+                    || !admit_rate(&state, additional_work)
                 {
                     let closed = closed_message(&subscription_id, "rate-limited: bounded REQ work");
                     send_text(&mut websocket, closed, &state, &mut egress_budget).await?;
@@ -531,12 +654,12 @@ async fn ingest_operation(
     event: ValidatedEvent,
     received_at: u64,
 ) -> Result<IngestDisposition, IngestOperationError> {
-    let permit = acquire_operation_permit(&state)
+    let permits = acquire_operation_permits(&state)
         .await
         .map_err(|_| IngestOperationError::NotStarted)?;
     let store = state.store.clone();
     let task = tokio::task::spawn_blocking(move || {
-        let _permit = permit;
+        let _permits = permits;
         let mut store = store
             .lock()
             .map_err(|_| "directory store lock poisoned".to_owned())?;
@@ -554,10 +677,10 @@ async fn freeze_snapshot_operation(
     state: Arc<ServerState>,
     filter: RequestFilter,
 ) -> Result<SnapshotPlan, String> {
-    let permit = acquire_operation_permit(&state).await?;
+    let permits = acquire_operation_permits(&state).await?;
     let store = state.store.clone();
     let task = tokio::task::spawn_blocking(move || {
-        let _permit = permit;
+        let _permits = permits;
         let store = store
             .lock()
             .map_err(|_| "directory store lock poisoned".to_owned())?;
@@ -574,10 +697,10 @@ async fn load_snapshot_page_operation(
     state: Arc<ServerState>,
     ids: Vec<[u8; 32]>,
 ) -> Result<Vec<Vec<u8>>, String> {
-    let permit = acquire_operation_permit(&state).await?;
+    let permits = acquire_operation_permits(&state).await?;
     let store = state.store.clone();
     let task = tokio::task::spawn_blocking(move || {
-        let _permit = permit;
+        let _permits = permits;
         let store = store
             .lock()
             .map_err(|_| "directory store lock poisoned".to_owned())?;
@@ -587,14 +710,24 @@ async fn load_snapshot_page_operation(
         .map_err(|_| "directory snapshot page worker failed".to_owned())?
 }
 
-async fn acquire_operation_permit(state: &ServerState) -> Result<OwnedSemaphorePermit, String> {
-    tokio::time::timeout(
+async fn acquire_operation_permits(
+    state: &ServerState,
+) -> Result<(OwnedSemaphorePermit, OwnedSemaphorePermit), String> {
+    let lane = tokio::time::timeout(
         state.operation_timeout,
         state.operation_slots.clone().acquire_owned(),
     )
     .await
-    .map_err(|_| "directory operation queue timeout".to_owned())?
-    .map_err(|_| "directory operation limiter closed".to_owned())
+    .map_err(|_| "directory lane operation queue timeout".to_owned())?
+    .map_err(|_| "directory lane operation limiter closed".to_owned())?;
+    let global = tokio::time::timeout(
+        state.operation_timeout,
+        state.global_operation_slots.clone().acquire_owned(),
+    )
+    .await
+    .map_err(|_| "directory global operation queue timeout".to_owned())?
+    .map_err(|_| "directory global operation limiter closed".to_owned())?;
+    Ok((lane, global))
 }
 
 async fn send_snapshot<S>(
@@ -666,6 +799,10 @@ where
     let bytes = u64::try_from(text.len()).map_err(|_| "egress byte count overflow".to_owned())?;
     tokio::time::timeout(state.egress_timeout, async {
         state.egress_rate_gate.wait_for_capacity(bytes).await?;
+        state
+            .global_egress_rate_gate
+            .wait_for_capacity(bytes)
+            .await?;
         websocket
             .send(Message::Text(text.into()))
             .await
@@ -750,13 +887,22 @@ mod tests {
 
     fn test_config(database: std::path::PathBuf, key: [u8; 32]) -> RelayConfig {
         RelayConfig {
-            listen: "127.0.0.1:0".parse().unwrap(),
+            public_listen: "127.0.0.1:0".parse().unwrap(),
+            publisher_listen: "127.0.0.2:0".parse().unwrap(),
             database,
             directory_pubkey: key,
             max_connections: 32,
+            max_public_connections: 24,
+            max_publisher_connections: 8,
             max_in_flight_operations: 4,
+            max_public_in_flight_operations: 3,
+            max_publisher_in_flight_operations: 1,
             max_operations_per_second: 1_000_000,
+            max_public_operations_per_second: 750_000,
+            max_publisher_operations_per_second: 250_000,
             max_egress_bytes_per_second: 1024 * 1024 * 1024,
+            max_public_egress_bytes_per_second: 768 * 1024 * 1024,
+            max_publisher_egress_bytes_per_second: 256 * 1024 * 1024,
             max_egress_bytes_per_connection: 64 * 1024 * 1024,
             max_archive_events: 20_000,
             max_archive_bytes: 64 * 1024 * 1024,
@@ -792,8 +938,15 @@ mod tests {
             .unwrap()
     }
 
-    async fn connect(handle: &RelayHandle) -> TestClient {
-        connect_async(format!("ws://{}", handle.local_addr()))
+    async fn connect_public(handle: &RelayHandle) -> TestClient {
+        connect_async(format!("ws://{}", handle.public_addr()))
+            .await
+            .unwrap()
+            .0
+    }
+
+    async fn connect_publisher(handle: &RelayHandle) -> TestClient {
+        connect_async(format!("ws://{}", handle.publisher_addr()))
             .await
             .unwrap()
             .0
@@ -860,6 +1013,54 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn public_and_publisher_lanes_are_not_interchangeable() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).unwrap();
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([60; 32]).unwrap();
+        let handle = start(test_config(
+            directory.path().join("lanes.sqlite"),
+            *publisher.public_key(),
+        ))
+        .await
+        .unwrap();
+        let now = now_unix().unwrap();
+        let event = signed_entry(&publisher, [0x20; 32], 1, now - 1, now, 1);
+
+        let mut public_writer = connect_public(&handle).await;
+        public_writer
+            .send(Message::Text(
+                String::from_utf8(event.to_event_message_json_bytes().unwrap())
+                    .unwrap()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        expect_connection_failure(&mut public_writer).await;
+
+        let mut publisher_reader = connect_publisher(&handle).await;
+        publisher_reader
+            .send(Message::Text(
+                String::from_utf8(catalog_req_json_v1(publisher.public_key(), 0).unwrap())
+                    .unwrap()
+                    .into(),
+            ))
+            .await
+            .unwrap();
+        expect_connection_failure(&mut publisher_reader).await;
+
+        let mut writer = connect_publisher(&handle).await;
+        assert!(publish(&mut writer, &event).await.0);
+        let mut reader = connect_public(&handle).await;
+        let request =
+            String::from_utf8(catalog_req_json_v1(publisher.public_key(), 0).unwrap()).unwrap();
+        assert_eq!(
+            receive_catalog(&mut reader, &request, "bitcoinpir-directory-v1-shard-0").await,
+            vec![hex::encode(event.id())]
+        );
+        handle.shutdown().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn websocket_profile_is_durable_paged_and_fail_closed() {
         let directory = tempfile::tempdir().unwrap();
         fs::set_permissions(directory.path(), fs::Permissions::from_mode(0o700)).unwrap();
@@ -873,13 +1074,13 @@ mod tests {
         let second = signed_entry(&publisher, provider, 2, now - 2, now, 2);
         let older = signed_entry(&publisher, provider, 1, now - 4, now, 3);
 
-        let mut client = connect(&handle).await;
-        assert!(publish(&mut client, &first).await.0);
-        assert!(publish(&mut client, &second).await.0);
-        let (accepted, reason) = publish(&mut client, &older).await;
+        let mut publisher_client = connect_publisher(&handle).await;
+        assert!(publish(&mut publisher_client, &first).await.0);
+        assert!(publish(&mut publisher_client, &second).await.0);
+        let (accepted, reason) = publish(&mut publisher_client, &older).await;
         assert!(!accepted);
         assert!(reason.starts_with("replaced:"));
-        let (accepted, reason) = publish(&mut client, &first).await;
+        let (accepted, reason) = publish(&mut publisher_client, &first).await;
         assert!(accepted);
         assert!(reason.starts_with("duplicate:"));
 
@@ -890,13 +1091,14 @@ mod tests {
             extra_provider[0] = 0x22 + offset;
             extra_provider[31] = offset;
             let event = signed_entry(&publisher, extra_provider, 1, now - 1, now, 10 + offset);
-            assert!(publish(&mut client, &event).await.0);
+            assert!(publish(&mut publisher_client, &event).await.0);
             stored.push(*event.id());
             expected_catalog.push(hex::encode(event.id()));
         }
 
         let catalog_request =
             String::from_utf8(catalog_req_json_v1(publisher.public_key(), 2).unwrap()).unwrap();
+        let mut client = connect_public(&handle).await;
         let catalog = receive_catalog(
             &mut client,
             &catalog_request,
@@ -951,7 +1153,7 @@ mod tests {
 
         // Simulate a committed EVENT whose positive OK is lost with the socket.
         let lost_ack_event = signed_entry(&publisher, [0x2f; 32], 1, now - 1, now, 31);
-        let mut lost_ack_client = connect(&handle).await;
+        let mut lost_ack_client = connect_publisher(&handle).await;
         lost_ack_client
             .send(Message::Text(
                 String::from_utf8(lost_ack_event.to_event_message_json_bytes().unwrap())
@@ -961,7 +1163,7 @@ mod tests {
             .await
             .unwrap();
         drop(lost_ack_client);
-        let mut commit_probe = connect(&handle).await;
+        let mut commit_probe = connect_public(&handle).await;
         tokio::time::timeout(Duration::from_secs(5), async {
             for attempt in 0u64.. {
                 let subscription_id = format!("commit-barrier-{attempt}");
@@ -983,7 +1185,7 @@ mod tests {
         .await
         .expect("lost-ACK event never crossed the durable readback barrier");
         commit_probe.send(Message::Close(None)).await.unwrap();
-        let mut retry_client = connect(&handle).await;
+        let mut retry_client = connect_publisher(&handle).await;
         let (accepted, reason) = publish(&mut retry_client, &lost_ack_event).await;
         assert!(accepted);
         assert!(reason.starts_with("duplicate:"));
@@ -991,11 +1193,13 @@ mod tests {
 
         client.send(Message::Close(None)).await.unwrap();
         drop(client);
+        publisher_client.send(Message::Close(None)).await.unwrap();
+        drop(publisher_client);
         handle.shutdown().await.unwrap();
 
         // A positive OK survived restart and all address heads are still deterministic.
         let restarted = start(config.clone()).await.unwrap();
-        let mut after_restart = connect(&restarted).await;
+        let mut after_restart = connect_public(&restarted).await;
         let catalog = receive_catalog(
             &mut after_restart,
             &catalog_request,
@@ -1010,7 +1214,7 @@ mod tests {
         assert_eq!(actual_sorted, expected_after_restart);
         after_restart.send(Message::Close(None)).await.unwrap();
 
-        let mut malformed = connect(&restarted).await;
+        let mut malformed = connect_public(&restarted).await;
         malformed
             .send(Message::Text(
                 r#"["REQ","bad",{"ids":[]}]"#.to_owned().into(),
@@ -1021,21 +1225,21 @@ mod tests {
         assert_eq!(response[0], "CLOSED");
         malformed.send(Message::Close(None)).await.unwrap();
 
-        let mut unknown = connect(&restarted).await;
+        let mut unknown = connect_public(&restarted).await;
         unknown
             .send(Message::Text(r#"["AUTH",{}]"#.to_owned().into()))
             .await
             .unwrap();
         expect_connection_failure(&mut unknown).await;
 
-        let mut binary = connect(&restarted).await;
+        let mut binary = connect_public(&restarted).await;
         binary
             .send(Message::Binary(vec![1, 2, 3].into()))
             .await
             .unwrap();
         expect_connection_failure(&mut binary).await;
 
-        let mut oversized = connect(&restarted).await;
+        let mut oversized = connect_public(&restarted).await;
         let oversized_message = format!(
             "[\"REQ\",\"oversized\",{{\"padding\":\"{}\"}}]",
             "x".repeat(MAX_WIRE_MESSAGE_BYTES)
@@ -1049,7 +1253,7 @@ mod tests {
             expect_connection_failure(&mut oversized).await;
         }
 
-        let mut fragmented = connect(&restarted).await;
+        let mut fragmented = connect_public(&restarted).await;
         fragmented
             .send(Message::Frame(Frame::message(
                 vec![b'x'; MAX_WIRE_MESSAGE_BYTES / 2 + 1],
@@ -1077,7 +1281,7 @@ mod tests {
         let mut low_budget_config = config;
         low_budget_config.max_egress_bytes_per_connection = 256;
         let low_budget = start(low_budget_config).await.unwrap();
-        let mut capped = connect(&low_budget).await;
+        let mut capped = connect_public(&low_budget).await;
         capped
             .send(Message::Text(catalog_request.into()))
             .await
@@ -1133,12 +1337,12 @@ mod tests {
         let now = now_unix().unwrap();
         let event = signed_entry(&publisher, [0x31; 32], 1, now - 1, now, 1);
 
-        let mut first = connect(&handle).await;
+        let mut first = connect_publisher(&handle).await;
         assert!(publish(&mut first, &event).await.0);
         first.send(Message::Close(None)).await.unwrap();
 
         let wire = String::from_utf8(event.to_event_message_json_bytes().unwrap()).unwrap();
-        let mut limited = connect(&handle).await;
+        let mut limited = connect_publisher(&handle).await;
         limited
             .send(Message::Text(wire.clone().into()))
             .await
@@ -1147,7 +1351,7 @@ mod tests {
 
         tokio::time::timeout(Duration::from_secs(3), async {
             loop {
-                let mut retry = connect(&handle).await;
+                let mut retry = connect_publisher(&handle).await;
                 retry
                     .send(Message::Text(wire.clone().into()))
                     .await
@@ -1194,7 +1398,7 @@ mod tests {
         );
         config.max_operations_per_second = 1;
         let handle = start(config).await.unwrap();
-        let mut client = connect(&handle).await;
+        let mut client = connect_public(&handle).await;
         let request =
             serde_json::to_string(&("REQ", "weighted-readback", IdFilter { ids: ids.clone() }))
                 .unwrap();
@@ -1211,7 +1415,7 @@ mod tests {
         );
         config.max_operations_per_second = 1;
         let handle = start(config).await.unwrap();
-        let mut client = connect(&handle).await;
+        let mut client = connect_public(&handle).await;
         let request = serde_json::to_string(&(
             "REQ",
             "one-unit-readback",
@@ -1257,7 +1461,7 @@ mod tests {
 
         let mut clients = Vec::new();
         for _ in &events {
-            clients.push(connect(&handle).await);
+            clients.push(connect_publisher(&handle).await);
         }
         let tasks = clients
             .into_iter()
@@ -1276,7 +1480,7 @@ mod tests {
 
         let request =
             String::from_utf8(catalog_req_json_v1(publisher.public_key(), 7).unwrap()).unwrap();
-        let mut reader = connect(&handle).await;
+        let mut reader = connect_public(&handle).await;
         assert_eq!(
             receive_catalog(&mut reader, &request, "bitcoinpir-directory-v1-shard-7").await,
             vec![hex::encode(expected)]
@@ -1300,7 +1504,7 @@ mod tests {
         );
         config.connection_timeout = Duration::from_millis(50);
         let handle = start(config).await.unwrap();
-        let mut client = connect(&handle).await;
+        let mut client = connect_public(&handle).await;
         expect_connection_failure(&mut client).await;
         handle.shutdown().await.unwrap();
     }

--- a/apps/directory-relay/src/server.rs
+++ b/apps/directory-relay/src/server.rs
@@ -313,6 +313,21 @@ pub async fn start(config: RelayConfig) -> Result<RelayHandle, String> {
     let global_connection_slots = Arc::new(Semaphore::new(config.max_connections));
     let public_connection_slots = Arc::new(Semaphore::new(config.max_public_connections));
     let publisher_connection_slots = Arc::new(Semaphore::new(config.max_publisher_connections));
+    let connection_timeouts = ConnectionTimeouts {
+        handshake: config.handshake_timeout,
+        idle: config.idle_timeout,
+        lifetime: config.connection_timeout,
+    };
+    let public_admission = ListenerAdmission {
+        lane_slots: public_connection_slots,
+        global_slots: global_connection_slots.clone(),
+        timeouts: connection_timeouts,
+    };
+    let publisher_admission = ListenerAdmission {
+        lane_slots: publisher_connection_slots,
+        global_slots: global_connection_slots,
+        timeouts: connection_timeouts,
+    };
     let (shutdown, shutdown_rx) = watch::channel(false);
     let task_shutdown = shutdown.clone();
     let task = tokio::spawn(async move {
@@ -320,21 +335,13 @@ pub async fn start(config: RelayConfig) -> Result<RelayHandle, String> {
         listeners.spawn(serve(
             public_listener,
             public_state,
-            public_connection_slots,
-            global_connection_slots.clone(),
-            config.handshake_timeout,
-            config.idle_timeout,
-            config.connection_timeout,
+            public_admission,
             shutdown_rx.clone(),
         ));
         listeners.spawn(serve(
             publisher_listener,
             publisher_state,
-            publisher_connection_slots,
-            global_connection_slots,
-            config.handshake_timeout,
-            config.idle_timeout,
-            config.connection_timeout,
+            publisher_admission,
             shutdown_rx,
         ));
         let mut first_error = None;
@@ -366,14 +373,23 @@ pub async fn start(config: RelayConfig) -> Result<RelayHandle, String> {
     })
 }
 
+#[derive(Clone, Copy)]
+struct ConnectionTimeouts {
+    handshake: Duration,
+    idle: Duration,
+    lifetime: Duration,
+}
+
+struct ListenerAdmission {
+    lane_slots: Arc<Semaphore>,
+    global_slots: Arc<Semaphore>,
+    timeouts: ConnectionTimeouts,
+}
+
 async fn serve(
     listener: TcpListener,
     state: Arc<ServerState>,
-    lane_connection_slots: Arc<Semaphore>,
-    global_connection_slots: Arc<Semaphore>,
-    handshake_timeout: Duration,
-    idle_timeout: Duration,
-    connection_timeout: Duration,
+    admission: ListenerAdmission,
     mut shutdown: watch::Receiver<bool>,
 ) -> Result<(), String> {
     let mut connections = JoinSet::new();
@@ -400,27 +416,26 @@ async fn serve(
                 // Acquire the lane reservation before the global slot. Since
                 // configured lane maxima exactly partition the global maximum,
                 // one lane can never wait on the other while holding global work.
-                let Ok(lane_permit) = lane_connection_slots.clone().try_acquire_owned() else {
+                let Ok(lane_permit) = admission.lane_slots.clone().try_acquire_owned() else {
                     log::warn!("directory_relay_connection_capacity_rejected");
                     drop(stream);
                     continue;
                 };
-                let Ok(global_permit) = global_connection_slots.clone().try_acquire_owned() else {
+                let Ok(global_permit) = admission.global_slots.clone().try_acquire_owned() else {
                     log::warn!("directory_relay_global_connection_capacity_rejected");
                     drop(stream);
                     continue;
                 };
                 let state = state.clone();
                 let connection_shutdown = shutdown.clone();
+                let timeouts = admission.timeouts;
                 connections.spawn(async move {
                     if handle_connection(
                         stream,
                         state,
                         lane_permit,
                         global_permit,
-                        handshake_timeout,
-                        idle_timeout,
-                        connection_timeout,
+                        timeouts,
                         connection_shutdown,
                     )
                     .await
@@ -447,18 +462,16 @@ async fn handle_connection(
     state: Arc<ServerState>,
     _lane_connection_permit: OwnedSemaphorePermit,
     _global_connection_permit: OwnedSemaphorePermit,
-    handshake_timeout: Duration,
-    idle_timeout: Duration,
-    connection_timeout: Duration,
+    timeouts: ConnectionTimeouts,
     mut shutdown: watch::Receiver<bool>,
 ) -> Result<(), String> {
-    let connection_deadline = Instant::now() + connection_timeout;
+    let connection_deadline = Instant::now() + timeouts.lifetime;
     let websocket_config = WebSocketConfig::default()
         .max_message_size(Some(MAX_WIRE_MESSAGE_BYTES))
         .max_frame_size(Some(MAX_WIRE_MESSAGE_BYTES))
         .max_write_buffer_size(MAX_WIRE_MESSAGE_BYTES * 2);
     let mut websocket = tokio::time::timeout(
-        handshake_timeout,
+        timeouts.handshake,
         tokio_tungstenite::accept_async_with_config(stream, Some(websocket_config)),
     )
     .await
@@ -473,7 +486,7 @@ async fn handle_connection(
         let remaining = connection_deadline
             .checked_duration_since(Instant::now())
             .ok_or_else(|| "WebSocket connection lifetime exceeded".to_owned())?;
-        let receive_timeout = idle_timeout.min(remaining);
+        let receive_timeout = timeouts.idle.min(remaining);
         let next = tokio::select! {
             changed = shutdown.changed() => {
                 if changed.is_err() || *shutdown.borrow() {
@@ -1024,18 +1037,36 @@ mod tests {
         .await
         .unwrap();
         let now = now_unix().unwrap();
-        let event = signed_entry(&publisher, [0x20; 32], 1, now - 1, now, 1);
+        let wrong_lane_sentinel = signed_entry(&publisher, [0x20; 32], 99, now - 2, now, 1);
+        let event = signed_entry(&publisher, [0x21; 32], 1, now - 1, now, 2);
 
         let mut public_writer = connect_public(&handle).await;
         public_writer
             .send(Message::Text(
-                String::from_utf8(event.to_event_message_json_bytes().unwrap())
+                String::from_utf8(wrong_lane_sentinel.to_event_message_json_bytes().unwrap())
                     .unwrap()
                     .into(),
             ))
             .await
             .unwrap();
         expect_connection_failure(&mut public_writer).await;
+
+        let absence_subscription = "wrong-lane-absence";
+        let absence_request = serde_json::to_string(&(
+            "REQ",
+            absence_subscription,
+            IdFilter {
+                ids: vec![hex::encode(wrong_lane_sentinel.id())],
+            },
+        ))
+        .unwrap();
+        let mut absence_reader = connect_public(&handle).await;
+        assert!(
+            receive_catalog(&mut absence_reader, &absence_request, absence_subscription,)
+                .await
+                .is_empty(),
+            "public-lane EVENT must not be archived before its connection closes"
+        );
 
         let mut publisher_reader = connect_publisher(&handle).await;
         publisher_reader
@@ -1052,9 +1083,9 @@ mod tests {
         assert!(publish(&mut writer, &event).await.0);
         let mut reader = connect_public(&handle).await;
         let request =
-            String::from_utf8(catalog_req_json_v1(publisher.public_key(), 0).unwrap()).unwrap();
+            String::from_utf8(catalog_req_json_v1(publisher.public_key(), 2).unwrap()).unwrap();
         assert_eq!(
-            receive_catalog(&mut reader, &request, "bitcoinpir-directory-v1-shard-0").await,
+            receive_catalog(&mut reader, &request, "bitcoinpir-directory-v1-shard-2").await,
             vec![hex::encode(event.id())]
         );
         handle.shutdown().await.unwrap();

--- a/apps/directory-relay/tests/payment_v1_two_relay_process_e2e.rs
+++ b/apps/directory-relay/tests/payment_v1_two_relay_process_e2e.rs
@@ -7,6 +7,7 @@
 
 #![cfg(unix)]
 
+use std::collections::BTreeSet;
 use std::fs::{self, File};
 use std::net::{TcpListener, TcpStream};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -52,7 +53,8 @@ enum DualRelayReadError {
 
 struct RelayMaterial {
     label: &'static str,
-    port: u16,
+    public_port: u16,
+    publisher_port: u16,
     config: PathBuf,
     database: PathBuf,
 }
@@ -92,7 +94,8 @@ impl RelayProcess {
             stdout_path,
             stderr_path,
         };
-        process.wait_until_listening(material.port);
+        process.wait_until_listening(material.public_port);
+        process.wait_until_listening(material.publisher_port);
         process
     }
 
@@ -164,13 +167,41 @@ async fn two_relay_real_process_catalog_e2e() {
     let publisher = DirectoryPublisherKeyV1::from_secret_bytes([0x61; 32])
         .expect("deterministic test directory key");
     let now = unix_now();
-    let relay0_port = distinct_unused_port(&[]);
-    let relay1_port = distinct_unused_port(&[relay0_port]);
-    let relay0 = prepare_relay(root.path(), "relay0", relay0_port, publisher.public_key());
-    let relay1 = prepare_relay(root.path(), "relay1", relay1_port, publisher.public_key());
+    let relay0_public_port = distinct_unused_port(&[]);
+    let relay0_publisher_port = distinct_unused_port(&[relay0_public_port]);
+    let relay1_public_port = distinct_unused_port(&[relay0_public_port, relay0_publisher_port]);
+    let relay1_publisher_port = distinct_unused_port(&[
+        relay0_public_port,
+        relay0_publisher_port,
+        relay1_public_port,
+    ]);
+    let relay0 = prepare_relay(
+        root.path(),
+        "relay0",
+        relay0_public_port,
+        relay0_publisher_port,
+        publisher.public_key(),
+    );
+    let relay1 = prepare_relay(
+        root.path(),
+        "relay1",
+        relay1_public_port,
+        relay1_publisher_port,
+        publisher.public_key(),
+    );
     assert_ne!(relay0.config, relay1.config);
     assert_ne!(relay0.database, relay1.database);
-    assert_ne!(relay0.port, relay1.port);
+    assert_eq!(
+        BTreeSet::from([
+            relay0.public_port,
+            relay0.publisher_port,
+            relay1.public_port,
+            relay1.publisher_port,
+        ])
+        .len(),
+        4,
+        "both relays require distinct public and publisher listeners"
+    );
 
     let mut process0 = RelayProcess::spawn(root.path(), &relay0, 0);
     let mut process1 = RelayProcess::spawn(root.path(), &relay1, 0);
@@ -187,34 +218,61 @@ async fn two_relay_real_process_catalog_e2e() {
 
     let initial = signed_catalog(&publisher, now, now.saturating_sub(2), 1, 1);
 
+    // The two sockets are protocol lanes, not interchangeable aliases. Wrong-
+    // lane messages close without an acknowledgement so a public EVENT cannot
+    // contradict a durable private-lane commit and a publisher connection
+    // cannot be repurposed as a read channel.
+    assert_wrong_lane_rejected(
+        relay0.public_port,
+        event_message_text(&initial[0]),
+        "EVENT on public relay lane",
+    )
+    .await;
+    assert_wrong_lane_rejected(
+        relay0.publisher_port,
+        serde_json::json!([
+            "REQ",
+            "wrong-lane-read",
+            {"ids": [hex::encode(initial[0].id())]}
+        ])
+        .to_string(),
+        "REQ on publisher relay lane",
+    )
+    .await;
+
     // Relay 0 durably commits the first event, but the socket carrying its OK
     // disappears. ID readback is the commit barrier; retrying the same signed
     // event must be accepted as an idempotent duplicate.
-    publish_without_reading_ack(relay0.port, &initial[0]).await;
-    wait_for_event_id(relay0.port, initial[0].id()).await;
-    let (accepted, reason) = publish(relay0.port, &initial[0]).await;
+    publish_without_reading_ack(relay0.publisher_port, &initial[0]).await;
+    wait_for_event_id(relay0.public_port, initial[0].id()).await;
+    let (accepted, reason) = publish(relay0.publisher_port, &initial[0]).await;
     assert!(accepted);
     assert!(
         reason.starts_with("duplicate:"),
         "unexpected retry reason: {reason}"
     );
 
-    publish_many(relay0.port, &initial[1..]).await;
-    publish_many(relay1.port, &initial).await;
-    let baseline = read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now)
-        .await
-        .expect("identical complete catalog");
+    publish_many(relay0.publisher_port, &initial[1..]).await;
+    publish_many(relay1.publisher_port, &initial).await;
+    let baseline = read_consistent_catalog(
+        relay0.public_port,
+        relay1.public_port,
+        publisher.public_key(),
+        now,
+    )
+    .await
+    .expect("identical complete catalog");
     assert_eq!(baseline.0.len(), usize::from(DIRECTORY_SHARD_COUNT_V1));
 
     // A newer shard-0 head on only one relay is a split view. The client must
     // reject the pair and must never merge the newer entry with the older
     // checkpoint (or vice versa).
     let shard0_update = signed_shard(&publisher, now, now.saturating_sub(1), 0, 2, 2, 0xb0);
-    publish_many(relay0.port, &shard0_update).await;
-    let relay0_split_head = read_catalog(relay0.port, publisher.public_key(), now)
+    publish_many(relay0.publisher_port, &shard0_update).await;
+    let relay0_split_head = read_catalog(relay0.public_port, publisher.public_key(), now)
         .await
         .expect("relay0 split-view head remains independently valid");
-    let relay1_split_head = read_catalog(relay1.port, publisher.public_key(), now)
+    let relay1_split_head = read_catalog(relay1.public_port, publisher.public_key(), now)
         .await
         .expect("relay1 split-view head remains independently valid");
     assert_ne!(
@@ -222,41 +280,64 @@ async fn two_relay_real_process_catalog_e2e() {
         "the two independently verified catalog heads must conflict"
     );
     assert_eq!(
-        read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now).await,
+        read_consistent_catalog(
+            relay0.public_port,
+            relay1.public_port,
+            publisher.public_key(),
+            now,
+        )
+        .await,
         Err(DualRelayReadError::SplitView),
         "stale relay head must fail closed with the exact split-view error"
     );
-    publish_many(relay1.port, &shard0_update).await;
-    let converged = read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now)
-        .await
-        .expect("relays converge after the same signed update");
+    publish_many(relay1.publisher_port, &shard0_update).await;
+    let converged = read_consistent_catalog(
+        relay0.public_port,
+        relay1.public_port,
+        publisher.public_key(),
+        now,
+    )
+    .await
+    .expect("relays converge after the same signed update");
     assert_ne!(converged, baseline);
     assert_eq!(converged.0[0].directory_sequence, 2);
     assert_eq!(converged.0[0].checkpoint_epoch, 2);
 
     // One offline relay is not silently replaced by the other relay's view.
     process1.stop();
-    read_catalog(relay0.port, publisher.public_key(), now)
+    read_catalog(relay0.public_port, publisher.public_key(), now)
         .await
         .expect("relay0 remains independently readable");
-    let offline_error =
-        read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now)
-            .await
-            .expect_err("dual-relay policy must fail closed while one relay is offline");
+    let offline_error = read_consistent_catalog(
+        relay0.public_port,
+        relay1.public_port,
+        publisher.public_key(),
+        now,
+    )
+    .await
+    .expect_err("dual-relay policy must fail closed while one relay is offline");
     assert!(
         matches!(
             offline_error,
             DualRelayReadError::Relay1(reason)
-                if reason.starts_with(&format!("connect relay {} failed:", relay1.port))
+                if reason.starts_with(&format!(
+                    "connect relay {} failed:",
+                    relay1.public_port
+                ))
         ),
         "offline relay1 must be attributed to the relay1 transport boundary"
     );
 
     process1 = RelayProcess::spawn(root.path(), &relay1, 1);
     assert_eq!(
-        read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now)
-            .await
-            .expect("relay1 durable restart restores the catalog"),
+        read_consistent_catalog(
+            relay0.public_port,
+            relay1.public_port,
+            publisher.public_key(),
+            now,
+        )
+        .await
+        .expect("relay1 durable restart restores the catalog"),
         converged
     );
 
@@ -264,9 +345,14 @@ async fn two_relay_real_process_catalog_e2e() {
     process0 = RelayProcess::spawn(root.path(), &relay0, 1);
     assert_ne!(process0.id(), process1.id());
     assert_eq!(
-        read_consistent_catalog(relay0.port, relay1.port, publisher.public_key(), now)
-            .await
-            .expect("both durable stores survive independent process restart"),
+        read_consistent_catalog(
+            relay0.public_port,
+            relay1.public_port,
+            publisher.public_key(),
+            now,
+        )
+        .await
+        .expect("both durable stores survive independent process restart"),
         converged
     );
 }
@@ -274,7 +360,8 @@ async fn two_relay_real_process_catalog_e2e() {
 fn prepare_relay(
     root: &Path,
     label: &'static str,
-    port: u16,
+    public_port: u16,
+    publisher_port: u16,
     directory_pubkey: &[u8; 32],
 ) -> RelayMaterial {
     let directory = root.join(label);
@@ -284,13 +371,22 @@ fn prepare_relay(
     let database = directory.join("relay.sqlite3");
     let text = format!(
         r#"profile = "bitcoinpir-directory-relay-v1"
-listen = "127.0.0.1:{port}"
+public_listen = "127.0.0.1:{public_port}"
+publisher_listen = "127.0.0.1:{publisher_port}"
 database = "{}"
 directory_pubkey_hex = "{}"
 max_connections = 32
+max_public_connections = 24
+max_publisher_connections = 8
 max_in_flight_operations = 4
+max_public_in_flight_operations = 3
+max_publisher_in_flight_operations = 1
 max_operations_per_second = 1000000
+max_public_operations_per_second = 750000
+max_publisher_operations_per_second = 250000
 max_egress_bytes_per_second = 1073741824
+max_public_egress_bytes_per_second = 805306368
+max_publisher_egress_bytes_per_second = 268435456
 max_egress_bytes_per_connection = 67108864
 max_archive_events = 20000
 max_archive_bytes = 67108864
@@ -307,7 +403,8 @@ egress_timeout_seconds = 10
     chmod(&config, 0o600);
     RelayMaterial {
         label,
-        port,
+        public_port,
+        publisher_port,
         config,
         database,
     }
@@ -403,18 +500,36 @@ async fn receive_text(client: &mut RelayClient) -> Result<String, String> {
     }
 }
 
+fn event_message_text(event: &NostrEventV1) -> String {
+    String::from_utf8(
+        event
+            .to_event_message_json_bytes()
+            .expect("publish envelope"),
+    )
+    .expect("UTF-8 publish envelope")
+}
+
+async fn assert_wrong_lane_rejected(port: u16, message: String, label: &str) {
+    let mut client = relay_client(port)
+        .await
+        .unwrap_or_else(|error| panic!("connect {label} client failed: {error}"));
+    client
+        .send(Message::Text(message.into()))
+        .await
+        .unwrap_or_else(|error| panic!("send {label} message failed: {error}"));
+    let observed = tokio::time::timeout(IO_TIMEOUT, client.next())
+        .await
+        .unwrap_or_else(|_| panic!("{label} was not rejected before the I/O timeout"));
+    match observed {
+        None | Some(Err(_)) | Some(Ok(Message::Close(_))) => {}
+        Some(Ok(other)) => panic!("{label} produced an application response: {other:?}"),
+    }
+}
+
 async fn publish(port: u16, event: &NostrEventV1) -> (bool, String) {
     let mut client = relay_client(port).await.expect("connect publish client");
     client
-        .send(Message::Text(
-            String::from_utf8(
-                event
-                    .to_event_message_json_bytes()
-                    .expect("publish envelope"),
-            )
-            .expect("UTF-8 publish envelope")
-            .into(),
-        ))
+        .send(Message::Text(event_message_text(event).into()))
         .await
         .expect("send event");
     let response: Value = serde_json::from_str(
@@ -442,15 +557,7 @@ async fn publish_many(port: u16, events: &[NostrEventV1]) {
 async fn publish_without_reading_ack(port: u16, event: &NostrEventV1) {
     let mut client = relay_client(port).await.expect("connect lost-ACK client");
     client
-        .send(Message::Text(
-            String::from_utf8(
-                event
-                    .to_event_message_json_bytes()
-                    .expect("publish envelope"),
-            )
-            .expect("UTF-8 publish envelope")
-            .into(),
-        ))
+        .send(Message::Text(event_message_text(event).into()))
         .await
         .expect("send event before losing ACK");
     drop(client);

--- a/apps/directory-relay/tests/payment_v1_two_relay_process_e2e.rs
+++ b/apps/directory-relay/tests/payment_v1_two_relay_process_e2e.rs
@@ -217,17 +217,22 @@ async fn two_relay_real_process_catalog_e2e() {
     );
 
     let initial = signed_catalog(&publisher, now, now.saturating_sub(2), 1, 1);
+    let wrong_lane_sentinel =
+        signed_shard(&publisher, now, now.saturating_sub(3), 0, 99, 99, 0xe0)[0].clone();
 
     // The two sockets are protocol lanes, not interchangeable aliases. Wrong-
     // lane messages close without an acknowledgement so a public EVENT cannot
-    // contradict a durable private-lane commit and a publisher connection
-    // cannot be repurposed as a read channel.
+    // create either an acknowledgement or an archived record, and a publisher
+    // connection cannot be repurposed as a read channel. The sentinel is not
+    // reused by a later valid publish, so exact-ID absence proves rejection did
+    // not silently commit before closing the connection.
     assert_wrong_lane_rejected(
         relay0.public_port,
-        event_message_text(&initial[0]),
+        event_message_text(&wrong_lane_sentinel),
         "EVENT on public relay lane",
     )
     .await;
+    assert_event_id_absent(relay0.public_port, wrong_lane_sentinel.id()).await;
     assert_wrong_lane_rejected(
         relay0.publisher_port,
         serde_json::json!([
@@ -610,6 +615,40 @@ async fn wait_for_event_id(port: u16, event_id: &[u8; 32]) {
     );
 }
 
+async fn assert_event_id_absent(port: u16, event_id: &[u8; 32]) {
+    let mut client = relay_client(port)
+        .await
+        .expect("connect wrong-lane absence probe");
+    let subscription = "wrong-lane-absence";
+    let request = serde_json::json!([
+        "REQ",
+        subscription,
+        {"ids": [hex::encode(event_id)]}
+    ]);
+    client
+        .send(Message::Text(request.to_string().into()))
+        .await
+        .expect("send wrong-lane absence probe");
+    let response: Value = serde_json::from_str(
+        &receive_text(&mut client)
+            .await
+            .expect("receive wrong-lane absence probe"),
+    )
+    .expect("parse wrong-lane absence response");
+    match response[0]
+        .as_str()
+        .expect("wrong-lane absence response kind")
+    {
+        "EVENT" => panic!(
+            "public-lane EVENT was silently persisted: {}",
+            hex::encode(event_id)
+        ),
+        "EOSE" => assert_eq!(response[1], subscription, "absence EOSE subscription"),
+        other => panic!("unexpected wrong-lane absence response: {other}"),
+    }
+    let _ = client.send(Message::Close(None)).await;
+}
+
 async fn read_consistent_catalog(
     relay0_port: u16,
     relay1_port: u16,
@@ -710,7 +749,7 @@ async fn read_catalog(
         let (checkpoint_event_id, checkpoint_epoch, checkpoint_entries) =
             checkpoint.ok_or_else(|| format!("shard {shard} has no checkpoint head"))?;
         if checkpoint_entries.as_slice()
-            != &[DirectoryCheckpointEntryV1 {
+            != [DirectoryCheckpointEntryV1 {
                 provider_id,
                 directory_sequence,
                 event_id: entry_event_id,

--- a/apps/server/tests/payment_v1_process_e2e.rs
+++ b/apps/server/tests/payment_v1_process_e2e.rs
@@ -1,11 +1,12 @@
 //! Loopback-only Payment V1 process/wire integration test.
 //!
-//! This test deliberately uses a tiny, manifest-bound DPF database and public
-//! deterministic test keys. It starts two independent `unified_server`
+//! This test deliberately uses a tiny, manifest-bound DPF/Harmony database and
+//! public deterministic test keys. It starts two independent `unified_server`
 //! processes and exercises the real WebSocket, attestation-bound secure
-//! channel, signed policy, direct-receipt authorization, backend gate, and
-//! durable replay boundary. It never starts an issuer, contacts a Lightning
-//! node/mint/relay, or moves funds.
+//! channel, signed per-workload policy and keys, direct-receipt authorization,
+//! DPF and four-frame K-padded Harmony query handlers, backend gate, and durable
+//! replay boundary. It never starts an issuer or hint server, contacts a
+//! Lightning node/mint/relay, or moves funds.
 //!
 //! On ordinary CI hosts this deliberately observes `NoSevHost` and uses the
 //! SDK's `dangerous_unpaired_*` helpers. That covers the local wire and gate
@@ -19,7 +20,9 @@ use libdpf::Dpf;
 use pir_core::cuckoo::write_header_with_anchor;
 use pir_core::merkle::sha256;
 use pir_core::params::{CHUNK_PARAMS, INDEX_PARAMS};
-use pir_runtime_core::protocol::{BatchQuery, Request, Response};
+use pir_runtime_core::protocol::{
+    BatchQuery, HarmonyBatchItem, HarmonyBatchQuery, Request, Response,
+};
 use pir_sdk_client::attest::{attest_with_eph_binding, SevStatus};
 use pir_sdk_client::channel::{establish, SecureChannelTransport};
 use pir_sdk_client::{
@@ -45,7 +48,8 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-const OFFER_ID: u32 = 2;
+const DPF_OFFER_ID: u32 = 2;
+const HARMONY_OFFER_ID: u32 = 3;
 const OPERATION_PROFILE: u16 = 11;
 const ENTITLEMENT_PROFILE: u16 = 101;
 const TINY_BINS_PER_TABLE: usize = 128;
@@ -56,31 +60,40 @@ struct ProviderFixture {
     index: u8,
     provider_id: [u8; 32],
     policy_signing_key: SigningKey,
-    receipt_signing_key: SigningKey,
+    dpf_receipt_signing_key: SigningKey,
+    harmony_receipt_signing_key: SigningKey,
     issuer_id: [u8; 32],
     policy_path: PathBuf,
     store_path: PathBuf,
     rollback_path: PathBuf,
-    scope_id: [u8; 32],
+    dpf_scope_id: [u8; 32],
+    harmony_scope_id: [u8; 32],
     policy_digest: [u8; 32],
     issued_at: u64,
     receipt_not_after: u64,
 }
 
 impl ProviderFixture {
-    fn receipt(&self, serial_byte: u8) -> PaidReceiptV1 {
+    fn receipt(&self, scope_id: [u8; 32], offer_id: u32, serial_byte: u8) -> PaidReceiptV1 {
+        let receipt_signing_key = if scope_id == self.dpf_scope_id {
+            &self.dpf_receipt_signing_key
+        } else if scope_id == self.harmony_scope_id {
+            &self.harmony_receipt_signing_key
+        } else {
+            panic!("receipt fixture requested for an unknown scope")
+        };
         PaidReceiptV1::sign(
             self.issuer_id,
             [serial_byte; 32],
             PaidReceiptBindingV1 {
-                scope_id: self.scope_id,
-                offer_id: OFFER_ID,
+                scope_id,
+                offer_id,
                 policy_digest: self.policy_digest,
                 entitlement_profile: ENTITLEMENT_PROFILE,
             },
             self.issued_at,
             self.receipt_not_after,
-            &self.receipt_signing_key,
+            receipt_signing_key,
         )
         .expect("deterministic receipt fixture must be valid")
     }
@@ -224,8 +237,16 @@ async fn two_independent_providers_enforce_secure_paid_capabilities_over_real_so
     );
     assert_ne!(provider0.issuer_id, provider1.issuer_id);
     assert_ne!(
-        paid_receipt_key_id(&provider0.receipt_signing_key.verifying_key()),
-        paid_receipt_key_id(&provider1.receipt_signing_key.verifying_key())
+        paid_receipt_key_id(&provider0.dpf_receipt_signing_key.verifying_key()),
+        paid_receipt_key_id(&provider1.dpf_receipt_signing_key.verifying_key())
+    );
+    assert_ne!(
+        paid_receipt_key_id(&provider0.harmony_receipt_signing_key.verifying_key()),
+        paid_receipt_key_id(&provider1.harmony_receipt_signing_key.verifying_key())
+    );
+    assert_ne!(
+        paid_receipt_key_id(&provider0.dpf_receipt_signing_key.verifying_key()),
+        paid_receipt_key_id(&provider0.harmony_receipt_signing_key.verifying_key())
     );
     assert_ne!(provider0.store_path, provider1.store_path);
 
@@ -242,19 +263,19 @@ async fn two_independent_providers_enforce_secure_paid_capabilities_over_real_so
     // a real server rejection, not a client-side pair simulation.
     let (mut wrong_target, accepted0) =
         open_verified_session(port0, &provider0, manifest_root, &request).await;
-    let provider1_receipt = provider1.receipt(0x71);
+    let provider1_receipt = provider1.receipt(provider1.dpf_scope_id, DPF_OFFER_ID, 0x71);
     let wrong_proof = dangerous_unpaired_build_authorization_proof_v1(
         &accepted0,
-        &provider0.scope_id,
-        OFFER_ID,
+        &provider0.dpf_scope_id,
+        DPF_OFFER_ID,
         &provider1_receipt.encode().unwrap(),
     )
     .unwrap();
     let error = dangerous_unpaired_authorize_service_operation_v1(
         &mut wrong_target,
         &accepted0,
-        provider0.scope_id,
-        OFFER_ID,
+        provider0.dpf_scope_id,
+        DPF_OFFER_ID,
         OperationStartV1::DpfQuery { db_id: 0 },
         wrong_proof,
     )
@@ -277,8 +298,69 @@ async fn two_independent_providers_enforce_secure_paid_capabilities_over_real_so
 
     // Provider 0 independently accepts only its own capability, then lets
     // exactly one bounded backend frame reach the real DPF handler.
-    let receipt0 = provider0.receipt(0x80);
+    let receipt0 = provider0.receipt(provider0.dpf_scope_id, DPF_OFFER_ID, 0x80);
     exercise_paid_grant(port0, &provider0, manifest_root, &request, &receipt0).await;
+
+    let harmony_requests = valid_tiny_harmony_query_requests();
+
+    // Entitlements are backend/workload-specific. A fresh DPF receipt cannot
+    // authorize a Harmony query scope, and the rejected mismatch must not burn
+    // the receipt at its intended DPF scope.
+    let dpf_only_receipt = provider0.receipt(provider0.dpf_scope_id, DPF_OFFER_ID, 0x81);
+    let (mut wrong_scope, wrong_scope_policy) =
+        open_verified_session(port0, &provider0, manifest_root, &harmony_requests[0]).await;
+    let wrong_scope_proof = dangerous_unpaired_build_authorization_proof_v1(
+        &wrong_scope_policy,
+        &provider0.harmony_scope_id,
+        HARMONY_OFFER_ID,
+        &dpf_only_receipt.encode().unwrap(),
+    )
+    .unwrap();
+    let wrong_scope_error = dangerous_unpaired_authorize_service_operation_v1(
+        &mut wrong_scope,
+        &wrong_scope_policy,
+        provider0.harmony_scope_id,
+        HARMONY_OFFER_ID,
+        OperationStartV1::HarmonyQuery { db_id: 0 },
+        wrong_scope_proof,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        wrong_scope_error.to_string().contains("invalid-or-spent"),
+        "{wrong_scope_error}"
+    );
+    wrong_scope.close().await.unwrap();
+    exercise_paid_grant(
+        port0,
+        &provider0,
+        manifest_root,
+        &request,
+        &dpf_only_receipt,
+    )
+    .await;
+
+    // Each provider independently prices and spends its Harmony query scope.
+    // The four accepted frames execute real INDEX/CHUNK K-padded queries in
+    // the production process without configuring or naming any hint server.
+    let harmony_receipt0 = provider0.receipt(provider0.harmony_scope_id, HARMONY_OFFER_ID, 0x90);
+    let harmony_receipt1 = provider1.receipt(provider1.harmony_scope_id, HARMONY_OFFER_ID, 0x91);
+    exercise_harmony_query_grant(
+        port0,
+        &provider0,
+        manifest_root,
+        &harmony_requests,
+        &harmony_receipt0,
+    )
+    .await;
+    exercise_harmony_query_grant(
+        port1,
+        &provider1,
+        manifest_root,
+        &harmony_requests,
+        &harmony_receipt1,
+    )
+    .await;
 
     // Stop and restart provider 0 against the same SQLite domain. Its durable
     // store must reject the same receipt on a fresh process and secure session.
@@ -289,16 +371,16 @@ async fn two_independent_providers_enforce_secure_paid_capabilities_over_real_so
         open_verified_session(port0, &provider0, manifest_root, &request).await;
     let replay_proof = dangerous_unpaired_build_authorization_proof_v1(
         &replay_policy,
-        &provider0.scope_id,
-        OFFER_ID,
+        &provider0.dpf_scope_id,
+        DPF_OFFER_ID,
         &receipt0.encode().unwrap(),
     )
     .unwrap();
     let replay = dangerous_unpaired_authorize_service_operation_v1(
         &mut replay_session,
         &replay_policy,
-        provider0.scope_id,
-        OFFER_ID,
+        provider0.dpf_scope_id,
+        DPF_OFFER_ID,
         OperationStartV1::DpfQuery { db_id: 0 },
         replay_proof,
     )
@@ -306,6 +388,31 @@ async fn two_independent_providers_enforce_secure_paid_capabilities_over_real_so
     .unwrap_err();
     assert!(replay.to_string().contains("invalid-or-spent"), "{replay}");
     replay_session.close().await.unwrap();
+
+    let (mut harmony_replay_session, harmony_replay_policy) =
+        open_verified_session(port0, &provider0, manifest_root, &harmony_requests[0]).await;
+    let harmony_replay_proof = dangerous_unpaired_build_authorization_proof_v1(
+        &harmony_replay_policy,
+        &provider0.harmony_scope_id,
+        HARMONY_OFFER_ID,
+        &harmony_receipt0.encode().unwrap(),
+    )
+    .unwrap();
+    let harmony_replay = dangerous_unpaired_authorize_service_operation_v1(
+        &mut harmony_replay_session,
+        &harmony_replay_policy,
+        provider0.harmony_scope_id,
+        HARMONY_OFFER_ID,
+        OperationStartV1::HarmonyQuery { db_id: 0 },
+        harmony_replay_proof,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        harmony_replay.to_string().contains("invalid-or-spent"),
+        "{harmony_replay}"
+    );
+    harmony_replay_session.close().await.unwrap();
 
     let (stdout0, stderr0) = server0.stop();
     let (stdout1, stderr1) = server1.stop();
@@ -373,22 +480,22 @@ async fn exercise_paid_grant(
     let (mut secure, accepted) = open_verified_session(port, fixture, manifest_root, request).await;
     let proof = dangerous_unpaired_build_authorization_proof_v1(
         &accepted,
-        &fixture.scope_id,
-        OFFER_ID,
+        &fixture.dpf_scope_id,
+        DPF_OFFER_ID,
         &receipt.encode().unwrap(),
     )
     .unwrap();
     let grant = dangerous_unpaired_authorize_service_operation_v1(
         &mut secure,
         &accepted,
-        fixture.scope_id,
-        OFFER_ID,
+        fixture.dpf_scope_id,
+        DPF_OFFER_ID,
         OperationStartV1::DpfQuery { db_id: 0 },
         proof,
     )
     .await
     .expect("provider-specific direct receipt must authorize");
-    assert_eq!(grant.scope_id, fixture.scope_id);
+    assert_eq!(grant.scope_id, fixture.dpf_scope_id);
     assert_eq!(grant.enforced_profile, ENTITLEMENT_PROFILE);
 
     let response = secure.roundtrip(request).await.unwrap();
@@ -406,6 +513,78 @@ async fn exercise_paid_grant(
     expect_error_response(
         &secure.roundtrip(request).await.unwrap(),
         "service entitlement limit exceeded",
+    );
+    secure.close().await.unwrap();
+}
+
+async fn exercise_harmony_query_grant(
+    port: u16,
+    fixture: &ProviderFixture,
+    manifest_root: [u8; 32],
+    requests: &[Vec<u8>],
+    receipt: &PaidReceiptV1,
+) {
+    assert_eq!(requests.len(), 4);
+    let (mut secure, accepted) =
+        open_verified_session(port, fixture, manifest_root, &requests[0]).await;
+    let proof = dangerous_unpaired_build_authorization_proof_v1(
+        &accepted,
+        &fixture.harmony_scope_id,
+        HARMONY_OFFER_ID,
+        &receipt.encode().unwrap(),
+    )
+    .unwrap();
+    let grant = dangerous_unpaired_authorize_service_operation_v1(
+        &mut secure,
+        &accepted,
+        fixture.harmony_scope_id,
+        HARMONY_OFFER_ID,
+        OperationStartV1::HarmonyQuery { db_id: 0 },
+        proof,
+    )
+    .await
+    .expect("provider-specific Harmony receipt must authorize");
+    assert_eq!(grant.scope_id, fixture.harmony_scope_id);
+    assert_eq!(grant.enforced_profile, ENTITLEMENT_PROFILE);
+
+    for (request, (expected_level, expected_round)) in
+        requests.iter().zip([(0u8, 0u16), (0, 1), (1, 0), (1, 1)])
+    {
+        let response = secure.roundtrip(request).await.unwrap();
+        match Response::decode(&response).unwrap() {
+            Response::HarmonyBatchResult(result) => {
+                assert_eq!(result.level, expected_level);
+                assert_eq!(result.round_id, expected_round);
+                assert_eq!(result.sub_results_per_group, 1);
+                let expected_groups = if expected_level == 0 {
+                    INDEX_PARAMS.k
+                } else {
+                    CHUNK_PARAMS.k
+                };
+                let expected_bin_size = if expected_level == 0 {
+                    INDEX_PARAMS.bin_size()
+                } else {
+                    CHUNK_PARAMS.bin_size()
+                };
+                assert_eq!(result.items.len(), expected_groups);
+                for (group, item) in result.items.iter().enumerate() {
+                    assert_eq!(usize::from(item.group_id), group);
+                    assert_eq!(item.sub_results.len(), 1);
+                    assert_eq!(item.sub_results[0].len(), expected_bin_size);
+                    assert!(item.sub_results[0].iter().all(|byte| *byte == 0));
+                }
+            }
+            other => panic!("authorized Harmony frame did not reach handler: {other:?}"),
+        }
+    }
+
+    // The price applies to one signed four-frame query job. The completed DFA
+    // is terminal: a second job cannot reopen or extend the consumed grant,
+    // even though the first repeated frame would fit an individual frame
+    // shape.
+    expect_error_response(
+        &secure.roundtrip(&requests[0]).await.unwrap(),
+        "backend frame violates the operation sequence",
     );
     secure.close().await.unwrap();
 }
@@ -504,14 +683,15 @@ fn build_provider(root: &Path, index: u8, manifest_root: [u8; 32], now: u64) -> 
     let operator_key = SigningKey::from_bytes(&[0x10u8.wrapping_add(index); 32]);
     let policy_signing_key = SigningKey::from_bytes(&[0x20u8.wrapping_add(index); 32]);
     let issuer_root_key = SigningKey::from_bytes(&[0x30u8.wrapping_add(index); 32]);
-    let receipt_signing_key = SigningKey::from_bytes(&[0x40u8.wrapping_add(index); 32]);
+    let dpf_receipt_signing_key = SigningKey::from_bytes(&[0x40u8.wrapping_add(index); 32]);
+    let harmony_receipt_signing_key = SigningKey::from_bytes(&[0x60u8.wrapping_add(index); 32]);
     let stable_server_id = format!("payment-v1-process-provider-{index}");
     let provider_id =
         derive_provider_id(&operator_key.verifying_key().to_bytes(), &stable_server_id);
     let issued_at = now.saturating_sub(60);
     let expires_at = now.checked_add(3_600).unwrap();
     let receipt_not_after = now.checked_add(600).unwrap();
-    let scope = ServiceScopeV1 {
+    let dpf_scope = ServiceScopeV1 {
         provider_id,
         backend: BackendId::DpfPirV1,
         workload: WorkloadId::DpfEvaluateJobV1,
@@ -522,30 +702,61 @@ fn build_provider(root: &Path, index: u8, manifest_root: [u8; 32], now: u64) -> 
         operation_profile: OPERATION_PROFILE,
         entitlement_profile: ENTITLEMENT_PROFILE,
     };
-    let scope_id = scope.scope_id();
-    let receipt_key_id = paid_receipt_key_id(&receipt_signing_key.verifying_key()).to_vec();
-    let retired_policy_grace_seconds = 1_800;
-    let binding = CredentialKeyBindingV1::sign(
-        CredentialKeyBindingClaimsV1 {
-            provider_id,
-            scope_id,
-            offer_id: OFFER_ID,
-            scheme: AuthScheme::Bolt11DirectReceiptV1,
-            keyset_epoch: 1,
-            entitlement_profile: ENTITLEMENT_PROFILE,
-            unit: CredentialUnitV1::Entitlement,
-            amount: 1,
-            presentation_limit: 1,
-            not_before: issued_at.saturating_sub(60),
-            not_after: expires_at + u64::from(retired_policy_grace_seconds),
-            credential_key_id: receipt_key_id.clone(),
-            verification_key: receipt_signing_key.verifying_key().to_bytes().to_vec(),
+    let harmony_scope = ServiceScopeV1 {
+        provider_id,
+        backend: BackendId::HarmonyPirV2,
+        workload: WorkloadId::HarmonyQueryJobV1,
+        protocol_version: 2,
+        dataset: DatasetBindingV1::ManifestRoot {
+            root: manifest_root,
         },
-        &issuer_root_key,
-    )
-    .unwrap();
-    let offer = ServiceOfferV1 {
-        offer_id: OFFER_ID,
+        operation_profile: OPERATION_PROFILE,
+        entitlement_profile: ENTITLEMENT_PROFILE,
+    };
+    let dpf_scope_id = dpf_scope.scope_id();
+    let harmony_scope_id = harmony_scope.scope_id();
+    let dpf_receipt_key_id = paid_receipt_key_id(&dpf_receipt_signing_key.verifying_key()).to_vec();
+    let harmony_receipt_key_id =
+        paid_receipt_key_id(&harmony_receipt_signing_key.verifying_key()).to_vec();
+    let retired_policy_grace_seconds = 1_800;
+    let make_binding =
+        |scope_id, offer_id, receipt_signing_key: &SigningKey, receipt_key_id: &[u8]| {
+            CredentialKeyBindingV1::sign(
+                CredentialKeyBindingClaimsV1 {
+                    provider_id,
+                    scope_id,
+                    offer_id,
+                    scheme: AuthScheme::Bolt11DirectReceiptV1,
+                    keyset_epoch: 1,
+                    entitlement_profile: ENTITLEMENT_PROFILE,
+                    unit: CredentialUnitV1::Entitlement,
+                    amount: 1,
+                    presentation_limit: 1,
+                    not_before: issued_at.saturating_sub(60),
+                    not_after: expires_at + u64::from(retired_policy_grace_seconds),
+                    credential_key_id: receipt_key_id.to_vec(),
+                    verification_key: receipt_signing_key.verifying_key().to_bytes().to_vec(),
+                },
+                &issuer_root_key,
+            )
+            .unwrap()
+        };
+    let dpf_binding = make_binding(
+        dpf_scope_id,
+        DPF_OFFER_ID,
+        &dpf_receipt_signing_key,
+        &dpf_receipt_key_id,
+    );
+    let harmony_binding = make_binding(
+        harmony_scope_id,
+        HARMONY_OFFER_ID,
+        &harmony_receipt_signing_key,
+        &harmony_receipt_key_id,
+    );
+    let issuer_id = dpf_binding.issuer_id;
+    assert_eq!(issuer_id, harmony_binding.issuer_id);
+    let make_offer = |offer_id, key_id: Vec<u8>, binding: CredentialKeyBindingV1| ServiceOfferV1 {
+        offer_id,
         acquisition: AcquisitionMethod::Bolt11V1,
         free_mode: FreeModeV1::NotFree,
         free_quota: 0,
@@ -557,8 +768,8 @@ fn build_provider(root: &Path, index: u8, manifest_root: [u8; 32], now: u64) -> 
         deployment_status: DeploymentStatus::Stable,
         price: PriceV1::MilliSatoshi(1_000),
         issuer_id: binding.issuer_id,
-        key_id: receipt_key_id,
-        credential_binding: Some(binding.clone()),
+        key_id,
+        credential_binding: Some(binding),
         cashu_mint_manifest: None,
         endpoint: format!("https://issuer-{index}.fixture.invalid"),
         invoice_expiry_seconds: 600,
@@ -576,20 +787,40 @@ fn build_provider(root: &Path, index: u8, manifest_root: [u8; 32], now: u64) -> 
         issued_at,
         expires_at,
         AuthPaddingClassV1::Class16KiB,
-        vec![ServiceScopePolicyV1 {
-            scope,
-            limits: EntitlementLimitsV1 {
-                max_logical_inputs: 1,
-                max_frames: 1,
-                max_request_bytes: 16 * 1024,
-                max_response_bytes: 4 * 1024,
-                max_wall_time_ms: 10_000,
-                max_concurrent_sockets: 1,
-                max_hint_groups: 0,
-                max_work_units: 2,
+        vec![
+            ServiceScopePolicyV1 {
+                scope: dpf_scope,
+                limits: EntitlementLimitsV1 {
+                    max_logical_inputs: 1,
+                    max_frames: 1,
+                    max_request_bytes: 16 * 1024,
+                    max_response_bytes: 4 * 1024,
+                    max_wall_time_ms: 10_000,
+                    max_concurrent_sockets: 1,
+                    max_hint_groups: 0,
+                    max_work_units: 2,
+                },
+                offers: vec![make_offer(DPF_OFFER_ID, dpf_receipt_key_id, dpf_binding)],
             },
-            offers: vec![offer],
-        }],
+            ServiceScopePolicyV1 {
+                scope: harmony_scope,
+                limits: EntitlementLimitsV1 {
+                    max_logical_inputs: 1,
+                    max_frames: 4,
+                    max_request_bytes: 64 * 1024,
+                    max_response_bytes: 64 * 1024,
+                    max_wall_time_ms: 10_000,
+                    max_concurrent_sockets: 1,
+                    max_hint_groups: 0,
+                    max_work_units: 320,
+                },
+                offers: vec![make_offer(
+                    HARMONY_OFFER_ID,
+                    harmony_receipt_key_id,
+                    harmony_binding,
+                )],
+            },
+        ],
         &policy_signing_key,
     )
     .unwrap();
@@ -620,12 +851,14 @@ fn build_provider(root: &Path, index: u8, manifest_root: [u8; 32], now: u64) -> 
         index,
         provider_id,
         policy_signing_key,
-        receipt_signing_key,
-        issuer_id: binding.issuer_id,
+        dpf_receipt_signing_key,
+        harmony_receipt_signing_key,
+        issuer_id,
         policy_path,
         store_path,
         rollback_path,
-        scope_id,
+        dpf_scope_id,
+        harmony_scope_id,
         policy_digest,
         issued_at,
         receipt_not_after,
@@ -674,6 +907,33 @@ fn valid_tiny_dpf_request() -> Vec<u8> {
         keys: vec![vec![key0.to_bytes(), key1.to_bytes()]],
     })
     .encode()
+}
+
+fn valid_tiny_harmony_query_requests() -> Vec<Vec<u8>> {
+    [(0u8, 0u16), (0, 1), (1, 0), (1, 1)]
+        .into_iter()
+        .map(|(level, round_id)| {
+            let group_count = if level == 0 {
+                INDEX_PARAMS.k
+            } else {
+                CHUNK_PARAMS.k
+            };
+            let items = (0..group_count)
+                .map(|group_id| HarmonyBatchItem {
+                    group_id: u8::try_from(group_id).expect("fixture K fits u8"),
+                    sub_queries: vec![vec![0]],
+                })
+                .collect();
+            Request::HarmonyBatchQuery(HarmonyBatchQuery {
+                level,
+                round_id,
+                sub_queries_per_group: 1,
+                items,
+                db_id: 0,
+            })
+            .encode()
+        })
+        .collect()
 }
 
 fn expect_error_response(response: &[u8], needle: &str) {

--- a/deploy/payment-v1/README.md
+++ b/deploy/payment-v1/README.md
@@ -31,7 +31,8 @@ The templates divide responsibilities as follows:
   exact CLN unit, RPC guard, and successful live preflight, and it never runs a
   fake settlement backend. The issuer has no native CLN or Bitcoin-cookie
   group and `/srv/lightning` plus `/srv/bitcoin` are inaccessible in its mount
-  namespace. The public edge exposes only credential redemption and
+  namespace; the source-fair socket namespace is inaccessible as well. The
+  public edge exposes only credential redemption and
   authenticated provider-balance lookup; payout-intent, payout and
   payout-status routes are not part of the V1 production product. Its command
   has no payout target, fee, or intent-TTL argument; the source gate rejects
@@ -39,12 +40,34 @@ The templates divide responsibilities as follows:
 - `systemd/rollback-authority.service.in` is instantiated only on a separately
   administered authority host. Provider 0, Provider 1, and the issuer each need
   their own host, keys, database, TLS edge, administrator, logs, and backup
-  domain.
+  domain. Its `edge-rollback-authority-v1` profile binds Caddy only to one
+  RFC1918/ULA address, admits only the sole client's exact private IP at the
+  systemd network boundary, uses a static TLS certificate compatible with the
+  existing strict SPKI-pinned client, and requires a separate private-ingress
+  sentinel. It does not pretend that server-only mTLS is deployable before the
+  client also has reviewed certificate/key support.
 - `systemd/hetzner-directory-relay.service.in` is deliberately blocked while
   `relay-selection.toml.example` is `UNRESOLVED`. It is a deployment contract
   for the repository's directory-only relay, not a generic Nostr relay unit.
   A future resolved service may pass only one absolute owner-only TOML path via
   `--config`; direct command-line overrides remain forbidden.
+- `systemd/payment-v1-source-fair-edge.service.in` runs pinned HAProxy 2.8
+  without a StateDirectory, logs, peers, stats, or persisted source state. It
+  owns a volatile `0750` runtime directory and four `0660` PROXY-v2 Unix
+  sockets. Provider, issuer, public directory, and private publisher lanes have
+  independent short-lived source tables and budgets.
+- `systemd/payment-v1-public-edge.service.in` runs pinned stock Caddy and binds
+  its lifecycle to the source-fair unit. It clears client headers, carries the
+  source only in PROXY v2 over those Unix sockets, and has no source-header
+  fallback. Both edge units send stdout/stderr to `null`, disable core limits
+  and swap for the service cgroups, and rendered/live evidence rejects
+  journal/core/swap drift. The publisher hostname binds a
+  distinct private address; Caddy and HAProxy both require the publisher's
+  exact WireGuard/private-route source IP, while a WebPKI server certificate
+  keeps the existing credential-free `bpir-admin` WSS client compatible. The
+  Nostr signature and pinned directory key remain the publication authority.
+  Both units require a separate publisher-private-ingress sentinel. Rollback
+  authorities do not use this public HAProxy.
 - `vpsbg/vpsbg-free-pow-service-auth.args.in` is the only VPSBG change described
   by this directory. It lists the enforced Payment V1 arguments that a reviewed
   UKI rebuild would append to the existing query-only provider's final exec. It
@@ -74,6 +97,9 @@ Run the repository gate before reviewing a rendered deployment:
 ```sh
 node scripts/payment-v1-deployment-template-gate.mjs
 node --test scripts/payment-v1-deployment-template-gate.test.mjs
+BPIR_HAPROXY_BIN=/absolute/pinned/haproxy \
+BPIR_CADDY_BIN=/absolute/pinned/caddy \
+  node --test scripts/payment-v1-source-fair-edge.test.mjs
 ```
 
 The gate also pins hashes of the pre-existing active systemd units and the
@@ -87,8 +113,24 @@ artifact/hash manifest, and reject placeholders, extra files, symlinks and
 cross-profile dependencies. Then use
 `scripts/payment-v1-linux-runtime-evidence.mjs` as root on the exact Linux host
 to bind effective systemd state, running process identities, NSS, ACLs, xattrs,
-capabilities, boot and host identity to that manifest. Offline review without
-the externally transferred full evidence digest is not activation evidence.
+capabilities, boot and host identity to that manifest. The Hetzner edge request
+also binds the live runtime directory and all four socket types, owners, groups,
+and modes. Edge live evidence additionally requires hard/soft core limits of
+zero, zero current/max cgroup swap, and the host-wide
+`kernel.core_pattern=|/usr/bin/false`; the collector also hashes and validates
+that exact root-owned, canonical, one-link, non-writable handler.
+`LimitCORE=0` alone is not sufficient when a
+kernel pipe handler ignores the resource limit. Offline review without the externally transferred full evidence
+digest is not activation evidence. HAProxy admission begins only after Caddy
+has accepted TCP/TLS and parsed HTTP; it does not replace independent
+Caddy-front slowloris, header, file-descriptor, memory, task, firewall, or
+volumetric limits.
+
+The exact production HAProxy must be a currently maintained 2.8.x build whose
+`haproxy -vv` feature list contains `+SYSTEMD`; the unit uses `Type=notify` and
+`-Ws`. CI's distribution package is only a compatibility baseline, not the
+production binary pin. The exact pinned bytes must pass the suite without any
+binary-dependent skip.
 
 See `docs/payment/HETZNER_VPSBG_DEPLOYMENT.md` for topology, rendering,
 activation, rollback, and remote-approval boundaries.

--- a/deploy/payment-v1/README.md
+++ b/deploy/payment-v1/README.md
@@ -126,6 +126,40 @@ has accepted TCP/TLS and parsed HTTP; it does not replace independent
 Caddy-front slowloris, header, file-descriptor, memory, task, firewall, or
 volumetric limits.
 
+The public edge has a mandatory two-evidence cold-start ceremony. While Caddy
+and HAProxy are inactive/dead and every Unix listener is absent, run
+`collect-stopped-edge`. It proves the manifest-bound service accounts are
+password-locked and login-disabled, no process/thread retains a protected
+UID/GID, no non-root thread retains CAP_SETUID/CAP_SETGID, and the stopped unit
+and socket-absence snapshots remain stable around both procfs passes. Only then
+start HAProxy followed by Caddy and run `collect-live` against the new
+generation. Neither command permits caller-authored evidence or challenge
+material; offline verification requires the complete independently transferred
+evidence digest. A warm reload is not an accepted replacement.
+
+Runtime-evidence v2 accepts only a local-files NSS authority (`passwd: files`,
+`group: files`, and no explicit `initgroups:` line). It snapshots the canonical
+root-owned `/etc/nsswitch.conf`, `/etc/passwd`, and `/etc/group` around NSS
+enumeration and confirms the same files again at the end of live collection,
+requires `getent` identity and membership projections to match those files, and
+checks `id -G` for every enumerated user. In live evidence, password, GECOS,
+home, shell and group-password fields are snapshot-bound but are not semantic
+identity comparisons; stopped-edge evidence additionally requires each service
+account's shell and locked shadow-password state described above.
+SSSD, LDAP, winbind, NIS and `systemd` UserDB are outside this
+V1 proof profile. The collector is trusted-root operational evidence rather
+than attestation: independently pin the exact collector script from the frozen
+commit before running it; the evidence-file digest alone does not prove an
+honest collector.
+
+The same evidence performs two bounded scans of every numeric Linux process
+and thread and rejects a non-root CAP_SETUID/CAP_SETGID holder. A retained
+protected service UID or GID is accepted only
+inside that service's exact current systemd cgroup with the full expected
+credential set; every long-running MainPID and the final unit generation are
+reconfirmed. This closes stale kernel credentials that a later `/etc/group`
+edit would not revoke.
+
 The exact production HAProxy must be a currently maintained 2.8.x build whose
 `haproxy -vv` feature list contains `+SYSTEMD`; the unit uses `Type=notify` and
 `-Ws`. CI's distribution package is only a compatibility baseline, not the

--- a/deploy/payment-v1/directory-relay.toml.example
+++ b/deploy/payment-v1/directory-relay.toml.example
@@ -4,19 +4,28 @@
 # or 0600 below /etc/bitcoinpir/payment-v1/directory-relay.
 
 profile = "bitcoinpir-directory-relay-v1"
-listen = "127.0.0.1:8080"
+public_listen = "127.0.0.1:8080"
+publisher_listen = "127.0.0.1:8081"
 database = "/var/lib/bitcoinpir-directory-relay/relay.sqlite3"
 directory_pubkey_hex = "@DIRECTORY_PUBLISHER_PUBKEY_HEX@"
 
 # These are relay abuse/capacity limits, not commercial policy. The cumulative
 # connection budget intentionally does not permit count and event-size maxima
-# to be saturated simultaneously. The supplied stock-Caddy edge is not
-# source-aware; a reviewed non-persistent source-fair boundary remains an
-# activation prerequisite.
-max_connections = 64
+# to be saturated simultaneously. Public reads and private signed writes have
+# exact reservations whose sums equal every global cap, so neither lane can
+# occupy the other's connection, operation, rate, or egress allocation.
+max_connections = 52
+max_public_connections = 48
+max_publisher_connections = 4
 max_in_flight_operations = 8
+max_public_in_flight_operations = 6
+max_publisher_in_flight_operations = 2
 max_operations_per_second = 64
+max_public_operations_per_second = 48
+max_publisher_operations_per_second = 16
 max_egress_bytes_per_second = 16777216
+max_public_egress_bytes_per_second = 12582912
+max_publisher_egress_bytes_per_second = 4194304
 max_egress_bytes_per_connection = 67108864
 
 # max_archive_bytes counts immutable event_json BLOB bytes, not SQLite/WAL/index

--- a/deploy/payment-v1/edge/README.md
+++ b/deploy/payment-v1/edge/README.md
@@ -27,6 +27,69 @@ the current directory/socket type, UID, GID, and mode twice around live unit
 collection. A world-writable socket, extra group member, symlink, stale socket,
 wrong owner, or changed path fails closed.
 
+Payment V1 does not claim that arbitrary NSS backends can be completely
+enumerated. Activation requires this local authority profile, with no explicit
+`initgroups:` database:
+
+```text
+passwd: files
+group: files
+```
+
+The v2 live collector takes stable, root-owned, one-link, non-writable snapshots
+without special mode bits of `/etc/nsswitch.conf`, `/etc/passwd`, and `/etc/group`
+before and after NSS enumeration, then confirms the same snapshot again after
+the remaining live checks. It requires the identity-relevant
+name/UID/primary-GID and name/GID/member projections from `getent passwd/group`
+to equal those exact local files, then runs `id -G` for every enumerated account
+on a monotonic bounded deadline.
+Duplicate UID/GID aliases, extra primary-GID holders, extra explicit or effective
+members, inconsistent reverse membership, change during collection, timeout, or
+record/byte overflow fails closed. `systemd`, SSSD, LDAP, winbind, NIS and other
+lookup-only or remotely cached identity sources are not accepted by this V1
+profile; supporting them requires their own authoritative complete-enumeration
+and generation proof.
+
+Static NSS membership is not enough because a process can retain an old UID or
+supplementary GID after the files change. The collector therefore performs two
+bounded full `/proc/<pid>/task/<tid>` credential passes. Every non-root thread
+must also lack CAP_SETUID and CAP_SETGID in its inheritable, permitted,
+effective and ambient sets. Every thread
+holding a protected UID or GID must have the exact reviewed UID/GID/group set
+and belong to the current exact `/system.slice/<unit>.service` cgroup. This
+admits HAProxy master/worker processes in the same unit while rejecting stale
+processes outside it. Every long-running MainPID must appear in both passes,
+whose holder records must be byte-identical; a final systemd generation check
+then rebinds MainPID, InvocationID and ControlGroup.
+
+This is a credential-holder closure, not proof that no process inherited an
+already-connected Unix socket file descriptor through `SCM_RIGHTS`. Activation
+must therefore start from a dead connection graph. With both units fully
+stopped, run `collect-stopped-edge`: it requires every unit to be
+inactive/dead with MainPID 0, an empty ControlGroup, no drop-ins, and no
+runtime socket path; requires every manifest-bound service account to use
+`/usr/sbin/nologin` or `/bin/false` and a locked `/etc/shadow` password; and
+requires two host-wide procfs passes with no protected UID/GID holder and no
+non-root CAP_SETUID/CAP_SETGID holder. Only after that exact evidence is
+reviewed may HAProxy start, followed by Caddy. A stopped HAProxy closes the
+server side of every old connection; its recreated RuntimeDirectory gives the
+next generation new listener inodes. The final `collect-live` pass binds the
+new listener/process generation. Do not approve evidence collected across an
+in-place reload or a warm edge handoff.
+
+The stopped pass closes ordinary credential reacquisition under the declared
+trusted-root boundary; it is not a proof against a compromised root, a new
+kernel/local-privilege exploit, or a service-account policy changed by root
+after collection. Root, systemd, the local authentication policy, the exact
+collector/Node/helper binaries, and the pinned Caddy/HAProxy processes remain
+in the activation TCB.
+
+The collector records that it shares the visible PID namespace of a systemd
+PID 1. That does not by itself distinguish a systemd container from the initial
+host PID namespace. The operator must run the ceremony directly in the target
+host's initial PID namespace and independently record/check the namespace link;
+a container or private PID namespace is not production evidence.
+
 There is no header fallback. Caddy clears all incoming headers before adding
 the small fixed application set and sends the real network source only in a
 PROXY-v2 preamble to a protected Unix socket. HAProxy consumes that preamble,
@@ -197,13 +260,40 @@ The production HAProxy must be a currently maintained 2.8.x release, show
 one-entry hash manifest; the CI distribution package is only compatibility
 evidence.
 
-Finally render the closed profile, run `systemd-analyze verify`, start only an
-unrouted canary, and collect root Linux evidence with
-`payment-v1-linux-runtime-evidence.mjs`. The evidence must show both units
+Finally render the closed profile and run `systemd-analyze verify`. For the
+unrouted canary, stop Caddy, stop HAProxy, reset failed unit state, and keep
+both listeners absent. Do this from the host's initial PID namespace, never by
+warm reload. First collect and externally pin stopped-edge evidence:
+
+```sh
+sudo /usr/bin/node scripts/payment-v1-linux-runtime-evidence.mjs collect-stopped-edge \
+  --bundle /absolute/rendered-bundle \
+  --approved-manifest-sha256 APPROVED_MANIFEST_SHA256 \
+  --approved-plan-sha256 APPROVED_PLAN_SHA256 \
+  --expected-machine-id-sha256 APPROVED_MACHINE_ID_SHA256 \
+  --output /absolute/evidence/stopped-edge.json
+```
+
+Verify its complete SHA-256 out of band. Only after that pass may the operator
+start `bitcoinpir-payment-v1-source-fair-edge.service`, wait for readiness,
+and then start `bitcoinpir-payment-v1-public-edge.service`. Immediately collect
+root Linux live evidence with the same exact script and pins using
+`collect-live`. The live evidence must show both units
 active with exact effective resource/hardening values, no drop-ins, exact
 process/group identities, zero current/max swap, zero hard/soft core limits,
-the safe host core pattern, and the five runtime path records. Public routing
-is a later, separately approved action.
+the safe host core pattern, the recorded systemd PID namespace, and the five
+runtime path records before and after the all-thread scan. Validate each file
+offline only with its independently transferred complete digest and the
+matching `verify-stopped-edge-offline` or `verify-offline` command. Public
+routing is a later, separately approved action.
+
+This is trusted-root operational evidence, not remote or hardware attestation.
+Its conclusion depends on the target root, the exact collector/Node/helper
+bytes, libc/NSS behavior, and the local policy files being honest. Run the
+collector only from the frozen commit after independently checking its script
+hash. The transferred evidence digest protects handoff integrity; it does not
+prove that the collecting root was honest, and the current manifest does not
+self-attest the collector script bytes.
 
 The separate `edge-rollback-authority-v1` rendered profile additionally closes
 over its static server certificate and owner-only private key. Its unit has no

--- a/deploy/payment-v1/edge/README.md
+++ b/deploy/payment-v1/edge/README.md
@@ -1,97 +1,213 @@
 # Payment V1 production edge templates
 
-These are non-activating review inputs. They do not authorize DNS changes,
-certificate issuance, public listeners, a remote-host change, or production
-deployment. Rendered files remain blocked by the Payment V1 activation
-sentinel and by exact binary/configuration hash manifests.
+These files are non-activating review inputs. They do not authorize listeners,
+DNS, certificates, deployment, remote-host changes, or funds. A rendered edge
+still requires the activation, edge-preflight, and source-fair-preflight
+sentinels plus exact binary/configuration hash manifests.
 
-The reviewed edge binary is stock Caddy. Do not add modules. Pin the complete
-single-file binary, its exact `caddy version` output, the rendered Caddyfile,
-and the rendered systemd unit before activation. The Caddy admin API,
-persistent autosaved configuration, HTTP redirects, 0-RTT, debug/trace,
-access logs and request/header/body logs are disabled. Operational logging is
-limited to non-request ERROR events; `http.log.access` and `http.log.error`
-are excluded explicitly.
+## Public-edge trust boundary
 
-## Public surfaces
+The Hetzner public path is deliberately two layers:
 
-`hetzner-public.Caddyfile.in` exposes exactly three independent TLS names:
+```text
+Internet
+  -> pinned stock Caddy (TLS, SNI/routes, 5 s header deadline, 16 KiB headers)
+  -> root-created 0750 runtime directory and four 0660 Unix sockets
+     carrying PROXY protocol v2 only
+  -> pinned HAProxy 2.8 (ephemeral source-fair admission and egress limits)
+  -> fixed loopback application listener (no PROXY protocol or source header)
+```
 
-| Public surface | Exact public path | Loopback upstream | Protocol bound |
-| --- | --- | --- | --- |
-| PIR provider | `/v1/pir` | `127.0.0.1:8191` | WebSocket upgrade; application frames are capped by `unified_server` at 512 KiB |
-| payment/credential issuer | the enumerated `/v1/...` paths in the template | `127.0.0.1:5610` | HTTP/1.1; body at most 66,445 bytes |
-| directory relay | `/v1/directory` | `127.0.0.1:8080` | WebSocket upgrade; relay frames are capped by the relay at 2 MiB |
+Caddy and HAProxy have separate UIDs and GIDs. Caddy receives only the
+`bitcoinpir-source-fair-edge` supplementary group needed to connect to the
+four sockets. HAProxy owns the socket directory and sockets. Provider, issuer,
+and directory processes have that runtime path hidden with
+`InaccessiblePaths=`. The rendered/live gates pin the group topology and check
+the current directory/socket type, UID, GID, and mode twice around live unit
+collection. A world-writable socket, extra group member, symlink, stale socket,
+wrong owner, or changed path fails closed.
 
-The edge does not inspect upgraded WebSocket frames. The application servers'
-fixed frame limits therefore remain part of the security boundary. The edge
-does bound the TLS handshake HTTP headers and the pre-upgrade request body.
-Do not replace either backend with one lacking those frame limits.
+There is no header fallback. Caddy clears all incoming headers before adding
+the small fixed application set and sends the real network source only in a
+PROXY-v2 preamble to a protected Unix socket. HAProxy consumes that preamble,
+deletes source, proxy, correlation, trace, authorization, cookie, and Via
+headers as applicable, and opens a new loopback TCP connection without
+`send-proxy`. The business process therefore sees HAProxy's loopback peer and
+never receives the source address.
 
-The three loopback ports are cross-file invariants, not deployment choices:
-the rendered edge, application unit, and application configuration must agree
-exactly. In particular, the directory-only relay configuration already fixes
-`127.0.0.1:8080`; rendering `7447` or any other relay upstream must fail the
-rendered-artifact gate.
+This does not make the edge host blind: Caddy and HAProxy necessarily observe
+source address and timing while a request is live. It prevents that data from
+becoming business state or a durable payment/query join key.
 
-`rollback-authority.Caddyfile.in` is rendered separately on each independent
-authority host. It exposes only `POST /v1/rollback-authority/calls`, caps the
-body at 1,404 bytes, and proxies to `127.0.0.1:8099`. Its upstream header
-rewrite is deliberately narrower than a normal reverse proxy: the authority's
-strict parser accepts no `Forwarded`, `X-Forwarded-*`, `Via`, authorization,
-cookie, transfer-encoding, expect or upgrade headers and requires
-`Connection: close`.
+## Surfaces and isolated lanes
 
-No edge forwards a client IP or proxy identity header to an application
-upstream. The edge host itself still observes source IP, TLS timing, SNI and
-traffic volume. This topology does not claim network-observer unlinkability.
+`hetzner-public.Caddyfile.in` and `source-fair-haproxy.cfg.in` define four
+independent lanes:
 
-## Rate and concurrency boundary
+| Lane | Ingress | HAProxy socket | Application | Global connections | Per-source connections |
+| --- | --- | --- | --- | ---: | ---: |
+| PIR provider | public HTTPS/WSS `/v1/pir` | `provider.sock` | `127.0.0.1:8191` | 128 | 8 |
+| payment issuer | public HTTPS enumerated routes | `issuer.sock` | `127.0.0.1:5610` | 128 | 8 |
+| directory readers | public WSS `/v1/directory` | `directory-public.sock` | `127.0.0.1:8080` | 48 | 4 |
+| directory publisher | private-route, exact-source WSS `/v1/directory` | `directory-publisher.sock` | `127.0.0.1:8081` | 4 | 2 |
 
-Stock Caddy has no bundled request-rate module, and this template forbids
-unreviewed third-party modules. It therefore applies fixed upstream connection
-ceilings rather than maintaining a new per-IP identity table: provider 128,
-issuer 128, directory relay 64, and rollback authority 32. The corresponding
-applications remain authoritative and fail closed at the same or tighter
-bounds. In particular, the issuer enforces quote 60/minute, status 600/minute,
-mutation 120/minute, and reconciliation 120/minute budgets; the directory
-relay enforces 64 operations/second; and the provider combines 128 total
-connections with its Payment V1 authentication/concurrency and signed-policy
-quota gates. A rendered-artifact validator must compare those values across
-edge, unit, application configuration, and signed policy instead of treating
-the prose as configuration.
+The publisher listener binds a distinct RFC1918/ULA address and hostname and
+requires the publisher's exact RFC1918/ULA WireGuard/private-route source in
+both Caddy's direct-peer matcher and HAProxy's authenticated PROXY-v2 source
+check. Its static server certificate must contain a WebPKI chain valid for the
+publisher hostname because the current `bpir-admin` publisher is a
+credential-free canonical WSS client. The HAProxy table, connection budget,
+egress budget, application listener, and relay application reservation are
+distinct from public readers. Source filtering is an ingress/DoS boundary,
+not publication authority: every accepted event still requires the pinned
+Nostr key and exact signed profile.
 
-Volumetric protection before Caddy is a separate host/network deployment
-decision. It must not reintroduce credential-bearing access logs or forward a
-source-IP header into PIR, issuer, relay, or authority application logs.
+The public and publisher sites still share one pinned Caddy process, UID,
+memory/task/file cgroup limits, and TLS scheduler. All four lanes likewise
+share one HAProxy master/worker and its process-level CPU, memory, task and file
+budget even though their frontends, stick tables, connection limits and egress
+limits are distinct. A public pre-routing TCP/TLS flood or HAProxy process-level
+pressure can therefore reduce publisher availability. V1 treats the private
+address, strict source filtering, process limits, and reserved lane budgets as
+a bounded residual risk; deployments that require a hard publisher
+availability boundary must split both publisher edge layers into separately
+rendered/evidenced units before activation.
 
-The global ceilings above are vulnerable to low-bandwidth starvation and are
-not production availability protection: one source can occupy the WebSocket
-pool, consume the anonymous quote budget, or hold the authority queue. Public
-activation is blocked until a reviewed edge/network control enforces ephemeral
-source-fair connection and request admission without persistent IP/request
-logs or forwarding source identity to the business services. Directory
-publishing additionally needs a separately reserved private ingress/budget.
-Every rollback authority must be reachable only through its client-specific
-private boundary (for example WireGuard, mutually authenticated TLS, or an
-equivalent narrow firewall allowlist), never as an ordinary public endpoint.
+Both relay lanes also share one process and one mutex-protected SQLite store.
+Lane/global connection, operation, rate, and egress reservations stop public
+work from occupying the publisher's reserved admission slots, but they do not
+make database execution fully independent: an already-running public read can
+briefly contend with a publisher write. This is a second explicit V1
+availability boundary; strict storage isolation would require independently
+designed state/replication semantics rather than another semaphore.
 
-## Rendering and activation boundary
+Rollback authorities are excluded from this public HAProxy. Each authority
+keeps its separately rendered Caddy/application unit. The V1 edge binds only
+one RFC1918/ULA address, accepts only its sole client's exact private IP through
+the systemd network filter, uses a static TLS server certificate, and retains
+the existing strict server-SPKI pin plus signed request authentication. This is
+intended for one narrow WireGuard/private route, not an Internet interface.
+The current client deliberately uses no TLS client certificate; enabling mTLS
+only on Caddy would break every request, so mTLS requires a later coordinated
+client certificate/key, private-file, gate, and real-handshake change. Adding
+`127.0.0.1:8099` or an authority route to the public source-fair configuration
+fails the source gate.
 
-Replace every `@...@` token with a reviewed value; tokens must not remain in a
-rendered file. Public host tokens are bare lower-case DNS names without a
-scheme, path, port, wildcard or trailing dot. Loopback ports are fixed in the
-templates and must match the corresponding application unit.
+## Ephemeral source fairness
 
-Render `systemd/payment-v1-edge.service.in` with one absolute Caddyfile path.
-Create root-owned, non-writable checksum manifests whose sole entries are the
-exact absolute binary and rendered-config paths. The service performs strict
-`sha256sum --check` and `caddy validate` before `caddy run`. Provisioning the
-sentinel, starting the unit and changing DNS remain separate approved actions.
+HAProxy has six isolated stick tables: provider, issuer, quote-source,
+quote-global, directory-reader, and directory-publisher. Source tables use an
+IPv6 key, map IPv4 as `/32`, aggregate IPv6 as `/64`, contain at most 4,096
+entries (64 for the publisher), expire after two minutes, and use `nopurge`.
+When a table is full, a new source is rejected rather than evicting an active
+bucket. HAProxy has no StateDirectory, peers, stats socket, server-state file,
+Lua/SPOE hook, access log, or source-table recovery; restart intentionally
+forgets every source bucket.
 
-Certificate automation may contact the configured public CA and stores state
-under `/var/lib/bitcoinpir-payment-edge`. If certificate issuance is not the
-reviewed production choice, replace automatic management with separately
-reviewed certificate/key custody before rendering; never place a private key
-on a command line. `auto_https disable_redirects` intentionally permits
-certificate management but forbids HTTP-to-HTTPS redirects.
+The issuer additionally permits at most six quote creations per source and 60
+globally per rolling minute. Every lane has both a shared-source egress limiter
+and a per-stream limiter. Application frame, operation, credential, signed
+policy, and store limits remain authoritative after edge admission.
+
+Source buckets are an availability control, not identity or commercial state.
+Users behind one NAT or one IPv6 `/64` share a bucket and can interfere with
+one another; attackers with many addresses can distribute load. Global
+volumetric attacks and TLS-handshake floods still need separately reviewed
+host/network protection that does not persist request identities.
+
+## Caddy is independently bounded
+
+HAProxy starts only after Caddy has accepted TCP, completed TLS, and parsed an
+HTTP request. HAProxy therefore does not protect Caddy from TCP/TLS slowloris,
+handshake exhaustion, oversized headers, or pre-routing floods. Caddy retains
+its own 5-second header deadline, 16 KiB header cap, 15-second request-body
+deadline, 60-second idle deadline, disabled 0-RTT, strict SNI, bounded
+connections, `MemoryMax=512 MiB`, `TasksMax=512`, and `LimitNOFILE=4096`.
+HAProxy separately has `MemoryMax=256 MiB`, `TasksMax=128`,
+`LimitNOFILE=2048`, and `maxconn 320`. Both units set `LimitCORE=0` and
+`MemorySwapMax=0`.
+
+Do not claim that HAProxy covers the Caddy front door. Linux SYN queues,
+firewall limits, certificate-handshake pressure, and any upstream DDoS control
+must be measured independently. An absolute Caddy write deadline remains zero
+because it would terminate valid long-lived WebSockets; application and
+HAProxy tunnel/egress limits bound the upgraded path.
+
+## Logging and privacy
+
+Caddy's admin API, autosave, access/request/error namespaces, debug/trace,
+redirects, and 0-RTT are disabled. HAProxy has exactly `no log`. Neither layer
+may emit raw IPs, SNI/path/request headers, PROXY frames, invoices, payment
+hashes, credential material, or query timing to application or durable logs.
+Both edge units set `StandardOutput=null` and `StandardError=null`; the rendered
+and live gates require those exact effective values so a Caddy or HAProxy
+request-path error cannot persist a peer address in journald. They also require
+the effective hard and soft core limits, cgroup swap maximum, and current swap
+usage to remain zero. Because Linux pipe-style core handlers can ignore
+`RLIMIT_CORE`, live edge evidence separately requires the host-wide
+`kernel.core_pattern` to equal `|/usr/bin/false` and binds the exact handler's
+root ownership, canonical path, one-link/non-writable metadata and SHA-256. A
+systemd-coredump/apport pipe is not accepted merely because the unit says
+`LimitCORE=0`.
+Non-request process-health events may be retained only when they cannot
+contain request context.
+
+## Rendering and activation evidence
+
+The `edge-hetzner-v1` rendered profile is closed over:
+
+- the public Caddyfile and public Caddy unit;
+- the HAProxy 2.8 configuration and source-fair unit;
+- exact Caddy and HAProxy binaries and one-entry hash manifests;
+- the rendered-config hash manifests; and
+- publisher WebPKI server certificate and owner-only private key.
+
+The public bind, publisher private bind, and publisher client placeholders are
+three distinct numeric addresses. The two publisher addresses must use the
+same IP family and both be RFC1918 or ULA. The source-fair unit creates only a
+volatile `RuntimeDirectory=`, while the public Caddy unit requires and binds to
+that active unit and checks all four sockets before start. Neither template has
+an `[Install]` section. Both units additionally require
+`DIRECTORY-PUBLISHER-PRIVATE-INGRESS-APPROVED`; creating it asserts that the
+private route, anti-spoofing firewall, WebPKI hostname, and exact client IP were
+reviewed, not merely that a placeholder was rendered.
+
+Before an activation sentinel may be approved, run all of the following with
+the exact pinned Linux binaries:
+
+```sh
+node scripts/payment-v1-deployment-template-gate.mjs
+node --test scripts/payment-v1-deployment-template-gate.test.mjs
+BPIR_HAPROXY_BIN=/absolute/pinned/haproxy \
+BPIR_CADDY_BIN=/absolute/pinned/caddy \
+  node --test scripts/payment-v1-source-fair-edge.test.mjs
+```
+
+The behavior suite validates the complete rendered Caddy template, starts real
+HAProxy, proves same-source slot rejection without cross-source starvation,
+checks per-source/global quote limits, verifies forbidden headers and source
+addresses do not reach a mock business service, rejects an unauthorized
+publisher source at both Caddy and HAProxy, and exercises the selected Caddy
+binary's Unix+PROXY-v2 transport. A skipped binary-dependent test is not
+production evidence.
+CI fixes this compatibility baseline to stock Caddy 2.11.3 (required for the
+explicit `0rtt off` server directive) and HAProxy 2.8.x with `+SYSTEMD` support.
+The production HAProxy must be a currently maintained 2.8.x release, show
+`+SYSTEMD` in `haproxy -vv`, and be pinned by exact approved bytes and a
+one-entry hash manifest; the CI distribution package is only compatibility
+evidence.
+
+Finally render the closed profile, run `systemd-analyze verify`, start only an
+unrouted canary, and collect root Linux evidence with
+`payment-v1-linux-runtime-evidence.mjs`. The evidence must show both units
+active with exact effective resource/hardening values, no drop-ins, exact
+process/group identities, zero current/max swap, zero hard/soft core limits,
+the safe host core pattern, and the five runtime path records. Public routing
+is a later, separately approved action.
+
+The separate `edge-rollback-authority-v1` rendered profile additionally closes
+over its static server certificate and owner-only private key. Its unit has no
+persistent StateDirectory, exposes only the private bind, allows loopback plus
+the exact sole-client private IP, and will not start without
+`ROLLBACK-AUTHORITY-PRIVATE-INGRESS-APPROVED`. The root live collector binds its
+volatile runtime directory and the same no-journal/no-core/no-swap controls.

--- a/deploy/payment-v1/edge/hetzner-public.Caddyfile.in
+++ b/deploy/payment-v1/edge/hetzner-public.Caddyfile.in
@@ -30,6 +30,7 @@
 }
 
 @PROVIDER_WSS_HOST@ {
+	bind @PUBLIC_HTTPS_BIND@
 	@provider_ws {
 		method GET
 		path /v1/pir
@@ -45,7 +46,7 @@
 		request_body {
 			max_size 1KiB
 		}
-		reverse_proxy 127.0.0.1:8191 {
+		reverse_proxy unix//run/bitcoinpir-source-fair-edge/provider.sock {
 			header_up -*
 			header_up Host @PROVIDER_WSS_HOST@
 			header_up Connection Upgrade
@@ -56,6 +57,7 @@
 			flush_interval -1
 			transport http {
 				versions 1.1
+				proxy_protocol v2
 				dial_timeout 3s
 				response_header_timeout 10s
 				max_response_header 16KiB
@@ -72,6 +74,7 @@
 }
 
 @PAYMENT_ISSUER_HTTPS_HOST@ {
+	bind @PUBLIC_HTTPS_BIND@
 	@issuer_quote_keys {
 		method GET OPTIONS
 		header Host @PAYMENT_ISSUER_HTTPS_HOST@
@@ -90,51 +93,27 @@
 		path_regexp issuer_action ^/v1/quotes/[0-9a-f]{64}/(status|claim)$
 		expression {http.request.uri.query} == ""
 	}
-		@issuer_provider_call {
-			method POST
-			header Host @PAYMENT_ISSUER_HTTPS_HOST@
-			path /v1/redeems /v1/settlement/balance
-			expression {http.request.uri.query} == ""
-		}
+	@issuer_provider_call {
+		method POST
+		header Host @PAYMENT_ISSUER_HTTPS_HOST@
+		path /v1/redeems /v1/settlement/balance
+		expression {http.request.uri.query} == ""
+	}
 
 	handle @issuer_quote_keys {
 		request_body {
 			max_size 66445B
 		}
-		reverse_proxy 127.0.0.1:5610 {
+		reverse_proxy unix//run/bitcoinpir-source-fair-edge/issuer.sock {
+			header_up -*
 			header_up Host @PAYMENT_ISSUER_HTTPS_HOST@
 			header_up Connection close
-			header_up -Accept
-			header_up -Accept-Encoding
-			header_up -Accept-Language
-			header_up -Authorization
-			header_up -Baggage
-			header_up -Cookie
-			header_up -DNT
-			header_up -Forwarded
-			header_up -Priority
-			header_up -Proxy-Authorization
-			header_up -Referer
-			header_up -Sec-CH-UA
-			header_up -Sec-CH-UA-Mobile
-			header_up -Sec-CH-UA-Platform
-			header_up -Sec-Fetch-Dest
-			header_up -Sec-Fetch-Mode
-			header_up -Sec-Fetch-Site
-			header_up -Sec-Fetch-User
-			header_up -Traceparent
-			header_up -Tracestate
-			header_up -User-Agent
-			header_up -Via
-			header_up -X-Correlation-ID
-			header_up -X-Forwarded-For
-			header_up -X-Forwarded-Host
-			header_up -X-Forwarded-Proto
-			header_up -X-Real-IP
-			header_up -X-Request-ID
+			header_up Content-Type {http.request.header.Content-Type}
+			header_up Origin {http.request.header.Origin}
 			header_down -Via
 			transport http {
 				versions 1.1
+				proxy_protocol v2
 				dial_timeout 3s
 				response_header_timeout 15s
 				read_timeout 15s
@@ -151,40 +130,16 @@
 		request_body {
 			max_size 66445B
 		}
-		reverse_proxy 127.0.0.1:5610 {
+		reverse_proxy unix//run/bitcoinpir-source-fair-edge/issuer.sock {
+			header_up -*
 			header_up Host @PAYMENT_ISSUER_HTTPS_HOST@
 			header_up Connection close
-			header_up -Accept
-			header_up -Accept-Encoding
-			header_up -Accept-Language
-			header_up -Authorization
-			header_up -Baggage
-			header_up -Cookie
-			header_up -DNT
-			header_up -Forwarded
-			header_up -Priority
-			header_up -Proxy-Authorization
-			header_up -Referer
-			header_up -Sec-CH-UA
-			header_up -Sec-CH-UA-Mobile
-			header_up -Sec-CH-UA-Platform
-			header_up -Sec-Fetch-Dest
-			header_up -Sec-Fetch-Mode
-			header_up -Sec-Fetch-Site
-			header_up -Sec-Fetch-User
-			header_up -Traceparent
-			header_up -Tracestate
-			header_up -User-Agent
-			header_up -Via
-			header_up -X-Correlation-ID
-			header_up -X-Forwarded-For
-			header_up -X-Forwarded-Host
-			header_up -X-Forwarded-Proto
-			header_up -X-Real-IP
-			header_up -X-Request-ID
+			header_up Content-Type {http.request.header.Content-Type}
+			header_up Origin {http.request.header.Origin}
 			header_down -Via
 			transport http {
 				versions 1.1
+				proxy_protocol v2
 				dial_timeout 3s
 				response_header_timeout 15s
 				read_timeout 15s
@@ -201,40 +156,16 @@
 		request_body {
 			max_size 66445B
 		}
-		reverse_proxy 127.0.0.1:5610 {
+		reverse_proxy unix//run/bitcoinpir-source-fair-edge/issuer.sock {
+			header_up -*
 			header_up Host @PAYMENT_ISSUER_HTTPS_HOST@
 			header_up Connection close
-			header_up -Accept
-			header_up -Accept-Encoding
-			header_up -Accept-Language
-			header_up -Authorization
-			header_up -Baggage
-			header_up -Cookie
-			header_up -DNT
-			header_up -Forwarded
-			header_up -Priority
-			header_up -Proxy-Authorization
-			header_up -Referer
-			header_up -Sec-CH-UA
-			header_up -Sec-CH-UA-Mobile
-			header_up -Sec-CH-UA-Platform
-			header_up -Sec-Fetch-Dest
-			header_up -Sec-Fetch-Mode
-			header_up -Sec-Fetch-Site
-			header_up -Sec-Fetch-User
-			header_up -Traceparent
-			header_up -Tracestate
-			header_up -User-Agent
-			header_up -Via
-			header_up -X-Correlation-ID
-			header_up -X-Forwarded-For
-			header_up -X-Forwarded-Host
-			header_up -X-Forwarded-Proto
-			header_up -X-Real-IP
-			header_up -X-Request-ID
+			header_up Content-Type {http.request.header.Content-Type}
+			header_up Origin {http.request.header.Origin}
 			header_down -Via
 			transport http {
 				versions 1.1
+				proxy_protocol v2
 				dial_timeout 3s
 				response_header_timeout 15s
 				read_timeout 15s
@@ -251,40 +182,16 @@
 		request_body {
 			max_size 66445B
 		}
-		reverse_proxy 127.0.0.1:5610 {
+		reverse_proxy unix//run/bitcoinpir-source-fair-edge/issuer.sock {
+			header_up -*
 			header_up Host @PAYMENT_ISSUER_HTTPS_HOST@
 			header_up Connection close
-			header_up -Accept
-			header_up -Accept-Encoding
-			header_up -Accept-Language
-			header_up -Authorization
-			header_up -Baggage
-			header_up -Cookie
-			header_up -DNT
-			header_up -Forwarded
-			header_up -Priority
-			header_up -Proxy-Authorization
-			header_up -Referer
-			header_up -Sec-CH-UA
-			header_up -Sec-CH-UA-Mobile
-			header_up -Sec-CH-UA-Platform
-			header_up -Sec-Fetch-Dest
-			header_up -Sec-Fetch-Mode
-			header_up -Sec-Fetch-Site
-			header_up -Sec-Fetch-User
-			header_up -Traceparent
-			header_up -Tracestate
-			header_up -User-Agent
-			header_up -Via
-			header_up -X-Correlation-ID
-			header_up -X-Forwarded-For
-			header_up -X-Forwarded-Host
-			header_up -X-Forwarded-Proto
-			header_up -X-Real-IP
-			header_up -X-Request-ID
+			header_up Content-Type {http.request.header.Content-Type}
+			header_up Origin {http.request.header.Origin}
 			header_down -Via
 			transport http {
 				versions 1.1
+				proxy_protocol v2
 				dial_timeout 3s
 				response_header_timeout 15s
 				read_timeout 15s
@@ -302,6 +209,7 @@
 	}
 }
 @DIRECTORY_RELAY_WSS_HOST@ {
+	bind @PUBLIC_HTTPS_BIND@
 	@directory_ws {
 		method GET
 		path /v1/directory
@@ -317,7 +225,7 @@
 		request_body {
 			max_size 1KiB
 		}
-		reverse_proxy 127.0.0.1:8080 {
+		reverse_proxy unix//run/bitcoinpir-source-fair-edge/directory-public.sock {
 			header_up -*
 			header_up Host @DIRECTORY_RELAY_WSS_HOST@
 			header_up Connection Upgrade
@@ -328,10 +236,62 @@
 			flush_interval -1
 			transport http {
 				versions 1.1
+				proxy_protocol v2
 				dial_timeout 3s
 				response_header_timeout 10s
 				max_response_header 16KiB
 				max_conns_per_host 64
+				keepalive off
+				compression off
+			}
+		}
+	}
+
+	handle {
+		respond "" 404
+	}
+}
+
+# Publisher ingress is bound to a different private host interface and admits
+# only the publisher's exact WireGuard/private-route source address. The public
+# directory hostname never routes to this socket. Signed-event verification by
+# the relay remains the publication authority.
+@DIRECTORY_PUBLISHER_HTTPS_HOST@ {
+	bind @DIRECTORY_PUBLISHER_PRIVATE_BIND@
+	tls /etc/bitcoinpir/payment-v1/edge/directory-publisher-server.crt /etc/bitcoinpir/payment-v1/edge/directory-publisher-server.key
+
+	@directory_publisher_ws {
+		remote_ip @DIRECTORY_PUBLISHER_CLIENT_IP@
+		method GET
+		path /v1/directory
+		header Host @DIRECTORY_PUBLISHER_HTTPS_HOST@
+		header Connection *Upgrade*
+		header Upgrade websocket
+		header Sec-WebSocket-Version 13
+		header_regexp Sec-WebSocket-Key ^[A-Za-z0-9+/]{22}==$
+		expression {http.request.uri} == "/v1/directory"
+	}
+
+	handle @directory_publisher_ws {
+		request_body {
+			max_size 1KiB
+		}
+		reverse_proxy unix//run/bitcoinpir-source-fair-edge/directory-publisher.sock {
+			header_up -*
+			header_up Host @DIRECTORY_PUBLISHER_HTTPS_HOST@
+			header_up Connection Upgrade
+			header_up Upgrade websocket
+			header_up Sec-WebSocket-Version 13
+			header_up Sec-WebSocket-Key {http.request.header.Sec-WebSocket-Key}
+			header_down -Via
+			flush_interval -1
+			transport http {
+				versions 1.1
+				proxy_protocol v2
+				dial_timeout 3s
+				response_header_timeout 10s
+				max_response_header 16KiB
+				max_conns_per_host 4
 				keepalive off
 				compression off
 			}

--- a/deploy/payment-v1/edge/rollback-authority.Caddyfile.in
+++ b/deploy/payment-v1/edge/rollback-authority.Caddyfile.in
@@ -24,6 +24,9 @@
 }
 
 @ROLLBACK_AUTHORITY_HTTPS_HOST@ {
+	bind @ROLLBACK_AUTHORITY_PRIVATE_BIND@
+	tls /etc/bitcoinpir/payment-v1/edge/rollback-authority-server.crt /etc/bitcoinpir/payment-v1/edge/rollback-authority-server.key
+
 	@authority_call {
 		method POST
 		path /v1/rollback-authority/calls

--- a/deploy/payment-v1/edge/source-fair-haproxy.cfg.in
+++ b/deploy/payment-v1/edge/source-fair-haproxy.cfg.in
@@ -1,0 +1,236 @@
+# BitcoinPIR Payment V1 public source-fair edge. This rendered configuration
+# is hash-pinned and runs only behind the pinned Caddy TLS edge.
+#
+# Privacy boundary: source addresses exist only in these bounded, expiring
+# in-process tables. There is intentionally no log target, stats socket, peers
+# section, server-state file, SPOE/Lua hook, or PROXY/header forwarding to an
+# application server.
+
+global
+    maxconn 320
+    hard-stop-after 10s
+    zero-warning
+
+defaults
+    mode http
+    no log
+    option http-server-close
+    option http-no-delay
+    timeout connect 3s
+    timeout client 15s
+    timeout client-fin 5s
+    timeout server 15s
+    timeout server-fin 5s
+    timeout http-request 5s
+    timeout http-keep-alive 1s
+    timeout queue 3s
+    timeout tunnel 300s
+
+# Every public lane has its own short-lived source table. IPv4 sources are
+# mapped into the IPv6 table; IPv6 clients share a /64 bucket. `nopurge` makes
+# table exhaustion fail closed instead of evicting an active source bucket.
+backend provider_sources
+    stick-table type ipv6 size 4096 expire 2m nopurge store conn_cur,conn_rate(10s),bytes_out_rate(1s)
+
+backend issuer_sources
+    stick-table type ipv6 size 4096 expire 2m nopurge store conn_cur,conn_rate(10s),http_req_rate(60s),bytes_out_rate(1s)
+
+backend issuer_quote_sources
+    stick-table type ipv6 size 4096 expire 2m nopurge store http_req_rate(60s)
+
+backend issuer_quote_global
+    stick-table type integer size 1 expire 2m nopurge store http_req_rate(60s)
+
+backend directory_public_sources
+    stick-table type ipv6 size 4096 expire 2m nopurge store conn_cur,conn_rate(10s),bytes_out_rate(1s)
+
+# The publisher has a distinct private-address Caddy ingress. HAProxy repeats
+# the exact WireGuard/private-route source check before allocating any source
+# state, so the public lane cannot reach the publisher application.
+backend directory_publisher_sources
+    stick-table type ipv6 size 64 expire 2m nopurge store conn_cur,conn_rate(10s),bytes_out_rate(1s)
+
+frontend provider_public
+    bind /run/bitcoinpir-source-fair-edge/provider.sock accept-proxy mode 660
+    maxconn 128
+    # Source is authoritative only after accept-proxy has parsed Caddy's
+    # PROXY-v2 preamble, so source-keyed admission deliberately begins in the
+    # HTTP rule set rather than an earlier tcp-request connection rule.
+    http-request deny deny_status 429 if { table_avl(provider_sources) eq 0 } !{ src,ipmask(32,64),in_table(provider_sources) }
+    http-request track-sc0 src,ipmask(32,64) table provider_sources
+    http-request deny deny_status 429 unless { sc0_tracked }
+    http-request deny deny_status 429 if { sc0_conn_cur gt 8 }
+    http-request deny deny_status 429 if { sc0_conn_rate gt 16 }
+    http-request deny deny_status 429 unless { method GET }
+    http-request deny deny_status 404 unless { path -m str /v1/pir }
+    http-request del-header Forwarded
+    http-request del-header X-Forwarded-For
+    http-request del-header X-Forwarded-Host
+    http-request del-header X-Forwarded-Proto
+    http-request del-header CF-Connecting-IP
+    http-request del-header Client-IP
+    http-request del-header Fastly-Client-IP
+    http-request del-header Fly-Client-IP
+    http-request del-header True-Client-IP
+    http-request del-header X-Client-IP
+    http-request del-header X-Cluster-Client-IP
+    http-request del-header X-Envoy-External-Address
+    http-request del-header X-Original-Client-IP
+    http-request del-header X-Original-Forwarded-For
+    http-request del-header X-Real-IP
+    http-request del-header X-Request-ID
+    http-request del-header X-Correlation-ID
+    http-request del-header Traceparent
+    http-request del-header Tracestate
+    http-request del-header Baggage
+    http-request del-header Via
+    http-response del-header Via
+    filter bwlim-out provider_source_egress key src,ipmask(32,64) table provider_sources limit 8m min-size 2896
+    filter bwlim-out provider_stream_egress default-limit 4m default-period 1s min-size 2896
+    http-request set-bandwidth-limit provider_source_egress
+    http-request set-bandwidth-limit provider_stream_egress
+    default_backend provider_application
+
+backend provider_application
+    http-reuse never
+    server provider 127.0.0.1:8191 maxconn 128
+
+frontend issuer_public
+    bind /run/bitcoinpir-source-fair-edge/issuer.sock accept-proxy mode 660
+    maxconn 128
+    http-request deny deny_status 429 if { table_avl(issuer_sources) eq 0 } !{ src,ipmask(32,64),in_table(issuer_sources) }
+    http-request track-sc0 src,ipmask(32,64) table issuer_sources
+    http-request deny deny_status 429 unless { sc0_tracked }
+    http-request deny deny_status 429 if { sc0_conn_cur gt 8 }
+    http-request deny deny_status 429 if { sc0_conn_rate gt 32 }
+    http-request deny deny_status 429 if { sc0_http_req_rate gt 120 }
+    acl quote_create method POST
+    acl quote_create path -m str /v1/quotes/bolt11
+    http-request deny deny_status 429 if quote_create { table_avl(issuer_quote_sources) eq 0 } !{ src,ipmask(32,64),in_table(issuer_quote_sources) }
+    http-request track-sc1 src,ipmask(32,64) table issuer_quote_sources if quote_create
+    http-request deny deny_status 429 if quote_create !{ sc1_tracked }
+    http-request track-sc2 int(1) table issuer_quote_global if quote_create
+    http-request deny deny_status 429 if quote_create !{ sc2_tracked }
+    http-request deny deny_status 429 if quote_create { sc1_http_req_rate gt 6 }
+    http-request deny deny_status 429 if quote_create { sc2_http_req_rate gt 60 }
+    http-request del-header Forwarded
+    http-request del-header X-Forwarded-For
+    http-request del-header X-Forwarded-Host
+    http-request del-header X-Forwarded-Proto
+    http-request del-header CF-Connecting-IP
+    http-request del-header Client-IP
+    http-request del-header Fastly-Client-IP
+    http-request del-header Fly-Client-IP
+    http-request del-header True-Client-IP
+    http-request del-header X-Client-IP
+    http-request del-header X-Cluster-Client-IP
+    http-request del-header X-Envoy-External-Address
+    http-request del-header X-Original-Client-IP
+    http-request del-header X-Original-Forwarded-For
+    http-request del-header X-Real-IP
+    http-request del-header X-Request-ID
+    http-request del-header X-Correlation-ID
+    http-request del-header Traceparent
+    http-request del-header Tracestate
+    http-request del-header Baggage
+    http-request del-header Via
+    http-request del-header Proxy-Authorization
+    http-request del-header Authorization
+    http-request del-header Cookie
+    http-response del-header Via
+    filter bwlim-out issuer_source_egress key src,ipmask(32,64) table issuer_sources limit 2m min-size 2896
+    filter bwlim-out issuer_stream_egress default-limit 1m default-period 1s min-size 2896
+    http-request set-bandwidth-limit issuer_source_egress
+    http-request set-bandwidth-limit issuer_stream_egress
+    default_backend issuer_application
+
+backend issuer_application
+    http-reuse never
+    server issuer 127.0.0.1:5610 maxconn 128
+
+frontend directory_public
+    bind /run/bitcoinpir-source-fair-edge/directory-public.sock accept-proxy mode 660
+    maxconn 48
+    http-request deny deny_status 429 if { table_avl(directory_public_sources) eq 0 } !{ src,ipmask(32,64),in_table(directory_public_sources) }
+    http-request track-sc0 src,ipmask(32,64) table directory_public_sources
+    http-request deny deny_status 429 unless { sc0_tracked }
+    http-request deny deny_status 429 if { sc0_conn_cur gt 4 }
+    http-request deny deny_status 429 if { sc0_conn_rate gt 12 }
+    http-request deny deny_status 429 unless { method GET }
+    http-request deny deny_status 404 unless { path -m str /v1/directory }
+    http-request del-header Forwarded
+    http-request del-header X-Forwarded-For
+    http-request del-header X-Forwarded-Host
+    http-request del-header X-Forwarded-Proto
+    http-request del-header CF-Connecting-IP
+    http-request del-header Client-IP
+    http-request del-header Fastly-Client-IP
+    http-request del-header Fly-Client-IP
+    http-request del-header True-Client-IP
+    http-request del-header X-Client-IP
+    http-request del-header X-Cluster-Client-IP
+    http-request del-header X-Envoy-External-Address
+    http-request del-header X-Original-Client-IP
+    http-request del-header X-Original-Forwarded-For
+    http-request del-header X-Real-IP
+    http-request del-header X-Request-ID
+    http-request del-header X-Correlation-ID
+    http-request del-header Traceparent
+    http-request del-header Tracestate
+    http-request del-header Baggage
+    http-request del-header Via
+    http-response del-header Via
+    filter bwlim-out directory_public_source_egress key src,ipmask(32,64) table directory_public_sources limit 4m min-size 2896
+    filter bwlim-out directory_public_stream_egress default-limit 2m default-period 1s min-size 2896
+    http-request set-bandwidth-limit directory_public_source_egress
+    http-request set-bandwidth-limit directory_public_stream_egress
+    default_backend directory_public_application
+
+backend directory_public_application
+    http-reuse never
+    server directory-public 127.0.0.1:8080 maxconn 48
+
+frontend directory_publisher
+    bind /run/bitcoinpir-source-fair-edge/directory-publisher.sock accept-proxy mode 660
+    maxconn 4
+    http-request deny deny_status 403 unless { src @DIRECTORY_PUBLISHER_CLIENT_IP@ }
+    http-request deny deny_status 429 if { table_avl(directory_publisher_sources) eq 0 } !{ src,ipmask(32,64),in_table(directory_publisher_sources) }
+    http-request track-sc0 src,ipmask(32,64) table directory_publisher_sources
+    http-request deny deny_status 429 unless { sc0_tracked }
+    http-request deny deny_status 429 if { sc0_conn_cur gt 2 }
+    http-request deny deny_status 429 if { sc0_conn_rate gt 8 }
+    http-request deny deny_status 429 unless { method GET }
+    http-request deny deny_status 404 unless { path -m str /v1/directory }
+    http-request del-header Forwarded
+    http-request del-header X-Forwarded-For
+    http-request del-header X-Forwarded-Host
+    http-request del-header X-Forwarded-Proto
+    http-request del-header CF-Connecting-IP
+    http-request del-header Client-IP
+    http-request del-header Fastly-Client-IP
+    http-request del-header Fly-Client-IP
+    http-request del-header True-Client-IP
+    http-request del-header X-Client-IP
+    http-request del-header X-Cluster-Client-IP
+    http-request del-header X-Envoy-External-Address
+    http-request del-header X-Original-Client-IP
+    http-request del-header X-Original-Forwarded-For
+    http-request del-header X-Real-IP
+    http-request del-header X-Request-ID
+    http-request del-header X-Correlation-ID
+    http-request del-header Traceparent
+    http-request del-header Tracestate
+    http-request del-header Baggage
+    http-request del-header Via
+    http-request del-header X-SSL-Client-Cert
+    http-request del-header X-Client-Cert
+    http-response del-header Via
+    filter bwlim-out directory_publisher_source_egress key src,ipmask(32,64) table directory_publisher_sources limit 2m min-size 2896
+    filter bwlim-out directory_publisher_stream_egress default-limit 1m default-period 1s min-size 2896
+    http-request set-bandwidth-limit directory_publisher_source_egress
+    http-request set-bandwidth-limit directory_publisher_stream_egress
+    default_backend directory_publisher_application
+
+backend directory_publisher_application
+    http-reuse never
+    server directory-publisher 127.0.0.1:8081 maxconn 4

--- a/deploy/payment-v1/systemd/hetzner-directory-relay.service.in
+++ b/deploy/payment-v1/systemd/hetzner-directory-relay.service.in
@@ -46,8 +46,9 @@ IPAddressDeny=any
 IPAddressAllow=localhost
 ReadOnlyPaths=/etc/bitcoinpir/payment-v1/directory-relay
 ReadWritePaths=/var/lib/bitcoinpir-directory-relay
+InaccessiblePaths=/run/bitcoinpir-source-fair-edge
 
 # A resolved relay config must bind the application to loopback; a same-host
-# WebSocket TLS edge provides public reads/writes. The directory publisher
+# WebSocket TLS edge provides separated public reads and private writes. The directory publisher
 # private key is never installed on this host. There is intentionally no
 # [Install] section.

--- a/deploy/payment-v1/systemd/hetzner-payment-issuer.service.in
+++ b/deploy/payment-v1/systemd/hetzner-payment-issuer.service.in
@@ -73,7 +73,7 @@ AmbientCapabilities=
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 ReadOnlyPaths=/etc/bitcoinpir/payment-v1/issuer /run/bitcoinpir-cln-rpc-guard/issuer /opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@
 ReadWritePaths=/var/lib/bitcoinpir-payment-issuer
-InaccessiblePaths=/srv/lightning /srv/bitcoin
+InaccessiblePaths=/srv/lightning /srv/bitcoin /run/bitcoinpir-source-fair-edge
 
 # Clearing is part of payment-issuer serve-cln; no separate clearing daemon is
 # installed. There is intentionally no [Install] section. The final unit name

--- a/deploy/payment-v1/systemd/hetzner-provider.service.in
+++ b/deploy/payment-v1/systemd/hetzner-provider.service.in
@@ -78,6 +78,7 @@ AmbientCapabilities=
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 ReadOnlyPaths=/etc/bitcoinpir/payment-v1/provider
 ReadWritePaths=/var/lib/bitcoinpir-provider-payment-v1
+InaccessiblePaths=/run/bitcoinpir-source-fair-edge
 
 # The signed policy may use direct receipts, provider-local BAT, Standard Cashu
 # and the approved shared issuer. Runtime method-coverage validation rejects

--- a/deploy/payment-v1/systemd/payment-v1-edge.service.in
+++ b/deploy/payment-v1/systemd/payment-v1-edge.service.in
@@ -1,30 +1,37 @@
-# BitcoinPIR Payment V1 TLS edge template; never install this .in file directly.
+# BitcoinPIR Payment V1 rollback-authority TLS edge; never install this .in file directly.
 [Unit]
-Description=BitcoinPIR Payment V1 pinned TLS edge (template only)
+Description=BitcoinPIR Payment V1 pinned private rollback-authority TLS edge (template only)
 After=network-online.target
 Wants=network-online.target
 ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED
 ConditionPathExists=/etc/bitcoinpir/payment-v1/EDGE-PREFLIGHT-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/ROLLBACK-AUTHORITY-PRIVATE-INGRESS-APPROVED
 
 [Service]
 Type=notify
 User=bitcoinpir-payment-edge
 Group=bitcoinpir-payment-edge
 UMask=0077
-StateDirectory=bitcoinpir-payment-edge
-StateDirectoryMode=0700
-WorkingDirectory=/var/lib/bitcoinpir-payment-edge
-Environment=XDG_DATA_HOME=/var/lib/bitcoinpir-payment-edge/data XDG_CONFIG_HOME=/var/lib/bitcoinpir-payment-edge/config
+RuntimeDirectory=bitcoinpir-rollback-authority-edge
+RuntimeDirectoryMode=0700
+WorkingDirectory=/run/bitcoinpir-rollback-authority-edge
+Environment=XDG_DATA_HOME=/run/bitcoinpir-rollback-authority-edge/data XDG_CONFIG_HOME=/run/bitcoinpir-rollback-authority-edge/config
+StandardOutput=null
+StandardError=null
 ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy
 ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/caddy.sha256
 ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/edge-config.sha256
-ExecStartPre=/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy validate --config /etc/bitcoinpir/payment-v1/edge/@EDGE_CADDYFILE@ --adapter caddyfile
-ExecStart=/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy run --config /etc/bitcoinpir/payment-v1/edge/@EDGE_CADDYFILE@ --adapter caddyfile
+ExecStartPre=/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy validate --config /etc/bitcoinpir/payment-v1/edge/rollback-authority.Caddyfile --adapter caddyfile
+ExecStart=/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy run --config /etc/bitcoinpir/payment-v1/edge/rollback-authority.Caddyfile --adapter caddyfile
 Restart=on-failure
 RestartSec=5
 TimeoutStartSec=60
 TimeoutStopSec=30
-LimitNOFILE=65535
+LimitNOFILE=1024
+LimitCORE=0
+MemoryMax=268435456
+MemorySwapMax=0
+TasksMax=128
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 NoNewPrivileges=true
@@ -45,9 +52,11 @@ RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+IPAddressDeny=any
+IPAddressAllow=localhost @ROLLBACK_AUTHORITY_CLIENT_IP@
 ReadOnlyPaths=/etc/bitcoinpir/payment-v1/edge
-ReadWritePaths=/var/lib/bitcoinpir-payment-edge
+ReadWritePaths=/run/bitcoinpir-rollback-authority-edge
 
-# There is intentionally no [Install] section. Rendering this unit, approving
-# edge preflight, creating the global activation sentinel and starting the
-# service are separate production actions.
+# There is intentionally no persistent state or [Install] section. Rendering
+# this unit, proving the private single-client ingress, creating the sentinels,
+# and starting the service are separate production actions.

--- a/deploy/payment-v1/systemd/payment-v1-public-edge.service.in
+++ b/deploy/payment-v1/systemd/payment-v1-public-edge.service.in
@@ -1,0 +1,67 @@
+# BitcoinPIR Payment V1 public TLS edge; never install this .in file directly.
+[Unit]
+Description=BitcoinPIR Payment V1 pinned public TLS edge (template only)
+After=network-online.target bitcoinpir-payment-v1-source-fair-edge.service
+Wants=network-online.target
+Requires=bitcoinpir-payment-v1-source-fair-edge.service
+BindsTo=bitcoinpir-payment-v1-source-fair-edge.service
+ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/EDGE-PREFLIGHT-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/SOURCE-FAIR-PREFLIGHT-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/DIRECTORY-PUBLISHER-PRIVATE-INGRESS-APPROVED
+
+[Service]
+Type=notify
+User=bitcoinpir-payment-edge
+Group=bitcoinpir-payment-edge
+SupplementaryGroups=bitcoinpir-source-fair-edge
+UMask=0077
+StateDirectory=bitcoinpir-payment-edge
+StateDirectoryMode=0700
+WorkingDirectory=/var/lib/bitcoinpir-payment-edge
+Environment=XDG_DATA_HOME=/var/lib/bitcoinpir-payment-edge/data XDG_CONFIG_HOME=/var/lib/bitcoinpir-payment-edge/config
+StandardOutput=null
+StandardError=null
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/caddy.sha256
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/edge-config.sha256
+ExecStartPre=/usr/bin/test -S /run/bitcoinpir-source-fair-edge/provider.sock
+ExecStartPre=/usr/bin/test -S /run/bitcoinpir-source-fair-edge/issuer.sock
+ExecStartPre=/usr/bin/test -S /run/bitcoinpir-source-fair-edge/directory-public.sock
+ExecStartPre=/usr/bin/test -S /run/bitcoinpir-source-fair-edge/directory-publisher.sock
+ExecStartPre=/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy validate --config /etc/bitcoinpir/payment-v1/edge/hetzner-public.Caddyfile --adapter caddyfile
+ExecStart=/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy run --config /etc/bitcoinpir/payment-v1/edge/hetzner-public.Caddyfile --adapter caddyfile
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=60
+TimeoutStopSec=30
+LimitNOFILE=4096
+LimitCORE=0
+MemoryMax=536870912
+MemorySwapMax=0
+TasksMax=512
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+RestrictNamespaces=true
+SystemCallArchitectures=native
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/edge /run/bitcoinpir-source-fair-edge
+ReadWritePaths=/var/lib/bitcoinpir-payment-edge
+
+# Caddy's bounded TLS/HTTP front door and HAProxy's source-fair admission are
+# separate fail-closed layers. There is intentionally no [Install] section.

--- a/deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in
+++ b/deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in
@@ -1,0 +1,61 @@
+# BitcoinPIR Payment V1 public source-fair edge; never install this .in file directly.
+[Unit]
+Description=BitcoinPIR Payment V1 pinned source-fair edge (template only)
+After=network-online.target
+Wants=network-online.target
+Before=bitcoinpir-payment-v1-public-edge.service
+ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/SOURCE-FAIR-PREFLIGHT-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/DIRECTORY-PUBLISHER-PRIVATE-INGRESS-APPROVED
+
+[Service]
+Type=notify
+User=bitcoinpir-source-fair-edge
+Group=bitcoinpir-source-fair-edge
+UMask=0007
+RuntimeDirectory=bitcoinpir-source-fair-edge
+RuntimeDirectoryMode=0750
+WorkingDirectory=/run/bitcoinpir-source-fair-edge
+StandardOutput=null
+StandardError=null
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/haproxy/@HAPROXY_SHA256@/haproxy
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/source-fair-edge/haproxy.sha256
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/source-fair-edge/source-fair-config.sha256
+ExecStartPre=/opt/bitcoinpir/haproxy/@HAPROXY_SHA256@/haproxy -c -q -f /etc/bitcoinpir/payment-v1/source-fair-edge/haproxy.cfg
+ExecStart=/opt/bitcoinpir/haproxy/@HAPROXY_SHA256@/haproxy -Ws -db -q -f /etc/bitcoinpir/payment-v1/source-fair-edge/haproxy.cfg
+Restart=on-failure
+RestartSec=5
+TimeoutStartSec=30
+TimeoutStopSec=15
+LimitNOFILE=2048
+LimitCORE=0
+MemoryMax=268435456
+MemorySwapMax=0
+TasksMax=128
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+RestrictNamespaces=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+IPAddressDeny=any
+IPAddressAllow=localhost
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/source-fair-edge /opt/bitcoinpir/haproxy/@HAPROXY_SHA256@
+ReadWritePaths=/run/bitcoinpir-source-fair-edge
+
+# No StateDirectory is allowed: source buckets die with the process and are
+# never replicated or recovered. There is intentionally no [Install] section.

--- a/docs/payment/DIRECTORY_PROTOCOL.md
+++ b/docs/payment/DIRECTORY_PROTOCOL.md
@@ -363,9 +363,11 @@ method/provider-pair lookup API.
 `apps/directory-relay` implements the server-side subset needed by this
 protocol. It is not a general-purpose Nostr relay. The sole process interface
 is `bitcoinpir-directory-relay --config /absolute/owner-only.toml`; the
-configuration fixes one loopback listener, one absolute SQLite database, one
-pinned non-zero directory publisher key and explicit concurrency, ingress,
-egress, archive and timeout bounds. No publisher private key is present.
+configuration fixes distinct public and publisher loopback listeners, one
+absolute SQLite database, one pinned non-zero directory publisher key and
+explicit global plus per-lane concurrency, ingress, egress, archive and
+timeout bounds. Every pair of lane reservations must add exactly to its global
+cap. No publisher private key is present.
 
 The accepted client messages are only the exact canonical NIP-01 `EVENT`,
 `REQ`, and `CLOSE` shapes used here. EVENT requires the pinned key, kind 30078,
@@ -373,6 +375,12 @@ valid signature, canonical JSON, and the exact `d`/`s` namespaces. There is no
 generic subscription language, live push, NIP-42 AUTH, NOTICE, or application
 heartbeat path. A reverse proxy may handle WebSocket control frames, but it
 must not log frames or silently transform application messages.
+The public listener accepts only `REQ`/`CLOSE`; the publisher listener accepts
+only `EVENT`. Each connection or operation acquires its lane reservation before
+the shared global reservation, and rate/egress gates apply at both levels.
+These reservations preserve publisher admission capacity under public load,
+but both lanes share the process and mutex-protected SQLite store, so they are
+not a storage-level availability boundary.
 
 SQLite keeps an immutable event archive and a separate addressable-event head.
 An unseen current event, its archive counters, and any head replacement commit

--- a/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
+++ b/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
@@ -34,6 +34,17 @@ separate authority hosts, service accounts, TLS keys, Ed25519 keys, namespaces,
 administrators, logs, and backup/restore domains. Co-location is permitted only
 for an explicitly non-production exercise.
 
+Each `edge-rollback-authority-v1` instance is also network-specific. Its Caddy
+listener binds one reviewed RFC1918/ULA address, systemd denies every address
+except loopback and the sole client's exact private IP, and the rendered
+profile closes over a static TLS certificate and owner-only key. The existing
+rollback client verifies WebPKI plus the configured leaf SPKI pin and signs the
+application request; it currently has no TLS client-certificate support. Do
+not turn on server-side mTLS alone. V1 therefore requires a narrow WireGuard or
+equivalent routed private link, the exact client-IP filter, and the
+`ROLLBACK-AUTHORITY-PRIVATE-INGRESS-APPROVED` sentinel. A later mTLS design must
+add client certificate/key custody and real-handshake tests atomically.
+
 ## Frozen active-service boundary
 
 This preparation does not modify or replace:
@@ -183,6 +194,12 @@ separate activation gates.
 The directory publisher key is a dedicated offline BIP340 key and is never
 installed on the relay. The relay sees only public signed directory events; it
 must accept writes only from the pinned publisher and only kind `30078`.
+The production publisher URL remains a canonical credential-free `wss://`
+hostname because `bpir-admin directory publish` uses WebPKI server
+authentication and no client certificate. Split DNS or an explicit private
+route resolves that hostname to the relay's private bind; Caddy and HAProxy
+both require the separately approved exact publisher-client address before the
+relay performs the signed-event check.
 
 `deploy/payment-v1/relay-selection.toml.example` deliberately starts with
 `status = "UNRESOLVED"`. While unresolved, the relay service has
@@ -202,10 +219,10 @@ Mutable branches, mutable container tags, `nostr-rs-relay` 0.9.0 at
 `b5c1f642e4f4c3b9c54f5d18d66f4c53642076b4` fail the repository gate. No
 generic third-party relay template is supplied.
 
-A resolved relay must bind its application listener to loopback, use a
-same-host WSS edge, disable access/event/body/IP logging, disable NIP-42 for the
-current publisher, retain the NIP-01 addressable-event replacement ordering,
-and enforce the
+A resolved relay must bind distinct public-reader and private-publisher
+application listeners to loopback, use the same-host WSS edge, disable
+access/event/body/IP logging, disable NIP-42 for the current publisher, retain
+the NIP-01 addressable-event replacement ordering, and enforce the
 BitcoinPIR bounds: 262,176-byte outer EVENT message, 192 KiB content, kind
 30078, and a deployment-config size no greater than 16 KiB. At least two relay
 hostnames are still required for directory use; two aliases on one Hetzner host
@@ -214,10 +231,10 @@ do not provide operator or failure independence.
 The reviewed process interface is intentionally narrow: exactly
 `bitcoinpir-directory-relay --config /absolute/owner-only.toml`, with no CLI
 overrides. The TOML must declare `profile = "bitcoinpir-directory-relay-v1"` and
-contain exactly the required fields `profile`, `listen`, `database`,
-`directory_pubkey_hex`, `max_connections`, `max_in_flight_operations`,
-`max_operations_per_second`, `max_egress_bytes_per_second`,
-`max_egress_bytes_per_connection`, `max_archive_events`, `max_archive_bytes`,
+contain exactly `public_listen`, `publisher_listen`, `database`,
+`directory_pubkey_hex`, the four global connection/operation/rate/egress caps,
+matching `max_public_*` and `max_publisher_*` reservations whose exact sums
+equal each global cap, `max_egress_bytes_per_connection`, `max_archive_events`, `max_archive_bytes`,
 `handshake_timeout_seconds`, `idle_timeout_seconds`,
 `connection_timeout_seconds`, `operation_timeout_seconds`, and
 `egress_timeout_seconds`; unknown fields and missing fields fail closed.
@@ -226,7 +243,11 @@ unit's only writable StateDirectory at
 `/var/lib/bitcoinpir-directory-relay/relay.sqlite3`. The config must be mode
 0400 or 0600 under a private parent directory.
 
-The relay reserves the exact complete snapshot response against a per-
+The relay has separate public-read and private-publisher accept loops and
+acquires a lane reservation before a shared global reservation. The public
+listener rejects EVENT writes; the publisher listener rejects REQ reads. This
+prevents public load from consuming the publisher's connection, operation,
+rate, or egress allocation. The relay reserves the exact complete snapshot response against a per-
 connection cumulative byte budget before sending its first EVENT, and applies
 a separate process-wide egress byte rate. The example intentionally does not
 allow the event-count and maximum-event-size dimensions to be saturated at the
@@ -308,19 +329,51 @@ activation actions and require separate approval.
 
 ## Rendering and preflight
 
-### P1 activation blocker: source-fair admission
+### P1 activation blocker: live source-fair evidence
 
-The supplied stock-Caddy templates have only global upstream connection caps;
-the issuer, relay and rollback-authority applications also use global budgets.
-A single low-bandwidth source can therefore starve anonymous quote creation,
-directory read/publish capacity, or rollback-floor calls without possessing a
-credential. Do not publicly activate these surfaces until the reviewed host or
-network layer supplies ephemeral source-fair admission without request/IP
-logging or source headers to the business services. Reserve a distinct private
-publisher ingress/budget for the directory, and place every rollback authority
-behind its one client's WireGuard, mTLS or equivalent narrow allowlist. These
-controls and their negative tests are required live deployment evidence, not a
-commercial pricing decision.
+The source tree now supplies a pinned-stock-Caddy front and pinned-HAProxy-2.8
+source-fair layer. Caddy sends PROXY v2 only over four protected Unix sockets;
+HAProxy keeps independent two-minute memory-only provider, issuer,
+quote-source/global, public-directory, and private-publisher buckets, then
+opens a source-free loopback connection to each business service. There is no
+header fallback, log, peers section, stats socket, StateDirectory, server-state
+file, or source-state recovery. The publisher uses a different private bind,
+an exact WireGuard/private-route client-IP check in both Caddy and HAProxy, a
+WebPKI server certificate, a dedicated ingress-approval sentinel, a separate
+application listener and stick table, and a reserved application budget.
+Rollback authorities remain outside the public HAProxy behind their one
+client's private boundary.
+The public and publisher sites nevertheless share one pinned Caddy process and
+its process-level CPU/memory/task/file budget, while all lanes share one
+HAProxy process/cgroup despite distinct frontend budgets. Public pre-routing
+TCP/TLS or HAProxy process-level pressure can therefore reduce publisher
+availability. Treat that as an explicit V1 residual risk, or split both
+publisher edge layers into separately rendered and evidenced units when a hard
+availability boundary is required.
+The two relay lanes also share one process and mutex-protected SQLite store;
+their reservations isolate admission capacity but not the duration of an
+already-running database operation.
+Both edge units require effective `StandardOutput=null` and
+`StandardError=null`, closing the remaining journald path for request errors
+that might contain a live peer address. They also set `LimitCORE=0` and
+`MemorySwapMax=0`; rendered/live checks bind hard and soft core limits, current
+and maximum cgroup swap, and reject drift. Linux can ignore `RLIMIT_CORE` when
+`kernel.core_pattern` names a pipe handler, so edge live evidence additionally
+requires the exact host policy `kernel.core_pattern=|/usr/bin/false` and binds
+that handler's canonical root-owned bytes and metadata into the trusted-command
+evidence. A default systemd-coredump or apport pipe is not accepted as
+non-persistent evidence.
+
+The code does not by itself clear this P1 blocker. Before public activation,
+the exact rendered Linux host must prove both units active, the volatile
+directory `0750`, all four sockets `0660` with the source-fair UID/GID, exact
+NSS/supplementary-group membership, effective memory/task/file limits, and no
+drop-ins. It must also prove zero current/max swap, zero hard/soft core limits,
+and the safe host core pattern. The exact pinned Caddy and HAProxy binaries must pass the real
+fairness/leak suite without skipped tests. HAProxy sees traffic only after
+Caddy accepts TCP/TLS and parses HTTP, so separate Caddy-front slowloris,
+header, handshake, firewall, and volumetric evidence is also mandatory. These
+are availability/privacy controls, not commercial pricing policy.
 
 1. Freeze exact BitcoinPIR commit, binaries, policies, directory artifacts,
    authority metadata and key-role inventory.
@@ -342,11 +395,27 @@ commercial pricing decision.
    `rollback-authority-deployment-lint` before any listener starts.
 7. Confirm provider, issuer and authority application origins are loopback;
    confirm same-host TLS edges have no redirects, access logs, identity headers
-   or unpinned certificate path.
+   or unpinned certificate path. For the public Hetzner edge, run
+   `payment-v1-source-fair-edge.test.mjs` with the exact pinned Caddy and
+   HAProxy binaries and treat any skip as failure. The HAProxy binary must be a
+   currently maintained 2.8.x build with `+SYSTEMD` in `haproxy -vv`, because
+   the unit uses `Type=notify` and `-Ws`; the CI package is only compatibility
+   evidence. Confirm the publisher bind and client address are distinct,
+   same-family RFC1918/ULA addresses; the static certificate is a WebPKI chain
+   for the canonical publisher hostname; Caddy and HAProxy reject every other
+   direct/PROXY source; the private route prevents source spoofing; the
+   publisher-private-ingress sentinel is present only after that review; and
+   rollback port 8099 is absent from HAProxy. For every rollback edge, confirm
+   the private bind, exact sole-client IP filter, static TLS/SPKI pin, and
+   private-ingress sentinel; do not claim mTLS with the current client.
 8. Start private/unrouted canaries. Verify identity, binary/attestation,
    database proof/root, signed policy, remote rollback failure behavior and
    exact method/scope matching from a strict client.
-9. Publish directory artifacts only after every advertised live value matches.
+9. Collect root Linux evidence after both edge units are active; require the
+   exact runtime directory/socket type, owner, group and mode records plus
+   effective `MemoryMax`/`TasksMax`, zero current/max swap, zero hard/soft core
+   limits, and `kernel.core_pattern=|/usr/bin/false`. Publish directory artifacts only after
+   every advertised live value matches.
 10. Provision an activation sentinel and change public routing only under the
     separately approved activation plan.
 

--- a/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
+++ b/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
@@ -367,13 +367,57 @@ non-persistent evidence.
 The code does not by itself clear this P1 blocker. Before public activation,
 the exact rendered Linux host must prove both units active, the volatile
 directory `0750`, all four sockets `0660` with the source-fair UID/GID, exact
-NSS/supplementary-group membership, effective memory/task/file limits, and no
+local-files NSS/supplementary-group membership, effective memory/task/file limits, and no
 drop-ins. It must also prove zero current/max swap, zero hard/soft core limits,
 and the safe host core pattern. The exact pinned Caddy and HAProxy binaries must pass the real
 fairness/leak suite without skipped tests. HAProxy sees traffic only after
 Caddy accepts TCP/TLS and parses HTTP, so separate Caddy-front slowloris,
 header, handshake, firewall, and volumetric evidence is also mandatory. These
 are availability/privacy controls, not commercial pricing policy.
+
+The V1 NSS statement is deliberately narrow. The activation host must use
+`passwd: files` and `group: files` with no separate `initgroups:` entry. The
+collector binds stable snapshots of `/etc/nsswitch.conf`, `/etc/passwd`, and
+`/etc/group` around enumeration and confirms them again after the remaining
+live checks, requires ordinary `getent` identity-relevant account/group
+projections to agree, and checks every enumerated account with `id -G`.
+The live pass hash-binds but does not semantically compare password, GECOS,
+home, shell and group-password fields. The mandatory stopped-edge pass also
+reads stable `/etc/passwd` and `/etc/shadow` snapshots and requires every
+manifest-bound service account to have the pinned UID/GID, a
+`/usr/sbin/nologin` or `/bin/false` shell, and a locked password. It rejects
+UID/GID aliases and any
+extra primary, explicit, or effective member of a protected group. A host using
+SSSD, LDAP, winbind, NIS or systemd UserDB cannot pass V1 merely because its
+currently visible `getent` output looks complete; such a backend needs an
+authoritative backend-specific generation/completeness proof.
+
+Because removing a user from NSS does not revoke credentials already held by a
+Linux thread, the collector also executes two bounded full `/proc` PID/TID
+passes and rejects every non-root thread with CAP_SETUID or CAP_SETGID in an
+inheritable, permitted, effective or ambient set. Any protected UID/GID holder
+must have the exact service credentials in
+the exact current systemd unit cgroup; both holder snapshots must agree, every
+long-running MainPID must be present, and MainPID/InvocationID/ControlGroup are
+confirmed once more after the scan. A protected holder observed outside the
+unit blocks activation; the discrete scans are not a continuous-time process
+monitor.
+
+This does not discover a connected Unix socket FD already transferred with
+`SCM_RIGHTS` to a process that later dropped the protected credential. The
+mandatory activation ceremony is therefore cold: stop public Caddy and
+source-fair HAProxy so every old accepted connection is dead, then run
+`collect-stopped-edge` while both units are inactive/dead and every manifest
+socket is absent. The pass must show an empty protected-credential closure,
+locked/non-login service accounts and no non-root set-ID capability holder.
+Only after that evidence and its complete digest are approved may HAProxy
+start, followed by Caddy; `collect-live` then binds the new generation.
+Evidence from a warm reload is invalid. Run both collectors directly in the
+host's initial PID namespace. The collector binds itself to the visible
+systemd PID 1 namespace, but the operator must independently rule out a private
+PID namespace or systemd container. This closes ordinary reacquisition under
+the trusted-root/authentication-policy boundary, not a compromised root or new
+local-privilege exploit.
 
 1. Freeze exact BitcoinPIR commit, binaries, policies, directory artifacts,
    authority metadata and key-role inventory.
@@ -408,10 +452,19 @@ are availability/privacy controls, not commercial pricing policy.
    rollback port 8099 is absent from HAProxy. For every rollback edge, confirm
    the private bind, exact sole-client IP filter, static TLS/SPKI pin, and
    private-ingress sentinel; do not claim mTLS with the current client.
-8. Start private/unrouted canaries. Verify identity, binary/attestation,
+8. From the host initial PID namespace, stop public Caddy and then source-fair
+   HAProxy and reset failed unit state. With both units inactive/dead and every
+   manifest socket absent, run `collect-stopped-edge`; transfer and approve the
+   complete evidence SHA-256. It must prove exact locked/non-login service
+   accounts, an empty protected-UID/GID closure and no non-root set-ID
+   capability holder. Only then start HAProxy before Caddy, with no warm reload,
+   and start the remaining
+   private/unrouted canaries. Verify identity, binary/attestation,
    database proof/root, signed policy, remote rollback failure behavior and
    exact method/scope matching from a strict client.
-9. Collect root Linux evidence after both edge units are active; require the
+9. Collect `collect-live` root Linux evidence immediately after both fresh edge
+   units are active; require
+   PID-namespace/systemd-PID1 binding, identical all-thread holder passes, and the
    exact runtime directory/socket type, owner, group and mode records plus
    effective `MemoryMax`/`TasksMax`, zero current/max swap, zero hard/soft core
    limits, and `kernel.core_pattern=|/usr/bin/false`. Publish directory artifacts only after
@@ -442,6 +495,13 @@ the successful exited state of the reviewed one-shot preflight, installed
 bytes, NSS, ACLs, xattrs, capabilities and `systemd-analyze verify`. Until that
 live evidence passes, these inputs remain deployment preparation rather than
 an activatable bundle.
+
+The live file is trusted-root operational evidence, not hardware attestation.
+Before collection, independently verify the collector script from the frozen
+commit and its exact Node/helper environment. The out-of-band evidence digest
+detects later handoff changes but cannot establish that the target root or the
+collector was honest; the current manifest does not self-attest those script
+bytes.
 
 ## Failure and rollback
 

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -381,11 +381,13 @@ operator has activated the path with real money or public infrastructure.
       remain exact-commit/deployment evidence rather than source claims.
 - [x] A CI-wired, explicitly selected process test starts two copies of the
       repository's production `bitcoinpir-directory-relay` binary with
-      independent config/SQLite/port/runtime state, publishes one signed
-      16-shard catalog to both and uses real WebSocket readback to fail closed
-      on offline/exact split-view errors, recover lost ACK by bounded-backoff
-      durable ID probe plus idempotent retry, and preserve heads across
-      independent restarts. A companion three-authority test separates provider
+      independent config/SQLite/runtime state and four distinct loopback
+      listeners. It sends signed `EVENT` messages only through each publisher
+      lane, sends ID/catalog `REQ` and receives `EOSE` only through each public
+      lane, fails closed on offline/exact split-view errors, recovers lost ACK by
+      a public-lane durable ID probe plus publisher-lane idempotent retry, and
+      verifies both listeners plus stored heads across independent restarts. A
+      companion three-authority test separates provider
       0, provider 1 and issuer DB/key/namespace/TLS material. It starts authority
       and TLS-edge child test harnesses; each authority harness invokes
       production `rollback_authority::run`, while the parent directly calls the
@@ -393,9 +395,10 @@ operator has activated the path with real money or public infrastructure.
       raw-client rejection and Store-adapter rejection are asserted at their
       respective boundaries. Provider- and issuer-authority backends are stopped
       independently while their TLS edges remain online; only the affected Store
-      fails closed, the other two domains remain usable, and the issuer recovers
-      the exact same generation and commitment from its original authority
-      database. It does not launch `unified_server`, `payment-issuer`, or
+      fails closed, while the other two Stores remain independently openable and
+      authenticated through their own authorities. The issuer recovers the exact
+      same generation and commitment from its original authority database. It
+      does not launch `unified_server`, `payment-issuer`, or
       installed binaries. These are local topology tests, not claims of
       operational independence; their first Linux CI execution remains
       candidate-commit evidence.

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -382,11 +382,13 @@ operator has activated the path with real money or public infrastructure.
 - [x] A CI-wired, explicitly selected process test starts two copies of the
       repository's production `bitcoinpir-directory-relay` binary with
       independent config/SQLite/runtime state and four distinct loopback
-      listeners. It sends signed `EVENT` messages only through each publisher
-      lane, sends ID/catalog `REQ` and receives `EOSE` only through each public
-      lane, fails closed on offline/exact split-view errors, recovers lost ACK by
-      a public-lane durable ID probe plus publisher-lane idempotent retry, and
-      verifies both listeners plus stored heads across independent restarts. A
+      listeners. Every accepted signed `EVENT` uses a publisher lane; every
+      accepted ID/catalog `REQ` and returned `EVENT`/`EOSE` uses a public lane.
+      Deliberate wrong-lane probes must close, and an exact-ID public readback
+      proves the rejected EVENT sentinel was not persisted. It fails closed on
+      offline/exact split-view errors, recovers lost ACK by a public-lane durable
+      ID probe plus publisher-lane idempotent retry, and verifies both listeners
+      plus stored heads across independent restarts. A
       companion three-authority test separates provider
       0, provider 1 and issuer DB/key/namespace/TLS material. It starts authority
       and TLS-edge child test harnesses; each authority harness invokes
@@ -758,9 +760,25 @@ unique aggregate count. Exact-head pushed CI remains a separate merge gate.
       VPSBG baseline. The rendered gate binds one externally approved plan to
       exact staged bytes, path/file classes and consuming service identities;
       the live collector binds installed bytes, systemd state and real process
-      credentials to one machine/boot/invocation. The current source gate passed
-      16/16 and the combined rendered/live-evidence Node suite passed 63/63 on
-      this preparation tree. The first root-only target Linux collection still
+      credentials to one machine/boot/invocation. Runtime-evidence v2 accepts
+      only stable local `files` NSS, binds `/etc/nsswitch.conf`, `/etc/passwd`
+      and `/etc/group`, and rejects UID/GID aliases or extra protected-group
+      primary/explicit/effective members; a final snapshot confirmation closes
+      drift during the remainder of live collection. Two bounded
+      all-process/all-thread passes additionally reject stale protected UID/GID
+      holders outside the exact current unit cgroups, reject every non-root
+      CAP_SETUID/CAP_SETGID holder, and re-confirm every
+      MainPID/unit generation; runtime paths are rechecked after the scan. This
+      is not an already-connected-FD proof. The stopped-edge evidence type
+      therefore requires inactive/dead units, absent socket paths, locked
+      non-login service accounts and an empty protected-credential closure
+      before HAProxy may start, followed by Caddy and a fresh live proof in the
+      host initial PID namespace. The current pinned Ubuntu 24.04,
+      HAProxy 2.8.16 and Caddy 2.11.3 container run passed the complete four-suite
+      deployment/rendered/live/source-fair Node gate 138/138 with no skip,
+      including real `getent`, per-user `id -G`, and full procfs thread scans.
+      An Alpine procfs regression also passes for legal repeated `Groups:`
+      entries. The first root-only target Linux collection still
       remains candidate-commit/host evidence and cannot be inferred from those
       deterministic tests.
 - [x] One authorized public-relay smoke published a 30-minute, empty 16-shard
@@ -790,10 +808,14 @@ unique aggregate count. Exact-head pushed CI remains a separate merge gate.
 
 ## Production release blockers and gates
 
-The implementation-code P1 findings, including initial payout
-persist-before-send, are closed. One production data-integrity P1 remains: an
-actually independent linearizable rollback authority is not deployed. The
-other numbered items below are mandatory production release, operations,
+The previously reviewed gate/store implementation P1 findings, including
+initial payout persist-before-send, are closed. Two distinct P1 classes remain:
+an actually independent linearizable rollback authority is not deployed, and
+the shared-issuer production path still lacks operator-facing builders for its
+clearing authorization/approval plus a production balance client whose key
+model matches the registration. Tests currently construct those artifacts or
+envelopes directly; that is not a deployable operator workflow. The other
+numbered items below are mandatory production release, operations,
 external-review or manual-acceptance gates; they are not all implementation P1
 findings and must not be collapsed into that count.
 

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -903,8 +903,11 @@ findings and must not be collapsed into that count.
    matrix. The isolated current-tree browser rerun passed the real-issuer case
    1/1 and complete-query topology 3/3. Pushed CI remains a per-commit merge
    gate. Production trust-chain, a
-   browser-to-Standard-Cashu-provider join,
-   Harmony query, Onion and TEE-ORAM process boundaries remain open.
+   browser-to-Standard-Cashu-provider join, and Onion and TEE-ORAM process
+   boundaries remain open. The direct-receipt two-provider process test now
+   executes a complete four-frame K-padded Harmony query under a distinct
+   Harmony scope, offer and credential key, including wrong-scope
+   non-consumption, terminal-DFA rejection and restart replay rejection.
 6. **External dependency canaries.** Recorded runs exist for the earlier
    two-node local CLN runner, the disposable CDK runner, and one short-lived
    public Nostr transport/readback smoke. The extended CDK lifecycle and forced

--- a/docs/payment/LOCAL_ACCEPTANCE.md
+++ b/docs/payment/LOCAL_ACCEPTANCE.md
@@ -591,11 +591,16 @@ a listener.
 The direct-receipt test covers cleartext backend rejection, ephemeral-bound
 attestation exchange, secure-channel upgrade, exact signed manifest-root
 policy verification, encrypted pre-authorization rejection, provider-specific
-direct-receipt authorization, a valid DPF request/response, signed one-frame
-limit rejection, and durable replay rejection after provider 0 is restarted.
-The exact provider-1 receipt is first rejected by provider 0 and then succeeds
-at provider 1, proving that the wrong-provider rejection neither burns it nor
-consults a shared cross-provider spent set.
+and workload-specific direct-receipt authorization, a valid DPF
+request/response, and a complete four-frame K-padded Harmony INDEX/CHUNK query
+through the real handler. DPF and Harmony use distinct signed scopes, globally
+unique offer IDs and credential keys. A DPF receipt rejected at the Harmony
+scope remains usable for DPF; a completed Harmony DFA is terminal; both DPF
+and Harmony spends remain rejected after provider 0 restarts. The exact
+provider-1 DPF receipt is first rejected by provider 0 and then succeeds at
+provider 1, proving that the wrong-provider rejection neither burns it nor
+consults a shared cross-provider spent set. No hint server is configured or
+named by this query-provider test.
 
 The method-adapter test repeats the real wire and DPF execution boundary for
 Free open, durable provider-local IP quota, provider-local Cashu BAT and
@@ -611,10 +616,10 @@ V1 gate, not production server identity, binary pinning, hardware attestation,
 production database proof/trusted-root pinning, Merkle tree-top/inclusion
 verification, or an attested build. Its receipt is constructed from public
 deterministic fixture keys: no issuer process, browser, wallet, Lightning node,
-external Cashu mint, Nostr relay or real funds participate. Only the DPF
-backend is executed through the first two multi-provider process tests. The five-method x
-five-workload in-process matrix remains the process-independent coverage for
-Standard Cashu, Harmony query, Onion and TEE-ORAM. The third process test
+external Cashu mint, Nostr relay or real funds participate. The direct-receipt
+test executes both DPF and Harmony query backends; the method-adapter test
+executes DPF. The five-method x five-workload in-process matrix remains the
+process-independent coverage for Standard Cashu, Onion and TEE-ORAM. The third process test
 launches one real Harmony V2Full hint provider with a private disk pool and
 checks invalid-proof non-consumption, pre-dispatch disconnect restoration,
 first-dispatch durable consumption, matching-marker restart and replaced-inode
@@ -1184,9 +1189,9 @@ At minimum, a release candidate needs evidence for:
   connection/auth limits, or tree-top bandwidth overload at the edge;
 - production identity/binary pins, remote servers, hardware attestation,
   production database proofs/trusted roots, or production databases;
-- process-level Harmony query, Onion or TEE-ORAM execution (their canonical
-  gate states are covered in-process; Harmony V2Full hint lifecycle now has a
-  dedicated local real-provider-process boundary);
+- process-level Onion or TEE-ORAM execution (their canonical gate states are
+  covered in-process; Harmony query and V2Full hint lifecycle now have distinct
+  local real-provider-process boundaries);
 - a deployed browser-to-issuer-to-provider main-page network E2E (the visible
   main-page controller is covered by unit tests; the local Chromium harness
   reaches two real issuers and two real providers and executes a DPF query with

--- a/docs/payment/LOCAL_ACCEPTANCE.md
+++ b/docs/payment/LOCAL_ACCEPTANCE.md
@@ -894,11 +894,14 @@ cargo test --locked --offline -p bitcoinpir-directory-relay \
 ```
 
 It launches two copies of the repository's production
-`bitcoinpir-directory-relay` binary and covers separate
-config/SQLite/ports/runtimes, complete 16-shard signed readback, one relay
-offline, two independently valid but conflicting stale-head views with an exact
-split-view error, bounded-backoff lost-ACK readback plus idempotent retry, and
-independent restart recovery. The remote-authority full-mode cell also selects
+`bitcoinpir-directory-relay` binary and covers separate config/SQLite/runtime
+state plus four distinct loopback listeners. Signed `EVENT` publication uses
+each relay's publisher lane; ID/catalog `REQ` and `EOSE` use its public lane.
+The test covers complete 16-shard signed readback, one relay offline, two
+independently valid but conflicting stale-head views with an exact split-view
+error, a public-lane lost-ACK durability barrier followed by an idempotent
+publisher-lane retry, and readiness of both listeners after independent restart.
+The remote-authority full-mode cell also selects
 `three_authority_process::three_authority_real_process_topology_e2e`. That test
 spawns three authority child test harnesses which invoke production
 `rollback_authority::run` and three TLS-edge child harnesses; the parent process
@@ -907,8 +910,9 @@ deployment-set validator owns duplicate-pin/namespace rejection, raw clients
 own wrong-pin/client/cross-domain transport assertions, and the production
 adapters own crossed-provider, independently isolated provider- and
 issuer-authority outages, exact same-generation issuer recovery and stale-floor
-assertions. During each authority outage the other two business domains remain
-usable. It does not launch `unified_server`, `payment-issuer`, or installed
+assertions. During each authority outage the other two Stores remain
+independently openable and authenticated through their own authorities. It does
+not launch `unified_server`, `payment-issuer`, or installed
 binaries. These new commands require their first Linux CI run on the candidate
 commit; no passing result is claimed here, and same-host processes do not prove
 operational independence.

--- a/docs/payment/LOCAL_ACCEPTANCE.md
+++ b/docs/payment/LOCAL_ACCEPTANCE.md
@@ -895,9 +895,11 @@ cargo test --locked --offline -p bitcoinpir-directory-relay \
 
 It launches two copies of the repository's production
 `bitcoinpir-directory-relay` binary and covers separate config/SQLite/runtime
-state plus four distinct loopback listeners. Signed `EVENT` publication uses
-each relay's publisher lane; ID/catalog `REQ` and `EOSE` use its public lane.
-The test covers complete 16-shard signed readback, one relay offline, two
+state plus four distinct loopback listeners. Every accepted signed `EVENT`
+publication uses a publisher lane; every accepted ID/catalog `REQ` and returned
+`EVENT`/`EOSE` uses a public lane. Deliberate wrong-lane probes must close, and
+an exact-ID public readback proves the rejected EVENT sentinel was not
+persisted. The test covers complete 16-shard signed readback, one relay offline, two
 independently valid but conflicting stale-head views with an exact split-view
 error, a public-lane lost-ACK durability barrier followed by an idempotent
 publisher-lane retry, and readiness of both listeners after independent restart.
@@ -1127,6 +1129,23 @@ local rollback floors and deterministic all-zero database remain
 non-production boundaries, and ARC remains experimental pending independent
 review.
 
+## Source-fair cold-activation evidence
+
+The pinned Ubuntu 24.04/HAProxy 2.8.16/Caddy 2.11.3 audit container passed the
+four deployment, rendered-artifact, runtime-evidence and source-fair suites
+138/138 with no skip. This includes real Linux `getent`, `id -G`, procfs
+all-thread scanning, non-root set-ID capability rejection, locked service-
+account policy validation and the stopped-edge evidence validator.
+
+This is deterministic compatibility evidence, not target-host activation. The
+actual candidate must first collect an independently digest-pinned
+`collect-stopped-edge` record while Caddy and HAProxy are fully stopped and all
+Unix listeners are absent. Only after approval may it start HAProxy then Caddy
+and collect a separate digest-pinned `collect-live` record. Both must run from
+the target host's independently confirmed initial PID namespace; a warm reload,
+container-only record or evidence without its complete transferred SHA-256 is
+not accepted.
+
 ## Expected acceptance record
 
 Record the commit, platform/toolchain, command mode, pass/fail result and any
@@ -1145,7 +1164,8 @@ At minimum, a release candidate needs evidence for:
 6. persistence/restart/concurrency suites;
 7. deterministic no-funds fixture generation;
 8. the locked product contract and exact external EasyCrypt record;
-9. an approved staging network E2E once its edge controls are implemented.
+9. the stopped-edge and fresh-live source-fair activation evidence pair;
+10. an approved staging network E2E once its edge controls are implemented.
 
 ## Not exercised by this procedure
 

--- a/docs/payment/SECURITY_REVIEW_2026-07-29_DEPLOYMENT.md
+++ b/docs/payment/SECURITY_REVIEW_2026-07-29_DEPLOYMENT.md
@@ -86,24 +86,48 @@ mandatory.
 
 ### Source-fair public admission
 
-The stock-Caddy templates and the application processes currently use global
-connection and operation budgets. A single low-bandwidth source can occupy the
-provider or directory WebSocket pool, consume the anonymous quote budget, or
-hold the rollback-authority queue without a payment or publisher key. This is
-not volumetric DDoS and cannot be dismissed as upstream capacity planning.
+The source-fair follow-up supplies separate stock-Caddy and HAProxy layers for
+the public Hetzner edge. Four protected PROXY-v2 Unix sockets feed independent,
+short-lived provider, issuer, directory-reader and directory-publisher source
+buckets. Every successful `track-sc` is checked explicitly, so full-table
+allocation failure rejects rather than admitting an unaccounted request. The
+business services receive only new source-free loopback connections.
 
-Before public activation:
+The source templates now enforce the following design requirements:
 
-1. add an ephemeral source-fair connection/request boundary in front of the
+1. an ephemeral source-fair connection/request boundary in front of the
    public provider, issuer and directory surfaces;
 2. do not persist IP/request records or forward source identity into the PIR,
    payment, directory or rollback business processes;
-3. give the signed directory publisher a separate private ingress and reserved
-   connection/operation/egress budget;
-4. place each rollback authority behind its sole client's WireGuard, mTLS or
-   equivalent narrow firewall allowlist; and
-5. collect negative live evidence that one source cannot exhaust every global
-   slot or quote token.
+3. the signed directory publisher has a separate private ingress, an exact
+   WireGuard/private-route client-IP check in both Caddy and HAProxy, a WebPKI
+   server certificate compatible with the current credential-free publisher,
+   a dedicated activation sentinel, and reserved connection/operation/egress
+   budget;
+4. each rollback authority binds one private address and its systemd unit
+   allows only the sole client's exact private IP; the current strict client
+   uses WebPKI/SPKI plus signed requests rather than an unsupported one-sided
+   mTLS configuration; and
+5. both edge processes have null output, zero core limits and zero cgroup swap.
+
+The public-reader and private-publisher sites currently share the pinned Caddy
+process and its process-level resource budget; all lanes also share one HAProxy
+process and cgroup despite separate frontend/table/connection/egress limits.
+Public pre-routing TCP/TLS or HAProxy process-level pressure can still affect
+publisher availability. This is an explicit residual V1 availability boundary,
+not evidence of complete ingress isolation; a deployment needing a hard
+publisher boundary must split both edge layers into separately evidenced units.
+The two relay listeners also share one mutex-protected SQLite store. Reserved
+admission slots prevent public work from consuming publisher lane capacity,
+but an active public database operation can still delay a publisher write;
+V1 does not claim storage-level availability isolation.
+
+This remains a P1 **activation** blocker until the exact pinned Linux binaries
+pass the no-skip behavior suite and target-host evidence proves the effective
+units, source-fair sockets, negative starvation cases, zero current/max swap,
+zero hard/soft core limits, and `kernel.core_pattern=|/usr/bin/false`, including
+the handler's canonical root-owned bytes and metadata. Linux pipe core handlers
+may ignore `RLIMIT_CORE`; the unit directive alone is not proof.
 
 The directory unit remains `UNRESOLVED` with `ExecStart=/usr/bin/false`, so the
 repository cannot accidentally activate it before this boundary and the final
@@ -194,6 +218,7 @@ Hetzner host; arbitrary unmeasured limits are not safe defaults.
 - no-funds local regtest and persistent default-Signet Lightning drills,
   including backup/restore and lost-response reconciliation;
 - source-fair starvation and cgroup pressure tests;
+- target-host no-core/no-swap evidence, including the host core pattern;
 - private provider/issuer/directory canaries with strict client verification;
   and
 - final manual browser acceptance by the user before public routing changes.

--- a/docs/payment/SECURITY_REVIEW_2026-07-29_DEPLOYMENT.md
+++ b/docs/payment/SECURITY_REVIEW_2026-07-29_DEPLOYMENT.md
@@ -78,9 +78,49 @@ must prove a successful zero-status completion in the current boot. Offline
 review is meaningful only with an independently transferred full evidence
 digest.
 
+Runtime-evidence v2 narrows NSS to a provable local-files profile: exactly
+`passwd: files`, `group: files`, and inherited group-based `initgroups`. Stable
+root-owned snapshots of `/etc/nsswitch.conf`, `/etc/passwd`, and `/etc/group`
+must agree around NSS enumeration, with the complete identity-relevant `getent`
+projection, and with a final confirmation after the remaining live checks;
+`id -G` is checked for every account under a monotonic deadline. The live pass
+leaves non-identity passwd/group fields hash-bound rather than semantically
+compared. The stopped-edge pass additionally binds `/etc/shadow` and requires
+each service account to be UID/GID-pinned, login-disabled and password-locked. Duplicate
+UID/GID aliases and extra protected-group primary, explicit, or effective
+members fail closed. Remote/cached or optionally enumerable NSS providers are
+not accepted by this V1 claim.
+
+Runtime-evidence v2 also closes credentials retained in the kernel after an NSS
+edit. Two bounded full process/thread scans must produce the same protected
+holder records and fail on any non-root CAP_SETUID/CAP_SETGID holder. Each
+protected holder is bound by UID, all four GIDs, supplementary group
+set, PID/TID, inode, start time and exact current systemd cgroup; all managed
+MainPIDs and a post-scan unit generation confirmation are mandatory. HAProxy's
+master and worker are allowed only because both remain in its reviewed unit
+cgroup with the same reviewed credentials.
+
+The scan does not prove ownership of an already-connected Unix socket FD after
+`SCM_RIGHTS` transfer. Source-fair activation consequently requires a cold
+connection reset. Stop Caddy and HAProxy, then run `collect-stopped-edge` while
+all units are inactive/dead and every manifest socket is absent. It requires
+locked/non-login service accounts plus an empty protected-credential closure;
+only then start HAProxy before Caddy and collect new-generation live evidence,
+without a warm reload. The collector also binds its namespace to a
+visible systemd PID 1, while the operator must independently attest that this
+is the target host's initial PID namespace rather than a private namespace.
+This is a trusted-root/authentication-policy argument, not proof against a
+compromised root or future local privilege escalation.
+
 These gates are source and staging controls, not hardware attestation. Their
 first real systemd/Linux execution on the target Hetzner staging host remains
 mandatory.
+
+The collector is also part of the trusted-root TCB. The evidence digest binds
+the transferred result, not the honesty of target root or the script that
+created it. The activation ceremony must independently verify and run the
+collector bytes from the frozen commit; adding the collector script itself to
+the approved rendered manifest remains a defense-in-depth follow-up.
 
 ## P1 production activation blockers
 
@@ -126,7 +166,10 @@ This remains a P1 **activation** blocker until the exact pinned Linux binaries
 pass the no-skip behavior suite and target-host evidence proves the effective
 units, source-fair sockets, negative starvation cases, zero current/max swap,
 zero hard/soft core limits, and `kernel.core_pattern=|/usr/bin/false`, including
-the handler's canonical root-owned bytes and metadata. Linux pipe core handlers
+the handler's canonical root-owned bytes and metadata. The same ceremony must
+perform the stopped-edge proof and cold Caddy/HAProxy connection reset from the
+initial host PID namespace, followed by a fresh live proof; a warm-reload
+snapshot is rejected. Linux pipe core handlers
 may ignore `RLIMIT_CORE`; the unit directive alone is not proof.
 
 The directory unit remains `UNRESOLVED` with `ExecStart=/usr/bin/false`, so the
@@ -212,12 +255,17 @@ Hetzner host; arbitrary unmeasured limits are not safe defaults.
 - green Linux CI for all Payment V1 crates, process E2Es and warnings-denied
   builds, including release rejection of every test-only feature;
 - reviewed merged commit and exact reproducible source/binary/config hashes;
-- passing rendered-profile gate and target-host live evidence collector;
+- passing rendered-profile gate and target-host stopped-edge/fresh-live
+  evidence pair, each bound to its independently transferred full digest;
 - independent rollback-authority topology lint plus private-network negative
   tests;
 - no-funds local regtest and persistent default-Signet Lightning drills,
   including backup/restore and lost-response reconciliation;
 - source-fair starvation and cgroup pressure tests;
+- cold Caddy/HAProxy stop, locked service-account/empty protected-credential
+  closure before listener creation, HAProxy-before-Caddy re-creation and
+  host-initial-PID-namespace evidence, with no warm reload or surviving
+  connection graph;
 - target-host no-core/no-swap evidence, including the host core pattern;
 - private provider/issuer/directory canaries with strict client verification;
   and

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -128,9 +128,10 @@ calls the production provider/issuer Store adapters to exercise correct-domain
 opens and a crossed provider authority. It independently stops one provider
 authority backend and then the issuer authority backend while each TLS edge
 continues listening: the affected Store returns
-`RollbackAuthorityUnavailable`, the other two business domains remain usable,
-and restart against the original authority database recovers the exact issuer
-store generation and commitment. A separate stale-provider-authority case first
+`RollbackAuthorityUnavailable`, while the other two Stores remain independently
+openable and authenticated through their own authorities. Restart against the
+original authority database recovers the exact issuer store generation and
+commitment. A separate stale-provider-authority case first
 proves that the restored backup returns an authenticated empty floor, and the
 provider adapter then requires the exact `RollbackFloorMissing` result.
 Restoring the current database is required for recovery. This test does **not**
@@ -192,14 +193,17 @@ cargo test --locked --offline -p bitcoinpir-directory-relay \
 ```
 
 Two copies of the repository's production `bitcoinpir-directory-relay` binary
-use different owner-only configs, loopback ports, SQLite files and runtimes. A
-real WebSocket client publishes and cryptographically verifies the same complete
-16-shard catalog from both, proves both stale-head views remain independently
-valid before requiring the exact split-view rejection, rejects one-relay-offline,
-resolves a lost positive ACK with bounded-backoff ID readback plus idempotent
-same-event retry, and verifies independent restart recovery. The test
-deliberately does not infer relay-operator or host independence from local
-process separation.
+use different owner-only configs, SQLite files and runtimes, plus four distinct
+loopback listeners: one public read lane and one private publisher lane per
+relay. A real WebSocket client sends every signed `EVENT` through a publisher
+lane and every `REQ`/`EOSE` readback through the corresponding public lane. It
+cryptographically verifies the same complete 16-shard catalog from both,
+proves both stale-head views remain independently valid before requiring the
+exact split-view rejection, rejects one-relay-offline, resolves a lost positive
+ACK with a public-lane bounded-backoff ID barrier followed by an idempotent
+same-event publisher-lane retry, and verifies both listeners return after each
+independent process restart. The test deliberately does not infer relay-operator
+or host independence from local process separation.
 
 A separate non-default Standard Cashu process test is implemented and wired
 into Payment CI:

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -195,8 +195,10 @@ cargo test --locked --offline -p bitcoinpir-directory-relay \
 Two copies of the repository's production `bitcoinpir-directory-relay` binary
 use different owner-only configs, SQLite files and runtimes, plus four distinct
 loopback listeners: one public read lane and one private publisher lane per
-relay. A real WebSocket client sends every signed `EVENT` through a publisher
-lane and every `REQ`/`EOSE` readback through the corresponding public lane. It
+relay. Every accepted signed `EVENT` uses a publisher lane, and every accepted
+ID/catalog `REQ` plus returned `EVENT`/`EOSE` uses the corresponding public
+lane. Deliberate wrong-lane probes must close; an exact-ID public readback
+proves the rejected EVENT sentinel was not persisted. The client
 cryptographically verifies the same complete 16-shard catalog from both,
 proves both stale-head views remain independently valid before requiring the
 exact split-view rejection, rejects one-relay-offline, resolves a lost positive
@@ -745,6 +747,38 @@ refunds or unspends the already committed capability.
 - routing fee is not treated as underpayment;
 - late settlement issues once if backend says settled;
 - no automatic refund/query-credit restore.
+
+## Deployment evidence tests
+
+- runtime-evidence accepts only the exact local-files NSS profile and checks
+  stable root-owned policy snapshots, identity-relevant `getent` projections,
+  every user's `id -G`, UID/GID uniqueness and protected-group closure;
+- a final policy snapshot detects `/etc/nsswitch.conf`, `/etc/passwd` or
+  `/etc/group` drift during later live checks;
+- two bounded full `/proc/<pid>/task/<tid>` scans must produce identical
+  protected UID/GID holder records and reject any non-root inheritable,
+  permitted, effective or ambient CAP_SETUID/CAP_SETGID; an unmanaged stale
+  holder, wrong cgroup, changed credential, omitted MainPID, pass race, set-ID
+  capability or legacy evidence fails;
+- an exact managed-unit cgroup may contain master/worker processes only with the
+  unit's complete reviewed UID/GID/group set, and a post-scan generation check
+  rebinds MainPID, InvocationID and ControlGroup;
+- post-scan directory/socket snapshots must still equal the pre-scan inode,
+  type, owner, group, mode, ACL/xattr/capability and stat-command evidence;
+- real Ubuntu procfs enumeration and an Alpine repeated-`Groups:` regression run
+  without skips; evidence count/byte/time bounds fail closed;
+- stopped-edge evidence requires every manifest unit inactive/dead with
+  MainPID 0 and empty ControlGroup, every runtime socket absent, every service
+  account UID/GID-pinned with a nologin/false shell and locked shadow password,
+  and an empty protected-holder closure across both passes; active units,
+  present sockets, login-capable/unlocked accounts, namespace drift and legacy
+  evidence fail closed;
+- target activation invalidates all old connected FDs, approves the exact
+  stopped-edge evidence digest before any listener, recreates the volatile
+  listeners in HAProxy-before-Caddy order, collects a fresh live digest, and
+  independently proves execution in the host initial PID namespace;
+- public and publisher relay listeners reject deliberate wrong-lane EVENTs and
+  prove their exact event IDs absent before a correct-lane publication.
 
 ## Directory tests
 

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -593,6 +593,12 @@ Cashu-specific:
 
 ### Harmony query
 
+- `payment_v1_process_e2e` launches two independent provider processes and
+  executes the canonical level-0 h0/h1 plus level-1 h0/h1 four-frame query at
+  each provider under distinct Harmony scopes/offers/credential keys. It also
+  checks DPF-to-Harmony scope mismatch non-consumption, terminal-DFA rejection,
+  and durable Harmony replay rejection after restart without naming a hint
+  provider;
 - query server does not learn hint provider;
 - query grant cannot fetch hints;
 - cached hint metadata is compatible with policy/dataset binding;

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,9 +26,11 @@ export const ACTIVE_BASELINES = Object.freeze({
 
 export const REVIEWED_PREPARATION_HASHES = Object.freeze({
   "deploy/payment-v1/edge/hetzner-public.Caddyfile.in":
-    "d54ae5e0ec9fea4a72b1eb83ebe1225f18d386437b639db7bc49fa03f730a3d8",
+    "f6d17399d323d49cbe0343c7a4faf31f3a7504b868fd087d2a99fd757831fbc3",
   "deploy/payment-v1/edge/rollback-authority.Caddyfile.in":
-    "7aa07c8d18c94708e6e58034066b1908456e6a5ac64d2ac2d169f4ed6822b95d",
+    "237162cb5d57333adf789e612fcdb4be602bf6e0c9cd99a03ecd079ab8aa257f",
+  "deploy/payment-v1/edge/source-fair-haproxy.cfg.in":
+    "5d3e28438563f592aea4d4a26a7e260f3e313a9e505a0b945bb9f602f0436653",
   "deploy/payment-v1/lightning/activation-prerequisites.toml.example":
     "937737e212f2be0a2fda92fe1aaa421b1aeefdd074261ca78485ca9430d0c443",
   "deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in":
@@ -46,9 +48,13 @@ export const REVIEWED_PREPARATION_HASHES = Object.freeze({
   "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in":
     "e0fa6b1213ae660f74a541d086a16f0c20b8b8eac91f7afe780ffb4ff67ed2ee",
   "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in":
-    "c9557f8d547bc4b800593452f5308d91d65419603e5a5f046f5d06af9033b4e9",
+    "7d43ab957b5b927936af34bb13ef165524d5ff3c80979e24830df2ea72670d55",
   "deploy/payment-v1/systemd/payment-v1-edge.service.in":
-    "49edab939937c98d420e6a6bef6ad3a834effa502630deb666229272993ca841",
+    "1d0c19241d66bd14b261ad20408dcf0a7f2487ece19503e9d7dcccda37d8aedb",
+  "deploy/payment-v1/systemd/payment-v1-public-edge.service.in":
+    "c820e03d9f2dd1d39c82c8a90e5794a8439b7bfbfac22b6387898ddd8184491e",
+  "deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in":
+    "392339c240062bfa301488ba50f5b05693bea5984d466f494303b9a1519ef074",
 });
 
 export const REQUIRED_PREPARATION_FILES = Object.freeze([
@@ -58,6 +64,7 @@ export const REQUIRED_PREPARATION_FILES = Object.freeze([
   "deploy/payment-v1/edge/README.md",
   "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
   "deploy/payment-v1/edge/rollback-authority.Caddyfile.in",
+  "deploy/payment-v1/edge/source-fair-haproxy.cfg.in",
   "deploy/payment-v1/lightning/README.md",
   "deploy/payment-v1/lightning/activation-prerequisites.toml.example",
   "deploy/payment-v1/lightning/cln-rpc-guard-tmpfiles.conf.in",
@@ -68,6 +75,8 @@ export const REQUIRED_PREPARATION_FILES = Object.freeze([
   "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in",
   "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in",
   "deploy/payment-v1/systemd/payment-v1-edge.service.in",
+  "deploy/payment-v1/systemd/payment-v1-public-edge.service.in",
+  "deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in",
   "deploy/payment-v1/systemd/hetzner-provider.service.in",
   "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
   "deploy/payment-v1/systemd/rollback-authority.service.in",
@@ -277,7 +286,12 @@ const COMMON_SERVICE_KEYS = new Set([
   "RestartSec",
   "TimeoutStopSec",
   "TimeoutStartSec",
+  "LimitCORE",
   "LimitNOFILE",
+  "MemoryMax",
+  "MemorySwapMax",
+  "StandardError",
+  "StandardOutput",
   "SupplementaryGroups",
   "Environment",
   "NoNewPrivileges",
@@ -297,6 +311,7 @@ const COMMON_SERVICE_KEYS = new Set([
   "RestrictNamespaces",
   "RestrictRealtime",
   "SystemCallArchitectures",
+  "TasksMax",
   "CapabilityBoundingSet",
   "AmbientCapabilities",
   "RestrictAddressFamilies",
@@ -479,6 +494,7 @@ function validateHetznerProvider(text) {
       "MemoryDenyWriteExecute", "RestrictSUIDSGID", "RestrictNamespaces",
       "RestrictRealtime", "SystemCallArchitectures", "CapabilityBoundingSet",
       "AmbientCapabilities", "RestrictAddressFamilies", "ReadOnlyPaths", "ReadWritePaths",
+      "InaccessiblePaths",
     ],
     label,
   );
@@ -497,6 +513,7 @@ function validateHetznerProvider(text) {
   exactDirectiveValues(unit, "Service", "ProtectHostname", ["true"], label);
   exactDirectiveValues(unit, "Service", "ReadOnlyPaths", ["/etc/bitcoinpir/payment-v1/provider"], label);
   exactDirectiveValues(unit, "Service", "ReadWritePaths", ["/var/lib/bitcoinpir-provider-payment-v1"], label);
+  exactDirectiveValues(unit, "Service", "InaccessiblePaths", ["/run/bitcoinpir-source-fair-edge"], label);
   exactDirectiveValues(
     unit,
     "Service",
@@ -612,7 +629,7 @@ function validateHetznerIssuer(text) {
   exactDirectiveValues(unit, "Service", "ProtectHostname", ["true"], label);
   exactDirectiveValues(unit, "Service", "ReadOnlyPaths", ["/etc/bitcoinpir/payment-v1/issuer /run/bitcoinpir-cln-rpc-guard/issuer /opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@"], label);
   exactDirectiveValues(unit, "Service", "ReadWritePaths", ["/var/lib/bitcoinpir-payment-issuer"], label);
-  exactDirectiveValues(unit, "Service", "InaccessiblePaths", ["/srv/lightning /srv/bitcoin"], label);
+  exactDirectiveValues(unit, "Service", "InaccessiblePaths", ["/srv/lightning /srv/bitcoin /run/bitcoinpir-source-fair-edge"], label);
   exactDirectiveValues(
     unit,
     "Service",
@@ -1007,44 +1024,55 @@ function validateLightningPreflightUnit(text) {
 }
 
 function validatePaymentEdgeUnit(text) {
-  const label = "Payment V1 Caddy edge template";
+  const label = "Payment V1 rollback-authority Caddy edge template";
   const unit = validateInactiveSystemdTemplate(text, label, [
     "/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
     "/etc/bitcoinpir/payment-v1/EDGE-PREFLIGHT-APPROVED",
-  ]);
+    "/etc/bitcoinpir/payment-v1/ROLLBACK-AUTHORITY-PRIVATE-INGRESS-APPROVED",
+  ], { requireStateDirectoryMode: false });
   exactDirectiveKeys(unit, "Unit", BASIC_UNIT_KEYS, label);
   exactDirectiveKeys(
     unit,
     "Service",
     [
-      "Type", "User", "Group", "UMask", "StateDirectory", "StateDirectoryMode",
+      "Type", "User", "Group", "UMask", "RuntimeDirectory", "RuntimeDirectoryMode",
       "WorkingDirectory", "Environment", "ExecStartPre", "ExecStart", "Restart",
       "RestartSec", "TimeoutStartSec", "TimeoutStopSec", "LimitNOFILE",
+      "LimitCORE", "MemoryMax", "MemorySwapMax", "TasksMax", "StandardError",
+      "StandardOutput",
       "AmbientCapabilities", "CapabilityBoundingSet", "NoNewPrivileges",
       "PrivateDevices", "PrivateTmp", "ProtectSystem", "ProtectHome",
       "ProtectKernelTunables", "ProtectKernelModules", "ProtectKernelLogs",
       "ProtectControlGroups", "ProtectClock", "ProtectHostname", "LockPersonality",
       "MemoryDenyWriteExecute", "RestrictSUIDSGID", "RestrictRealtime",
       "RestrictNamespaces", "SystemCallArchitectures", "RestrictAddressFamilies",
-      "ReadOnlyPaths", "ReadWritePaths",
+      "IPAddressDeny", "IPAddressAllow", "ReadOnlyPaths", "ReadWritePaths",
     ],
     label,
   );
   validatePinnedServiceSandbox(unit, label, "notify", "CAP_NET_BIND_SERVICE");
-  exactDirectiveValues(unit, "Unit", "Description", ["BitcoinPIR Payment V1 pinned TLS edge (template only)"], label);
+  exactDirectiveValues(unit, "Unit", "Description", ["BitcoinPIR Payment V1 pinned private rollback-authority TLS edge (template only)"], label);
   exactDirectiveValues(unit, "Unit", "After", ["network-online.target"], label);
   exactDirectiveValues(unit, "Unit", "Wants", ["network-online.target"], label);
   exactDirectiveValues(unit, "Service", "User", ["bitcoinpir-payment-edge"], label);
   exactDirectiveValues(unit, "Service", "Group", ["bitcoinpir-payment-edge"], label);
-  exactDirectiveValues(unit, "Service", "StateDirectory", ["bitcoinpir-payment-edge"], label);
-  exactDirectiveValues(unit, "Service", "StateDirectoryMode", ["0700"], label);
-  exactDirectiveValues(unit, "Service", "WorkingDirectory", ["/var/lib/bitcoinpir-payment-edge"], label);
-  exactDirectiveValues(unit, "Service", "Environment", ["XDG_DATA_HOME=/var/lib/bitcoinpir-payment-edge/data XDG_CONFIG_HOME=/var/lib/bitcoinpir-payment-edge/config"], label);
+  exactDirectiveValues(unit, "Service", "RuntimeDirectory", ["bitcoinpir-rollback-authority-edge"], label);
+  exactDirectiveValues(unit, "Service", "RuntimeDirectoryMode", ["0700"], label);
+  exactDirectiveValues(unit, "Service", "WorkingDirectory", ["/run/bitcoinpir-rollback-authority-edge"], label);
+  exactDirectiveValues(unit, "Service", "Environment", ["XDG_DATA_HOME=/run/bitcoinpir-rollback-authority-edge/data XDG_CONFIG_HOME=/run/bitcoinpir-rollback-authority-edge/config"], label);
   exactDirectiveValues(unit, "Service", "Restart", ["on-failure"], label);
   exactDirectiveValues(unit, "Service", "RestartSec", ["5"], label);
   exactDirectiveValues(unit, "Service", "TimeoutStartSec", ["60"], label);
   exactDirectiveValues(unit, "Service", "TimeoutStopSec", ["30"], label);
-  exactDirectiveValues(unit, "Service", "LimitNOFILE", ["65535"], label);
+  exactDirectiveValues(unit, "Service", "LimitNOFILE", ["1024"], label);
+  exactDirectiveValues(unit, "Service", "LimitCORE", ["0"], label);
+  exactDirectiveValues(unit, "Service", "MemoryMax", ["268435456"], label);
+  exactDirectiveValues(unit, "Service", "MemorySwapMax", ["0"], label);
+  exactDirectiveValues(unit, "Service", "TasksMax", ["128"], label);
+  exactDirectiveValues(unit, "Service", "StandardError", ["null"], label);
+  exactDirectiveValues(unit, "Service", "StandardOutput", ["null"], label);
+  exactDirectiveValues(unit, "Service", "IPAddressDeny", ["any"], label);
+  exactDirectiveValues(unit, "Service", "IPAddressAllow", ["localhost @ROLLBACK_AUTHORITY_CLIENT_IP@"], label);
   exactDirectiveValues(
     unit,
     "Service",
@@ -1053,7 +1081,7 @@ function validatePaymentEdgeUnit(text) {
       "/usr/bin/test -x /opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy",
       "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/caddy.sha256",
       "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/edge-config.sha256",
-      "/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy validate --config /etc/bitcoinpir/payment-v1/edge/@EDGE_CADDYFILE@ --adapter caddyfile",
+      "/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy validate --config /etc/bitcoinpir/payment-v1/edge/rollback-authority.Caddyfile --adapter caddyfile",
     ],
     label,
   );
@@ -1061,11 +1089,150 @@ function validatePaymentEdgeUnit(text) {
     unit,
     "Service",
     "ExecStart",
-    ["/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy run --config /etc/bitcoinpir/payment-v1/edge/@EDGE_CADDYFILE@ --adapter caddyfile"],
+    ["/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy run --config /etc/bitcoinpir/payment-v1/edge/rollback-authority.Caddyfile --adapter caddyfile"],
     label,
   );
   exactDirectiveValues(unit, "Service", "ReadOnlyPaths", ["/etc/bitcoinpir/payment-v1/edge"], label);
+  exactDirectiveValues(unit, "Service", "ReadWritePaths", ["/run/bitcoinpir-rollback-authority-edge"], label);
+  rejectPattern(text, /(?:^|\n)\s*StateDirectory/um, label, "persistent state directory");
+}
+
+function validatePublicPaymentEdgeUnit(text) {
+  const label = "Payment V1 public Caddy edge template";
+  const unit = validateInactiveSystemdTemplate(text, label, [
+    "/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+    "/etc/bitcoinpir/payment-v1/EDGE-PREFLIGHT-APPROVED",
+    "/etc/bitcoinpir/payment-v1/SOURCE-FAIR-PREFLIGHT-APPROVED",
+    "/etc/bitcoinpir/payment-v1/DIRECTORY-PUBLISHER-PRIVATE-INGRESS-APPROVED",
+  ]);
+  exactDirectiveKeys(unit, "Unit", [
+    "Description", "After", "Wants", "Requires", "BindsTo", "ConditionPathExists",
+  ], label);
+  exactDirectiveKeys(unit, "Service", [
+    "Type", "User", "Group", "SupplementaryGroups", "UMask", "StateDirectory",
+    "StateDirectoryMode", "WorkingDirectory", "Environment", "ExecStartPre",
+    "ExecStart", "Restart", "RestartSec", "TimeoutStartSec", "TimeoutStopSec",
+    "LimitNOFILE", "MemoryMax", "TasksMax", "StandardError", "StandardOutput", "AmbientCapabilities",
+    "LimitCORE", "MemorySwapMax",
+    "CapabilityBoundingSet", "NoNewPrivileges", "PrivateDevices", "PrivateTmp",
+    "ProtectSystem", "ProtectHome", "ProtectKernelTunables", "ProtectKernelModules",
+    "ProtectKernelLogs", "ProtectControlGroups", "ProtectClock", "ProtectHostname",
+    "LockPersonality", "MemoryDenyWriteExecute", "RestrictSUIDSGID",
+    "RestrictRealtime", "RestrictNamespaces", "SystemCallArchitectures",
+    "RestrictAddressFamilies", "ReadOnlyPaths", "ReadWritePaths",
+  ], label);
+  validatePinnedServiceSandbox(unit, label, "notify", "CAP_NET_BIND_SERVICE");
+  exactDirectiveValues(unit, "Unit", "Description", ["BitcoinPIR Payment V1 pinned public TLS edge (template only)"], label);
+  exactDirectiveValues(unit, "Unit", "After", ["network-online.target bitcoinpir-payment-v1-source-fair-edge.service"], label);
+  exactDirectiveValues(unit, "Unit", "Wants", ["network-online.target"], label);
+  exactDirectiveValues(unit, "Unit", "Requires", ["bitcoinpir-payment-v1-source-fair-edge.service"], label);
+  exactDirectiveValues(unit, "Unit", "BindsTo", ["bitcoinpir-payment-v1-source-fair-edge.service"], label);
+  exactDirectiveValues(unit, "Service", "User", ["bitcoinpir-payment-edge"], label);
+  exactDirectiveValues(unit, "Service", "Group", ["bitcoinpir-payment-edge"], label);
+  exactDirectiveValues(unit, "Service", "SupplementaryGroups", ["bitcoinpir-source-fair-edge"], label);
+  exactDirectiveValues(unit, "Service", "StateDirectory", ["bitcoinpir-payment-edge"], label);
+  exactDirectiveValues(unit, "Service", "WorkingDirectory", ["/var/lib/bitcoinpir-payment-edge"], label);
+  exactDirectiveValues(unit, "Service", "Environment", ["XDG_DATA_HOME=/var/lib/bitcoinpir-payment-edge/data XDG_CONFIG_HOME=/var/lib/bitcoinpir-payment-edge/config"], label);
+  exactDirectiveValues(unit, "Service", "Restart", ["on-failure"], label);
+  exactDirectiveValues(unit, "Service", "RestartSec", ["5"], label);
+  exactDirectiveValues(unit, "Service", "TimeoutStartSec", ["60"], label);
+  exactDirectiveValues(unit, "Service", "TimeoutStopSec", ["30"], label);
+  exactDirectiveValues(unit, "Service", "LimitNOFILE", ["4096"], label);
+  exactDirectiveValues(unit, "Service", "LimitCORE", ["0"], label);
+  exactDirectiveValues(unit, "Service", "MemoryMax", ["536870912"], label);
+  exactDirectiveValues(unit, "Service", "MemorySwapMax", ["0"], label);
+  exactDirectiveValues(unit, "Service", "TasksMax", ["512"], label);
+  exactDirectiveValues(unit, "Service", "StandardError", ["null"], label);
+  exactDirectiveValues(unit, "Service", "StandardOutput", ["null"], label);
+  exactDirectiveValues(unit, "Service", "ExecStartPre", [
+    "/usr/bin/test -x /opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy",
+    "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/caddy.sha256",
+    "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/edge/edge-config.sha256",
+    "/usr/bin/test -S /run/bitcoinpir-source-fair-edge/provider.sock",
+    "/usr/bin/test -S /run/bitcoinpir-source-fair-edge/issuer.sock",
+    "/usr/bin/test -S /run/bitcoinpir-source-fair-edge/directory-public.sock",
+    "/usr/bin/test -S /run/bitcoinpir-source-fair-edge/directory-publisher.sock",
+    "/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy validate --config /etc/bitcoinpir/payment-v1/edge/hetzner-public.Caddyfile --adapter caddyfile",
+  ], label);
+  exactDirectiveValues(unit, "Service", "ExecStart", [
+    "/opt/bitcoinpir/caddy/@CADDY_SHA256@/caddy run --config /etc/bitcoinpir/payment-v1/edge/hetzner-public.Caddyfile --adapter caddyfile",
+  ], label);
+  exactDirectiveValues(unit, "Service", "ReadOnlyPaths", ["/etc/bitcoinpir/payment-v1/edge /run/bitcoinpir-source-fair-edge"], label);
   exactDirectiveValues(unit, "Service", "ReadWritePaths", ["/var/lib/bitcoinpir-payment-edge"], label);
+}
+
+function validateSourceFairEdgeUnit(text) {
+  const label = "Payment V1 HAProxy source-fair edge template";
+  const unit = validateInactiveSystemdTemplate(text, label, [
+    "/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+    "/etc/bitcoinpir/payment-v1/SOURCE-FAIR-PREFLIGHT-APPROVED",
+    "/etc/bitcoinpir/payment-v1/DIRECTORY-PUBLISHER-PRIVATE-INGRESS-APPROVED",
+  ], { requireStateDirectoryMode: false });
+  exactDirectiveKeys(unit, "Unit", [
+    "Description", "After", "Wants", "Before", "ConditionPathExists",
+  ], label);
+  exactDirectiveKeys(unit, "Service", [
+    "Type", "User", "Group", "UMask", "RuntimeDirectory", "RuntimeDirectoryMode",
+    "WorkingDirectory", "ExecStartPre", "ExecStart", "Restart", "RestartSec",
+    "TimeoutStartSec", "TimeoutStopSec", "LimitNOFILE", "MemoryMax", "TasksMax",
+    "LimitCORE", "MemorySwapMax",
+    "StandardError", "StandardOutput",
+    "NoNewPrivileges", "PrivateDevices", "PrivateTmp", "ProtectSystem",
+    "ProtectHome", "ProtectKernelTunables", "ProtectKernelModules", "ProtectKernelLogs",
+    "ProtectControlGroups", "ProtectClock", "ProtectHostname", "LockPersonality",
+    "MemoryDenyWriteExecute", "RestrictSUIDSGID", "RestrictRealtime",
+    "RestrictNamespaces", "SystemCallArchitectures", "CapabilityBoundingSet",
+    "AmbientCapabilities", "RestrictAddressFamilies", "IPAddressDeny",
+    "IPAddressAllow", "ReadOnlyPaths", "ReadWritePaths",
+  ], label);
+  for (const key of [
+    "NoNewPrivileges", "PrivateDevices", "PrivateTmp", "ProtectHome",
+    "ProtectKernelTunables", "ProtectKernelModules", "ProtectKernelLogs",
+    "ProtectControlGroups", "ProtectClock", "ProtectHostname", "LockPersonality",
+    "MemoryDenyWriteExecute", "RestrictSUIDSGID", "RestrictRealtime",
+    "RestrictNamespaces",
+  ]) exactDirectiveValues(unit, "Service", key, ["true"], label);
+  exactDirectiveValues(unit, "Service", "ProtectSystem", ["strict"], label);
+  exactDirectiveValues(unit, "Service", "SystemCallArchitectures", ["native"], label);
+  exactDirectiveValues(unit, "Service", "CapabilityBoundingSet", [""], label);
+  exactDirectiveValues(unit, "Service", "AmbientCapabilities", [""], label);
+  exactDirectiveValues(unit, "Unit", "Description", ["BitcoinPIR Payment V1 pinned source-fair edge (template only)"], label);
+  exactDirectiveValues(unit, "Unit", "After", ["network-online.target"], label);
+  exactDirectiveValues(unit, "Unit", "Wants", ["network-online.target"], label);
+  exactDirectiveValues(unit, "Unit", "Before", ["bitcoinpir-payment-v1-public-edge.service"], label);
+  exactDirectiveValues(unit, "Service", "Type", ["notify"], label);
+  exactDirectiveValues(unit, "Service", "User", ["bitcoinpir-source-fair-edge"], label);
+  exactDirectiveValues(unit, "Service", "Group", ["bitcoinpir-source-fair-edge"], label);
+  exactDirectiveValues(unit, "Service", "UMask", ["0007"], label);
+  exactDirectiveValues(unit, "Service", "RuntimeDirectory", ["bitcoinpir-source-fair-edge"], label);
+  exactDirectiveValues(unit, "Service", "RuntimeDirectoryMode", ["0750"], label);
+  exactDirectiveValues(unit, "Service", "WorkingDirectory", ["/run/bitcoinpir-source-fair-edge"], label);
+  exactDirectiveValues(unit, "Service", "Restart", ["on-failure"], label);
+  exactDirectiveValues(unit, "Service", "RestartSec", ["5"], label);
+  exactDirectiveValues(unit, "Service", "TimeoutStartSec", ["30"], label);
+  exactDirectiveValues(unit, "Service", "TimeoutStopSec", ["15"], label);
+  exactDirectiveValues(unit, "Service", "LimitNOFILE", ["2048"], label);
+  exactDirectiveValues(unit, "Service", "LimitCORE", ["0"], label);
+  exactDirectiveValues(unit, "Service", "MemoryMax", ["268435456"], label);
+  exactDirectiveValues(unit, "Service", "MemorySwapMax", ["0"], label);
+  exactDirectiveValues(unit, "Service", "TasksMax", ["128"], label);
+  exactDirectiveValues(unit, "Service", "StandardError", ["null"], label);
+  exactDirectiveValues(unit, "Service", "StandardOutput", ["null"], label);
+  exactDirectiveValues(unit, "Service", "RestrictAddressFamilies", ["AF_UNIX AF_INET AF_INET6"], label);
+  exactDirectiveValues(unit, "Service", "IPAddressDeny", ["any"], label);
+  exactDirectiveValues(unit, "Service", "IPAddressAllow", ["localhost"], label);
+  exactDirectiveValues(unit, "Service", "ExecStartPre", [
+    "/usr/bin/test -x /opt/bitcoinpir/haproxy/@HAPROXY_SHA256@/haproxy",
+    "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/source-fair-edge/haproxy.sha256",
+    "/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/source-fair-edge/source-fair-config.sha256",
+    "/opt/bitcoinpir/haproxy/@HAPROXY_SHA256@/haproxy -c -q -f /etc/bitcoinpir/payment-v1/source-fair-edge/haproxy.cfg",
+  ], label);
+  exactDirectiveValues(unit, "Service", "ExecStart", [
+    "/opt/bitcoinpir/haproxy/@HAPROXY_SHA256@/haproxy -Ws -db -q -f /etc/bitcoinpir/payment-v1/source-fair-edge/haproxy.cfg",
+  ], label);
+  exactDirectiveValues(unit, "Service", "ReadOnlyPaths", ["/etc/bitcoinpir/payment-v1/source-fair-edge /opt/bitcoinpir/haproxy/@HAPROXY_SHA256@"], label);
+  exactDirectiveValues(unit, "Service", "ReadWritePaths", ["/run/bitcoinpir-source-fair-edge"], label);
+  rejectPattern(text, /(?:^|\n)\s*StateDirectory/um, label, "persistent state directory");
 }
 
 function activeTemplateLines(text, label) {
@@ -1219,12 +1386,164 @@ function validateCaddyTemplate(text, label, requiredUpstreams) {
     const matches = text.match(new RegExp(`reverse_proxy\\s+${escaped}`, "gu")) ?? [];
     if (matches.length === 0) fail(`${label} must contain reviewed loopback upstream ${upstream}`);
   }
+  const approvedUpstreams = new Set([
+    "127.0.0.1:5610",
+    "127.0.0.1:8191",
+    "127.0.0.1:8080",
+    "127.0.0.1:8099",
+    "unix//run/bitcoinpir-source-fair-edge/provider.sock",
+    "unix//run/bitcoinpir-source-fair-edge/issuer.sock",
+    "unix//run/bitcoinpir-source-fair-edge/directory-public.sock",
+    "unix//run/bitcoinpir-source-fair-edge/directory-publisher.sock",
+  ]);
+  for (const match of text.matchAll(/(?:^|\n)\s*reverse_proxy[ \t]+(\S+)/gu)) {
+    if (!approvedUpstreams.has(match[1])) {
+      fail(`${label} contains non-reviewed upstream ${match[1]}`);
+    }
+  }
+}
+
+function validateSourceFairHaproxy(text) {
+  const label = "Payment V1 HAProxy source-fair configuration";
+  const active = activeTemplateLines(text, label);
+  const activeText = active.join("\n");
+  for (const required of [
+    "maxconn 320",
+    "backend provider_sources",
+    "backend issuer_sources",
+    "backend issuer_quote_sources",
+    "backend issuer_quote_global",
+    "backend directory_public_sources",
+    "backend directory_publisher_sources",
+    "bind /run/bitcoinpir-source-fair-edge/provider.sock accept-proxy mode 660",
+    "bind /run/bitcoinpir-source-fair-edge/issuer.sock accept-proxy mode 660",
+    "bind /run/bitcoinpir-source-fair-edge/directory-public.sock accept-proxy mode 660",
+    "bind /run/bitcoinpir-source-fair-edge/directory-publisher.sock accept-proxy mode 660",
+    "http-request deny deny_status 403 unless { src @DIRECTORY_PUBLISHER_CLIENT_IP@ }",
+    "stick-table type ipv6 size 4096 expire 2m nopurge store conn_cur,conn_rate(10s),bytes_out_rate(1s)",
+    "stick-table type ipv6 size 4096 expire 2m nopurge store conn_cur,conn_rate(10s),http_req_rate(60s),bytes_out_rate(1s)",
+    "stick-table type integer size 1 expire 2m nopurge store http_req_rate(60s)",
+    "http-request track-sc0 src,ipmask(32,64) table provider_sources",
+    "http-request track-sc0 src,ipmask(32,64) table issuer_sources",
+    "http-request track-sc0 src,ipmask(32,64) table directory_public_sources",
+    "http-request track-sc0 src,ipmask(32,64) table directory_publisher_sources",
+    "http-request track-sc1 src,ipmask(32,64) table issuer_quote_sources if quote_create",
+    "http-request track-sc2 int(1) table issuer_quote_global if quote_create",
+    "http-request deny deny_status 429 unless { sc0_tracked }",
+    "http-request deny deny_status 429 if quote_create !{ sc1_tracked }",
+    "http-request deny deny_status 429 if quote_create !{ sc2_tracked }",
+    "http-request deny deny_status 429 if { sc0_conn_cur gt 8 }",
+    "http-request deny deny_status 429 if { sc0_conn_cur gt 4 }",
+    "http-request deny deny_status 429 if { sc0_conn_cur gt 2 }",
+    "http-request deny deny_status 429 if quote_create { sc1_http_req_rate gt 6 }",
+    "http-request deny deny_status 429 if quote_create { sc2_http_req_rate gt 60 }",
+    "server provider 127.0.0.1:8191 maxconn 128",
+    "server issuer 127.0.0.1:5610 maxconn 128",
+    "server directory-public 127.0.0.1:8080 maxconn 48",
+    "server directory-publisher 127.0.0.1:8081 maxconn 4",
+  ]) requireText(activeText, required, label);
+  const proxyBinds = active.filter((line) => /^bind .*accept-proxy mode 660$/u.test(line));
+  if (proxyBinds.length !== 4) fail(`${label} must expose exactly four protected PROXY-v2 Unix sockets`);
+  const tables = active.filter((line) => line.startsWith("stick-table "));
+  if (tables.length !== 6 || tables.some((line) => !line.includes("expire 2m nopurge"))) {
+    fail(`${label} must have exactly six bounded, expiring, non-evicting memory tables`);
+  }
+  const sourceTableFullChecks = active.filter((line) => line.includes("table_avl(") && line.includes("in_table("));
+  if (sourceTableFullChecks.length !== 5) {
+    fail(`${label} must fail closed when any source-keyed table is full`);
+  }
+  const trackedAllocationGuards = [
+    [
+      "http-request track-sc0 src,ipmask(32,64) table provider_sources",
+      "http-request deny deny_status 429 unless { sc0_tracked }",
+    ],
+    [
+      "http-request track-sc0 src,ipmask(32,64) table issuer_sources",
+      "http-request deny deny_status 429 unless { sc0_tracked }",
+    ],
+    [
+      "http-request track-sc1 src,ipmask(32,64) table issuer_quote_sources if quote_create",
+      "http-request deny deny_status 429 if quote_create !{ sc1_tracked }",
+    ],
+    [
+      "http-request track-sc2 int(1) table issuer_quote_global if quote_create",
+      "http-request deny deny_status 429 if quote_create !{ sc2_tracked }",
+    ],
+    [
+      "http-request track-sc0 src,ipmask(32,64) table directory_public_sources",
+      "http-request deny deny_status 429 unless { sc0_tracked }",
+    ],
+    [
+      "http-request track-sc0 src,ipmask(32,64) table directory_publisher_sources",
+      "http-request deny deny_status 429 unless { sc0_tracked }",
+    ],
+  ];
+  for (const [track, guard] of trackedAllocationGuards) {
+    const trackIndex = active.indexOf(track);
+    if (trackIndex < 0 || active[trackIndex + 1] !== guard) {
+      fail(`${label} must immediately reject a failed ${track} allocation`);
+    }
+  }
+  const publisherSourceGuard =
+    "http-request deny deny_status 403 unless { src @DIRECTORY_PUBLISHER_CLIENT_IP@ }";
+  if (
+    active.filter((line) => line === publisherSourceGuard).length !== 1 ||
+    active.indexOf(publisherSourceGuard) >=
+      active.indexOf(
+        "http-request track-sc0 src,ipmask(32,64) table directory_publisher_sources",
+      )
+  ) {
+    fail(`${label} must reject the non-publisher source before allocating publisher state`);
+  }
+  const allocationGuardCount = active.filter((line) =>
+    /sc[012]_tracked/u.test(line)
+  ).length;
+  if (allocationGuardCount !== trackedAllocationGuards.length) {
+    fail(`${label} must have exactly six post-allocation tracking guards`);
+  }
+  const egressFilters = active.filter((line) => line.startsWith("filter bwlim-out "));
+  const enabledEgressFilters = active.filter((line) => line.startsWith("http-request set-bandwidth-limit "));
+  if (egressFilters.length !== 8 || enabledEgressFilters.length !== 8) {
+    fail(`${label} must enforce shared-source and per-stream egress on every lane`);
+  }
+  if (active.filter((line) => line === "no log").length !== 1) {
+    fail(`${label} must explicitly disable transaction logging once`);
+  }
+  const expectedApplicationServers = [
+    "server directory-public 127.0.0.1:8080 maxconn 48",
+    "server directory-publisher 127.0.0.1:8081 maxconn 4",
+    "server issuer 127.0.0.1:5610 maxconn 128",
+    "server provider 127.0.0.1:8191 maxconn 128",
+  ];
+  const applicationServers = active
+    .filter((line) => line.startsWith("server "))
+    .sort();
+  if (JSON.stringify(applicationServers) !== JSON.stringify(expectedApplicationServers)) {
+    fail(`${label} must open exactly the four reviewed source-free loopback application peers`);
+  }
+  for (const line of active) {
+    if (/^log(?:\s|$)/u.test(line)) fail(`${label} contains a log target`);
+  }
   rejectPattern(
-    text,
-    /(?:^|\n)\s*reverse_proxy[ \t]+(?!127\.0\.0\.1:(?:5610|8191|8080|8099)\b)\S+/gu,
+    activeText,
+    /(?:^|\s)(?:peers|stats|server-state-file|load-server-state-from-file|send-proxy(?:-v2)?|option\s+forwardfor|unique-id-format|capture|lua-load|filter\s+spoe)(?:\s|$)/u,
     label,
-    "non-reviewed or non-loopback upstream",
+    "persistent/replicated state, identity forwarding, capture, or extension hook",
   );
+  rejectPattern(activeText, /127\.0\.0\.1:8099/u, label, "rollback-authority routing");
+  rejectPattern(activeText, /http-request\s+(?:add|set)-header/iu, label, "header identity injection");
+  for (const header of [
+    "Baggage", "CF-Connecting-IP", "Client-IP", "Fastly-Client-IP",
+    "Fly-Client-IP", "Forwarded", "Traceparent", "Tracestate",
+    "True-Client-IP", "Via", "X-Client-IP", "X-Cluster-Client-IP",
+    "X-Correlation-ID", "X-Envoy-External-Address", "X-Forwarded-For",
+    "X-Forwarded-Host", "X-Forwarded-Proto", "X-Original-Client-IP",
+    "X-Original-Forwarded-For", "X-Real-IP", "X-Request-ID",
+  ]) {
+    if (active.filter((line) => line === `http-request del-header ${header}`).length !== 4) {
+      fail(`${label} must delete ${header} independently on all four application lanes`);
+    }
+  }
 }
 
 function validateVpsbgFreePow(text, mode) {
@@ -1374,13 +1693,22 @@ function validateRelayConfigExample(text, selection) {
   const config = parseRelaySelection(text);
   const expectedKeys = [
     "profile",
-    "listen",
+    "public_listen",
+    "publisher_listen",
     "database",
     "directory_pubkey_hex",
     "max_connections",
+    "max_public_connections",
+    "max_publisher_connections",
     "max_in_flight_operations",
+    "max_public_in_flight_operations",
+    "max_publisher_in_flight_operations",
     "max_operations_per_second",
+    "max_public_operations_per_second",
+    "max_publisher_operations_per_second",
     "max_egress_bytes_per_second",
+    "max_public_egress_bytes_per_second",
+    "max_publisher_egress_bytes_per_second",
     "max_egress_bytes_per_connection",
     "max_archive_events",
     "max_archive_bytes",
@@ -1399,12 +1727,21 @@ function validateRelayConfigExample(text, selection) {
   }
   for (const [field, expected] of [
     ["profile", "bitcoinpir-directory-relay-v1"],
-    ["listen", "127.0.0.1:8080"],
+    ["public_listen", "127.0.0.1:8080"],
+    ["publisher_listen", "127.0.0.1:8081"],
     ["database", "/var/lib/bitcoinpir-directory-relay/relay.sqlite3"],
-    ["max_connections", 64],
+    ["max_connections", 52],
+    ["max_public_connections", 48],
+    ["max_publisher_connections", 4],
     ["max_in_flight_operations", 8],
+    ["max_public_in_flight_operations", 6],
+    ["max_publisher_in_flight_operations", 2],
     ["max_operations_per_second", 64],
+    ["max_public_operations_per_second", 48],
+    ["max_publisher_operations_per_second", 16],
     ["max_egress_bytes_per_second", 16_777_216],
+    ["max_public_egress_bytes_per_second", 12_582_912],
+    ["max_publisher_egress_bytes_per_second", 4_194_304],
     ["max_egress_bytes_per_connection", 67_108_864],
     ["max_archive_events", 100_000],
     ["max_archive_bytes", 268_435_456],
@@ -1456,6 +1793,7 @@ function validateTemplateTreeShape(root) {
       !rel.endsWith(".service.in") &&
       !rel.endsWith(".args.in") &&
       !rel.endsWith(".Caddyfile.in") &&
+      !rel.endsWith(".cfg.in") &&
       !rel.endsWith(".conf.in") &&
       !rel.endsWith(".sh.in") &&
       !rel.endsWith(".toml.example") &&
@@ -1539,6 +1877,24 @@ export function validateDeploymentTree(rootInput) {
   );
   validatePaymentEdgeUnit(paymentEdge.text);
 
+  const publicPaymentEdge = readRequired(
+    root,
+    "deploy/payment-v1/systemd/payment-v1-public-edge.service.in",
+  );
+  validatePublicPaymentEdgeUnit(publicPaymentEdge.text);
+
+  const sourceFairEdgeUnit = readRequired(
+    root,
+    "deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in",
+  );
+  validateSourceFairEdgeUnit(sourceFairEdgeUnit.text);
+
+  const sourceFairHaproxy = readRequired(
+    root,
+    "deploy/payment-v1/edge/source-fair-haproxy.cfg.in",
+  );
+  validateSourceFairHaproxy(sourceFairHaproxy.text);
+
   const activationPrerequisites = readRequired(
     root,
     "deploy/payment-v1/lightning/activation-prerequisites.toml.example",
@@ -1587,7 +1943,49 @@ export function validateDeploymentTree(rootInput) {
   validateCaddyTemplate(
     publicEdge.text,
     "Hetzner public Caddy template",
-    ["127.0.0.1:8191", "127.0.0.1:5610", "127.0.0.1:8080"],
+    [
+      "unix//run/bitcoinpir-source-fair-edge/provider.sock",
+      "unix//run/bitcoinpir-source-fair-edge/issuer.sock",
+      "unix//run/bitcoinpir-source-fair-edge/directory-public.sock",
+      "unix//run/bitcoinpir-source-fair-edge/directory-publisher.sock",
+    ],
+  );
+  for (const required of [
+    "read_header 5s",
+    "read_body 15s",
+    "idle 60s",
+    "max_header_size 16KiB",
+    "bind @PUBLIC_HTTPS_BIND@",
+    "bind @DIRECTORY_PUBLISHER_PRIVATE_BIND@",
+    "remote_ip @DIRECTORY_PUBLISHER_CLIENT_IP@",
+    "tls /etc/bitcoinpir/payment-v1/edge/directory-publisher-server.crt /etc/bitcoinpir/payment-v1/edge/directory-publisher-server.key",
+  ]) requireText(publicEdge.text, required, "Hetzner public Caddy template");
+  if ((publicEdge.text.match(/remote_ip @DIRECTORY_PUBLISHER_CLIENT_IP@/gu) ?? []).length !== 1) {
+    fail("Hetzner public Caddy template must use the exact publisher client address once");
+  }
+  rejectPattern(
+    publicEdge.text,
+    /\b(?:client_auth|trust_pool)\b/u,
+    "Hetzner public Caddy template",
+    "publisher client-certificate requirement unsupported by bpir-admin",
+  );
+  if ((publicEdge.text.match(/proxy_protocol v2/gu) ?? []).length !== 7) {
+    fail("Hetzner public Caddy template must use PROXY v2 on exactly seven reviewed upstream routes");
+  }
+  if ((publicEdge.text.match(/header_up -\*/gu) ?? []).length !== 7) {
+    fail("Hetzner public Caddy template must clear all client headers on every upstream route");
+  }
+  rejectPattern(
+    publicEdge.text,
+    /header_up\s+(?:CF-Connecting-IP|Client-IP|Fastly-Client-IP|Fly-Client-IP|Forwarded|True-Client-IP|X-Client-IP|X-Cluster-Client-IP|X-Envoy-External-Address|X-Forwarded(?:-[A-Za-z0-9-]+)?|X-Original-(?:Client-IP|Forwarded-For)|X-Real-IP)\b/iu,
+    "Hetzner public Caddy template",
+    "source identity header forwarding",
+  );
+  rejectPattern(
+    publicEdge.text,
+    /reverse_proxy\s+127\.0\.0\.1:/u,
+    "Hetzner public Caddy template",
+    "direct business-service bypass",
   );
   requireText(
     publicEdge.text,
@@ -1610,6 +2008,10 @@ export function validateDeploymentTree(rootInput) {
     "rollback-authority Caddy template",
     ["127.0.0.1:8099"],
   );
+  for (const required of [
+    "bind @ROLLBACK_AUTHORITY_PRIVATE_BIND@",
+    "tls /etc/bitcoinpir/payment-v1/edge/rollback-authority-server.crt /etc/bitcoinpir/payment-v1/edge/rollback-authority-server.key",
+  ]) requireText(authorityEdge.text, required, "rollback-authority Caddy template");
 
   const authority = readRequired(
     root,
@@ -1666,7 +2068,7 @@ export function validateDeploymentTree(rootInput) {
       "RestrictSUIDSGID", "RestrictNamespaces", "RestrictRealtime",
       "SystemCallArchitectures", "CapabilityBoundingSet", "AmbientCapabilities",
       "RestrictAddressFamilies", "IPAddressDeny", "IPAddressAllow", "ReadOnlyPaths",
-      "ReadWritePaths",
+      "ReadWritePaths", "InaccessiblePaths",
       ...(selection.status === "RESOLVED" ? ["ExecStartPre"] : []),
       ...(selection.status === "RESOLVED" ? ["RestartSec"] : []),
     ],
@@ -1685,6 +2087,7 @@ export function validateDeploymentTree(rootInput) {
   exactDirectiveValues(relayParsed, "Service", "IPAddressAllow", ["localhost"], relayLabel);
   exactDirectiveValues(relayParsed, "Service", "ReadOnlyPaths", ["/etc/bitcoinpir/payment-v1/directory-relay"], relayLabel);
   exactDirectiveValues(relayParsed, "Service", "ReadWritePaths", ["/var/lib/bitcoinpir-directory-relay"], relayLabel);
+  exactDirectiveValues(relayParsed, "Service", "InaccessiblePaths", ["/run/bitcoinpir-source-fair-edge"], relayLabel);
   rejectPattern(
     relayUnit.text,
     /publisher-(?:private|signing)-key|directory-(?:private|signing)-key/i,

--- a/scripts/payment-v1-deployment-template-gate.test.mjs
+++ b/scripts/payment-v1-deployment-template-gate.test.mjs
@@ -365,7 +365,10 @@ test("edge and Lightning templates reject reviewed P1 bypass mutations", () => {
   const mutations = [
     [
       "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
-      (text) => text.replace("reverse_proxy 127.0.0.1:8191", "reverse_proxy attacker.example:443"),
+      (text) => text.replace(
+        "reverse_proxy unix//run/bitcoinpir-source-fair-edge/provider.sock",
+        "reverse_proxy attacker.example:443",
+      ),
       /reviewed loopback upstream|non-reviewed or non-loopback upstream/,
     ],
     [
@@ -449,6 +452,139 @@ test("public issuer edge exposes ledger accrual only", () => {
   });
 });
 
+test("source-fair edge rejects identity leaks, persistence, bypasses, and unbounded lanes", () => {
+  const mutations = [
+    [
+      "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
+      (text) => text.replace("proxy_protocol v2", "proxy_protocol v1"),
+      /proxy_protocol v2|PROXY v2/,
+    ],
+    [
+      "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
+      (text) => text.replace("header_up -*", "header_up X-Forwarded-For {http.request.remote.host}"),
+      /clear all client headers|header_up -\*|source or correlation header/,
+    ],
+    [
+      "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
+      (text) => text.replace(
+        "header_up -*",
+        "header_up -*\n\t\t\theader_up CF-Connecting-IP {http.request.remote.host}",
+      ),
+      /source identity header forwarding/,
+    ],
+    [
+      "deploy/payment-v1/edge/source-fair-haproxy.cfg.in",
+      (text) => text.replace("    no log\n", "    log stdout format raw local0\n"),
+      /no log|logging|persistent/,
+    ],
+    [
+      "deploy/payment-v1/edge/source-fair-haproxy.cfg.in",
+      (text) => text.replace("expire 2m nopurge", "expire 24h"),
+      /bounded|expiring|nopurge|stick-table/,
+    ],
+    [
+      "deploy/payment-v1/edge/source-fair-haproxy.cfg.in",
+      (text) => text.replace(
+        "    http-request deny deny_status 429 unless { sc0_tracked }\n",
+        "",
+      ),
+      /immediately reject|post-allocation tracking guards/,
+    ],
+    [
+      "deploy/payment-v1/edge/source-fair-haproxy.cfg.in",
+      (text) => text.replace(
+        "server provider 127.0.0.1:8191 maxconn 128",
+        "server provider 127.0.0.1:8191 maxconn 128 send-proxy-v2",
+      ),
+      /PROXY|source|application backend/,
+    ],
+    [
+      "deploy/payment-v1/edge/source-fair-haproxy.cfg.in",
+      (text) => text.replace(
+        "server provider 127.0.0.1:8191 maxconn 128",
+        "server provider 127.0.0.1:8191 maxconn 128\n    server observer 127.0.0.1:8192",
+      ),
+      /exactly the four reviewed source-free loopback application peers/,
+    ],
+    [
+      "deploy/payment-v1/edge/source-fair-haproxy.cfg.in",
+      (text) => text.replace("    http-request del-header CF-Connecting-IP\n", ""),
+      /delete CF-Connecting-IP independently on all four application lanes/,
+    ],
+    [
+      "deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in",
+      (text) => text.replace(
+        "RuntimeDirectory=bitcoinpir-source-fair-edge",
+        "StateDirectory=bitcoinpir-source-fair-edge\nRuntimeDirectory=bitcoinpir-source-fair-edge",
+      ),
+      /StateDirectory|directive keys/,
+    ],
+    [
+      "deploy/payment-v1/systemd/payment-v1-public-edge.service.in",
+      (text) => text.replace(
+        "Requires=bitcoinpir-payment-v1-source-fair-edge.service\n",
+        "",
+      ),
+      /Requires|directive keys/,
+    ],
+    [
+      "deploy/payment-v1/systemd/payment-v1-public-edge.service.in",
+      (text) => text.replace("StandardOutput=null", "StandardOutput=journal"),
+      /StandardOutput/,
+    ],
+    [
+      "deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in",
+      (text) => text.replace("StandardError=null", "StandardError=journal"),
+      /StandardError/,
+    ],
+    [
+      "deploy/payment-v1/systemd/payment-v1-public-edge.service.in",
+      (text) => text.replace("LimitCORE=0", "LimitCORE=infinity"),
+      /LimitCORE/,
+    ],
+    [
+      "deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in",
+      (text) => text.replace("MemorySwapMax=0", "MemorySwapMax=infinity"),
+      /MemorySwapMax/,
+    ],
+    [
+      "deploy/payment-v1/edge/rollback-authority.Caddyfile.in",
+      (text) => text.replace("\tbind @ROLLBACK_AUTHORITY_PRIVATE_BIND@\n", ""),
+      /ROLLBACK_AUTHORITY_PRIVATE_BIND|bind/,
+    ],
+    [
+      "deploy/payment-v1/edge/rollback-authority.Caddyfile.in",
+      (text) => text.replace(
+        "\ttls /etc/bitcoinpir/payment-v1/edge/rollback-authority-server.crt /etc/bitcoinpir/payment-v1/edge/rollback-authority-server.key\n",
+        "",
+      ),
+      /rollback-authority-server|tls/,
+    ],
+    [
+      "deploy/payment-v1/systemd/payment-v1-edge.service.in",
+      (text) => text.replace(
+        "IPAddressAllow=localhost @ROLLBACK_AUTHORITY_CLIENT_IP@",
+        "IPAddressAllow=localhost",
+      ),
+      /ROLLBACK_AUTHORITY_CLIENT_IP|IPAddressAllow/,
+    ],
+    [
+      "deploy/payment-v1/systemd/payment-v1-edge.service.in",
+      (text) => text.replace(
+        "RuntimeDirectory=bitcoinpir-rollback-authority-edge",
+        "StateDirectory=bitcoinpir-rollback-authority-edge\nRuntimeDirectory=bitcoinpir-rollback-authority-edge",
+      ),
+      /StateDirectory|directive keys/,
+    ],
+  ];
+  for (const [relativePath, transform, expected] of mutations) {
+    withFixture((root) => {
+      mutate(root, relativePath, transform);
+      assert.throws(() => validateDeploymentTree(root), expected);
+    });
+  }
+});
+
 test("CLN guard and cross-UID isolation reject topology regressions", () => {
   const mutations = [
     [
@@ -491,7 +627,10 @@ test("CLN guard and cross-UID isolation reject topology regressions", () => {
     ],
     [
       "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
-      (text) => text.replace("InaccessiblePaths=/srv/lightning /srv/bitcoin\n", ""),
+      (text) => text.replace(
+        "InaccessiblePaths=/srv/lightning /srv/bitcoin /run/bitcoinpir-source-fair-edge\n",
+        "",
+      ),
       /InaccessiblePaths/,
     ],
     [

--- a/scripts/payment-v1-linux-runtime-evidence.mjs
+++ b/scripts/payment-v1-linux-runtime-evidence.mjs
@@ -2,8 +2,8 @@
 
 // Production runtime evidence is collected and checked in one root-owned Linux
 // process.  Offline JSON is only meaningful when its complete SHA-256 digest is
-// approved out of band; this program never accepts caller-authored JSON in the
-// collect-live path.
+// approved out of band; this program never accepts caller-authored JSON in a
+// collection path.
 
 import { spawnSync } from "node:child_process";
 import { createHash, randomBytes } from "node:crypto";
@@ -15,11 +15,15 @@ import {
   lstatSync,
   openSync,
   readFileSync,
+  readlinkSync,
+  readdirSync,
   readSync,
   realpathSync,
+  statfsSync,
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
 
 import {
@@ -30,13 +34,38 @@ import {
   runtimeRequestFromManifest,
 } from "./payment-v1-rendered-artifact-gate.mjs";
 
-export const LIVE_EVIDENCE_KIND = "bitcoinpir-payment-v1-linux-root-live-v1";
-const LIVE_SCHEMA_VERSION = 1;
+export const LIVE_EVIDENCE_KIND = "bitcoinpir-payment-v1-linux-root-live-v2";
+export const STOPPED_EDGE_EVIDENCE_KIND =
+  "bitcoinpir-payment-v1-linux-root-stopped-edge-v1";
+export const NSS_ENUMERATION_KIND = "getent-passwd-group-plus-id-groups-v2";
+export const NSS_BACKEND_PROFILE = "local-files-only-v1";
+const LIVE_SCHEMA_VERSION = 2;
+const STOPPED_EDGE_SCHEMA_VERSION = 1;
 const MAX_JSON_BYTES = 8 * 1024 * 1024;
 const MAX_COMMAND_OUTPUT_BYTES = 2 * 1024 * 1024;
 const MAX_COLLECTION_SECONDS = 120;
+const MAX_NSS_EVIDENCE_BYTES = 2 * 1024 * 1024;
+const MAX_NSS_USERS = 4096;
+const MAX_NSS_GROUPS = 16384;
+const MAX_NSS_GROUP_MEMBERS = 4096;
+const MAX_NSS_NAME_BYTES = 128;
+const MAX_NSS_ID_COLLECTION_MILLISECONDS = 30_000;
+const MAX_NSS_ID_LOOKUP_MILLISECONDS = 2_000;
+const MAX_NSS_POLICY_FILE_BYTES = 1024 * 1024;
 const MAX_PROC_STAT_BYTES = 16 * 1024;
 const MAX_PROC_STATUS_BYTES = 256 * 1024;
+const MAX_PROC_CGROUP_BYTES = 64 * 1024;
+const MAX_PROC_PROCESSES = 65_536;
+const MAX_PROC_THREADS = 262_144;
+const MAX_PROC_CREDENTIAL_SCAN_MILLISECONDS = 30_000;
+const MAX_PROC_CLOSURE_EVIDENCE_BYTES = 4 * 1024 * 1024;
+const PROC_SUPER_MAGIC = 0x9fa0;
+export const PROTECTED_PROCESS_ENUMERATION_KIND =
+  "procfs-v2-all-thread-protected-credentials-nonroot-setid-capabilities-two-pass-v2";
+const LOCKED_SERVICE_ACCOUNT_SHELLS = Object.freeze([
+  "/bin/false",
+  "/usr/sbin/nologin",
+]);
 const REVIEWED_ONESHOT_UNIT = "bitcoinpir-lightning-preflight.service";
 const REVIEWED_ONESHOT_FRAGMENT = "/etc/systemd/system/bitcoinpir-lightning-preflight.service";
 const REQUIRED_COMMANDS = Object.freeze([
@@ -283,53 +312,429 @@ function collectInstalledFile(expected) {
   }
 }
 
-function parseGetentLine(record, label) {
-  if (record.exit_status !== 0 || record.stderr !== "") fail(`${label} NSS lookup failed`);
-  const line = record.stdout.trim();
-  if (line === "" || line.includes("\n")) fail(`${label} NSS lookup was ambiguous`);
-  return line.split(":");
+function validateNssName(value, label) {
+  if (
+    typeof value !== "string" ||
+    Buffer.byteLength(value, "utf8") < 1 ||
+    Buffer.byteLength(value, "utf8") > MAX_NSS_NAME_BYTES ||
+    !/^[A-Za-z_][A-Za-z0-9_.-]{0,126}\$?$/u.test(value)
+  ) {
+    fail(`${label} is not a bounded canonical NSS name`);
+  }
+  return value;
 }
 
-function collectNss(request) {
-  const userNames = new Set();
-  const groupNames = new Set();
-  for (const unit of request.units) {
-    for (const value of unit.hardening.User ?? []) userNames.add(value);
-    for (const value of unit.hardening.Group ?? []) groupNames.add(value);
-    for (const directive of unit.hardening.SupplementaryGroups ?? []) {
-      for (const value of directive.split(/\s+/u)) groupNames.add(value);
-    }
+function compareNssNames(left, right) {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function parseNssUnsigned(value, label) {
+  if (typeof value !== "string" || !/^(?:0|[1-9][0-9]*)$/u.test(value)) {
+    fail(`${label} is not a canonical unsigned decimal`);
   }
-  for (const directory of request.tmpfiles_directories) {
-    userNames.add(directory.user_name);
-    groupNames.add(directory.group_name);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > 0xffff_ffff) {
+    fail(`${label} is outside the supported Linux ID range`);
   }
-  const users = [...userNames].sort().map((name) => {
-    const fields = parseGetentLine(runAbsolute("/usr/bin/getent", ["passwd", name]), `user ${name}`);
-    if (fields.length !== 7 || fields[0] !== name) fail(`user ${name} has malformed NSS data`);
-    const groupsRecord = runAbsolute("/usr/bin/id", ["-G", name]);
-    if (groupsRecord.exit_status !== 0 || groupsRecord.stderr !== "") fail(`id -G failed for ${name}`);
-    const supplementaryGids = groupsRecord.stdout.trim().split(/\s+/u).map(Number);
-    if (supplementaryGids.some((gid) => !Number.isSafeInteger(gid) || gid < 1)) {
-      fail(`user ${name} has malformed group membership`);
-    }
+  return parsed;
+}
+
+function nssEnumerationLines(stdout, label, maximumRecords) {
+  if (
+    typeof stdout !== "string" ||
+    stdout === "" ||
+    stdout.includes("\0") ||
+    stdout.includes("\r") ||
+    Buffer.byteLength(stdout, "utf8") > MAX_COMMAND_OUTPUT_BYTES
+  ) {
+    fail(`${label} enumeration output is malformed or oversized`);
+  }
+  const lines = stdout.endsWith("\n") ? stdout.slice(0, -1).split("\n") : stdout.split("\n");
+  if (lines.length < 1 || lines.length > maximumRecords || lines.some((line) => line === "")) {
+    fail(`${label} enumeration record count is invalid`);
+  }
+  return lines;
+}
+
+export function parsePasswdEnumerationV2(stdout) {
+  const records = nssEnumerationLines(stdout, "passwd", MAX_NSS_USERS).map((line, index) => {
+    const fields = line.split(":");
+    if (fields.length !== 7) fail(`passwd record ${index} does not have seven fields`);
     return {
-      name,
-      primary_gid: Number(fields[3]),
-      supplementary_gids: [...new Set(supplementaryGids)].sort((left, right) => left - right),
-      uid: Number(fields[2]),
+      name: validateNssName(fields[0], `passwd record ${index} name`),
+      primary_gid: parseNssUnsigned(fields[3], `passwd record ${index} primary GID`),
+      uid: parseNssUnsigned(fields[2], `passwd record ${index} UID`),
     };
   });
-  const groups = [...groupNames].sort().map((name) => {
-    const fields = parseGetentLine(runAbsolute("/usr/bin/getent", ["group", name]), `group ${name}`);
-    if (fields.length !== 4 || fields[0] !== name) fail(`group ${name} has malformed NSS data`);
+  records.sort((left, right) => compareNssNames(left.name, right.name));
+  if (new Set(records.map((record) => record.name)).size !== records.length) {
+    fail("passwd enumeration repeats a user name");
+  }
+  return records;
+}
+
+export function parseGroupEnumerationV2(stdout) {
+  const records = nssEnumerationLines(stdout, "group", MAX_NSS_GROUPS).map((line, index) => {
+    const fields = line.split(":");
+    if (fields.length !== 4) fail(`group record ${index} does not have four fields`);
+    const members = fields[3] === ""
+      ? []
+      : fields[3].split(",").map((member, memberIndex) =>
+        validateNssName(member, `group record ${index} member ${memberIndex}`));
+    if (members.length > MAX_NSS_GROUP_MEMBERS || new Set(members).size !== members.length) {
+      fail(`group record ${index} has duplicate or excessive members`);
+    }
+    members.sort(compareNssNames);
     return {
-      gid: Number(fields[2]),
-      members: fields[3] === "" ? [] : fields[3].split(",").sort(),
-      name,
+      gid: parseNssUnsigned(fields[2], `group record ${index} GID`),
+      members,
+      name: validateNssName(fields[0], `group record ${index} name`),
     };
   });
-  return { groups, users };
+  records.sort((left, right) => compareNssNames(left.name, right.name));
+  if (new Set(records.map((record) => record.name)).size !== records.length) {
+    fail("group enumeration repeats a group name");
+  }
+  return records;
+}
+
+function localPolicyLines(text, label, maximumRecords) {
+  if (
+    typeof text !== "string" ||
+    text === "" ||
+    text.includes("\0") ||
+    text.includes("\r") ||
+    Buffer.byteLength(text, "utf8") > MAX_NSS_POLICY_FILE_BYTES
+  ) {
+    fail(`${label} is malformed or oversized`);
+  }
+  const lines = text.endsWith("\n") ? text.slice(0, -1).split("\n") : text.split("\n");
+  if (
+    lines.length < 1 ||
+    lines.length > maximumRecords ||
+    lines.some((line) => line === "")
+  ) {
+    fail(`${label} record count is invalid`);
+  }
+  return lines;
+}
+
+export function parseLockedServiceAccountPolicyV1(
+  passwdText,
+  shadowText,
+  serviceIdentities,
+) {
+  if (
+    !Array.isArray(serviceIdentities) ||
+    serviceIdentities.length < 1 ||
+    serviceIdentities.length > MAX_NSS_USERS
+  ) {
+    fail("service identity policy is empty or oversized");
+  }
+  const expectedByName = new Map();
+  for (const [index, identity] of serviceIdentities.entries()) {
+    exactKeys(
+      identity,
+      ["gid", "group_name", "uid", "unit_name", "user_name"],
+      `service identity policy[${index}]`,
+    );
+    const userName = validateNssName(identity.user_name, `service identity policy[${index}] user`);
+    if (
+      expectedByName.has(userName) ||
+      !Number.isSafeInteger(identity.uid) ||
+      identity.uid < 1 ||
+      identity.uid > 0xffff_ffff ||
+      !Number.isSafeInteger(identity.gid) ||
+      identity.gid < 1 ||
+      identity.gid > 0xffff_ffff
+    ) {
+      fail("service identity account binding is duplicated or malformed");
+    }
+    expectedByName.set(userName, identity);
+  }
+
+  const passwdByName = new Map();
+  for (const [index, line] of localPolicyLines(passwdText, "passwd account policy", MAX_NSS_USERS).entries()) {
+    const fields = line.split(":");
+    if (fields.length !== 7) fail(`passwd account policy record ${index} does not have seven fields`);
+    const name = validateNssName(fields[0], `passwd account policy record ${index} name`);
+    if (passwdByName.has(name)) fail("passwd account policy repeats a user name");
+    passwdByName.set(name, {
+      gid: parseNssUnsigned(fields[3], `passwd account policy record ${index} GID`),
+      shell: fields[6],
+      uid: parseNssUnsigned(fields[2], `passwd account policy record ${index} UID`),
+    });
+  }
+
+  const shadowByName = new Map();
+  for (const [index, line] of localPolicyLines(shadowText, "shadow account policy", MAX_NSS_USERS).entries()) {
+    const fields = line.split(":");
+    if (fields.length !== 9) fail(`shadow account policy record ${index} does not have nine fields`);
+    const name = validateNssName(fields[0], `shadow account policy record ${index} name`);
+    if (shadowByName.has(name)) fail("shadow account policy repeats a user name");
+    shadowByName.set(name, fields[1]);
+  }
+
+  const accounts = [];
+  for (const [userName, expected] of expectedByName) {
+    const passwd = passwdByName.get(userName);
+    const password = shadowByName.get(userName);
+    if (
+      !passwd ||
+      passwd.uid !== expected.uid ||
+      passwd.gid !== expected.gid ||
+      !LOCKED_SERVICE_ACCOUNT_SHELLS.includes(passwd.shell) ||
+      typeof password !== "string" ||
+      !/^[!*]/u.test(password)
+    ) {
+      fail(`service account is not identity-pinned, login-disabled, and password-locked: ${userName}`);
+    }
+    accounts.push({
+      gid: passwd.gid,
+      password_state: "locked",
+      shell: passwd.shell,
+      uid: passwd.uid,
+      user_name: userName,
+    });
+  }
+  accounts.sort((left, right) => compareNssNames(left.user_name, right.user_name));
+  return accounts;
+}
+
+function decodeNssPolicyFile(bytes, label) {
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    fail(`${label} is not UTF-8`);
+  }
+  if (text === "" || text.includes("\0") || text.includes("\r")) {
+    fail(`${label} is empty or contains forbidden bytes`);
+  }
+  return text;
+}
+
+function readNssPolicyFile(path, label) {
+  const before = lstatSync(path);
+  if (
+    !before.isFile() ||
+    before.isSymbolicLink() ||
+    before.uid !== 0 ||
+    before.nlink !== 1 ||
+    (before.mode & 0o7000) !== 0 ||
+    (before.mode & 0o022) !== 0 ||
+    before.size < 1 ||
+    before.size > MAX_NSS_POLICY_FILE_BYTES ||
+    realpathSync(path) !== path
+  ) {
+    fail(`${label} must be a bounded root-owned, one-link, non-writable regular file`);
+  }
+  const fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const opened = fstatSync(fd);
+    const bytes = readFileSync(fd);
+    const after = fstatSync(fd);
+    if (
+      canonicalJson(stableStat(before)) !== canonicalJson(stableStat(opened)) ||
+      canonicalJson(stableStat(opened)) !== canonicalJson(stableStat(after))
+    ) {
+      fail(`${label} changed while collecting its NSS policy snapshot`);
+    }
+    return {
+      bytes,
+      evidence: {
+        ...stableStat(after),
+        path,
+        sha256: hashBytes(bytes),
+      },
+    };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+export function parseLocalFilesNsswitchV1(text) {
+  if (
+    typeof text !== "string" ||
+    text === "" ||
+    text.includes("\0") ||
+    text.includes("\r") ||
+    Buffer.byteLength(text, "utf8") > MAX_NSS_POLICY_FILE_BYTES
+  ) {
+    fail("nsswitch.conf is malformed or oversized");
+  }
+  const databases = new Map();
+  for (const [index, sourceLine] of text.split("\n").entries()) {
+    const line = sourceLine.split("#", 1)[0].trim();
+    if (line === "") continue;
+    const separator = line.indexOf(":");
+    if (separator < 1 || line.indexOf(":", separator + 1) !== -1) {
+      fail(`nsswitch.conf line ${index} is malformed`);
+    }
+    const database = line.slice(0, separator).trim();
+    if (!/^[a-z][a-z0-9_-]{0,63}$/u.test(database)) {
+      fail(`nsswitch.conf line ${index} has a noncanonical database name`);
+    }
+    if (!new Set(["passwd", "group", "initgroups"]).has(database)) continue;
+    if (databases.has(database)) fail(`nsswitch.conf repeats the ${database} database`);
+    const sourceText = line.slice(separator + 1).trim();
+    const sources = sourceText === "" ? [] : sourceText.split(/\s+/u);
+    if (sources.some((source) => !/^[a-z][a-z0-9_-]{0,63}$/u.test(source))) {
+      fail(`nsswitch.conf ${database} sources are not a simple local profile`);
+    }
+    databases.set(database, sources);
+  }
+  if (
+    canonicalJson(databases.get("passwd")) !== canonicalJson(["files"]) ||
+    canonicalJson(databases.get("group")) !== canonicalJson(["files"]) ||
+    databases.has("initgroups")
+  ) {
+    fail("NSS backend is not the reviewed local-files-only profile");
+  }
+  return {
+    group: ["files"],
+    initgroups: "inherits-group",
+    passwd: ["files"],
+  };
+}
+
+function collectLocalFilesNssPolicy() {
+  const nsswitch = readNssPolicyFile("/etc/nsswitch.conf", "nsswitch.conf");
+  const passwd = readNssPolicyFile("/etc/passwd", "passwd file");
+  const group = readNssPolicyFile("/etc/group", "group file");
+  const sources = parseLocalFilesNsswitchV1(
+    decodeNssPolicyFile(nsswitch.bytes, "nsswitch.conf"),
+  );
+  const passwdRecords = parsePasswdEnumerationV2(
+    decodeNssPolicyFile(passwd.bytes, "passwd file"),
+  );
+  const groupRecords = parseGroupEnumerationV2(
+    decodeNssPolicyFile(group.bytes, "group file"),
+  );
+  return {
+    evidence: {
+      backend_profile: NSS_BACKEND_PROFILE,
+      group_file: group.evidence,
+      nsswitch_file: nsswitch.evidence,
+      passwd_file: passwd.evidence,
+      sources,
+    },
+    groupRecords,
+    passwdRecords,
+  };
+}
+
+export function collectVisibleNssEvidenceV2() {
+  const passwdRecord = runAbsolute("/usr/bin/getent", ["passwd"], { timeout: 15_000 });
+  const groupRecord = runAbsolute("/usr/bin/getent", ["group"], { timeout: 15_000 });
+  if (passwdRecord.exit_status !== 0 || passwdRecord.stderr !== "") {
+    fail("complete passwd NSS enumeration failed");
+  }
+  if (groupRecord.exit_status !== 0 || groupRecord.stderr !== "") {
+    fail("complete group NSS enumeration failed");
+  }
+  const passwdRecords = parsePasswdEnumerationV2(passwdRecord.stdout);
+  const groups = parseGroupEnumerationV2(groupRecord.stdout);
+  const idDeadline = performance.now() + MAX_NSS_ID_COLLECTION_MILLISECONDS;
+  const users = passwdRecords.map((record) => {
+    const remaining = idDeadline - performance.now();
+    if (remaining < 1) fail("complete NSS supplementary-group enumeration timed out");
+    const groupsRecord = runAbsolute("/usr/bin/id", ["-G", "--", record.name], {
+      timeout: Math.max(
+        1,
+        Math.floor(Math.min(MAX_NSS_ID_LOOKUP_MILLISECONDS, remaining)),
+      ),
+    });
+    if (groupsRecord.exit_status !== 0 || groupsRecord.stderr !== "") {
+      fail(`id -G failed for enumerated user ${record.name}`);
+    }
+    const text = groupsRecord.stdout.trim();
+    if (text === "" || !/^(?:0|[1-9][0-9]*)(?:\s+(?:0|[1-9][0-9]*))*$/u.test(text)) {
+      fail(`enumerated user ${record.name} has malformed group membership`);
+    }
+    const supplementaryGids = text
+      .split(/\s+/u)
+      .map((gid, index) => parseNssUnsigned(gid, `${record.name} group ${index}`));
+    const canonicalGids = [...new Set(supplementaryGids)].sort((left, right) => left - right);
+    if (!canonicalGids.includes(record.primary_gid)) {
+      fail(`enumerated user ${record.name} group set omits its primary GID`);
+    }
+    return { ...record, supplementary_gids: canonicalGids };
+  });
+  const nss = {
+    enumeration_kind: NSS_ENUMERATION_KIND,
+    group_stdout_sha256: hashBytes(Buffer.from(groupRecord.stdout)),
+    groups,
+    passwd_stdout_sha256: hashBytes(Buffer.from(passwdRecord.stdout)),
+    users,
+  };
+  return nss;
+}
+
+function collectNss() {
+  const policyBefore = collectLocalFilesNssPolicy();
+  const visible = collectVisibleNssEvidenceV2();
+  const policyAfter = collectLocalFilesNssPolicy();
+  if (
+    canonicalJson(policyBefore) !== canonicalJson(policyAfter) ||
+    canonicalJson(policyAfter.passwdRecords) !==
+      canonicalJson(visible.users.map(({ supplementary_gids: _ignored, ...record }) => record)) ||
+    canonicalJson(policyAfter.groupRecords) !== canonicalJson(visible.groups)
+  ) {
+    fail("local NSS policy or files changed, or getent did not enumerate the exact local files");
+  }
+  const nss = {
+    ...policyAfter.evidence,
+    ...visible,
+  };
+  if (Buffer.byteLength(canonicalJson(nss), "utf8") > MAX_NSS_EVIDENCE_BYTES) {
+    fail("canonical complete NSS evidence exceeds its size limit");
+  }
+  return nss;
+}
+
+function recordedLocalFilesNssPolicy(nss) {
+  return {
+    evidence: {
+      backend_profile: nss.backend_profile,
+      group_file: nss.group_file,
+      nsswitch_file: nss.nsswitch_file,
+      passwd_file: nss.passwd_file,
+      sources: nss.sources,
+    },
+    groupRecords: nss.groups,
+    passwdRecords: nss.users.map(({ supplementary_gids: _ignored, ...record }) => record),
+  };
+}
+
+export function assertLocalFilesNssPolicyUnchanged(nss, currentPolicy) {
+  if (canonicalJson(recordedLocalFilesNssPolicy(nss)) !== canonicalJson(currentPolicy)) {
+    fail("local NSS policy or identity files changed after complete enumeration");
+  }
+  return true;
+}
+
+function confirmLocalFilesNssPolicyUnchanged(nss) {
+  return assertLocalFilesNssPolicyUnchanged(nss, collectLocalFilesNssPolicy());
+}
+
+function collectLockedServiceAccountPolicy(request, nss) {
+  const passwd = readNssPolicyFile("/etc/passwd", "passwd account policy file");
+  const shadow = readNssPolicyFile("/etc/shadow", "shadow account policy file");
+  if (canonicalJson(passwd.evidence) !== canonicalJson(nss.passwd_file)) {
+    fail("passwd account policy is not bound to the complete NSS snapshot");
+  }
+  return {
+    accounts: parseLockedServiceAccountPolicyV1(
+      decodeNssPolicyFile(passwd.bytes, "passwd account policy file"),
+      decodeNssPolicyFile(shadow.bytes, "shadow account policy file"),
+      request.service_identities,
+    ),
+    passwd_file: passwd.evidence,
+    shadow_file: shadow.evidence,
+  };
 }
 
 function collectTmpfilesDirectory(expected, nss) {
@@ -374,6 +779,80 @@ function collectRuntimePath(expected) {
     }
   }
   return observed;
+}
+
+function collectAbsentRuntimeSocket(expected) {
+  if (expected.file_type !== "socket") {
+    fail(`stopped-edge absence collection only accepts sockets: ${expected.target_path}`);
+  }
+  const assertAbsent = () => {
+    try {
+      lstatSync(expected.target_path);
+    } catch (error) {
+      if (error?.code === "ENOENT") return;
+      throw error;
+    }
+    fail(`runtime socket still exists before edge activation: ${expected.target_path}`);
+  };
+  const parentPath = dirname(expected.target_path);
+  assertAbsent();
+  let parentBefore;
+  try {
+    parentBefore = lstatSync(parentPath);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    assertAbsent();
+    try {
+      lstatSync(parentPath);
+    } catch (confirmationError) {
+      if (confirmationError?.code === "ENOENT") {
+        return {
+          parent_dev: null,
+          parent_ino: null,
+          parent_path: parentPath,
+          parent_state: "absent",
+          target_path: expected.target_path,
+        };
+      }
+      throw confirmationError;
+    }
+    fail(`runtime socket parent appeared during absence collection: ${parentPath}`);
+  }
+  if (
+    !parentBefore.isDirectory() ||
+    parentBefore.isSymbolicLink() ||
+    realpathSync(parentPath) !== parentPath
+  ) {
+    fail(`runtime socket parent is not a canonical directory: ${parentPath}`);
+  }
+  assertAbsent();
+  const parentAfter = lstatSync(parentPath);
+  if (
+    !parentAfter.isDirectory() ||
+    parentAfter.isSymbolicLink() ||
+    realpathSync(parentPath) !== parentPath ||
+    parentAfter.dev !== parentBefore.dev ||
+    parentAfter.ino !== parentBefore.ino
+  ) {
+    fail(`runtime socket parent changed during absence collection: ${parentPath}`);
+  }
+  assertAbsent();
+  return {
+    parent_dev: parentAfter.dev.toString(),
+    parent_ino: parentAfter.ino.toString(),
+    parent_path: parentPath,
+    parent_state: "canonical-directory",
+    target_path: expected.target_path,
+  };
+}
+
+function collectAbsentRuntimeSockets(request) {
+  const sockets = request.runtime_paths
+    .filter((entry) => entry.file_type === "socket")
+    .map(collectAbsentRuntimeSocket)
+    .sort((left, right) => left.target_path < right.target_path ? -1 : left.target_path > right.target_path ? 1 : 0);
+  if (sockets.length < 1) fail("edge runtime request has no socket listener to prove absent");
+  return sockets;
 }
 
 function secretParentPaths(secretFiles) {
@@ -506,6 +985,41 @@ function resolveExpectedUnitProcessIdentity(unit, nss, serviceIdentities) {
   };
 }
 
+function protectedCredentialsForRequest(request, nss) {
+  const { groupsByName, usersByName } = nssMaps(nss);
+  const protectedGids = new Set();
+  const protectedUids = new Set();
+  const add = (set, value, label) => {
+    if (!Number.isSafeInteger(value) || value < 0 || value > 0xffff_ffff) {
+      fail(`${label} is not a reviewed Linux identity`);
+    }
+    if (value > 0) set.add(value);
+  };
+  for (const unit of request.units) {
+    const identity = resolveExpectedUnitProcessIdentity(unit, nss, request.service_identities);
+    add(protectedUids, identity.uid, `${unit.unit_name} UID`);
+    add(protectedGids, identity.gid, `${unit.unit_name} GID`);
+    for (const gid of identity.groups) add(protectedGids, gid, `${unit.unit_name} group`);
+  }
+  for (const entry of [...request.runtime_paths, ...request.secret_files]) {
+    add(protectedUids, entry.uid, `${entry.target_path} owner UID`);
+    add(protectedGids, entry.gid, `${entry.target_path} owner GID`);
+  }
+  for (const directory of request.tmpfiles_directories) {
+    const user = usersByName.get(directory.user_name);
+    const group = groupsByName.get(directory.group_name);
+    if (!user || !group) {
+      fail(`tmpfiles directory has unresolved protected identity: ${directory.target_path}`);
+    }
+    add(protectedUids, user.uid, `${directory.target_path} owner UID`);
+    add(protectedGids, group.gid, `${directory.target_path} owner GID`);
+  }
+  return {
+    protectedGids: [...protectedGids].sort((left, right) => left - right),
+    protectedUids: [...protectedUids].sort((left, right) => left - right),
+  };
+}
+
 function readBoundedProcFile(path, label, maxBytes) {
   const before = lstatSync(path);
   if (
@@ -560,8 +1074,7 @@ function decodeProcText(bytes, label) {
   return text;
 }
 
-function parseProcStat(bytes, pid) {
-  const label = `/proc/${pid}/stat`;
+function parseProcStat(bytes, pid, label = `/proc/${pid}/stat`) {
   const text = decodeProcText(bytes, label).trimEnd();
   const prefix = `${pid} (`;
   const close = text.lastIndexOf(")");
@@ -578,8 +1091,11 @@ function parseProcStat(bytes, pid) {
   return { processState: fields[0], startTimeTicks };
 }
 
-function parseProcStatus(bytes, pid) {
-  const label = `/proc/${pid}/status`;
+export function parseProcStatus(
+  bytes,
+  pid,
+  { expectedTgid = pid, label = `/proc/${pid}/status` } = {},
+) {
   const lines = decodeProcText(bytes, label).split("\n");
   const field = (name) => {
     const matches = lines.filter((line) => line.startsWith(`${name}:`));
@@ -599,6 +1115,8 @@ function parseProcStatus(bytes, pid) {
   };
   const observedPid = parseIds("Pid", 1)[0];
   if (observedPid !== pid) fail(`${label} belongs to a different process`);
+  const observedTgid = parseIds("Tgid", 1)[0];
+  if (observedTgid !== expectedTgid) fail(`${label} belongs to a different thread group`);
   const groupsText = field("Groups");
   const groups = groupsText === "" ? [] : groupsText.split(/\s+/u).map((token) => {
     if (!/^(?:0|[1-9][0-9]*)$/u.test(token)) fail(`${label} has malformed Groups: values`);
@@ -606,43 +1124,54 @@ function parseProcStatus(bytes, pid) {
     if (!Number.isSafeInteger(gid) || gid < 0) fail(`${label} has out-of-range Groups: values`);
     return gid;
   });
-  if (new Set(groups).size !== groups.length) fail(`${label} repeats a Groups: value`);
+  const capabilityMask = ["CapInh", "CapPrm", "CapEff", "CapAmb"].reduce(
+    (mask, name) => {
+      const value = field(name);
+      if (!/^[0-9a-fA-F]{1,16}$/u.test(value)) fail(`${label} has malformed ${name}: value`);
+      return mask | BigInt(`0x${value}`);
+    },
+    0n,
+  );
+  const setidCapabilities = (capabilityMask & ((1n << 6n) | (1n << 7n))) !== 0n;
   return {
     gid: parseIds("Gid", 4),
-    groups: [...groups].sort((left, right) => left - right),
+    groups: [...new Set(groups)].sort((left, right) => left - right),
+    setidCapabilities,
     uid: parseIds("Uid", 4),
   };
 }
 
-function inspectProcDirectory(pid) {
-  const path = `/proc/${pid}`;
+function inspectProcDirectory(path, label) {
   const stat = lstatSync(path);
   if (!stat.isDirectory() || stat.isSymbolicLink() || realpathSync(path) !== path) {
-    fail(`process directory is not a canonical procfs directory: ${path}`);
+    fail(`${label} is not a canonical procfs directory: ${path}`);
   }
   return { dev: stat.dev.toString(), ino: stat.ino.toString() };
 }
 
-function collectProcIdentitySnapshot(pid) {
-  const directoryBefore = inspectProcDirectory(pid);
+function collectProcIdentityAt(path, pid, expectedTgid, label) {
+  const directoryBefore = inspectProcDirectory(path, `${label} directory`);
   const statBefore = parseProcStat(
-    readBoundedProcFile(`/proc/${pid}/stat`, `process ${pid} stat`, MAX_PROC_STAT_BYTES),
+    readBoundedProcFile(`${path}/stat`, `${label} stat`, MAX_PROC_STAT_BYTES),
     pid,
+    `${path}/stat`,
   );
   const identity = parseProcStatus(
-    readBoundedProcFile(`/proc/${pid}/status`, `process ${pid} status`, MAX_PROC_STATUS_BYTES),
+    readBoundedProcFile(`${path}/status`, `${label} status`, MAX_PROC_STATUS_BYTES),
     pid,
+    { expectedTgid, label: `${path}/status` },
   );
   const statAfter = parseProcStat(
-    readBoundedProcFile(`/proc/${pid}/stat`, `process ${pid} stat confirmation`, MAX_PROC_STAT_BYTES),
+    readBoundedProcFile(`${path}/stat`, `${label} stat confirmation`, MAX_PROC_STAT_BYTES),
     pid,
+    `${path}/stat`,
   );
-  const directoryAfter = inspectProcDirectory(pid);
+  const directoryAfter = inspectProcDirectory(path, `${label} directory`);
   if (
     canonicalJson(directoryBefore) !== canonicalJson(directoryAfter) ||
     statBefore.startTimeTicks !== statAfter.startTimeTicks
   ) {
-    fail(`process ${pid} restarted while its procfs identity was collected`);
+    fail(`${label} restarted while its procfs identity was collected`);
   }
   return {
     ...identity,
@@ -651,6 +1180,188 @@ function collectProcIdentitySnapshot(pid) {
     processState: statAfter.processState,
     startTimeTicks: statAfter.startTimeTicks,
   };
+}
+
+function collectProcIdentitySnapshot(pid) {
+  return collectProcIdentityAt(`/proc/${pid}`, pid, pid, `process ${pid}`);
+}
+
+function isVanishedProcError(error) {
+  return error?.code === "ENOENT" || error?.code === "ESRCH";
+}
+
+function canonicalNumericProcEntries(path, label, maximum) {
+  const entries = readdirSync(path, { withFileTypes: true });
+  const values = [];
+  for (const entry of entries) {
+    if (!/^[0-9]+$/u.test(entry.name)) continue;
+    if (!/^[1-9][0-9]*$/u.test(entry.name) || !entry.isDirectory()) {
+      fail(`${label} contains a noncanonical numeric entry`);
+    }
+    const value = Number(entry.name);
+    if (!Number.isSafeInteger(value) || value < 1) {
+      fail(`${label} contains an out-of-range numeric entry`);
+    }
+    values.push(value);
+  }
+  values.sort((left, right) => left - right);
+  if (values.length > maximum || new Set(values).size !== values.length) {
+    fail(`${label} exceeds its reviewed unique-entry bound`);
+  }
+  return values;
+}
+
+function parseUnifiedProcCgroup(bytes, label) {
+  const text = decodeProcText(bytes, label);
+  if (!text.endsWith("\n") || text.includes("\r")) {
+    fail(`${label} is not a canonical cgroup membership record`);
+  }
+  const lines = text.trimEnd().split("\n");
+  if (lines.length !== 1 || !lines[0].startsWith("0::")) {
+    fail(`${label} does not describe exactly one unified cgroup v2 membership`);
+  }
+  const controlGroup = lines[0].slice(3);
+  if (
+    controlGroup.length < 1 ||
+    controlGroup.length > 4096 ||
+    !controlGroup.startsWith("/") ||
+    controlGroup.includes("//") ||
+    controlGroup.split("/").some((segment) => segment === "." || segment === "..")
+  ) {
+    fail(`${label} has a noncanonical unified control-group path`);
+  }
+  return controlGroup;
+}
+
+function hasProtectedCredential(identity, protectedUids, protectedGids) {
+  return (
+    identity.uid.some((uid) => protectedUids.has(uid)) ||
+    identity.gid.some((gid) => protectedGids.has(gid)) ||
+    identity.groups.some((gid) => protectedGids.has(gid))
+  );
+}
+
+function collectStableProtectedTask(pid, tid, protectedUids, protectedGids) {
+  const path = `/proc/${pid}/task/${tid}`;
+  const cgroupPath = `${path}/cgroup`;
+  const cgroupBefore = parseUnifiedProcCgroup(
+    readBoundedProcFile(cgroupPath, `thread ${pid}/${tid} cgroup`, MAX_PROC_CGROUP_BYTES),
+    cgroupPath,
+  );
+  const snapshot = collectProcIdentityAt(path, tid, pid, `thread ${pid}/${tid}`);
+  const cgroupAfter = parseUnifiedProcCgroup(
+    readBoundedProcFile(cgroupPath, `thread ${pid}/${tid} cgroup confirmation`, MAX_PROC_CGROUP_BYTES),
+    cgroupPath,
+  );
+  if (cgroupAfter !== cgroupBefore) {
+    fail(`thread ${pid}/${tid} changed control groups during credential collection`);
+  }
+  if (snapshot.setidCapabilities && !snapshot.uid.includes(0)) {
+    fail(`non-root thread ${pid}/${tid} retains CAP_SETUID or CAP_SETGID`);
+  }
+  if (!hasProtectedCredential(snapshot, protectedUids, protectedGids)) return null;
+  return {
+    control_group: cgroupAfter,
+    gid: snapshot.gid,
+    groups: snapshot.groups,
+    pid,
+    proc_directory_dev: snapshot.procDirectoryDev,
+    proc_directory_ino: snapshot.procDirectoryIno,
+    start_time_ticks: snapshot.startTimeTicks,
+    tid,
+    uid: snapshot.uid,
+  };
+}
+
+function collectProtectedCredentialProcessPass(protectedUids, protectedGids, deadline) {
+  const pids = canonicalNumericProcEntries("/proc", "/proc", MAX_PROC_PROCESSES);
+  const holders = [];
+  let processesEnumerated = 0;
+  let threadsExamined = 0;
+  for (const pid of pids) {
+    if (performance.now() > deadline) fail("protected process credential scan timed out");
+    let tids;
+    try {
+      tids = canonicalNumericProcEntries(
+        `/proc/${pid}/task`,
+        `process ${pid} task directory`,
+        MAX_PROC_THREADS,
+      );
+    } catch (error) {
+      if (isVanishedProcError(error)) continue;
+      throw error;
+    }
+    processesEnumerated += 1;
+    for (const tid of tids) {
+      threadsExamined += 1;
+      if (threadsExamined > MAX_PROC_THREADS) {
+        fail("protected process credential scan exceeds its total thread bound");
+      }
+      if (performance.now() > deadline) fail("protected process credential scan timed out");
+      const statusPath = `/proc/${pid}/task/${tid}/status`;
+      let initial;
+      try {
+        initial = parseProcStatus(
+          readBoundedProcFile(statusPath, `thread ${pid}/${tid} status`, MAX_PROC_STATUS_BYTES),
+          tid,
+          { expectedTgid: pid, label: statusPath },
+        );
+      } catch (error) {
+        if (isVanishedProcError(error)) continue;
+        throw error;
+      }
+      if (initial.setidCapabilities && !initial.uid.includes(0)) {
+        fail(`non-root thread ${pid}/${tid} retains CAP_SETUID or CAP_SETGID`);
+      }
+      if (!hasProtectedCredential(initial, protectedUids, protectedGids)) continue;
+      let holder;
+      try {
+        holder = collectStableProtectedTask(pid, tid, protectedUids, protectedGids);
+      } catch (error) {
+        if (isVanishedProcError(error)) continue;
+        throw error;
+      }
+      if (holder !== null) holders.push(holder);
+    }
+  }
+  holders.sort((left, right) => left.pid - right.pid || left.tid - right.tid);
+  return {
+    holders,
+    processes_enumerated: processesEnumerated,
+    threads_examined: threadsExamined,
+  };
+}
+
+export function collectProtectedCredentialProcessClosureV1({ protectedGids, protectedUids }) {
+  const procType = statfsSync("/proc").type;
+  if (procType !== PROC_SUPER_MAGIC) fail("/proc is not the reviewed procfs filesystem");
+  const canonicalUids = [...new Set(protectedUids)].sort((left, right) => left - right);
+  const canonicalGids = [...new Set(protectedGids)].sort((left, right) => left - right);
+  for (const [label, values] of [["UID", canonicalUids], ["GID", canonicalGids]]) {
+    if (
+      values.some((value) => !Number.isSafeInteger(value) || value < 1 || value > 0xffff_ffff)
+    ) {
+      fail(`protected ${label} set is malformed`);
+    }
+  }
+  const deadline = performance.now() + MAX_PROC_CREDENTIAL_SCAN_MILLISECONDS;
+  const passes = [
+    collectProtectedCredentialProcessPass(new Set(canonicalUids), new Set(canonicalGids), deadline),
+    collectProtectedCredentialProcessPass(new Set(canonicalUids), new Set(canonicalGids), deadline),
+  ];
+  if (canonicalJson(passes[0].holders) !== canonicalJson(passes[1].holders)) {
+    fail("protected process holders changed between complete procfs passes");
+  }
+  const closure = {
+    enumeration_kind: PROTECTED_PROCESS_ENUMERATION_KIND,
+    passes,
+    protected_gids: canonicalGids,
+    protected_uids: canonicalUids,
+  };
+  if (Buffer.byteLength(canonicalJson(closure), "utf8") > MAX_PROC_CLOSURE_EVIDENCE_BYTES) {
+    fail("protected process closure exceeds its reviewed evidence byte bound");
+  }
+  return closure;
 }
 
 const EFFECTIVE_CRITICAL_KEYS = Object.freeze([
@@ -704,6 +1415,7 @@ const EFFECTIVE_BASE_PROPERTIES = Object.freeze([
   "BindReadOnlyPaths",
   "ConditionResult",
   "Conditions",
+  "ControlGroup",
   "DropInPaths",
   "Environment",
   "EnvironmentFiles",
@@ -768,6 +1480,13 @@ function parseUnsignedDecimal(value, label, { allowZero = true } = {}) {
   return parsed;
 }
 
+function expectedSystemUnitControlGroup(unitName) {
+  if (typeof unitName !== "string" || !/^[a-z0-9][a-z0-9_.@-]{0,127}\.service$/u.test(unitName)) {
+    fail("systemd unit name cannot be mapped to a reviewed control group");
+  }
+  return `/system.slice/${unitName}`;
+}
+
 function validateUnitLifecycle(unit, properties, uptimeFinishedMilliseconds) {
   if (properties.ActiveState !== "active") fail(`unit is not active: ${unit.unit_name}`);
   if (properties.ConditionResult !== "yes") fail(`unit conditions did not pass: ${unit.unit_name}`);
@@ -786,6 +1505,9 @@ function validateUnitLifecycle(unit, properties, uptimeFinishedMilliseconds) {
     fail(`unit activation timestamp is not bound to this boot: ${unit.unit_name}`);
   }
   const mainPid = parseUnsignedDecimal(properties.MainPID, `${unit.unit_name}.MainPID`);
+  if (properties.ControlGroup !== expectedSystemUnitControlGroup(unit.unit_name)) {
+    fail(`unit is outside its reviewed system.slice control group: ${unit.unit_name}`);
+  }
   if (properties.Type === "oneshot") {
     if (
       unit.unit_name !== REVIEWED_ONESHOT_UNIT ||
@@ -886,15 +1608,48 @@ function collectSystemctlValue(unitName, property) {
   return record.stdout.replace(/\n$/u, "");
 }
 
+function collectStoppedUnitState(unit) {
+  const state = {
+    active_state: collectSystemctlValue(unit.unit_name, "ActiveState"),
+    control_group: collectSystemctlValue(unit.unit_name, "ControlGroup"),
+    drop_in_paths: collectSystemctlValue(unit.unit_name, "DropInPaths"),
+    fragment_path: collectSystemctlValue(unit.unit_name, "FragmentPath"),
+    invocation_id: collectSystemctlValue(unit.unit_name, "InvocationID"),
+    load_state: collectSystemctlValue(unit.unit_name, "LoadState"),
+    main_pid: collectSystemctlValue(unit.unit_name, "MainPID"),
+    sub_state: collectSystemctlValue(unit.unit_name, "SubState"),
+    unit_name: unit.unit_name,
+  };
+  if (
+    state.active_state !== "inactive" ||
+    state.sub_state !== "dead" ||
+    state.main_pid !== "0" ||
+    state.control_group !== "" ||
+    state.drop_in_paths !== "" ||
+    state.fragment_path !== unit.fragment_path ||
+    state.load_state !== "loaded" ||
+    !new Set(["", "0".repeat(32)]).has(state.invocation_id)
+  ) {
+    fail(`unit is not in the reviewed fully stopped state: ${unit.unit_name}`);
+  }
+  return state;
+}
+
+function collectStoppedUnitStates(request) {
+  return request.units.map(collectStoppedUnitState);
+}
+
 function confirmUnitGeneration(unit, properties) {
   const confirmation = {
     active_enter_timestamp_monotonic: collectSystemctlValue(unit.unit_name, "ActiveEnterTimestampMonotonic"),
     active_state: collectSystemctlValue(unit.unit_name, "ActiveState"),
+    control_group: collectSystemctlValue(unit.unit_name, "ControlGroup"),
     invocation_id: collectSystemctlValue(unit.unit_name, "InvocationID"),
     main_pid: collectSystemctlValue(unit.unit_name, "MainPID"),
   };
   if (
     confirmation.active_state !== properties.ActiveState ||
+    confirmation.control_group !== properties.ControlGroup ||
     confirmation.main_pid !== properties.MainPID ||
     confirmation.invocation_id !== properties.InvocationID ||
     confirmation.active_enter_timestamp_monotonic !== properties.ActiveEnterTimestampMonotonic
@@ -908,7 +1663,8 @@ function assertSnapshotIdentity(snapshot, expected, unitName) {
   if (
     canonicalJson(snapshot.uid) !== canonicalJson([expected.uid, expected.uid, expected.uid, expected.uid]) ||
     canonicalJson(snapshot.gid) !== canonicalJson([expected.gid, expected.gid, expected.gid, expected.gid]) ||
-    canonicalJson(snapshot.groups) !== canonicalJson(expected.groups)
+    canonicalJson(snapshot.groups) !== canonicalJson(expected.groups) ||
+    snapshot.setidCapabilities
   ) {
     fail(`running process identity differs from the reviewed unit identity: ${unitName}`);
   }
@@ -985,6 +1741,39 @@ function collectUnit(unit, nss, serviceIdentities, uptimeFinishedMilliseconds) {
   };
 }
 
+function readPidNamespaceBinding() {
+  const readNamespace = (path) => {
+    const stat = lstatSync(path);
+    if (!stat.isSymbolicLink()) fail(`${path} is not a procfs namespace link`);
+    const value = readlinkSync(path);
+    if (!/^pid:\[[1-9][0-9]*\]$/u.test(value)) fail(`${path} has a malformed namespace id`);
+    return value;
+  };
+  const pid1Namespace = readNamespace("/proc/1/ns/pid");
+  const collectorNamespace = readNamespace("/proc/self/ns/pid");
+  if (pid1Namespace !== collectorNamespace) {
+    fail("collector does not share PID 1's visible PID namespace");
+  }
+  const pid1Status = decodeProcText(
+    readBoundedProcFile("/proc/1/status", "PID 1 status", MAX_PROC_STATUS_BYTES),
+    "/proc/1/status",
+  ).split("\n");
+  const uniqueField = (name) => {
+    const matches = pid1Status.filter((line) => line.startsWith(`${name}:`));
+    if (matches.length !== 1) fail(`/proc/1/status must contain one ${name}: field`);
+    return matches[0].slice(name.length + 1).trim();
+  };
+  if (uniqueField("Name") !== "systemd" || uniqueField("NSpid") !== "1") {
+    fail("PID 1 is not the reviewed systemd namespace root");
+  }
+  return {
+    collector_pid_namespace: collectorNamespace,
+    pid1_name: "systemd",
+    pid1_nspid: [1],
+    pid1_pid_namespace: pid1Namespace,
+  };
+}
+
 function readHostBinding() {
   const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
   validateUuid(bootId, "Linux boot id");
@@ -1001,33 +1790,36 @@ function readHostBinding() {
   if (kernel.exit_status !== 0 || kernel.stderr !== "" || systemd.exit_status !== 0 || systemd.stderr !== "") {
     fail("host version collection failed");
   }
+  const pidNamespace = readPidNamespaceBinding();
   return {
     boot_id: bootId,
     core_pattern: corePattern,
     kernel_release: kernel.stdout.trim(),
     machine_id_sha256: hashBytes(machineId),
+    ...pidNamespace,
     systemd_version: systemd.stdout.split("\n", 1)[0],
     uptime_milliseconds: uptimeMilliseconds,
   };
 }
 
 function validateGenerationConfirmations(confirmations, properties, unitName) {
-  if (!Array.isArray(confirmations) || confirmations.length !== 2) {
+  if (!Array.isArray(confirmations) || confirmations.length !== 3) {
     fail(`unit generation confirmations are incomplete: ${unitName}`);
   }
   for (const [index, confirmation] of confirmations.entries()) {
     exactKeys(
       confirmation,
-      ["active_enter_timestamp_monotonic", "active_state", "invocation_id", "main_pid"],
+      ["active_enter_timestamp_monotonic", "active_state", "control_group", "invocation_id", "main_pid"],
       `${unitName} generation confirmation[${index}]`,
     );
     if (
       confirmation.active_enter_timestamp_monotonic !== properties.ActiveEnterTimestampMonotonic ||
       confirmation.active_state !== properties.ActiveState ||
+      confirmation.control_group !== properties.ControlGroup ||
       confirmation.invocation_id !== properties.InvocationID ||
       confirmation.main_pid !== properties.MainPID
     ) {
-      fail(`unit MainPID or InvocationID changed during collection: ${unitName}`);
+      fail(`unit generation changed during collection: ${unitName}`);
     }
   }
 }
@@ -1119,6 +1911,630 @@ function validateProcessIdentityEvidence(processIdentity, lifecycle, expectedIde
   }
 }
 
+function validateProtectedProcessIdVector(value, expected, label) {
+  if (
+    !Array.isArray(value) ||
+    value.length !== 4 ||
+    value.some((entry) => !Number.isSafeInteger(entry) || entry < 0 || entry > 0xffff_ffff) ||
+    value.some((entry) => entry !== expected)
+  ) {
+    fail(`${label} does not match the reviewed service identity`);
+  }
+}
+
+function validateProtectedProcessClosure(closure, request, nss, units, lifecycleByUnit) {
+  exactKeys(
+    closure,
+    ["enumeration_kind", "passes", "protected_gids", "protected_uids"],
+    "protected process credential closure",
+  );
+  if (closure.enumeration_kind !== PROTECTED_PROCESS_ENUMERATION_KIND) {
+    fail("protected process closure does not use the reviewed full-thread enumeration");
+  }
+  const expectedProtected = protectedCredentialsForRequest(request, nss);
+  if (
+    canonicalJson(closure.protected_gids) !== canonicalJson(expectedProtected.protectedGids) ||
+    canonicalJson(closure.protected_uids) !== canonicalJson(expectedProtected.protectedUids)
+  ) {
+    fail("protected process closure identity set is incomplete");
+  }
+  if (!Array.isArray(closure.passes) || closure.passes.length !== 2) {
+    fail("protected process closure requires exactly two complete passes");
+  }
+  if (Buffer.byteLength(canonicalJson(closure), "utf8") > MAX_PROC_CLOSURE_EVIDENCE_BYTES) {
+    fail("protected process closure exceeds its reviewed evidence byte bound");
+  }
+  const allowedByControlGroup = new Map();
+  const allowedByUid = new Map();
+  for (const unit of request.units) {
+    const lifecycle = lifecycleByUnit.get(unit.unit_name);
+    if (lifecycle?.kind !== "long-running") continue;
+    const actual = units.find((entry) => entry.unit_name === unit.unit_name);
+    const controlGroup = actual?.properties?.ControlGroup;
+    if (allowedByControlGroup.has(controlGroup)) {
+      fail("multiple managed units share one protected control group");
+    }
+    const identity = resolveExpectedUnitProcessIdentity(unit, nss, request.service_identities);
+    if (allowedByUid.has(identity.uid)) {
+      fail("multiple managed units share one protected service UID");
+    }
+    allowedByUid.set(identity.uid, unit.unit_name);
+    allowedByControlGroup.set(controlGroup, {
+      identity,
+      mainPid: lifecycle.mainPid,
+      unitName: unit.unit_name,
+    });
+  }
+  for (const [passIndex, pass] of closure.passes.entries()) {
+    exactKeys(
+      pass,
+      ["holders", "processes_enumerated", "threads_examined"],
+      `protected process pass[${passIndex}]`,
+    );
+    if (
+      !Number.isSafeInteger(pass.processes_enumerated) ||
+      pass.processes_enumerated < 1 ||
+      pass.processes_enumerated > MAX_PROC_PROCESSES ||
+      !Number.isSafeInteger(pass.threads_examined) ||
+      pass.threads_examined < pass.processes_enumerated ||
+      pass.threads_examined > MAX_PROC_THREADS ||
+      !Array.isArray(pass.holders) ||
+      pass.holders.length > pass.threads_examined
+    ) {
+      fail(`protected process pass[${passIndex}] has invalid enumeration bounds`);
+    }
+    const observed = new Set();
+    let previous = null;
+    for (const [holderIndex, holder] of pass.holders.entries()) {
+      exactKeys(
+        holder,
+        [
+          "control_group",
+          "gid",
+          "groups",
+          "pid",
+          "proc_directory_dev",
+          "proc_directory_ino",
+          "start_time_ticks",
+          "tid",
+          "uid",
+        ],
+        `protected process pass[${passIndex}] holder[${holderIndex}]`,
+      );
+      if (
+        !Number.isSafeInteger(holder.pid) ||
+        holder.pid < 1 ||
+        !Number.isSafeInteger(holder.tid) ||
+        holder.tid < 1 ||
+        typeof holder.control_group !== "string" ||
+        typeof holder.proc_directory_dev !== "string" ||
+        !/^[1-9][0-9]*$/u.test(holder.proc_directory_dev) ||
+        typeof holder.proc_directory_ino !== "string" ||
+        !/^[1-9][0-9]*$/u.test(holder.proc_directory_ino) ||
+        typeof holder.start_time_ticks !== "string" ||
+        !/^[1-9][0-9]*$/u.test(holder.start_time_ticks)
+      ) {
+        fail(`protected process pass[${passIndex}] holder is malformed`);
+      }
+      const ordering = [holder.pid, holder.tid];
+      if (
+        previous !== null &&
+        (ordering[0] < previous[0] ||
+          (ordering[0] === previous[0] && ordering[1] <= previous[1]))
+      ) {
+        fail(`protected process pass[${passIndex}] holders are not uniquely sorted`);
+      }
+      previous = ordering;
+      const allowed = allowedByControlGroup.get(holder.control_group);
+      if (!allowed) {
+        fail(`protected credential holder is outside every managed unit cgroup: ${holder.pid}/${holder.tid}`);
+      }
+      validateProtectedProcessIdVector(
+        holder.uid,
+        allowed.identity.uid,
+        `${allowed.unitName} protected holder UID`,
+      );
+      validateProtectedProcessIdVector(
+        holder.gid,
+        allowed.identity.gid,
+        `${allowed.unitName} protected holder GID`,
+      );
+      if (canonicalJson(holder.groups) !== canonicalJson(allowed.identity.groups)) {
+        fail(`${allowed.unitName} protected holder supplementary groups drift`);
+      }
+      if (holder.pid === allowed.mainPid && holder.tid === allowed.mainPid) {
+        observed.add(allowed.unitName);
+      }
+    }
+    for (const allowed of allowedByControlGroup.values()) {
+      if (!observed.has(allowed.unitName)) {
+        fail(`protected process pass[${passIndex}] omits managed MainPID: ${allowed.unitName}`);
+      }
+    }
+  }
+  if (canonicalJson(closure.passes[0].holders) !== canonicalJson(closure.passes[1].holders)) {
+    fail("protected process holders changed between complete procfs passes");
+  }
+}
+
+function validatePolicyFileEvidence(file, path, label) {
+  exactKeys(
+    file,
+    ["dev", "gid", "ino", "mode", "nlink", "path", "sha256", "size", "uid"],
+    label,
+  );
+  validateDigest(file.sha256, `${label} SHA-256`);
+  if (
+    file.path !== path ||
+    file.uid !== 0 ||
+    !Number.isSafeInteger(file.gid) ||
+    file.gid < 0 ||
+    file.gid > 0xffff_ffff ||
+    file.nlink !== 1 ||
+    !Number.isSafeInteger(file.size) ||
+    file.size < 1 ||
+    file.size > MAX_NSS_POLICY_FILE_BYTES ||
+    typeof file.dev !== "string" ||
+    !/^(?:0|[1-9][0-9]*)$/u.test(file.dev) ||
+    typeof file.ino !== "string" ||
+    !/^(?:0|[1-9][0-9]*)$/u.test(file.ino) ||
+    typeof file.mode !== "string" ||
+    !/^[0-7]{4}$/u.test(file.mode) ||
+    (Number.parseInt(file.mode, 8) & 0o7000) !== 0 ||
+    (Number.parseInt(file.mode, 8) & 0o022) !== 0
+  ) {
+    fail(`${label} metadata is not trusted`);
+  }
+}
+
+function validateStoppedNssEvidence(nss, request) {
+  exactKeys(
+    nss,
+    [
+      "backend_profile",
+      "enumeration_kind",
+      "group_file",
+      "group_stdout_sha256",
+      "groups",
+      "nsswitch_file",
+      "passwd_file",
+      "passwd_stdout_sha256",
+      "sources",
+      "users",
+    ],
+    "stopped-edge NSS evidence",
+  );
+  if (
+    nss.backend_profile !== NSS_BACKEND_PROFILE ||
+    nss.enumeration_kind !== NSS_ENUMERATION_KIND ||
+    canonicalJson(nss.sources) !== canonicalJson({
+      group: ["files"],
+      initgroups: "inherits-group",
+      passwd: ["files"],
+    })
+  ) {
+    fail("stopped-edge NSS evidence is not the reviewed complete local-files profile");
+  }
+  validatePolicyFileEvidence(nss.nsswitch_file, "/etc/nsswitch.conf", "stopped-edge nsswitch file");
+  validatePolicyFileEvidence(nss.passwd_file, "/etc/passwd", "stopped-edge passwd file");
+  validatePolicyFileEvidence(nss.group_file, "/etc/group", "stopped-edge group file");
+  validateDigest(nss.passwd_stdout_sha256, "stopped-edge passwd enumeration SHA-256");
+  validateDigest(nss.group_stdout_sha256, "stopped-edge group enumeration SHA-256");
+  if (
+    !Array.isArray(nss.users) ||
+    nss.users.length < 1 ||
+    nss.users.length > MAX_NSS_USERS ||
+    !Array.isArray(nss.groups) ||
+    nss.groups.length < 1 ||
+    nss.groups.length > MAX_NSS_GROUPS ||
+    Buffer.byteLength(canonicalJson(nss), "utf8") > MAX_NSS_EVIDENCE_BYTES
+  ) {
+    fail("stopped-edge NSS evidence exceeds its reviewed bounds");
+  }
+  const usersByName = new Map();
+  const usersByUid = new Map();
+  for (const user of nss.users) {
+    exactKeys(user, ["name", "primary_gid", "supplementary_gids", "uid"], "stopped-edge NSS user");
+    validateNssName(user.name, "stopped-edge NSS user name");
+    if (
+      usersByName.has(user.name) ||
+      usersByUid.has(user.uid) ||
+      !Number.isSafeInteger(user.uid) ||
+      user.uid < 0 ||
+      user.uid > 0xffff_ffff ||
+      !Number.isSafeInteger(user.primary_gid) ||
+      user.primary_gid < 0 ||
+      user.primary_gid > 0xffff_ffff ||
+      !Array.isArray(user.supplementary_gids) ||
+      user.supplementary_gids.length < 1 ||
+      user.supplementary_gids.some((gid) => !Number.isSafeInteger(gid) || gid < 0 || gid > 0xffff_ffff) ||
+      canonicalJson(user.supplementary_gids) !==
+        canonicalJson([...new Set(user.supplementary_gids)].sort((left, right) => left - right)) ||
+      !user.supplementary_gids.includes(user.primary_gid)
+    ) {
+      fail("stopped-edge NSS user data is malformed or aliased");
+    }
+    usersByName.set(user.name, user);
+    usersByUid.set(user.uid, user);
+  }
+  if (canonicalJson([...usersByName.keys()]) !== canonicalJson([...usersByName.keys()].sort())) {
+    fail("stopped-edge NSS users are not canonically sorted");
+  }
+  const groupsByName = new Map();
+  const groupsByGid = new Map();
+  for (const group of nss.groups) {
+    exactKeys(group, ["gid", "members", "name"], "stopped-edge NSS group");
+    validateNssName(group.name, "stopped-edge NSS group name");
+    if (
+      groupsByName.has(group.name) ||
+      groupsByGid.has(group.gid) ||
+      !Number.isSafeInteger(group.gid) ||
+      group.gid < 0 ||
+      group.gid > 0xffff_ffff ||
+      !Array.isArray(group.members) ||
+      group.members.length > MAX_NSS_GROUP_MEMBERS ||
+      canonicalJson(group.members) !== canonicalJson([...new Set(group.members)].sort())
+    ) {
+      fail("stopped-edge NSS group data is malformed or aliased");
+    }
+    for (const member of group.members) validateNssName(member, "stopped-edge NSS group member");
+    groupsByName.set(group.name, group);
+    groupsByGid.set(group.gid, group);
+  }
+  if (canonicalJson([...groupsByName.keys()]) !== canonicalJson([...groupsByName.keys()].sort())) {
+    fail("stopped-edge NSS groups are not canonically sorted");
+  }
+  for (const group of nss.groups) {
+    for (const memberName of group.members) {
+      const member = usersByName.get(memberName);
+      if (!member || !member.supplementary_gids.includes(group.gid)) {
+        fail(`stopped-edge NSS group membership is inconsistent: ${group.name}`);
+      }
+    }
+  }
+  for (const user of nss.users) {
+    if (!groupsByGid.has(user.primary_gid)) {
+      fail(`stopped-edge NSS user primary group is missing: ${user.name}`);
+    }
+    for (const gid of user.supplementary_gids) {
+      if (gid === user.primary_gid) continue;
+      if (!groupsByGid.get(gid)?.members.includes(user.name)) {
+        fail(`stopped-edge NSS reverse group membership is inconsistent: ${user.name}`);
+      }
+    }
+  }
+
+  const expectedByUser = new Map();
+  const expectedExplicitMembersByGid = new Map();
+  for (const unit of request.units) {
+    const identity = resolveExpectedUnitProcessIdentity(unit, nss, request.service_identities);
+    const userName = unit.hardening.User?.[0];
+    if (expectedByUser.has(userName)) fail("multiple stopped-edge units share one service user");
+    expectedByUser.set(userName, identity);
+    for (const gid of identity.groups) {
+      if (gid === identity.gid) continue;
+      const members = expectedExplicitMembersByGid.get(gid) ?? [];
+      members.push(userName);
+      expectedExplicitMembersByGid.set(gid, members);
+    }
+  }
+  const expectedProtected = protectedCredentialsForRequest(request, nss);
+  const protectedUids = new Set(expectedProtected.protectedUids);
+  const protectedGids = new Set(expectedProtected.protectedGids);
+  for (const user of nss.users) {
+    const expected = expectedByUser.get(user.name);
+    if (expected) {
+      if (
+        user.uid !== expected.uid ||
+        user.primary_gid !== expected.gid ||
+        canonicalJson(user.supplementary_gids) !== canonicalJson(expected.groups)
+      ) {
+        fail(`stopped-edge service account group closure drift: ${user.name}`);
+      }
+      continue;
+    }
+    if (
+      protectedUids.has(user.uid) ||
+      protectedGids.has(user.primary_gid) ||
+      user.supplementary_gids.some((gid) => protectedGids.has(gid))
+    ) {
+      fail(`stopped-edge protected identity is held by an unreviewed account: ${user.name}`);
+    }
+  }
+  for (const gid of expectedProtected.protectedGids) {
+    const group = groupsByGid.get(gid);
+    if (!group) fail(`stopped-edge protected GID is not enumerable: ${gid}`);
+    const expectedMembers = [...(expectedExplicitMembersByGid.get(gid) ?? [])].sort();
+    if (canonicalJson(group.members) !== canonicalJson(expectedMembers)) {
+      fail(`stopped-edge protected group membership drift: ${group.name}`);
+    }
+  }
+  return expectedProtected;
+}
+
+function validateStoppedProtectedClosure(closure, expectedProtected) {
+  exactKeys(
+    closure,
+    ["enumeration_kind", "passes", "protected_gids", "protected_uids"],
+    "stopped-edge protected process closure",
+  );
+  if (
+    closure.enumeration_kind !== PROTECTED_PROCESS_ENUMERATION_KIND ||
+    canonicalJson(closure.protected_gids) !== canonicalJson(expectedProtected.protectedGids) ||
+    canonicalJson(closure.protected_uids) !== canonicalJson(expectedProtected.protectedUids) ||
+    !Array.isArray(closure.passes) ||
+    closure.passes.length !== 2 ||
+    Buffer.byteLength(canonicalJson(closure), "utf8") > MAX_PROC_CLOSURE_EVIDENCE_BYTES
+  ) {
+    fail("stopped-edge protected process closure is incomplete");
+  }
+  for (const [index, pass] of closure.passes.entries()) {
+    exactKeys(pass, ["holders", "processes_enumerated", "threads_examined"], `stopped-edge proc pass[${index}]`);
+    if (
+      !Number.isSafeInteger(pass.processes_enumerated) ||
+      pass.processes_enumerated < 1 ||
+      pass.processes_enumerated > MAX_PROC_PROCESSES ||
+      !Number.isSafeInteger(pass.threads_examined) ||
+      pass.threads_examined < pass.processes_enumerated ||
+      pass.threads_examined > MAX_PROC_THREADS ||
+      !Array.isArray(pass.holders) ||
+      pass.holders.length !== 0
+    ) {
+      fail(`stopped-edge proc pass[${index}] found a protected credential holder or invalid bounds`);
+    }
+  }
+  if (canonicalJson(closure.passes[0].holders) !== canonicalJson(closure.passes[1].holders)) {
+    fail("stopped-edge proc passes are not one stable empty credential closure");
+  }
+}
+
+function validateStoppedUnitPasses(passes, request) {
+  if (!Array.isArray(passes) || passes.length !== 2) {
+    fail("stopped-edge unit evidence requires two complete passes");
+  }
+  for (const [passIndex, pass] of passes.entries()) {
+    if (!Array.isArray(pass) || pass.length !== request.units.length) {
+      fail(`stopped-edge unit pass[${passIndex}] is incomplete`);
+    }
+    for (const [index, state] of pass.entries()) {
+      const expected = request.units[index];
+      exactKeys(
+        state,
+        [
+          "active_state",
+          "control_group",
+          "drop_in_paths",
+          "fragment_path",
+          "invocation_id",
+          "load_state",
+          "main_pid",
+          "sub_state",
+          "unit_name",
+        ],
+        `stopped-edge unit pass[${passIndex}][${index}]`,
+      );
+      if (
+        state.unit_name !== expected.unit_name ||
+        state.active_state !== "inactive" ||
+        state.sub_state !== "dead" ||
+        state.main_pid !== "0" ||
+        state.control_group !== "" ||
+        state.drop_in_paths !== "" ||
+        state.fragment_path !== expected.fragment_path ||
+        state.load_state !== "loaded" ||
+        !new Set(["", "0".repeat(32)]).has(state.invocation_id)
+      ) {
+        fail(`stopped-edge unit is not fully stopped: ${expected.unit_name}`);
+      }
+    }
+  }
+  if (canonicalJson(passes[0]) !== canonicalJson(passes[1])) {
+    fail("stopped-edge unit state changed during credential closure collection");
+  }
+}
+
+function validateRuntimeSocketAbsencePasses(passes, request) {
+  const expectedPaths = request.runtime_paths
+    .filter((entry) => entry.file_type === "socket")
+    .map((entry) => entry.target_path)
+    .sort();
+  if (expectedPaths.length < 1 || !Array.isArray(passes) || passes.length !== 2) {
+    fail("stopped-edge socket absence evidence is incomplete");
+  }
+  for (const [passIndex, pass] of passes.entries()) {
+    if (!Array.isArray(pass) || pass.length !== expectedPaths.length) {
+      fail(`stopped-edge socket absence pass[${passIndex}] is incomplete`);
+    }
+    for (const [index, entry] of pass.entries()) {
+      exactKeys(
+        entry,
+        ["parent_dev", "parent_ino", "parent_path", "parent_state", "target_path"],
+        `stopped-edge socket absence pass[${passIndex}][${index}]`,
+      );
+      if (
+        entry.target_path !== expectedPaths[index] ||
+        entry.parent_path !== dirname(entry.target_path) ||
+        !new Set(["absent", "canonical-directory"]).has(entry.parent_state)
+      ) {
+        fail(`stopped-edge socket absence path drift: ${expectedPaths[index]}`);
+      }
+      if (entry.parent_state === "absent") {
+        if (entry.parent_dev !== null || entry.parent_ino !== null) {
+          fail("absent stopped-edge socket parent carries an inode claim");
+        }
+      } else if (
+        typeof entry.parent_dev !== "string" ||
+        !/^(?:0|[1-9][0-9]*)$/u.test(entry.parent_dev) ||
+        typeof entry.parent_ino !== "string" ||
+        !/^[1-9][0-9]*$/u.test(entry.parent_ino)
+      ) {
+        fail("canonical stopped-edge socket parent has malformed inode evidence");
+      }
+    }
+  }
+  if (canonicalJson(passes[0]) !== canonicalJson(passes[1])) {
+    fail("stopped-edge socket absence changed during credential closure collection");
+  }
+}
+
+function validateStoppedAccountPolicy(policy, request, nss) {
+  exactKeys(policy, ["accounts", "passwd_file", "shadow_file"], "stopped-edge account policy");
+  if (canonicalJson(policy.passwd_file) !== canonicalJson(nss.passwd_file)) {
+    fail("stopped-edge account policy is not bound to the NSS passwd file");
+  }
+  validatePolicyFileEvidence(policy.shadow_file, "/etc/shadow", "stopped-edge shadow file");
+  const expected = [...request.service_identities]
+    .sort((left, right) => compareNssNames(left.user_name, right.user_name));
+  if (!Array.isArray(policy.accounts) || policy.accounts.length !== expected.length) {
+    fail("stopped-edge account policy does not cover every service identity");
+  }
+  for (const [index, account] of policy.accounts.entries()) {
+    exactKeys(account, ["gid", "password_state", "shell", "uid", "user_name"], `stopped-edge account[${index}]`);
+    if (
+      account.user_name !== expected[index].user_name ||
+      account.uid !== expected[index].uid ||
+      account.gid !== expected[index].gid ||
+      account.password_state !== "locked" ||
+      !LOCKED_SERVICE_ACCOUNT_SHELLS.includes(account.shell)
+    ) {
+      fail(`stopped-edge service account is not locked and login-disabled: ${expected[index].user_name}`);
+    }
+  }
+}
+
+function validateStoppedHost(host, request, expectedMachineIdSha256, expectedBootId) {
+  exactKeys(
+    host,
+    [
+      "boot_id",
+      "collector_pid_namespace",
+      "core_pattern",
+      "kernel_release",
+      "machine_id_sha256",
+      "pid1_name",
+      "pid1_nspid",
+      "pid1_pid_namespace",
+      "systemd_version",
+      "uptime_finished_milliseconds",
+      "uptime_started_milliseconds",
+    ],
+    "stopped-edge host",
+  );
+  validateUuid(host.boot_id, "stopped-edge boot id");
+  if (
+    host.machine_id_sha256 !== expectedMachineIdSha256 ||
+    (expectedBootId !== undefined && host.boot_id !== expectedBootId) ||
+    host.collector_pid_namespace !== host.pid1_pid_namespace ||
+    typeof host.pid1_pid_namespace !== "string" ||
+    !/^pid:\[[1-9][0-9]*\]$/u.test(host.pid1_pid_namespace) ||
+    host.pid1_name !== "systemd" ||
+    canonicalJson(host.pid1_nspid) !== canonicalJson([1]) ||
+    !Number.isSafeInteger(host.uptime_started_milliseconds) ||
+    !Number.isSafeInteger(host.uptime_finished_milliseconds) ||
+    host.uptime_finished_milliseconds < host.uptime_started_milliseconds ||
+    request.deployment_profile !== "edge-hetzner-v1" ||
+    host.core_pattern !== "|/usr/bin/false"
+  ) {
+    fail("stopped-edge host, boot, PID namespace, or core policy is not approved");
+  }
+}
+
+function validateTrustedCommandClosure(commands, label) {
+  if (!Array.isArray(commands) || commands.length !== REQUIRED_COMMANDS.length + 1) {
+    fail(`${label} does not bind the complete command TCB`);
+  }
+  for (const command of commands) {
+    exactKeys(command, ["gid", "mode", "nlink", "path", "sha256", "uid"], `${label} command`);
+    validateAbsolutePath(command.path, `${label} command path`);
+    validateDigest(command.sha256, `${label} command digest`);
+    if (command.uid !== 0 || command.nlink !== 1 || (Number.parseInt(command.mode, 8) & 0o022) !== 0) {
+      fail(`${label} has untrusted command metadata: ${command.path}`);
+    }
+  }
+  if (
+    canonicalJson(commands.map((entry) => entry.path).sort()) !==
+    canonicalJson([...REQUIRED_COMMANDS, "/usr/bin/node"].sort())
+  ) {
+    fail(`${label} command TCB paths are not closed`);
+  }
+}
+
+export function validateStoppedEdgeActivationEvidence({
+  evidence,
+  request,
+  expectedMachineIdSha256,
+  expectedBootId,
+  nowUnixSeconds,
+  maxAgeSeconds = 120,
+}) {
+  exactKeys(
+    evidence,
+    [
+      "account_policy",
+      "approved_plan_sha256",
+      "challenge_hex",
+      "collected_finished_unix_seconds",
+      "collected_started_unix_seconds",
+      "collector",
+      "collector_process",
+      "evidence_kind",
+      "host",
+      "manifest_sha256",
+      "nss",
+      "protected_process_closure",
+      "runtime_socket_absence_passes",
+      "schema_version",
+      "stopped_unit_passes",
+      "trusted_commands",
+    ],
+    "stopped-edge activation evidence",
+  );
+  if (
+    evidence.schema_version !== STOPPED_EDGE_SCHEMA_VERSION ||
+    evidence.evidence_kind !== STOPPED_EDGE_EVIDENCE_KIND ||
+    evidence.collector !== RUNTIME_COLLECTOR ||
+    request.schema_version !== LIVE_SCHEMA_VERSION ||
+    request.collector !== RUNTIME_COLLECTOR ||
+    request.deployment_profile !== "edge-hetzner-v1" ||
+    evidence.manifest_sha256 !== request.manifest_sha256 ||
+    evidence.approved_plan_sha256 !== request.approved_plan_sha256
+  ) {
+    fail("stopped-edge evidence schema, collector, profile, or artifact binding is not reviewed");
+  }
+  if (
+    typeof evidence.challenge_hex !== "string" ||
+    !/^[0-9a-f]{64}$/u.test(evidence.challenge_hex) ||
+    /^0{64}$/u.test(evidence.challenge_hex)
+  ) {
+    fail("stopped-edge challenge must be an internally random 256-bit value");
+  }
+  const start = evidence.collected_started_unix_seconds;
+  const finish = evidence.collected_finished_unix_seconds;
+  if (
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(finish) ||
+    finish < start ||
+    finish - start > MAX_COLLECTION_SECONDS ||
+    !Number.isSafeInteger(nowUnixSeconds) ||
+    nowUnixSeconds < finish ||
+    nowUnixSeconds - finish > maxAgeSeconds
+  ) {
+    fail("stopped-edge evidence collection window is stale or invalid");
+  }
+  exactKeys(evidence.collector_process, ["egid", "euid", "pid"], "stopped-edge collector process");
+  if (evidence.collector_process.euid !== 0 || evidence.collector_process.egid !== 0) {
+    fail("stopped-edge collector was not root");
+  }
+  validateStoppedHost(evidence.host, request, expectedMachineIdSha256, expectedBootId);
+  validateTrustedCommandClosure(evidence.trusted_commands, "stopped-edge evidence");
+  const expectedProtected = validateStoppedNssEvidence(evidence.nss, request);
+  validateStoppedAccountPolicy(evidence.account_policy, request, evidence.nss);
+  validateStoppedUnitPasses(evidence.stopped_unit_passes, request);
+  validateRuntimeSocketAbsencePasses(evidence.runtime_socket_absence_passes, request);
+  validateStoppedProtectedClosure(evidence.protected_process_closure, expectedProtected);
+  return true;
+}
+
 export function validateLiveRuntimeEvidence({
   evidence,
   request,
@@ -1141,6 +2557,7 @@ export function validateLiveRuntimeEvidence({
       "installed_files",
       "manifest_sha256",
       "nss",
+      "protected_process_closure",
       "runtime_directories",
       "runtime_paths",
       "schema_version",
@@ -1154,6 +2571,9 @@ export function validateLiveRuntimeEvidence({
   );
   if (evidence.schema_version !== LIVE_SCHEMA_VERSION || evidence.evidence_kind !== LIVE_EVIDENCE_KIND) {
     fail("live runtime evidence schema or kind is not reviewed");
+  }
+  if (request.schema_version !== LIVE_SCHEMA_VERSION || request.collector !== RUNTIME_COLLECTOR) {
+    fail("runtime evidence request schema or collector is not reviewed");
   }
   if (evidence.collector !== RUNTIME_COLLECTOR) fail("live runtime collector identity mismatch");
   if (canonicalJson(request.systemctl_show_properties) !== canonicalJson(RUNTIME_SYSTEMCTL_SHOW_PROPERTIES)) {
@@ -1182,12 +2602,33 @@ export function validateLiveRuntimeEvidence({
   }
   exactKeys(
     evidence.host,
-    ["boot_id", "core_pattern", "kernel_release", "machine_id_sha256", "systemd_version", "uptime_finished_milliseconds", "uptime_started_milliseconds"],
+    [
+      "boot_id",
+      "collector_pid_namespace",
+      "core_pattern",
+      "kernel_release",
+      "machine_id_sha256",
+      "pid1_name",
+      "pid1_nspid",
+      "pid1_pid_namespace",
+      "systemd_version",
+      "uptime_finished_milliseconds",
+      "uptime_started_milliseconds",
+    ],
     "live evidence host",
   );
   validateUuid(evidence.host.boot_id, "live evidence boot id");
   if (evidence.host.machine_id_sha256 !== expectedMachineIdSha256) fail("live evidence came from another host");
   if (expectedBootId !== undefined && evidence.host.boot_id !== expectedBootId) fail("live evidence came from another boot");
+  if (
+    evidence.host.collector_pid_namespace !== evidence.host.pid1_pid_namespace ||
+    typeof evidence.host.pid1_pid_namespace !== "string" ||
+    !/^pid:\[[1-9][0-9]*\]$/u.test(evidence.host.pid1_pid_namespace) ||
+    evidence.host.pid1_name !== "systemd" ||
+    canonicalJson(evidence.host.pid1_nspid) !== canonicalJson([1])
+  ) {
+    fail("live evidence is not bound to its visible systemd PID namespace root");
+  }
   if (
     new Set(["edge-hetzner-v1", "edge-rollback-authority-v1"]).has(
       request.deployment_profile,
@@ -1323,8 +2764,12 @@ export function validateLiveRuntimeEvidence({
       actual.mode !== expected.mode ||
       actual.user_name !== expected.user_name ||
       actual.group_name !== expected.group_name ||
-      actual.file_type !== "directory"
+      actual.file_type !== "directory" ||
+      actual.expected_type !== "directory"
     ) fail(`live tmpfiles directory drift: ${expected.target_path}`);
+    for (const key of ["acl_sha256", "capability_sha256", "stat_command_sha256", "xattr_sha256"]) {
+      validateDigest(actual[key], `live tmpfiles directory ${key}`);
+    }
   }
   if (!Array.isArray(request.runtime_paths) || !Array.isArray(evidence.runtime_paths)) {
     fail("live runtime path schema is incomplete");
@@ -1404,34 +2849,150 @@ export function validateLiveRuntimeEvidence({
     evidence.systemd_analyze_verify.stderr !== "" ||
     canonicalJson(evidence.systemd_analyze_verify.argv) !== canonicalJson(request.systemd_analyze_argv)
   ) fail("live systemd-analyze verify evidence failed");
-  exactKeys(evidence.nss, ["groups", "users"], "live NSS evidence");
+  exactKeys(
+    evidence.nss,
+    [
+      "backend_profile",
+      "enumeration_kind",
+      "group_file",
+      "group_stdout_sha256",
+      "groups",
+      "nsswitch_file",
+      "passwd_file",
+      "passwd_stdout_sha256",
+      "sources",
+      "users",
+    ],
+    "live NSS evidence",
+  );
+  if (evidence.nss.backend_profile !== NSS_BACKEND_PROFILE) {
+    fail("live NSS evidence does not use the reviewed local-files-only backend");
+  }
+  if (evidence.nss.enumeration_kind !== NSS_ENUMERATION_KIND) {
+    fail("live NSS evidence does not use the reviewed complete-enumeration profile");
+  }
+  exactKeys(evidence.nss.sources, ["group", "initgroups", "passwd"], "live NSS sources");
+  if (
+    canonicalJson(evidence.nss.sources) !== canonicalJson({
+      group: ["files"],
+      initgroups: "inherits-group",
+      passwd: ["files"],
+    })
+  ) {
+    fail("live NSS sources are not the reviewed local-files-only profile");
+  }
+  for (const [key, path] of [
+    ["nsswitch_file", "/etc/nsswitch.conf"],
+    ["passwd_file", "/etc/passwd"],
+    ["group_file", "/etc/group"],
+  ]) {
+    const file = evidence.nss[key];
+    exactKeys(
+      file,
+      ["dev", "gid", "ino", "mode", "nlink", "path", "sha256", "size", "uid"],
+      `live NSS ${key}`,
+    );
+    validateDigest(file.sha256, `live NSS ${key} SHA-256`);
+    if (
+      file.path !== path ||
+      file.uid !== 0 ||
+      !Number.isSafeInteger(file.gid) ||
+      file.gid < 0 ||
+      file.gid > 0xffff_ffff ||
+      file.nlink !== 1 ||
+      !Number.isSafeInteger(file.size) ||
+      file.size < 1 ||
+      file.size > MAX_NSS_POLICY_FILE_BYTES ||
+      typeof file.dev !== "string" ||
+      !/^(?:0|[1-9][0-9]*)$/u.test(file.dev) ||
+      typeof file.ino !== "string" ||
+      !/^(?:0|[1-9][0-9]*)$/u.test(file.ino) ||
+      typeof file.mode !== "string" ||
+      !/^[0-7]{4}$/u.test(file.mode) ||
+      (Number.parseInt(file.mode, 8) & 0o7000) !== 0 ||
+      (Number.parseInt(file.mode, 8) & 0o022) !== 0
+    ) {
+      fail(`live NSS ${key} metadata is not trusted`);
+    }
+  }
+  validateDigest(evidence.nss.passwd_stdout_sha256, "live passwd enumeration SHA-256");
+  validateDigest(evidence.nss.group_stdout_sha256, "live group enumeration SHA-256");
   if (!Array.isArray(evidence.nss.groups) || !Array.isArray(evidence.nss.users)) {
     fail("live NSS evidence arrays are missing");
+  }
+  if (
+    evidence.nss.users.length < 1 ||
+    evidence.nss.users.length > MAX_NSS_USERS ||
+    evidence.nss.groups.length < 1 ||
+    evidence.nss.groups.length > MAX_NSS_GROUPS ||
+    Buffer.byteLength(canonicalJson(evidence.nss), "utf8") > MAX_NSS_EVIDENCE_BYTES
+  ) {
+    fail("live complete NSS evidence exceeds its record or byte bound");
   }
   const usersByName = new Map(evidence.nss.users.map((user) => [user.name, user]));
   const groupsByName = new Map(evidence.nss.groups.map((group) => [group.name, group]));
   if (usersByName.size !== evidence.nss.users.length || groupsByName.size !== evidence.nss.groups.length) {
     fail("live NSS evidence repeats identities");
   }
+  if (
+    canonicalJson(evidence.nss.users.map((user) => user.name)) !==
+      canonicalJson(evidence.nss.users.map((user) => user.name).sort()) ||
+    canonicalJson(evidence.nss.groups.map((group) => group.name)) !==
+      canonicalJson(evidence.nss.groups.map((group) => group.name).sort())
+  ) {
+    fail("live NSS evidence identities are not canonically sorted");
+  }
   if (new Set(evidence.nss.users.map((user) => user.uid)).size !== evidence.nss.users.length) {
-    fail("live NSS evidence aliases service UIDs");
+    fail("live complete NSS evidence aliases a UID");
   }
   if (new Set(evidence.nss.groups.map((group) => group.gid)).size !== evidence.nss.groups.length) {
-    fail("live NSS evidence aliases service GIDs");
+    fail("live complete NSS evidence aliases a GID");
   }
   for (const group of evidence.nss.groups) {
     exactKeys(group, ["gid", "members", "name"], `live NSS group ${group.name ?? "<unknown>"}`);
-    if (!Number.isSafeInteger(group.gid) || group.gid < 1 || !Array.isArray(group.members)) {
+    validateNssName(group.name, "live NSS group name");
+    if (Array.isArray(group.members)) {
+      for (const member of group.members) {
+        validateNssName(member, `live NSS group ${group.name} member`);
+      }
+    }
+    if (
+      !Number.isSafeInteger(group.gid) ||
+      group.gid < 0 ||
+      group.gid > 0xffff_ffff ||
+      !Array.isArray(group.members) ||
+      group.members.length > MAX_NSS_GROUP_MEMBERS ||
+      canonicalJson(group.members) !== canonicalJson([...new Set(group.members)].sort())
+    ) {
       fail("live NSS group data is malformed");
     }
   }
   for (const user of evidence.nss.users) {
     exactKeys(user, ["name", "primary_gid", "supplementary_gids", "uid"], `live NSS user ${user.name ?? "<unknown>"}`);
+    validateNssName(user.name, "live NSS user name");
     if (
-      !Number.isSafeInteger(user.uid) || user.uid < 1 ||
-      !Number.isSafeInteger(user.primary_gid) || user.primary_gid < 1 ||
-      !Array.isArray(user.supplementary_gids)
+      !Number.isSafeInteger(user.uid) || user.uid < 0 || user.uid > 0xffff_ffff ||
+      !Number.isSafeInteger(user.primary_gid) ||
+      user.primary_gid < 0 ||
+      user.primary_gid > 0xffff_ffff ||
+      !Array.isArray(user.supplementary_gids) ||
+      user.supplementary_gids.length < 1 ||
+      user.supplementary_gids.some(
+        (gid) => !Number.isSafeInteger(gid) || gid < 0 || gid > 0xffff_ffff,
+      ) ||
+      canonicalJson(user.supplementary_gids) !==
+        canonicalJson([...new Set(user.supplementary_gids)].sort((left, right) => left - right)) ||
+      !user.supplementary_gids.includes(user.primary_gid)
     ) fail("live NSS user data is malformed");
+  }
+  for (let index = 0; index < request.tmpfiles_directories.length; index += 1) {
+    const expected = request.tmpfiles_directories[index];
+    const actual = evidence.runtime_directories[index];
+    const user = usersByName.get(expected.user_name);
+    const group = groupsByName.get(expected.group_name);
+    if (!user || !group || actual.uid !== user.uid || actual.gid !== group.gid) {
+      fail(`live tmpfiles directory NSS owner drift: ${expected.target_path}`);
+    }
   }
   for (const group of evidence.nss.groups) {
     for (const memberName of group.members) {
@@ -1450,6 +3011,15 @@ export function validateLiveRuntimeEvidence({
       }
     }
   }
+  const expectedPrimaryUsersByGid = new Map();
+  const expectedExplicitMembersByGid = new Map();
+  const expectedAllMembersByGid = new Map();
+  const protectedGids = new Set();
+  const addExpected = (map, gid, userName) => {
+    const values = map.get(gid) ?? new Set();
+    values.add(userName);
+    map.set(gid, values);
+  };
   for (const unit of request.units) {
     const userName = unit.hardening.User?.[0];
     const groupName = unit.hardening.Group?.[0];
@@ -1470,12 +3040,18 @@ export function validateLiveRuntimeEvidence({
     ) {
       fail(`live NSS primary identity drift: ${unit.unit_name}`);
     }
+    protectedGids.add(group.gid);
+    addExpected(expectedPrimaryUsersByGid, group.gid, userName);
+    addExpected(expectedAllMembersByGid, group.gid, userName);
     const expectedGroups = new Set([group.gid]);
     for (const directive of unit.hardening.SupplementaryGroups ?? []) {
       for (const supplementaryName of directive.split(/\s+/u)) {
         const supplementary = groupsByName.get(supplementaryName);
         if (!supplementary) fail(`live NSS supplementary group missing: ${supplementaryName}`);
         expectedGroups.add(supplementary.gid);
+        protectedGids.add(supplementary.gid);
+        addExpected(expectedExplicitMembersByGid, supplementary.gid, userName);
+        addExpected(expectedAllMembersByGid, supplementary.gid, userName);
       }
     }
     if (
@@ -1497,6 +3073,45 @@ export function validateLiveRuntimeEvidence({
       unit.unit_name,
     );
   }
+  for (const entry of [...request.runtime_paths, ...request.secret_files]) {
+    if (Number.isSafeInteger(entry.gid) && entry.gid > 0) protectedGids.add(entry.gid);
+  }
+  for (const directory of request.tmpfiles_directories) {
+    const group = groupsByName.get(directory.group_name);
+    if (!group) fail(`live NSS tmpfiles group missing: ${directory.group_name}`);
+    if (group.gid > 0) protectedGids.add(group.gid);
+  }
+  for (const gid of [...protectedGids].sort((left, right) => left - right)) {
+    const group = evidence.nss.groups.find((entry) => entry.gid === gid);
+    if (!group) fail(`live NSS protected GID is not enumerable: ${gid}`);
+    const actualPrimaryUsers = evidence.nss.users
+      .filter((user) => user.primary_gid === gid)
+      .map((user) => user.name)
+      .sort();
+    const expectedPrimaryUsers = [...(expectedPrimaryUsersByGid.get(gid) ?? [])].sort();
+    if (canonicalJson(actualPrimaryUsers) !== canonicalJson(expectedPrimaryUsers)) {
+      fail(`live NSS protected primary-GID holder drift: ${group.name}`);
+    }
+    const expectedExplicitMembers = [...(expectedExplicitMembersByGid.get(gid) ?? [])].sort();
+    if (canonicalJson(group.members) !== canonicalJson(expectedExplicitMembers)) {
+      fail(`live NSS protected explicit group membership drift: ${group.name}`);
+    }
+    const actualAllMembers = evidence.nss.users
+      .filter((user) => user.supplementary_gids.includes(gid))
+      .map((user) => user.name)
+      .sort();
+    const expectedAllMembers = [...(expectedAllMembersByGid.get(gid) ?? [])].sort();
+    if (canonicalJson(actualAllMembers) !== canonicalJson(expectedAllMembers)) {
+      fail(`live NSS protected effective group membership drift: ${group.name}`);
+    }
+  }
+  validateProtectedProcessClosure(
+    evidence.protected_process_closure,
+    request,
+    evidence.nss,
+    evidence.units,
+    lifecycleByUnit,
+  );
   const expectedAccessCheckCount = request.secret_files.length * request.service_identities.length;
   if (!Array.isArray(evidence.secret_access_checks) || evidence.secret_access_checks.length !== expectedAccessCheckCount) {
     fail("live secret positive/negative access probes are incomplete");
@@ -1534,15 +3149,117 @@ export function validateLiveRuntimeEvidence({
   return true;
 }
 
-export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256, approvedPlanSha256, expectedMachineIdSha256 }) {
-  if (process.platform !== "linux") fail("collect-live is Linux-only");
+function assertRootLinuxCollector(command) {
+  if (process.platform !== "linux") fail(`${command} is Linux-only`);
   if (
     process.getuid?.() !== 0 ||
     process.getgid?.() !== 0 ||
     process.geteuid?.() !== 0 ||
     process.getegid?.() !== 0
-  ) fail("collect-live requires real and effective root");
-  if (process.execPath !== "/usr/bin/node") fail("collect-live requires the reviewed absolute /usr/bin/node runtime");
+  ) fail(`${command} requires real and effective root`);
+  if (process.execPath !== "/usr/bin/node") {
+    fail(`${command} requires the reviewed absolute /usr/bin/node runtime`);
+  }
+}
+
+function sameHostGeneration(started, finished) {
+  return (
+    finished.boot_id === started.boot_id &&
+    finished.core_pattern === started.core_pattern &&
+    finished.machine_id_sha256 === started.machine_id_sha256 &&
+    finished.collector_pid_namespace === started.collector_pid_namespace &&
+    finished.pid1_pid_namespace === started.pid1_pid_namespace &&
+    finished.pid1_name === started.pid1_name &&
+    canonicalJson(finished.pid1_nspid) === canonicalJson(started.pid1_nspid)
+  );
+}
+
+export function collectStoppedEdgeActivationEvidence({
+  bundleRoot,
+  approvedManifestSha256,
+  approvedPlanSha256,
+  expectedMachineIdSha256,
+}) {
+  assertRootLinuxCollector("collect-stopped-edge");
+  validateDigest(approvedManifestSha256, "approved manifest SHA-256");
+  validateDigest(approvedPlanSha256, "approved plan SHA-256");
+  validateDigest(expectedMachineIdSha256, "expected machine-id SHA-256");
+  const { request } = readPinnedBundle(bundleRoot, approvedManifestSha256, approvedPlanSha256);
+  if (request.deployment_profile !== "edge-hetzner-v1") {
+    fail("collect-stopped-edge only accepts the reviewed Hetzner public-edge profile");
+  }
+  const trustedCommands = [...REQUIRED_COMMANDS, process.execPath].sort().map(inspectTrustedCommand);
+  const started = Math.floor(Date.now() / 1000);
+  const hostStarted = readHostBinding();
+  if (hostStarted.machine_id_sha256 !== expectedMachineIdSha256) {
+    fail("collector is running on an unapproved host");
+  }
+  const challengeHex = randomBytes(32).toString("hex");
+  const nss = collectNss();
+  const accountPolicyStarted = collectLockedServiceAccountPolicy(request, nss);
+  const stoppedUnitStarted = collectStoppedUnitStates(request);
+  const runtimeSocketAbsenceStarted = collectAbsentRuntimeSockets(request);
+  const protectedProcessClosure = collectProtectedCredentialProcessClosureV1(
+    protectedCredentialsForRequest(request, nss),
+  );
+  const runtimeSocketAbsenceFinished = collectAbsentRuntimeSockets(request);
+  const stoppedUnitFinished = collectStoppedUnitStates(request);
+  const accountPolicyFinished = collectLockedServiceAccountPolicy(request, nss);
+  if (canonicalJson(accountPolicyStarted) !== canonicalJson(accountPolicyFinished)) {
+    fail("service account login policy changed during stopped-edge collection");
+  }
+  confirmLocalFilesNssPolicyUnchanged(nss);
+  const hostFinished = readHostBinding();
+  const finished = Math.floor(Date.now() / 1000);
+  if (!sameHostGeneration(hostStarted, hostFinished)) {
+    fail("host or boot identity changed during stopped-edge collection");
+  }
+  const evidence = {
+    account_policy: accountPolicyFinished,
+    approved_plan_sha256: approvedPlanSha256,
+    challenge_hex: challengeHex,
+    collected_finished_unix_seconds: finished,
+    collected_started_unix_seconds: started,
+    collector: RUNTIME_COLLECTOR,
+    collector_process: { egid: process.getegid(), euid: process.geteuid(), pid: process.pid },
+    evidence_kind: STOPPED_EDGE_EVIDENCE_KIND,
+    host: {
+      boot_id: hostStarted.boot_id,
+      collector_pid_namespace: hostStarted.collector_pid_namespace,
+      core_pattern: hostStarted.core_pattern,
+      kernel_release: hostStarted.kernel_release,
+      machine_id_sha256: hostStarted.machine_id_sha256,
+      pid1_name: hostStarted.pid1_name,
+      pid1_nspid: hostStarted.pid1_nspid,
+      pid1_pid_namespace: hostStarted.pid1_pid_namespace,
+      systemd_version: hostStarted.systemd_version,
+      uptime_finished_milliseconds: hostFinished.uptime_milliseconds,
+      uptime_started_milliseconds: hostStarted.uptime_milliseconds,
+    },
+    manifest_sha256: approvedManifestSha256,
+    nss,
+    protected_process_closure: protectedProcessClosure,
+    runtime_socket_absence_passes: [
+      runtimeSocketAbsenceStarted,
+      runtimeSocketAbsenceFinished,
+    ],
+    schema_version: STOPPED_EDGE_SCHEMA_VERSION,
+    stopped_unit_passes: [stoppedUnitStarted, stoppedUnitFinished],
+    trusted_commands: trustedCommands,
+  };
+  validateStoppedEdgeActivationEvidence({
+    evidence,
+    expectedBootId: hostStarted.boot_id,
+    expectedMachineIdSha256,
+    maxAgeSeconds: 0,
+    nowUnixSeconds: finished,
+    request,
+  });
+  return evidence;
+}
+
+export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256, approvedPlanSha256, expectedMachineIdSha256 }) {
+  assertRootLinuxCollector("collect-live");
   validateDigest(approvedManifestSha256, "approved manifest SHA-256");
   validateDigest(approvedPlanSha256, "approved plan SHA-256");
   validateDigest(expectedMachineIdSha256, "expected machine-id SHA-256");
@@ -1552,7 +3269,7 @@ export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256,
   const hostStarted = readHostBinding();
   if (hostStarted.machine_id_sha256 !== expectedMachineIdSha256) fail("collector is running on an unapproved host");
   const challengeHex = randomBytes(32).toString("hex");
-  const nss = collectNss(request);
+  const nss = collectNss();
   const installedFiles = request.installed_files.map(collectInstalledFile);
   const runtimeDirectories = request.tmpfiles_directories.map((entry) => collectTmpfilesDirectory(entry, nss));
   const runtimePaths = request.runtime_paths.map(collectRuntimePath);
@@ -1580,13 +3297,28 @@ export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256,
   }
   const analyze = runAbsolute(request.systemd_analyze_argv[0], request.systemd_analyze_argv.slice(1), { allowOutput: false, timeout: 30_000 });
   if (analyze.exit_status !== 0) fail("systemd-analyze verify failed");
+  const protectedProcessClosure = collectProtectedCredentialProcessClosureV1(
+    protectedCredentialsForRequest(request, nss),
+  );
+  const finalRuntimeDirectories = request.tmpfiles_directories.map((entry) =>
+    collectTmpfilesDirectory(entry, nss),
+  );
+  if (canonicalJson(runtimeDirectories) !== canonicalJson(finalRuntimeDirectories)) {
+    fail("runtime directory metadata changed during protected process collection");
+  }
+  const finalRuntimePaths = request.runtime_paths.map(collectRuntimePath);
+  if (canonicalJson(runtimePaths) !== canonicalJson(finalRuntimePaths)) {
+    fail("runtime path metadata changed during protected process collection");
+  }
+  for (let index = 0; index < request.units.length; index += 1) {
+    units[index].generation_confirmations.push(
+      confirmUnitGeneration(request.units[index], units[index].properties),
+    );
+  }
+  confirmLocalFilesNssPolicyUnchanged(nss);
   const hostFinished = readHostBinding();
   const finished = Math.floor(Date.now() / 1000);
-  if (
-    hostFinished.boot_id !== hostStarted.boot_id ||
-    hostFinished.core_pattern !== hostStarted.core_pattern ||
-    hostFinished.machine_id_sha256 !== hostStarted.machine_id_sha256
-  ) {
+  if (!sameHostGeneration(hostStarted, hostFinished)) {
     fail("host or boot identity changed during live collection");
   }
   const evidence = {
@@ -1599,9 +3331,13 @@ export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256,
     evidence_kind: LIVE_EVIDENCE_KIND,
     host: {
       boot_id: hostStarted.boot_id,
+      collector_pid_namespace: hostStarted.collector_pid_namespace,
       core_pattern: hostStarted.core_pattern,
       kernel_release: hostStarted.kernel_release,
       machine_id_sha256: hostStarted.machine_id_sha256,
+      pid1_name: hostStarted.pid1_name,
+      pid1_nspid: hostStarted.pid1_nspid,
+      pid1_pid_namespace: hostStarted.pid1_pid_namespace,
       systemd_version: hostStarted.systemd_version,
       uptime_finished_milliseconds: hostFinished.uptime_milliseconds,
       uptime_started_milliseconds: hostStarted.uptime_milliseconds,
@@ -1609,6 +3345,7 @@ export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256,
     installed_files: installedFiles,
     manifest_sha256: approvedManifestSha256,
     nss,
+    protected_process_closure: protectedProcessClosure,
     runtime_directories: runtimeDirectories,
     runtime_paths: runtimePaths,
     schema_version: LIVE_SCHEMA_VERSION,
@@ -1631,8 +3368,13 @@ export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256,
 
 function parseCli(argv) {
   const command = argv[0];
-  if (!["collect-live", "verify-offline"].includes(command)) {
-    fail("usage: payment-v1-linux-runtime-evidence.mjs <collect-live|verify-offline> --bundle ABS --approved-manifest-sha256 HEX --approved-plan-sha256 HEX --expected-machine-id-sha256 HEX --output ABS | --evidence ABS --trusted-evidence-sha256 HEX --expected-boot-id UUID");
+  if (![
+    "collect-live",
+    "collect-stopped-edge",
+    "verify-offline",
+    "verify-stopped-edge-offline",
+  ].includes(command)) {
+    fail("usage: payment-v1-linux-runtime-evidence.mjs <collect-live|collect-stopped-edge|verify-offline|verify-stopped-edge-offline> --bundle ABS --approved-manifest-sha256 HEX --approved-plan-sha256 HEX --expected-machine-id-sha256 HEX --output ABS | --evidence ABS --trusted-evidence-sha256 HEX --expected-boot-id UUID");
   }
   const values = Object.create(null);
   const allowed = new Set([
@@ -1660,17 +3402,17 @@ function parseCli(argv) {
   for (const flag of ["--approved-manifest-sha256", "--approved-plan-sha256", "--expected-machine-id-sha256"]) {
     validateDigest(values[flag], flag);
   }
-  if (command === "collect-live") {
-    if (values["--output"] === undefined) fail("collect-live requires --output");
+  if (command.startsWith("collect-")) {
+    if (values["--output"] === undefined) fail(`${command} requires --output`);
     validateAbsolutePath(values["--output"], "CLI output path");
     for (const forbidden of ["--evidence", "--trusted-evidence-sha256", "--expected-boot-id"]) {
-      if (values[forbidden] !== undefined) fail(`collect-live forbids caller evidence option ${forbidden}`);
+      if (values[forbidden] !== undefined) fail(`${command} forbids caller evidence option ${forbidden}`);
     }
   } else {
     for (const required of ["--evidence", "--trusted-evidence-sha256", "--expected-boot-id"]) {
-      if (values[required] === undefined) fail(`verify-offline requires ${required}`);
+      if (values[required] === undefined) fail(`${command} requires ${required}`);
     }
-    if (values["--output"] !== undefined) fail("verify-offline forbids --output");
+    if (values["--output"] !== undefined) fail(`${command} forbids --output`);
     validateAbsolutePath(values["--evidence"], "CLI evidence path");
     validateDigest(values["--trusted-evidence-sha256"], "trusted evidence SHA-256");
     validateUuid(values["--expected-boot-id"], "expected boot id");
@@ -1686,14 +3428,17 @@ function runCli(argv) {
     bundleRoot: values["--bundle"],
     expectedMachineIdSha256: values["--expected-machine-id-sha256"],
   };
-  if (command === "collect-live") {
-    if (existsSync(values["--output"])) fail("collect-live refuses to overwrite evidence output");
+  if (command.startsWith("collect-")) {
+    if (existsSync(values["--output"])) fail(`${command} refuses to overwrite evidence output`);
     if (realpathSync(dirname(values["--output"])) !== dirname(values["--output"])) {
-      fail("collect-live output parent must be canonical");
+      fail(`${command} output parent must be canonical`);
     }
-    const evidence = collectLiveRuntimeEvidence(common);
+    const evidence = command === "collect-live"
+      ? collectLiveRuntimeEvidence(common)
+      : collectStoppedEdgeActivationEvidence(common);
     writeFileSync(values["--output"], canonicalJson(evidence), { flag: "wx", mode: 0o600 });
-    process.stdout.write(`payment-v1-linux-runtime-evidence: live PASS challenge=${evidence.challenge_hex}\n`);
+    const label = command === "collect-live" ? "live" : "stopped-edge";
+    process.stdout.write(`payment-v1-linux-runtime-evidence: ${label} PASS challenge=${evidence.challenge_hex}\n`);
     return;
   }
   const { request } = readPinnedBundle(common.bundleRoot, common.approvedManifestSha256, common.approvedPlanSha256);
@@ -1702,7 +3447,10 @@ function runCli(argv) {
     fail("offline evidence does not match the out-of-band trusted SHA-256 pin");
   }
   const evidence = strictJsonBytes(evidenceBytes, "offline live evidence");
-  validateLiveRuntimeEvidence({
+  const validate = command === "verify-offline"
+    ? validateLiveRuntimeEvidence
+    : validateStoppedEdgeActivationEvidence;
+  validate({
     evidence,
     expectedBootId: values["--expected-boot-id"],
     expectedMachineIdSha256: common.expectedMachineIdSha256,
@@ -1710,7 +3458,8 @@ function runCli(argv) {
     nowUnixSeconds: evidence.collected_finished_unix_seconds,
     request,
   });
-  process.stdout.write("payment-v1-linux-runtime-evidence: offline trusted-pin structure PASS\n");
+  const label = command === "verify-offline" ? "live" : "stopped-edge";
+  process.stdout.write(`payment-v1-linux-runtime-evidence: offline trusted-pin ${label} structure PASS\n`);
 }
 
 const isMain = process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;

--- a/scripts/payment-v1-linux-runtime-evidence.mjs
+++ b/scripts/payment-v1-linux-runtime-evidence.mjs
@@ -40,6 +40,7 @@ const MAX_PROC_STATUS_BYTES = 256 * 1024;
 const REVIEWED_ONESHOT_UNIT = "bitcoinpir-lightning-preflight.service";
 const REVIEWED_ONESHOT_FRAGMENT = "/etc/systemd/system/bitcoinpir-lightning-preflight.service";
 const REQUIRED_COMMANDS = Object.freeze([
+  "/usr/bin/false",
   "/usr/bin/getent",
   "/usr/bin/getfacl",
   "/usr/bin/getfattr",
@@ -210,9 +211,15 @@ function collectExtendedMetadata(path, expectedType) {
   const statRecord = runAbsolute("/usr/bin/stat", ["-c", "%d:%i:%u:%g:%a:%h:%s:%F", "--", path]);
   if (statRecord.exit_status !== 0 || statRecord.stderr !== "") fail(`stat failed for ${path}`);
   const nodeStat = lstatSync(path);
+  const statType = {
+    directory: "directory",
+    regular: "regular file",
+    socket: "socket",
+  }[expectedType];
+  if (statType === undefined) fail(`unreviewed extended metadata type: ${expectedType}`);
   const expectedStatLine = `${nodeStat.dev}:${nodeStat.ino}:${nodeStat.uid}:${nodeStat.gid}:${(
     nodeStat.mode & 0o7777
-  ).toString(8)}:${nodeStat.nlink}:${nodeStat.size}:${expectedType === "regular" ? "regular file" : "directory"}\n`;
+  ).toString(8)}:${nodeStat.nlink}:${nodeStat.size}:${statType}\n`;
   if (statRecord.stdout !== expectedStatLine) fail(`independent stat mismatch for ${path}`);
 
   const acl = runAbsolute("/usr/bin/getfacl", ["-c", "-p", "-n", "--", path]);
@@ -343,6 +350,28 @@ function collectTmpfilesDirectory(expected, nss) {
   };
   if (observed.uid !== user.uid || observed.gid !== group.gid || observed.mode !== expected.mode) {
     fail(`tmpfiles directory owner or mode mismatch: ${expected.target_path}`);
+  }
+  return observed;
+}
+
+function collectRuntimePath(expected) {
+  const stat = lstatSync(expected.target_path);
+  const typeMatches =
+    (expected.file_type === "directory" && stat.isDirectory()) ||
+    (expected.file_type === "socket" && stat.isSocket());
+  if (!typeMatches || stat.isSymbolicLink() || realpathSync(expected.target_path) !== expected.target_path) {
+    fail(`runtime path is not the expected canonical ${expected.file_type}: ${expected.target_path}`);
+  }
+  const observed = {
+    ...stableStat(stat),
+    file_type: expected.file_type,
+    target_path: expected.target_path,
+    ...collectExtendedMetadata(expected.target_path, expected.file_type),
+  };
+  for (const key of ["file_type", "gid", "mode", "target_path", "uid"]) {
+    if (observed[key] !== expected[key]) {
+      fail(`runtime path ${key} mismatch: ${expected.target_path}`);
+    }
   }
   return observed;
 }
@@ -631,8 +660,13 @@ const EFFECTIVE_CRITICAL_KEYS = Object.freeze([
   "IPAddressAllow",
   "IPAddressDeny",
   "InaccessiblePaths",
+  "LimitCORE",
+  "LimitCORESoft",
   "LockPersonality",
   "MemoryDenyWriteExecute",
+  "MemoryMax",
+  "MemorySwapCurrent",
+  "MemorySwapMax",
   "NoNewPrivileges",
   "PrivateDevices",
   "PrivateTmp",
@@ -652,8 +686,11 @@ const EFFECTIVE_CRITICAL_KEYS = Object.freeze([
   "RestrictNamespaces",
   "RestrictRealtime",
   "RestrictSUIDSGID",
+  "StandardError",
+  "StandardOutput",
   "SupplementaryGroups",
   "SystemCallArchitectures",
+  "TasksMax",
   "Type",
   "UMask",
   "User",
@@ -831,6 +868,15 @@ function validateEffectiveUnitProperties(unit, properties, uptimeFinishedMillise
       fail(`effective ${key} drift: ${unit.unit_name}`);
     }
   }
+  if (unit.hardening.LimitCORE !== undefined && properties.LimitCORESoft !== "0") {
+    fail(`effective LimitCORESoft drift: ${unit.unit_name}`);
+  }
+  if (
+    unit.hardening.MemorySwapMax !== undefined &&
+    properties.MemorySwapCurrent !== "0"
+  ) {
+    fail(`effective MemorySwapCurrent drift: ${unit.unit_name}`);
+  }
   return validateUnitLifecycle(unit, properties, uptimeFinishedMilliseconds);
 }
 
@@ -942,6 +988,10 @@ function collectUnit(unit, nss, serviceIdentities, uptimeFinishedMilliseconds) {
 function readHostBinding() {
   const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
   validateUuid(bootId, "Linux boot id");
+  const corePattern = readFileSync("/proc/sys/kernel/core_pattern", "utf8").trim();
+  if (corePattern === "" || /[\r\n\0]/u.test(corePattern)) {
+    fail("Linux core_pattern is malformed");
+  }
   const machineId = readFileSync("/etc/machine-id");
   const uptimeText = readFileSync("/proc/uptime", "utf8").trim().split(/\s+/u)[0];
   const uptimeMilliseconds = Math.floor(Number(uptimeText) * 1000);
@@ -953,6 +1003,7 @@ function readHostBinding() {
   }
   return {
     boot_id: bootId,
+    core_pattern: corePattern,
     kernel_release: kernel.stdout.trim(),
     machine_id_sha256: hashBytes(machineId),
     systemd_version: systemd.stdout.split("\n", 1)[0],
@@ -1091,6 +1142,7 @@ export function validateLiveRuntimeEvidence({
       "manifest_sha256",
       "nss",
       "runtime_directories",
+      "runtime_paths",
       "schema_version",
       "secret_access_checks",
       "secret_parent_directories",
@@ -1130,12 +1182,20 @@ export function validateLiveRuntimeEvidence({
   }
   exactKeys(
     evidence.host,
-    ["boot_id", "kernel_release", "machine_id_sha256", "systemd_version", "uptime_finished_milliseconds", "uptime_started_milliseconds"],
+    ["boot_id", "core_pattern", "kernel_release", "machine_id_sha256", "systemd_version", "uptime_finished_milliseconds", "uptime_started_milliseconds"],
     "live evidence host",
   );
   validateUuid(evidence.host.boot_id, "live evidence boot id");
   if (evidence.host.machine_id_sha256 !== expectedMachineIdSha256) fail("live evidence came from another host");
   if (expectedBootId !== undefined && evidence.host.boot_id !== expectedBootId) fail("live evidence came from another boot");
+  if (
+    new Set(["edge-hetzner-v1", "edge-rollback-authority-v1"]).has(
+      request.deployment_profile,
+    ) &&
+    evidence.host.core_pattern !== "|/usr/bin/false"
+  ) {
+    fail("edge live evidence requires kernel.core_pattern=|/usr/bin/false");
+  }
   if (
     !Number.isSafeInteger(evidence.host.uptime_started_milliseconds) ||
     !Number.isSafeInteger(evidence.host.uptime_finished_milliseconds) ||
@@ -1266,6 +1326,47 @@ export function validateLiveRuntimeEvidence({
       actual.file_type !== "directory"
     ) fail(`live tmpfiles directory drift: ${expected.target_path}`);
   }
+  if (!Array.isArray(request.runtime_paths) || !Array.isArray(evidence.runtime_paths)) {
+    fail("live runtime path schema is incomplete");
+  }
+  if (evidence.runtime_paths.length !== request.runtime_paths.length) {
+    fail("live runtime path evidence is incomplete");
+  }
+  for (let index = 0; index < request.runtime_paths.length; index += 1) {
+    const expected = request.runtime_paths[index];
+    const actual = evidence.runtime_paths[index];
+    exactKeys(
+      actual,
+      [
+        "acl_sha256",
+        "capability_sha256",
+        "dev",
+        "expected_type",
+        "file_type",
+        "gid",
+        "ino",
+        "mode",
+        "nlink",
+        "size",
+        "stat_command_sha256",
+        "target_path",
+        "uid",
+        "xattr_sha256",
+      ],
+      `live runtime_paths[${index}]`,
+    );
+    for (const key of ["file_type", "gid", "mode", "target_path", "uid"]) {
+      if (actual[key] !== expected[key]) {
+        fail(`live runtime path ${key} drift: ${expected.target_path}`);
+      }
+    }
+    if (actual.expected_type !== expected.file_type) {
+      fail(`live runtime path type drift: ${expected.target_path}`);
+    }
+    for (const key of ["acl_sha256", "capability_sha256", "stat_command_sha256", "xattr_sha256"]) {
+      validateDigest(actual[key], `live runtime path ${key}`);
+    }
+  }
   if (!Array.isArray(evidence.units) || evidence.units.length !== request.units.length) {
     fail("live systemd unit evidence is incomplete");
   }
@@ -1340,6 +1441,15 @@ export function validateLiveRuntimeEvidence({
       }
     }
   }
+  for (const user of evidence.nss.users) {
+    for (const gid of user.supplementary_gids) {
+      if (gid === user.primary_gid) continue;
+      const group = evidence.nss.groups.find((entry) => entry.gid === gid);
+      if (!group || !group.members.includes(user.name)) {
+        fail(`live NSS reverse group membership is inconsistent: ${user.name}`);
+      }
+    }
+  }
   for (const unit of request.units) {
     const userName = unit.hardening.User?.[0];
     const groupName = unit.hardening.Group?.[0];
@@ -1365,6 +1475,7 @@ export function validateLiveRuntimeEvidence({
       for (const supplementaryName of directive.split(/\s+/u)) {
         const supplementary = groupsByName.get(supplementaryName);
         if (!supplementary) fail(`live NSS supplementary group missing: ${supplementaryName}`);
+        expectedGroups.add(supplementary.gid);
       }
     }
     if (
@@ -1444,6 +1555,7 @@ export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256,
   const nss = collectNss(request);
   const installedFiles = request.installed_files.map(collectInstalledFile);
   const runtimeDirectories = request.tmpfiles_directories.map((entry) => collectTmpfilesDirectory(entry, nss));
+  const runtimePaths = request.runtime_paths.map(collectRuntimePath);
   const secretParentDirectories = secretParentPaths(request.secret_files).map(collectSecretParentDirectory);
   const secretAccessChecks = collectSecretAccessChecks(request, nss);
   for (const secret of request.secret_files) {
@@ -1462,11 +1574,19 @@ export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256,
   const units = request.units.map((unit) =>
     collectUnit(unit, nss, request.service_identities, hostStarted.uptime_milliseconds),
   );
+  const runtimePathConfirmation = request.runtime_paths.map(collectRuntimePath);
+  if (canonicalJson(runtimePaths) !== canonicalJson(runtimePathConfirmation)) {
+    fail("runtime path metadata changed while live unit evidence was collected");
+  }
   const analyze = runAbsolute(request.systemd_analyze_argv[0], request.systemd_analyze_argv.slice(1), { allowOutput: false, timeout: 30_000 });
   if (analyze.exit_status !== 0) fail("systemd-analyze verify failed");
   const hostFinished = readHostBinding();
   const finished = Math.floor(Date.now() / 1000);
-  if (hostFinished.boot_id !== hostStarted.boot_id || hostFinished.machine_id_sha256 !== hostStarted.machine_id_sha256) {
+  if (
+    hostFinished.boot_id !== hostStarted.boot_id ||
+    hostFinished.core_pattern !== hostStarted.core_pattern ||
+    hostFinished.machine_id_sha256 !== hostStarted.machine_id_sha256
+  ) {
     fail("host or boot identity changed during live collection");
   }
   const evidence = {
@@ -1479,6 +1599,7 @@ export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256,
     evidence_kind: LIVE_EVIDENCE_KIND,
     host: {
       boot_id: hostStarted.boot_id,
+      core_pattern: hostStarted.core_pattern,
       kernel_release: hostStarted.kernel_release,
       machine_id_sha256: hostStarted.machine_id_sha256,
       systemd_version: hostStarted.systemd_version,
@@ -1489,6 +1610,7 @@ export function collectLiveRuntimeEvidence({ bundleRoot, approvedManifestSha256,
     manifest_sha256: approvedManifestSha256,
     nss,
     runtime_directories: runtimeDirectories,
+    runtime_paths: runtimePaths,
     schema_version: LIVE_SCHEMA_VERSION,
     secret_access_checks: secretAccessChecks,
     secret_parent_directories: secretParentDirectories,

--- a/scripts/payment-v1-linux-runtime-evidence.test.mjs
+++ b/scripts/payment-v1-linux-runtime-evidence.test.mjs
@@ -17,6 +17,7 @@ import {
 const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
 const COLLECTOR = join(SCRIPT_DIRECTORY, "payment-v1-linux-runtime-evidence.mjs");
 const COMMANDS = [
+  "/usr/bin/false",
   "/usr/bin/getent",
   "/usr/bin/getfacl",
   "/usr/bin/getfattr",
@@ -58,8 +59,11 @@ function fixture() {
       AmbientCapabilities: [""],
       CapabilityBoundingSet: [""],
       Group: ["bitcoinpir-test"],
+      LimitCORE: ["0"],
       LockPersonality: ["true"],
       MemoryDenyWriteExecute: ["true"],
+      MemoryMax: ["268435456"],
+      MemorySwapMax: ["0"],
       NoNewPrivileges: ["true"],
       PrivateDevices: ["true"],
       PrivateTmp: ["true"],
@@ -75,8 +79,11 @@ function fixture() {
       RestrictNamespaces: ["true"],
       RestrictRealtime: ["true"],
       RestrictSUIDSGID: ["true"],
+      StandardError: ["null"],
+      StandardOutput: ["null"],
       SupplementaryGroups: ["bitcoinpir-shared"],
       SystemCallArchitectures: ["native"],
+      TasksMax: ["128"],
       Type: ["simple"],
       UMask: ["0077"],
       User: ["bitcoinpir-test"],
@@ -94,6 +101,13 @@ function fixture() {
     deployment_profile: "test",
     installed_files: installedFiles,
     manifest_sha256: hash("manifest"),
+    runtime_paths: [{
+      file_type: "socket",
+      gid: 731,
+      mode: "0660",
+      target_path: "/run/bitcoinpir-test/service.sock",
+      uid: 730,
+    }],
     schema_version: 1,
     secret_files: [],
     service_identities: [{
@@ -137,8 +151,13 @@ function fixture() {
     LoadCredential: "",
     LoadState: "loaded",
     LockPersonality: "yes",
+    LimitCORE: "0",
+    LimitCORESoft: "0",
     MainPID: "4242",
     MemoryDenyWriteExecute: "yes",
+    MemoryMax: "268435456",
+    MemorySwapCurrent: "0",
+    MemorySwapMax: "0",
     NoNewPrivileges: "yes",
     PrivateDevices: "yes",
     PrivateTmp: "yes",
@@ -162,9 +181,12 @@ function fixture() {
     RootDirectory: "",
     RootImage: "",
     SetCredential: "",
+    StandardError: "null",
+    StandardOutput: "null",
     SubState: "running",
     SupplementaryGroups: "bitcoinpir-shared",
     SystemCallArchitectures: "native",
+    TasksMax: "128",
     Type: "simple",
     UMask: "0077",
     User: "bitcoinpir-test",
@@ -219,6 +241,7 @@ function fixture() {
     evidence_kind: LIVE_EVIDENCE_KIND,
     host: {
       boot_id: boot,
+      core_pattern: "|/usr/bin/false",
       kernel_release: "6.8.0-test",
       machine_id_sha256: machine,
       systemd_version: "systemd 257",
@@ -230,10 +253,10 @@ function fixture() {
     nss: {
       groups: [
         { gid: 731, members: [], name: "bitcoinpir-test" },
-        { gid: 732, members: [], name: "bitcoinpir-shared" },
+        { gid: 732, members: ["bitcoinpir-test"], name: "bitcoinpir-shared" },
       ],
       users: [
-        { name: "bitcoinpir-test", primary_gid: 731, supplementary_gids: [731], uid: 730 },
+        { name: "bitcoinpir-test", primary_gid: 731, supplementary_gids: [731, 732], uid: 730 },
       ],
     },
     runtime_directories: [
@@ -256,6 +279,22 @@ function fixture() {
         xattr_sha256: hash("dir-xattr"),
       },
     ],
+    runtime_paths: [{
+      acl_sha256: hash("socket-acl"),
+      capability_sha256: hash(""),
+      dev: "1",
+      expected_type: "socket",
+      file_type: "socket",
+      gid: 731,
+      ino: "300",
+      mode: "0660",
+      nlink: 1,
+      size: 0,
+      stat_command_sha256: hash("socket-stat"),
+      target_path: "/run/bitcoinpir-test/service.sock",
+      uid: 730,
+      xattr_sha256: hash("socket-xattr"),
+    }],
     schema_version: 1,
     secret_access_checks: [],
     secret_parent_directories: [],
@@ -360,7 +399,8 @@ function secretIsolationFixture() {
     user_name: "bitcoinpir-z-peer",
   });
   value.evidence.nss.groups.push({ gid: 734, members: [], name: "bitcoinpir-z-peer" });
-  value.evidence.nss.users.push({ name: "bitcoinpir-z-peer", primary_gid: 734, supplementary_gids: [734], uid: 733 });
+  value.evidence.nss.groups.find((group) => group.gid === 731).members.push("bitcoinpir-z-peer");
+  value.evidence.nss.users.push({ name: "bitcoinpir-z-peer", primary_gid: 734, supplementary_gids: [731, 734], uid: 733 });
 
   const peerFragment = { file_type: "regular", gid: 0, mode: "0644", nlink: 1, sha256: hash("peer-fragment"), target_path: peerUnit.fragment_path, uid: 0 };
   value.request.installed_files.push(peerFragment);
@@ -508,10 +548,19 @@ for (const [label, mutate, expected] of [
   ["root image", (f) => { f.evidence.units[0].properties.RootImage = "/tmp/root.img"; }, /RootImage/],
   ["file hash", (f) => { f.evidence.installed_files[0].sha256 = hash("evil"); }, /sha256 drift/],
   ["tmpfiles mode", (f) => { f.evidence.runtime_directories[0].mode = "0777"; }, /tmpfiles directory drift/],
-  ["unexpected issuer group", (f) => { f.evidence.nss.users[0].supplementary_gids.push(999); }, /unexpected supplementary group/],
+  ["runtime socket mode", (f) => { f.evidence.runtime_paths[0].mode = "0666"; }, /runtime path mode drift/],
+  ["unexpected issuer group", (f) => { f.evidence.nss.users[0].supplementary_gids.push(999); }, /unexpected supplementary group|reverse group membership/],
   ["inactive unit", (f) => { f.evidence.units[0].properties.ActiveState = "inactive"; }, /not active/],
   ["zero MainPID", (f) => { f.evidence.units[0].properties.MainPID = "0"; }, /no active MainPID/],
   ["effective Restart drift", (f) => { f.evidence.units[0].properties.Restart = "on-failure"; }, /Restart drift/],
+  ["effective LimitCORE drift", (f) => { f.evidence.units[0].properties.LimitCORE = "infinity"; }, /LimitCORE drift/],
+  ["effective LimitCORESoft drift", (f) => { f.evidence.units[0].properties.LimitCORESoft = "infinity"; }, /LimitCORESoft drift/],
+  ["effective MemoryMax drift", (f) => { f.evidence.units[0].properties.MemoryMax = "infinity"; }, /MemoryMax drift/],
+  ["effective MemorySwapCurrent drift", (f) => { f.evidence.units[0].properties.MemorySwapCurrent = "1"; }, /MemorySwapCurrent drift/],
+  ["effective MemorySwapMax drift", (f) => { f.evidence.units[0].properties.MemorySwapMax = "infinity"; }, /MemorySwapMax drift/],
+  ["effective TasksMax drift", (f) => { f.evidence.units[0].properties.TasksMax = "infinity"; }, /TasksMax drift/],
+  ["effective StandardOutput drift", (f) => { f.evidence.units[0].properties.StandardOutput = "journal"; }, /StandardOutput drift/],
+  ["effective StandardError drift", (f) => { f.evidence.units[0].properties.StandardError = "journal"; }, /StandardError drift/],
   ["MainPID confirmation race", (f) => { f.evidence.units[0].generation_confirmations[1].main_pid = "4243"; }, /MainPID or InvocationID changed/],
   ["InvocationID generation race", (f) => { f.evidence.units[0].generation_confirmations[1].invocation_id = "b".repeat(32); }, /MainPID or InvocationID changed/],
   ["proc starttime race", (f) => { f.evidence.units[0].process_identity.start_time_ticks_after = "123457"; }, /restart race/],
@@ -529,6 +578,13 @@ for (const [label, mutate, expected] of [
     assert.throws(() => validate(value), expected);
   });
 }
+
+test("edge live evidence rejects a core pipe that can persist request-source memory", () => {
+  const value = fixture();
+  value.request.deployment_profile = "edge-hetzner-v1";
+  value.evidence.host.core_pattern = "|/usr/lib/systemd/systemd-coredump";
+  assert.throws(() => validate(value), /kernel\.core_pattern=\|\/usr\/bin\/false/);
+});
 
 test("live verifier rejects replay, foreign host, foreign boot, and forged challenge", () => {
   const stale = fixture();

--- a/scripts/payment-v1-linux-runtime-evidence.test.mjs
+++ b/scripts/payment-v1-linux-runtime-evidence.test.mjs
@@ -6,8 +6,21 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  assertLocalFilesNssPolicyUnchanged,
   LIVE_EVIDENCE_KIND,
+  STOPPED_EDGE_EVIDENCE_KIND,
+  NSS_BACKEND_PROFILE,
+  NSS_ENUMERATION_KIND,
+  PROTECTED_PROCESS_ENUMERATION_KIND,
+  collectProtectedCredentialProcessClosureV1,
+  collectVisibleNssEvidenceV2,
+  parseGroupEnumerationV2,
+  parseLocalFilesNsswitchV1,
+  parseLockedServiceAccountPolicyV1,
+  parsePasswdEnumerationV2,
+  parseProcStatus,
   validateLiveRuntimeEvidence,
+  validateStoppedEdgeActivationEvidence,
 } from "./payment-v1-linux-runtime-evidence.mjs";
 import {
   RUNTIME_COLLECTOR,
@@ -41,8 +54,30 @@ function clone(value) {
   return structuredClone(value);
 }
 
+function sortNssEvidence(nss) {
+  for (const group of nss.groups) group.members.sort();
+  for (const user of nss.users) user.supplementary_gids.sort((left, right) => left - right);
+  nss.groups.sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0);
+  nss.users.sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0);
+  return nss;
+}
+
 function execValue(command) {
   return `{ path=${command.split(" ", 1)[0]} ; argv[]=${command} ; ignore_errors=no ; start_time=[n/a] ; }`;
+}
+
+function protectedHolder({ controlGroup, gid, groups, ino, pid, startTime, uid, tid = pid }) {
+  return {
+    control_group: controlGroup,
+    gid: [gid, gid, gid, gid],
+    groups: [...groups],
+    pid,
+    proc_directory_dev: "9",
+    proc_directory_ino: ino,
+    start_time_ticks: startTime,
+    tid,
+    uid: [uid, uid, uid, uid],
+  };
 }
 
 function fixture() {
@@ -108,7 +143,7 @@ function fixture() {
       target_path: "/run/bitcoinpir-test/service.sock",
       uid: 730,
     }],
-    schema_version: 1,
+    schema_version: 2,
     secret_files: [],
     service_identities: [{
       gid: 731,
@@ -133,6 +168,7 @@ function fixture() {
     CapabilityBoundingSet: "",
     ConditionResult: "yes",
     Conditions: "ConditionPathExists=/etc/bitcoinpir/payment-v1/ACTIVATION-APPROVED",
+    ControlGroup: "/system.slice/bitcoinpir-test.service",
     DropInPaths: "",
     Environment: "RUST_LOG=error",
     EnvironmentFiles: "",
@@ -206,11 +242,25 @@ function fixture() {
       xattr_sha256: hash(`xattr-${index}`),
     };
   }
+  function nssPolicyFile(path, index) {
+    return {
+      dev: "1",
+      gid: 0,
+      ino: String(600 + index),
+      mode: "0644",
+      nlink: 1,
+      path,
+      sha256: hash(`nss-policy-${index}`),
+      size: 100 + index,
+      uid: 0,
+    };
+  }
   const machine = hash("machine");
   const boot = "12345678-1234-4abc-8def-123456789abc";
   const generationConfirmation = {
     active_enter_timestamp_monotonic: properties.ActiveEnterTimestampMonotonic,
     active_state: properties.ActiveState,
+    control_group: properties.ControlGroup,
     invocation_id: properties.InvocationID,
     main_pid: properties.MainPID,
   };
@@ -241,9 +291,13 @@ function fixture() {
     evidence_kind: LIVE_EVIDENCE_KIND,
     host: {
       boot_id: boot,
+      collector_pid_namespace: "pid:[4026531836]",
       core_pattern: "|/usr/bin/false",
       kernel_release: "6.8.0-test",
       machine_id_sha256: machine,
+      pid1_name: "systemd",
+      pid1_nspid: [1],
+      pid1_pid_namespace: "pid:[4026531836]",
       systemd_version: "systemd 257",
       uptime_finished_milliseconds: 5010,
       uptime_started_milliseconds: 5000,
@@ -251,13 +305,45 @@ function fixture() {
     installed_files: installedFiles.map(richFile),
     manifest_sha256: request.manifest_sha256,
     nss: {
+      backend_profile: NSS_BACKEND_PROFILE,
+      enumeration_kind: NSS_ENUMERATION_KIND,
+      group_file: nssPolicyFile("/etc/group", 2),
+      group_stdout_sha256: hash("group-enumeration"),
       groups: [
-        { gid: 731, members: [], name: "bitcoinpir-test" },
         { gid: 732, members: ["bitcoinpir-test"], name: "bitcoinpir-shared" },
+        { gid: 731, members: [], name: "bitcoinpir-test" },
+        { gid: 0, members: [], name: "root" },
       ],
+      nsswitch_file: nssPolicyFile("/etc/nsswitch.conf", 0),
+      passwd_file: nssPolicyFile("/etc/passwd", 1),
+      passwd_stdout_sha256: hash("passwd-enumeration"),
+      sources: {
+        group: ["files"],
+        initgroups: "inherits-group",
+        passwd: ["files"],
+      },
       users: [
         { name: "bitcoinpir-test", primary_gid: 731, supplementary_gids: [731, 732], uid: 730 },
+        { name: "root", primary_gid: 0, supplementary_gids: [0], uid: 0 },
       ],
+    },
+    protected_process_closure: {
+      enumeration_kind: PROTECTED_PROCESS_ENUMERATION_KIND,
+      passes: [0, 1].map(() => ({
+        holders: [protectedHolder({
+          controlGroup: properties.ControlGroup,
+          gid: 731,
+          groups: [731, 732],
+          ino: "99",
+          pid: 4242,
+          startTime: "123456",
+          uid: 730,
+        })],
+        processes_enumerated: 1,
+        threads_examined: 1,
+      })),
+      protected_gids: [731, 732],
+      protected_uids: [730],
     },
     runtime_directories: [
       {
@@ -295,7 +381,7 @@ function fixture() {
       uid: 730,
       xattr_sha256: hash("socket-xattr"),
     }],
-    schema_version: 1,
+    schema_version: 2,
     secret_access_checks: [],
     secret_parent_directories: [],
     systemd_analyze_verify: {
@@ -314,13 +400,92 @@ function fixture() {
     })),
     units: [{
       fragment_sha256: hash("fragment"),
-      generation_confirmations: [clone(generationConfirmation), clone(generationConfirmation)],
+      generation_confirmations: [
+        clone(generationConfirmation),
+        clone(generationConfirmation),
+        clone(generationConfirmation),
+      ],
       process_identity: processIdentity,
       properties,
       unit_name: unit.unit_name,
     }],
   };
   return { boot, evidence, machine, request };
+}
+
+function stoppedEdgeFixture() {
+  const live = fixture();
+  live.request.deployment_profile = "edge-hetzner-v1";
+  const unitState = {
+    active_state: "inactive",
+    control_group: "",
+    drop_in_paths: "",
+    fragment_path: live.request.units[0].fragment_path,
+    invocation_id: "",
+    load_state: "loaded",
+    main_pid: "0",
+    sub_state: "dead",
+    unit_name: live.request.units[0].unit_name,
+  };
+  const socketAbsence = {
+    parent_dev: "1",
+    parent_ino: "200",
+    parent_path: "/run/bitcoinpir-test",
+    parent_state: "canonical-directory",
+    target_path: "/run/bitcoinpir-test/service.sock",
+  };
+  const shadowFile = {
+    ...clone(live.evidence.nss.passwd_file),
+    gid: 42,
+    ino: "604",
+    mode: "0640",
+    path: "/etc/shadow",
+    sha256: hash("shadow-policy"),
+  };
+  const evidence = {
+    account_policy: {
+      accounts: [{
+        gid: 731,
+        password_state: "locked",
+        shell: "/usr/sbin/nologin",
+        uid: 730,
+        user_name: "bitcoinpir-test",
+      }],
+      passwd_file: clone(live.evidence.nss.passwd_file),
+      shadow_file: shadowFile,
+    },
+    approved_plan_sha256: live.request.approved_plan_sha256,
+    challenge_hex: hash("stopped-edge-internal-challenge"),
+    collected_finished_unix_seconds: 1_800_000_010,
+    collected_started_unix_seconds: 1_800_000_000,
+    collector: RUNTIME_COLLECTOR,
+    collector_process: { egid: 0, euid: 0, pid: 42 },
+    evidence_kind: STOPPED_EDGE_EVIDENCE_KIND,
+    host: clone(live.evidence.host),
+    manifest_sha256: live.request.manifest_sha256,
+    nss: clone(live.evidence.nss),
+    protected_process_closure: {
+      enumeration_kind: PROTECTED_PROCESS_ENUMERATION_KIND,
+      passes: [0, 1].map(() => ({
+        holders: [],
+        processes_enumerated: 10,
+        threads_examined: 12,
+      })),
+      protected_gids: [731, 732],
+      protected_uids: [730],
+    },
+    runtime_socket_absence_passes: [
+      [clone(socketAbsence)],
+      [clone(socketAbsence)],
+    ],
+    schema_version: 1,
+    stopped_unit_passes: [
+      [clone(unitState)],
+      [clone(unitState)],
+    ],
+    trusted_commands: clone(live.evidence.trusted_commands),
+  };
+  return { ...live, evidence };
 }
 
 function validate(value) {
@@ -332,6 +497,31 @@ function validate(value) {
     nowUnixSeconds: 1_800_000_020,
     request: value.request,
   });
+}
+
+function validateStopped(value) {
+  return validateStoppedEdgeActivationEvidence({
+    evidence: value.evidence,
+    expectedBootId: value.boot,
+    expectedMachineIdSha256: value.machine,
+    maxAgeSeconds: 30,
+    nowUnixSeconds: 1_800_000_020,
+    request: value.request,
+  });
+}
+
+function localFilesPolicySnapshot(nss) {
+  return {
+    evidence: {
+      backend_profile: nss.backend_profile,
+      group_file: clone(nss.group_file),
+      nsswitch_file: clone(nss.nsswitch_file),
+      passwd_file: clone(nss.passwd_file),
+      sources: clone(nss.sources),
+    },
+    groupRecords: clone(nss.groups),
+    passwdRecords: nss.users.map(({ supplementary_gids: _ignored, ...record }) => clone(record)),
+  };
 }
 
 function oneshotFixture() {
@@ -350,6 +540,7 @@ function oneshotFixture() {
   const actual = value.evidence.units[0];
   actual.unit_name = unit.unit_name;
   actual.properties.FragmentPath = fragmentPath;
+  actual.properties.ControlGroup = `/system.slice/${unit.unit_name}`;
   actual.properties.Type = "oneshot";
   actual.properties.RemainAfterExit = "yes";
   actual.properties.MainPID = "0";
@@ -359,9 +550,11 @@ function oneshotFixture() {
   actual.properties.ExecMainStatus = "0";
   actual.generation_confirmations = actual.generation_confirmations.map((confirmation) => ({
     ...confirmation,
+    control_group: actual.properties.ControlGroup,
     main_pid: "0",
   }));
   actual.process_identity = null;
+  for (const pass of value.evidence.protected_process_closure.passes) pass.holders = [];
   return value;
 }
 
@@ -401,6 +594,7 @@ function secretIsolationFixture() {
   value.evidence.nss.groups.push({ gid: 734, members: [], name: "bitcoinpir-z-peer" });
   value.evidence.nss.groups.find((group) => group.gid === 731).members.push("bitcoinpir-z-peer");
   value.evidence.nss.users.push({ name: "bitcoinpir-z-peer", primary_gid: 734, supplementary_gids: [731, 734], uid: 733 });
+  sortNssEvidence(value.evidence.nss);
 
   const peerFragment = { file_type: "regular", gid: 0, mode: "0644", nlink: 1, sha256: hash("peer-fragment"), target_path: peerUnit.fragment_path, uid: 0 };
   value.request.installed_files.push(peerFragment);
@@ -415,6 +609,7 @@ function secretIsolationFixture() {
   value.evidence.systemd_analyze_verify.argv.push(peerUnit.fragment_path);
   const peerProperties = {
     ...clone(value.evidence.units[0].properties),
+    ControlGroup: `/system.slice/${peerUnit.unit_name}`,
     FragmentPath: peerUnit.fragment_path,
     Group: "bitcoinpir-z-peer",
     InvocationID: "b".repeat(32),
@@ -425,12 +620,17 @@ function secretIsolationFixture() {
   const peerConfirmation = {
     active_enter_timestamp_monotonic: peerProperties.ActiveEnterTimestampMonotonic,
     active_state: "active",
+    control_group: peerProperties.ControlGroup,
     invocation_id: peerProperties.InvocationID,
     main_pid: peerProperties.MainPID,
   };
   value.evidence.units.push({
     fragment_sha256: peerFragment.sha256,
-    generation_confirmations: [clone(peerConfirmation), clone(peerConfirmation)],
+    generation_confirmations: [
+      clone(peerConfirmation),
+      clone(peerConfirmation),
+      clone(peerConfirmation),
+    ],
     process_identity: {
       gid_after: [734, 734, 734, 734],
       gid_before: [734, 734, 734, 734],
@@ -451,6 +651,25 @@ function secretIsolationFixture() {
     properties: peerProperties,
     unit_name: peerUnit.unit_name,
   });
+  const holders = [
+    clone(value.evidence.protected_process_closure.passes[0].holders[0]),
+    protectedHolder({
+      controlGroup: peerProperties.ControlGroup,
+      gid: 734,
+      groups: [731, 734],
+      ino: "100",
+      pid: 4243,
+      startTime: "123457",
+      uid: 733,
+    }),
+  ];
+  value.evidence.protected_process_closure.passes = [0, 1].map(() => ({
+    holders: clone(holders),
+    processes_enumerated: 2,
+    threads_examined: 2,
+  }));
+  value.evidence.protected_process_closure.protected_gids = [731, 732, 734];
+  value.evidence.protected_process_closure.protected_uids = [730, 733];
 
   const targetPath = "/etc/bitcoinpir/payment-v1/issuer/quote-signing.key";
   const secret = { file_type: "regular", gid: 731, mode: "0400", nlink: 1, sha256: hash("issuer-secret"), target_path: targetPath, uid: 730 };
@@ -513,6 +732,434 @@ test("valid live evidence binds challenge, host, boot, files, NSS, units, and co
   assert.equal(validate(fixture()), true);
 });
 
+test("complete NSS parsers retain every primary GID and canonicalize ASCII names and members", () => {
+  assert.deepEqual(
+    parsePasswdEnumerationV2([
+      "rogue:x:900:731::/nonexistent:/usr/sbin/nologin",
+      "Root:x:0:0:root:/root:/bin/sh",
+      "",
+    ].join("\n")),
+    [
+      { name: "Root", primary_gid: 0, uid: 0 },
+      { name: "rogue", primary_gid: 731, uid: 900 },
+    ],
+  );
+  assert.deepEqual(
+    parseGroupEnumerationV2([
+      "z-group:x:900:rogue,Root",
+      "Root:x:0:",
+      "",
+    ].join("\n")),
+    [
+      { gid: 0, members: [], name: "Root" },
+      { gid: 900, members: ["Root", "rogue"], name: "z-group" },
+    ],
+  );
+});
+
+test("complete NSS parsers reject ambiguous, noncanonical, or duplicate enumeration records", () => {
+  for (const [parse, input, expected] of [
+    [parsePasswdEnumerationV2, "root:x:00:0:root:/root:/bin/sh\n", /canonical unsigned decimal/],
+    [parsePasswdEnumerationV2, "root:x:0:0:root:/root\n", /seven fields/],
+    [parsePasswdEnumerationV2, "root:x:0:0:root:/root:/bin/sh\nroot:x:1:1::/:/bin/false\n", /repeats a user name/],
+    [parseGroupEnumerationV2, "root:x:0:root,root\n", /duplicate or excessive members/],
+    [parseGroupEnumerationV2, "root:x:0:\r\n", /malformed or oversized/],
+  ]) {
+    assert.throws(() => parse(input), expected);
+  }
+});
+
+test("NSS policy accepts only local files with inherited initgroups", () => {
+  assert.deepEqual(
+    parseLocalFilesNsswitchV1([
+      "passwd: files",
+      "group: files # local groups are the sole authority",
+      "hosts: files dns",
+      "",
+    ].join("\n")),
+    {
+      group: ["files"],
+      initgroups: "inherits-group",
+      passwd: ["files"],
+    },
+  );
+  for (const input of [
+    "passwd: files systemd\ngroup: files\n",
+    "passwd: files\ngroup: files sss\n",
+    "passwd: files\ngroup: files\ninitgroups: files\n",
+    "passwd: files\npasswd: files\ngroup: files\n",
+    "passwd: files\ngroup: files [SUCCESS=merge] systemd\n",
+    "passwd: compat\ngroup: compat\n",
+  ]) {
+    assert.throws(
+      () => parseLocalFilesNsswitchV1(input),
+      /local-files-only|repeats|simple local profile/,
+    );
+  }
+});
+
+test("final NSS policy confirmation rejects identity or policy drift after enumeration", () => {
+  const nss = fixture().evidence.nss;
+  assert.equal(assertLocalFilesNssPolicyUnchanged(nss, localFilesPolicySnapshot(nss)), true);
+
+  const changedPolicy = localFilesPolicySnapshot(nss);
+  changedPolicy.evidence.group_file.sha256 = hash("changed-group-file");
+  assert.throws(
+    () => assertLocalFilesNssPolicyUnchanged(nss, changedPolicy),
+    /changed after complete enumeration/,
+  );
+
+  const changedIdentity = localFilesPolicySnapshot(nss);
+  changedIdentity.passwdRecords[0].uid += 1;
+  assert.throws(
+    () => assertLocalFilesNssPolicyUnchanged(nss, changedIdentity),
+    /changed after complete enumeration/,
+  );
+});
+
+test(
+  "Linux smoke exercises real getent enumeration and id -G for every visible user",
+  { skip: process.platform !== "linux" },
+  () => {
+    const nss = collectVisibleNssEvidenceV2();
+    assert.equal(nss.enumeration_kind, NSS_ENUMERATION_KIND);
+    assert.ok(nss.users.length > 0);
+    assert.ok(nss.groups.length > 0);
+    for (const user of nss.users) {
+      assert.ok(user.supplementary_gids.includes(user.primary_gid));
+    }
+  },
+);
+
+test(
+  "Linux smoke performs two complete bounded procfs thread-credential passes",
+  { skip: process.platform !== "linux" },
+  () => {
+    const closure = collectProtectedCredentialProcessClosureV1({
+      protectedGids: [],
+      protectedUids: [],
+    });
+    assert.equal(closure.enumeration_kind, PROTECTED_PROCESS_ENUMERATION_KIND);
+    assert.equal(closure.passes.length, 2);
+    for (const pass of closure.passes) {
+      assert.ok(pass.processes_enumerated >= 1);
+      assert.ok(pass.threads_examined >= pass.processes_enumerated);
+      assert.deepEqual(pass.holders, []);
+    }
+  },
+);
+
+test("procfs status treats repeated supplementary GIDs as one kernel credential set", () => {
+  const identity = parseProcStatus(
+    Buffer.from([
+      "Tgid:\t42",
+      "Pid:\t42",
+      "Uid:\t730\t730\t730\t730",
+      "Gid:\t731\t731\t731\t731",
+      "Groups:\t732 731 732 731",
+      "CapInh:\t0000000000000000",
+      "CapPrm:\t0000000000000000",
+      "CapEff:\t0000000000000000",
+      "CapAmb:\t0000000000000000",
+      "",
+    ].join("\n")),
+    42,
+    { expectedTgid: 42, label: "test proc status" },
+  );
+  assert.deepEqual(identity.groups, [731, 732]);
+  assert.equal(identity.setidCapabilities, false);
+
+  const setidIdentity = parseProcStatus(
+    Buffer.from([
+      "Tgid:\t43",
+      "Pid:\t43",
+      "Uid:\t730\t730\t730\t730",
+      "Gid:\t731\t731\t731\t731",
+      "Groups:\t731",
+      "CapInh:\t0000000000000000",
+      "CapPrm:\t00000000000000c0",
+      "CapEff:\t0000000000000000",
+      "CapAmb:\t0000000000000000",
+      "",
+    ].join("\n")),
+    43,
+    { expectedTgid: 43, label: "setid proc status" },
+  );
+  assert.equal(setidIdentity.setidCapabilities, true);
+});
+
+test("service-account policy requires pinned IDs, nologin shell, and a locked shadow password", () => {
+  const identities = [{
+    gid: 731,
+    group_name: "bitcoinpir-test",
+    uid: 730,
+    unit_name: "bitcoinpir-test.service",
+    user_name: "bitcoinpir-test",
+  }];
+  assert.deepEqual(
+    parseLockedServiceAccountPolicyV1(
+      "root:x:0:0:root:/root:/bin/bash\nbitcoinpir-test:x:730:731::/nonexistent:/usr/sbin/nologin\n",
+      "root:*:1:0:99999:7:::\nbitcoinpir-test:!:1:0:99999:7:::\n",
+      identities,
+    ),
+    [{
+      gid: 731,
+      password_state: "locked",
+      shell: "/usr/sbin/nologin",
+      uid: 730,
+      user_name: "bitcoinpir-test",
+    }],
+  );
+  assert.throws(
+    () => parseLockedServiceAccountPolicyV1(
+      "bitcoinpir-test:x:730:731::/home/test:/bin/bash\n",
+      "bitcoinpir-test:secret:1:0:99999:7:::\n",
+      identities,
+    ),
+    /login-disabled, and password-locked/,
+  );
+});
+
+test("stopped-edge activation evidence closes units, sockets, identities, and login reacquisition", () => {
+  const value = stoppedEdgeFixture();
+  assert.equal(validateStopped(value), true);
+
+  const active = stoppedEdgeFixture();
+  active.evidence.stopped_unit_passes[1][0].active_state = "active";
+  assert.throws(() => validateStopped(active), /not fully stopped/);
+
+  const holder = stoppedEdgeFixture();
+  holder.evidence.protected_process_closure.passes[0].holders.push(protectedHolder({
+    controlGroup: "/user.slice/rogue.service",
+    gid: 731,
+    groups: [731],
+    ino: "999",
+    pid: 999,
+    startTime: "888",
+    uid: 730,
+  }));
+  assert.throws(() => validateStopped(holder), /protected credential holder/);
+
+  const login = stoppedEdgeFixture();
+  login.evidence.account_policy.accounts[0].shell = "/bin/bash";
+  assert.throws(() => validateStopped(login), /not locked and login-disabled/);
+
+  const socket = stoppedEdgeFixture();
+  socket.evidence.runtime_socket_absence_passes[1][0].parent_ino = "201";
+  assert.throws(() => validateStopped(socket), /absence changed/);
+
+  const namespace = stoppedEdgeFixture();
+  namespace.evidence.host.collector_pid_namespace = "pid:[4026539999]";
+  assert.throws(() => validateStopped(namespace), /PID namespace/);
+
+  const legacy = stoppedEdgeFixture();
+  legacy.evidence.protected_process_closure.enumeration_kind =
+    "procfs-v2-all-thread-credentials-two-pass-v1";
+  assert.throws(() => validateStopped(legacy), /closure is incomplete/);
+});
+
+test("live verifier closes protected NSS primary, explicit, effective, UID, and GID aliases", () => {
+  const roguePrimary = fixture();
+  roguePrimary.evidence.nss.users.push({
+    name: "rogue",
+    primary_gid: 731,
+    supplementary_gids: [731],
+    uid: 900,
+  });
+  sortNssEvidence(roguePrimary.evidence.nss);
+  assert.throws(() => validate(roguePrimary), /protected primary-GID holder drift/);
+
+  const uidAlias = fixture();
+  uidAlias.evidence.nss.groups.push({ gid: 900, members: [], name: "rogue" });
+  uidAlias.evidence.nss.users.push({
+    name: "rogue",
+    primary_gid: 900,
+    supplementary_gids: [900],
+    uid: 730,
+  });
+  sortNssEvidence(uidAlias.evidence.nss);
+  assert.throws(() => validate(uidAlias), /aliases a UID/);
+
+  const gidAlias = fixture();
+  gidAlias.evidence.nss.groups.push({ gid: 731, members: [], name: "rogue" });
+  sortNssEvidence(gidAlias.evidence.nss);
+  assert.throws(() => validate(gidAlias), /aliases a GID/);
+
+  const rogueMember = fixture();
+  rogueMember.evidence.nss.groups.push({ gid: 900, members: [], name: "rogue" });
+  rogueMember.evidence.nss.groups.find((group) => group.gid === 732).members.push("rogue");
+  rogueMember.evidence.nss.users.push({
+    name: "rogue",
+    primary_gid: 900,
+    supplementary_gids: [732, 900],
+    uid: 900,
+  });
+  sortNssEvidence(rogueMember.evidence.nss);
+  assert.throws(
+    () => validate(rogueMember),
+    /protected explicit group membership drift|protected effective group membership drift/,
+  );
+});
+
+test("live verifier closes stale protected UID/GID holders across every procfs thread", () => {
+  const managedWorker = fixture();
+  const worker = protectedHolder({
+    controlGroup: "/system.slice/bitcoinpir-test.service",
+    gid: 731,
+    groups: [731, 732],
+    ino: "101",
+    pid: 4243,
+    startTime: "123457",
+    uid: 730,
+  });
+  for (const pass of managedWorker.evidence.protected_process_closure.passes) {
+    pass.holders.push(clone(worker));
+    pass.processes_enumerated += 1;
+    pass.threads_examined += 1;
+  }
+  assert.equal(validate(managedWorker), true);
+
+  const staleHolder = fixture();
+  const rogue = protectedHolder({
+    controlGroup: "/system.slice/unmanaged.service",
+    gid: 900,
+    groups: [732, 900],
+    ino: "102",
+    pid: 5000,
+    startTime: "123458",
+    uid: 900,
+  });
+  for (const pass of staleHolder.evidence.protected_process_closure.passes) {
+    pass.holders.push(clone(rogue));
+    pass.processes_enumerated += 1;
+    pass.threads_examined += 1;
+  }
+  assert.throws(() => validate(staleHolder), /outside every managed unit cgroup/);
+
+  const omittedMain = fixture();
+  for (const pass of omittedMain.evidence.protected_process_closure.passes) {
+    pass.holders = [clone(worker)];
+  }
+  assert.throws(() => validate(omittedMain), /omits managed MainPID/);
+
+  const wrongUid = fixture();
+  for (const pass of wrongUid.evidence.protected_process_closure.passes) {
+    pass.holders[0].uid = [733, 733, 733, 733];
+  }
+  assert.throws(() => validate(wrongUid), /protected holder UID/);
+
+  const racedPass = fixture();
+  racedPass.evidence.protected_process_closure.passes[1].holders[0].proc_directory_ino = "103";
+  assert.throws(() => validate(racedPass), /holders changed between complete procfs passes/);
+
+  const legacy = fixture();
+  delete legacy.evidence.protected_process_closure;
+  assert.throws(() => validate(legacy), /live runtime evidence keys/);
+});
+
+test("live verifier rejects omitted service identities and noncanonical complete NSS evidence", () => {
+  const omitted = fixture();
+  omitted.evidence.nss.users = omitted.evidence.nss.users.filter(
+    (user) => user.name !== "bitcoinpir-test",
+  );
+  omitted.evidence.nss.groups.find((group) => group.gid === 732).members = [];
+  assert.throws(
+    () => validate(omitted),
+    /tmpfiles directory NSS owner drift|primary identity drift/,
+  );
+
+  const unsortedUsers = fixture();
+  unsortedUsers.evidence.nss.users.reverse();
+  assert.throws(() => validate(unsortedUsers), /not canonically sorted/);
+
+  const unsortedGroups = fixture();
+  unsortedGroups.evidence.nss.groups.reverse();
+  assert.throws(() => validate(unsortedGroups), /not canonically sorted/);
+
+  const duplicateMember = fixture();
+  duplicateMember.evidence.nss.groups[0].members.push("bitcoinpir-test");
+  assert.throws(() => validate(duplicateMember), /group data is malformed/);
+
+  const invalidUid = fixture();
+  invalidUid.evidence.nss.users[0].uid = -1;
+  assert.throws(() => validate(invalidUid), /user data is malformed/);
+
+  const oversizedName = fixture();
+  oversizedName.evidence.nss.users[0].name = `a${"b".repeat(128)}`;
+  assert.throws(() => validate(oversizedName), /bounded canonical NSS name/);
+
+  const duplicateSupplementary = fixture();
+  duplicateSupplementary.evidence.nss.users[0].supplementary_gids.push(732);
+  assert.throws(() => validate(duplicateSupplementary), /user data is malformed/);
+
+  const unknownMember = fixture();
+  unknownMember.evidence.nss.groups[0].members.push("rogue");
+  assert.throws(() => validate(unknownMember), /group membership is inconsistent/);
+
+  const maximumId = fixture();
+  maximumId.evidence.nss.groups.push({ gid: 0xffff_ffff, members: [], name: "z-max" });
+  maximumId.evidence.nss.users.push({
+    name: "z-max",
+    primary_gid: 0xffff_ffff,
+    supplementary_gids: [0xffff_ffff],
+    uid: 0xffff_ffff,
+  });
+  sortNssEvidence(maximumId.evidence.nss);
+  assert.equal(validate(maximumId), true);
+
+  const overflowingId = fixture();
+  overflowingId.evidence.nss.groups.push({
+    gid: 0x1_0000_0000,
+    members: [],
+    name: "z-overflow",
+  });
+  sortNssEvidence(overflowingId.evidence.nss);
+  assert.throws(() => validate(overflowingId), /group data is malformed/);
+
+  const excessiveUsers = fixture();
+  for (let index = 0; index < 4095; index += 1) {
+    excessiveUsers.evidence.nss.users.push({
+      name: `u${String(index).padStart(4, "0")}`,
+      primary_gid: 0,
+      supplementary_gids: [0],
+      uid: 1000 + index,
+    });
+  }
+  sortNssEvidence(excessiveUsers.evidence.nss);
+  assert.throws(() => validate(excessiveUsers), /record or byte bound/);
+
+  const excessiveMembers = fixture();
+  excessiveMembers.evidence.nss.groups.find((group) => group.gid === 0).members =
+    Array.from({ length: 4097 }, (_, index) => `u${String(index).padStart(4, "0")}`);
+  assert.throws(() => validate(excessiveMembers), /group data is malformed/);
+});
+
+test("live verifier rejects legacy request/evidence and untrusted NSS policy metadata", () => {
+  const legacyEvidence = fixture();
+  legacyEvidence.evidence.schema_version = 1;
+  assert.throws(() => validate(legacyEvidence), /schema or kind/);
+
+  const legacyRequest = fixture();
+  legacyRequest.request.schema_version = 1;
+  assert.throws(() => validate(legacyRequest), /request schema or collector/);
+
+  const remoteBackend = fixture();
+  remoteBackend.evidence.nss.sources.passwd.push("sss");
+  assert.throws(() => validate(remoteBackend), /local-files-only profile/);
+
+  const writablePolicy = fixture();
+  writablePolicy.evidence.nss.nsswitch_file.mode = "0664";
+  assert.throws(() => validate(writablePolicy), /metadata is not trusted/);
+
+  const specialPolicy = fixture();
+  specialPolicy.evidence.nss.group_file.mode = "4644";
+  assert.throws(() => validate(specialPolicy), /metadata is not trusted/);
+
+  const wrongPolicyPath = fixture();
+  wrongPolicyPath.evidence.nss.passwd_file.path = "/tmp/passwd";
+  assert.throws(() => validate(wrongPolicyPath), /metadata is not trusted/);
+});
+
 test("reviewed preflight oneshot uses active-exited boot-bound completion evidence without fake procfs identity", () => {
   assert.equal(validate(oneshotFixture()), true);
   for (const [mutate, expected] of [
@@ -541,6 +1188,8 @@ test("secret evidence binds parent metadata and positive owner/negative cross-ro
 
 for (const [label, mutate, expected] of [
   ["drop-in", (f) => { f.evidence.units[0].properties.DropInPaths = "/etc/systemd/system/x.d/evil.conf"; }, /drop-in/],
+  ["foreign PID namespace", (f) => { f.evidence.host.collector_pid_namespace = "pid:[4026532557]"; }, /visible systemd PID namespace root/],
+  ["non-systemd PID 1", (f) => { f.evidence.host.pid1_name = "sh"; }, /visible systemd PID namespace root/],
   ["ExecStart reset", (f) => { f.evidence.units[0].properties.ExecStart = execValue("/usr/bin/true"); }, /ExecStart drift/],
   ["ExecStartPost", (f) => { f.evidence.units[0].properties.ExecStartPost = execValue("/usr/bin/true"); }, /ExecStartPost/],
   ["EnvironmentFile", (f) => { f.evidence.units[0].properties.EnvironmentFiles = "/tmp/evil"; }, /EnvironmentFiles/],
@@ -548,9 +1197,13 @@ for (const [label, mutate, expected] of [
   ["root image", (f) => { f.evidence.units[0].properties.RootImage = "/tmp/root.img"; }, /RootImage/],
   ["file hash", (f) => { f.evidence.installed_files[0].sha256 = hash("evil"); }, /sha256 drift/],
   ["tmpfiles mode", (f) => { f.evidence.runtime_directories[0].mode = "0777"; }, /tmpfiles directory drift/],
+  ["tmpfiles UID", (f) => { f.evidence.runtime_directories[0].uid = 999; }, /tmpfiles directory NSS owner drift/],
+  ["tmpfiles GID", (f) => { f.evidence.runtime_directories[0].gid = 999; }, /tmpfiles directory NSS owner drift/],
+  ["tmpfiles evidence type", (f) => { f.evidence.runtime_directories[0].expected_type = "socket"; }, /tmpfiles directory drift/],
   ["runtime socket mode", (f) => { f.evidence.runtime_paths[0].mode = "0666"; }, /runtime path mode drift/],
   ["unexpected issuer group", (f) => { f.evidence.nss.users[0].supplementary_gids.push(999); }, /unexpected supplementary group|reverse group membership/],
   ["inactive unit", (f) => { f.evidence.units[0].properties.ActiveState = "inactive"; }, /not active/],
+  ["ControlGroup drift", (f) => { f.evidence.units[0].properties.ControlGroup = "/system.slice/evil.service"; }, /reviewed system\.slice control group/],
   ["zero MainPID", (f) => { f.evidence.units[0].properties.MainPID = "0"; }, /no active MainPID/],
   ["effective Restart drift", (f) => { f.evidence.units[0].properties.Restart = "on-failure"; }, /Restart drift/],
   ["effective LimitCORE drift", (f) => { f.evidence.units[0].properties.LimitCORE = "infinity"; }, /LimitCORE drift/],
@@ -561,8 +1214,9 @@ for (const [label, mutate, expected] of [
   ["effective TasksMax drift", (f) => { f.evidence.units[0].properties.TasksMax = "infinity"; }, /TasksMax drift/],
   ["effective StandardOutput drift", (f) => { f.evidence.units[0].properties.StandardOutput = "journal"; }, /StandardOutput drift/],
   ["effective StandardError drift", (f) => { f.evidence.units[0].properties.StandardError = "journal"; }, /StandardError drift/],
-  ["MainPID confirmation race", (f) => { f.evidence.units[0].generation_confirmations[1].main_pid = "4243"; }, /MainPID or InvocationID changed/],
-  ["InvocationID generation race", (f) => { f.evidence.units[0].generation_confirmations[1].invocation_id = "b".repeat(32); }, /MainPID or InvocationID changed/],
+  ["MainPID confirmation race", (f) => { f.evidence.units[0].generation_confirmations[1].main_pid = "4243"; }, /unit generation changed/],
+  ["InvocationID generation race", (f) => { f.evidence.units[0].generation_confirmations[1].invocation_id = "b".repeat(32); }, /unit generation changed/],
+  ["final ControlGroup confirmation race", (f) => { f.evidence.units[0].generation_confirmations[2].control_group = "/system.slice/evil.service"; }, /unit generation changed/],
   ["proc starttime race", (f) => { f.evidence.units[0].process_identity.start_time_ticks_after = "123457"; }, /restart race/],
   ["proc inode race", (f) => { f.evidence.units[0].process_identity.proc_directory_ino_after = "100"; }, /restart race/],
   ["old process retained supplementary group", (f) => {
@@ -619,6 +1273,12 @@ test("collect-live rejects caller JSON, caller challenge, and offline verificati
   const offline = spawnSync(process.execPath, [COLLECTOR, "verify-offline", ...base, "--evidence", "/tmp/forged.json", "--expected-boot-id", "12345678-1234-4abc-8def-123456789abc"], { encoding: "utf8" });
   assert.notEqual(offline.status, 0);
   assert.match(offline.stderr, /trusted-evidence-sha256/);
+  const stoppedCallerJson = spawnSync(process.execPath, [COLLECTOR, "collect-stopped-edge", ...base, "--output", "/tmp/output", "--evidence", "/tmp/forged.json"], { encoding: "utf8" });
+  assert.notEqual(stoppedCallerJson.status, 0);
+  assert.match(stoppedCallerJson.stderr, /collect-stopped-edge forbids caller evidence/);
+  const stoppedOffline = spawnSync(process.execPath, [COLLECTOR, "verify-stopped-edge-offline", ...base, "--evidence", "/tmp/forged.json", "--expected-boot-id", "12345678-1234-4abc-8def-123456789abc"], { encoding: "utf8" });
+  assert.notEqual(stoppedOffline.status, 0);
+  assert.match(stoppedOffline.stderr, /trusted-evidence-sha256/);
 });
 
 test("collect-live is Linux-only and root-only before any runtime evidence can be claimed", () => {

--- a/scripts/payment-v1-local-check.sh
+++ b/scripts/payment-v1-local-check.sh
@@ -90,9 +90,11 @@ node --check scripts/payment-v1-rendered-artifact-gate.mjs
 node --check scripts/payment-v1-rendered-artifact-gate.test.mjs
 node --check scripts/payment-v1-linux-runtime-evidence.mjs
 node --check scripts/payment-v1-linux-runtime-evidence.test.mjs
+node --check scripts/payment-v1-source-fair-edge.test.mjs
 node --test \
   scripts/payment-v1-rendered-artifact-gate.test.mjs \
-  scripts/payment-v1-linux-runtime-evidence.test.mjs
+  scripts/payment-v1-linux-runtime-evidence.test.mjs \
+  scripts/payment-v1-source-fair-edge.test.mjs
 
 if [[ "$mode" == "quick" ]]; then
   echo "[5/5] quick mode complete (no external network, no funds)"
@@ -333,9 +335,11 @@ node --check scripts/payment-v1-rendered-artifact-gate.mjs
 node --check scripts/payment-v1-rendered-artifact-gate.test.mjs
 node --check scripts/payment-v1-linux-runtime-evidence.mjs
 node --check scripts/payment-v1-linux-runtime-evidence.test.mjs
+node --check scripts/payment-v1-source-fair-edge.test.mjs
 node --test \
   scripts/payment-v1-rendered-artifact-gate.test.mjs \
-  scripts/payment-v1-linux-runtime-evidence.test.mjs
+  scripts/payment-v1-linux-runtime-evidence.test.mjs \
+  scripts/payment-v1-source-fair-edge.test.mjs
 
 echo "[7/9] warnings denied in dedicated Payment V1 crates and tools"
 cargo clippy --locked --offline --all-targets --no-deps \

--- a/scripts/payment-v1-rendered-artifact-gate.mjs
+++ b/scripts/payment-v1-rendered-artifact-gate.mjs
@@ -28,9 +28,9 @@ import { pathToFileURL } from "node:url";
 
 const PLAN_SCHEMA_VERSION = 1;
 const MANIFEST_SCHEMA_VERSION = 1;
-const EVIDENCE_SCHEMA_VERSION = 1;
+const EVIDENCE_SCHEMA_VERSION = 2;
 export const RUNTIME_COLLECTOR =
-  "bitcoinpir-payment-v1-linux-runtime-evidence-v1";
+  "bitcoinpir-payment-v1-linux-runtime-evidence-v2";
 
 const MAX_JSON_BYTES = 8 * 1024 * 1024;
 const MAX_TEMPLATE_BYTES = 2 * 1024 * 1024;
@@ -178,6 +178,7 @@ export const RUNTIME_SYSTEMCTL_SHOW_PROPERTIES = Object.freeze([
   "CapabilityBoundingSet",
   "ConditionResult",
   "Conditions",
+  "ControlGroup",
   "DropInPaths",
   "Environment",
   "EnvironmentFiles",

--- a/scripts/payment-v1-rendered-artifact-gate.mjs
+++ b/scripts/payment-v1-rendered-artifact-gate.mjs
@@ -48,8 +48,11 @@ const SYSTEMD_HARDENING_KEYS = Object.freeze([
   "IPAddressAllow",
   "IPAddressDeny",
   "InaccessiblePaths",
+  "LimitCORE",
   "LimitNOFILE",
   "LockPersonality",
+  "MemoryMax",
+  "MemorySwapMax",
   "MemoryDenyWriteExecute",
   "NoNewPrivileges",
   "PrivateDevices",
@@ -75,8 +78,11 @@ const SYSTEMD_HARDENING_KEYS = Object.freeze([
   "RuntimeDirectoryMode",
   "StateDirectory",
   "StateDirectoryMode",
+  "StandardError",
+  "StandardOutput",
   "SupplementaryGroups",
   "SystemCallArchitectures",
+  "TasksMax",
   "TimeoutStartSec",
   "TimeoutStopSec",
   "Type",
@@ -106,7 +112,9 @@ const PROFILE_CATALOG = Object.freeze({
   "edge-hetzner-v1": Object.freeze({
     templates: Object.freeze([
       "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
-      "deploy/payment-v1/systemd/payment-v1-edge.service.in",
+      "deploy/payment-v1/edge/source-fair-haproxy.cfg.in",
+      "deploy/payment-v1/systemd/payment-v1-public-edge.service.in",
+      "deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in",
     ]),
   }),
   "edge-rollback-authority-v1": Object.freeze({
@@ -185,11 +193,16 @@ export const RUNTIME_SYSTEMCTL_SHOW_PROPERTIES = Object.freeze([
   "IPAddressDeny",
   "InaccessiblePaths",
   "InvocationID",
+  "LimitCORE",
+  "LimitCORESoft",
   "LoadCredential",
   "LoadState",
   "LockPersonality",
   "MainPID",
   "MemoryDenyWriteExecute",
+  "MemoryMax",
+  "MemorySwapCurrent",
+  "MemorySwapMax",
   "NoNewPrivileges",
   "PrivateDevices",
   "PrivateTmp",
@@ -213,9 +226,12 @@ export const RUNTIME_SYSTEMCTL_SHOW_PROPERTIES = Object.freeze([
   "RootDirectory",
   "RootImage",
   "SetCredential",
+  "StandardError",
+  "StandardOutput",
   "SubState",
   "SupplementaryGroups",
   "SystemCallArchitectures",
+  "TasksMax",
   "Type",
   "UMask",
   "User",
@@ -259,6 +275,18 @@ const TEMPLATE_CATALOG = Object.freeze({
     modes: ["0644"],
     rootOwned: true,
   },
+  "deploy/payment-v1/systemd/payment-v1-public-edge.service.in": {
+    artifactClass: "systemd-unit",
+    targetPath: "/etc/systemd/system/bitcoinpir-payment-v1-public-edge.service",
+    modes: ["0644"],
+    rootOwned: true,
+  },
+  "deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in": {
+    artifactClass: "systemd-unit",
+    targetPath: "/etc/systemd/system/bitcoinpir-payment-v1-source-fair-edge.service",
+    modes: ["0644"],
+    rootOwned: true,
+  },
   "deploy/payment-v1/systemd/rollback-authority.service.in": {
     artifactClass: "systemd-unit",
     targetPath: "/etc/systemd/system/bitcoinpir-rollback-authority.service",
@@ -280,6 +308,12 @@ const TEMPLATE_CATALOG = Object.freeze({
   "deploy/payment-v1/edge/rollback-authority.Caddyfile.in": {
     artifactClass: "config",
     targetPath: "/etc/bitcoinpir/payment-v1/edge/rollback-authority.Caddyfile",
+    modes: ["0400", "0440", "0600", "0640"],
+    rootOwned: false,
+  },
+  "deploy/payment-v1/edge/source-fair-haproxy.cfg.in": {
+    artifactClass: "config",
+    targetPath: "/etc/bitcoinpir/payment-v1/source-fair-edge/haproxy.cfg",
     modes: ["0400", "0440", "0600", "0640"],
     rootOwned: false,
   },
@@ -324,6 +358,7 @@ const HEX64_PLACEHOLDERS = new Set([
   "CLN_BUNDLE_SHA256",
   "CLN_RPC_GUARD_SHA256",
   "DIRECTORY_PUBLISHER_PUBKEY_HEX",
+  "HAPROXY_SHA256",
   "HETZNER_OPERATOR_PUBKEY_HEX",
   "HETZNER_POLICY_PUBKEY_HEX",
   "HETZNER_PROVIDER_ID_HEX",
@@ -334,10 +369,19 @@ const HEX64_PLACEHOLDERS = new Set([
 ]);
 
 const DNS_HOST_PLACEHOLDERS = new Set([
+  "DIRECTORY_PUBLISHER_HTTPS_HOST",
   "DIRECTORY_RELAY_WSS_HOST",
   "PAYMENT_ISSUER_HTTPS_HOST",
   "PROVIDER_WSS_HOST",
   "ROLLBACK_AUTHORITY_HTTPS_HOST",
+]);
+
+const IP_ADDRESS_PLACEHOLDERS = new Set([
+  "DIRECTORY_PUBLISHER_CLIENT_IP",
+  "DIRECTORY_PUBLISHER_PRIVATE_BIND",
+  "PUBLIC_HTTPS_BIND",
+  "ROLLBACK_AUTHORITY_CLIENT_IP",
+  "ROLLBACK_AUTHORITY_PRIVATE_BIND",
 ]);
 
 const UID_GID_PLACEHOLDERS = new Set([
@@ -359,6 +403,7 @@ const POSITIVE_SERVICE_VALUE_PLACEHOLDERS = new Set([
 const ALL_PLACEHOLDER_NAMES = new Set([
   ...HEX64_PLACEHOLDERS,
   ...DNS_HOST_PLACEHOLDERS,
+  ...IP_ADDRESS_PLACEHOLDERS,
   ...UID_GID_PLACEHOLDERS,
   ...POSITIVE_SERVICE_VALUE_PLACEHOLDERS,
   "BITCOIND_SYSTEMD_UNIT",
@@ -370,7 +415,6 @@ const ALL_PLACEHOLDER_NAMES = new Set([
   "CLN_GUARD_MAX_INVOICES_PER_RUNTIME",
   "CLN_P2P_ANNOUNCE_ADDR",
   "CLN_P2P_BIND_ADDR",
-  "EDGE_CADDYFILE",
   "HETZNER_PROVIDER_SERVER_ID",
   "LIGHTNING_NETWORK",
 ]);
@@ -778,6 +822,22 @@ function parseHostPort(value, label, { announce = false } = {}) {
   }
 }
 
+function isPrivateNumericAddress(value) {
+  if (isIP(value) === 4) {
+    const [first, second] = value.split(".").map(Number);
+    return (
+      first === 10 ||
+      (first === 172 && second >= 16 && second <= 31) ||
+      (first === 192 && second === 168)
+    );
+  }
+  if (isIP(value) === 6) {
+    const canonical = value.toLowerCase();
+    return canonical.startsWith("fc") || canonical.startsWith("fd");
+  }
+  return false;
+}
+
 function validatePlaceholderValue(name, value) {
   const label = `placeholder ${name}`;
   if (!ALL_PLACEHOLDER_NAMES.has(name)) fail(`${label} is not in the closed-world schema`);
@@ -788,6 +848,24 @@ function validatePlaceholderValue(name, value) {
   }
   if (DNS_HOST_PLACEHOLDERS.has(name)) {
     validateDnsHost(value, label);
+    return;
+  }
+  if (IP_ADDRESS_PLACEHOLDERS.has(name)) {
+    validateSafeAscii(value, label, 45);
+    if (isIP(value) === 0 || ["0.0.0.0", "127.0.0.1", "::", "::1"].includes(value)) {
+      fail(`${label} must be one concrete non-loopback numeric address`);
+    }
+    if (
+      new Set([
+        "DIRECTORY_PUBLISHER_CLIENT_IP",
+        "DIRECTORY_PUBLISHER_PRIVATE_BIND",
+        "ROLLBACK_AUTHORITY_CLIENT_IP",
+        "ROLLBACK_AUTHORITY_PRIVATE_BIND",
+      ]).has(name) &&
+      !isPrivateNumericAddress(value)
+    ) {
+      fail(`${label} must be an RFC1918 IPv4 or ULA IPv6 private address`);
+    }
     return;
   }
   if (UID_GID_PLACEHOLDERS.has(name)) {
@@ -830,11 +908,6 @@ function validatePlaceholderValue(name, value) {
       return;
     case "CLN_P2P_BIND_ADDR":
       parseHostPort(value, label);
-      return;
-    case "EDGE_CADDYFILE":
-      if (!["hetzner-public.Caddyfile", "rollback-authority.Caddyfile"].includes(value)) {
-        fail(`${label} is not a reviewed edge Caddyfile basename`);
-      }
       return;
     case "HETZNER_PROVIDER_SERVER_ID":
       if (!/^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$/u.test(value)) {
@@ -932,7 +1005,7 @@ function validateRenderedMetadata(artifact, catalog, label) {
 
 function secretConsumerUnit(deploymentProfile, targetPath) {
   const mappings = {
-    "edge-hetzner-v1": [["/etc/bitcoinpir/payment-v1/edge/", "bitcoinpir-payment-v1-edge.service"]],
+    "edge-hetzner-v1": [["/etc/bitcoinpir/payment-v1/edge/", "bitcoinpir-payment-v1-public-edge.service"]],
     "edge-rollback-authority-v1": [["/etc/bitcoinpir/payment-v1/edge/", "bitcoinpir-payment-v1-edge.service"]],
     "issuer-lightning-signet-v1": [
       ["/etc/bitcoinpir/payment-v1/issuer/", "bitcoinpir-payment-issuer.service"],
@@ -1081,11 +1154,9 @@ function validatePlan(plan) {
     targets.add(artifact.target_path);
   }
 
-  validateSecretOwnerBindings(plan);
-
-
   const expectedTemplates = PROFILE_CATALOG[plan.deployment_profile].templates;
   assertSameStringSet(renderedSources, expectedTemplates, "deployment profile templates");
+  validateSecretOwnerBindings(plan);
 }
 
 function extractPlaceholders(text) {
@@ -1252,6 +1323,26 @@ function parseSystemdUnit(text, label) {
 }
 
 function validateProfileUnitPolicy(deploymentProfile, fragmentPath, hardening, label) {
+  const privateRequestEdge =
+    (deploymentProfile === "edge-hetzner-v1" &&
+      new Set([
+        "/etc/systemd/system/bitcoinpir-payment-v1-public-edge.service",
+        "/etc/systemd/system/bitcoinpir-payment-v1-source-fair-edge.service",
+      ]).has(fragmentPath)) ||
+    (deploymentProfile === "edge-rollback-authority-v1" &&
+      fragmentPath === "/etc/systemd/system/bitcoinpir-payment-v1-edge.service");
+  if (privateRequestEdge) {
+    for (const [key, expected] of [
+      ["StandardError", "null"],
+      ["StandardOutput", "null"],
+      ["LimitCORE", "0"],
+      ["MemorySwapMax", "0"],
+    ]) {
+      if (canonicalize(hardening[key] ?? []) !== canonicalize([expected])) {
+        fail(`${label} must keep ${key}=${expected} so request-source state cannot persist`);
+      }
+    }
+  }
   if (
     deploymentProfile === "issuer-lightning-signet-v1" &&
     fragmentPath === "/etc/systemd/system/bitcoinpir-cln-rpc-guard.service"
@@ -1322,6 +1413,27 @@ function hashBindingClass(artifactClass) {
 }
 
 function configManagedReferences(sourcePath, text) {
+  const edgeReferences = {
+    "deploy/payment-v1/edge/hetzner-public.Caddyfile.in": [
+      "/etc/bitcoinpir/payment-v1/edge/directory-publisher-server.crt",
+      "/etc/bitcoinpir/payment-v1/edge/directory-publisher-server.key",
+    ],
+    "deploy/payment-v1/edge/rollback-authority.Caddyfile.in": [
+      "/etc/bitcoinpir/payment-v1/edge/rollback-authority-server.crt",
+      "/etc/bitcoinpir/payment-v1/edge/rollback-authority-server.key",
+    ],
+  };
+  if (edgeReferences[sourcePath]) {
+    const expected = new Set(edgeReferences[sourcePath]);
+    const observed = new Set();
+    for (const match of text.matchAll(/\/(?:[A-Za-z0-9._-]+\/)*[A-Za-z0-9._-]+/gu)) {
+      if (match[0].startsWith("/etc/bitcoinpir/payment-v1/edge/")) observed.add(match[0]);
+    }
+    if (canonicalize([...observed].sort(asciiCompare)) !== canonicalize([...expected].sort(asciiCompare))) {
+      fail(`rendered ${sourcePath} must reference exactly its reviewed TLS files`);
+    }
+    return [...observed].sort(asciiCompare);
+  }
   if (sourcePath !== "deploy/payment-v1/lightning/lightningd.conf.in") return [];
   const references = new Set();
   for (const original of text.split("\n")) {
@@ -1418,7 +1530,17 @@ function validateHashManifestScope(manifestPath, entries, plan) {
       oneExact(`/opt/bitcoinpir/caddy/${plan.placeholders.CADDY_SHA256}/caddy`);
       return;
     case "/etc/bitcoinpir/payment-v1/edge/edge-config.sha256":
-      oneExact(`/etc/bitcoinpir/payment-v1/edge/${plan.placeholders.EDGE_CADDYFILE}`);
+      oneExact(
+        plan.deployment_profile === "edge-hetzner-v1"
+          ? "/etc/bitcoinpir/payment-v1/edge/hetzner-public.Caddyfile"
+          : "/etc/bitcoinpir/payment-v1/edge/rollback-authority.Caddyfile",
+      );
+      return;
+    case "/etc/bitcoinpir/payment-v1/source-fair-edge/haproxy.sha256":
+      oneExact(`/opt/bitcoinpir/haproxy/${plan.placeholders.HAPROXY_SHA256}/haproxy`);
+      return;
+    case "/etc/bitcoinpir/payment-v1/source-fair-edge/source-fair-config.sha256":
+      oneExact("/etc/bitcoinpir/payment-v1/source-fair-edge/haproxy.cfg");
       return;
     case "/etc/bitcoinpir/payment-v1/issuer/payment-issuer.sha256":
       oneExact(`/opt/bitcoinpir/payment-issuer/${plan.placeholders.PAYMENT_ISSUER_SHA256}/payment-issuer`);
@@ -1521,6 +1643,7 @@ function enforceDependencyClosure({ artifacts, fileBytes, initialReferences, pla
 
   const pathChecks = [
     ["CADDY_SHA256", "/opt/bitcoinpir/caddy/", "/caddy", true],
+    ["HAPROXY_SHA256", "/opt/bitcoinpir/haproxy/", "/haproxy", true],
     ["CLN_RPC_GUARD_SHA256", "/opt/bitcoinpir/cln-rpc-guard/", "/bitcoinpir-cln-rpc-guard", true],
     ["BPIR_ADMIN_SHA256", "/opt/bitcoinpir/bpir-admin/", "/bpir-admin", true],
     ["PAYMENT_ISSUER_SHA256", "/opt/bitcoinpir/payment-issuer/", "/payment-issuer", true],
@@ -1583,15 +1706,27 @@ function buildBundleModel({ sourceRoot, inputRoot, plan, approvedPlanSha256 }) {
   for (const name of requiredPlaceholders) validatePlaceholderValue(name, plan.placeholders[name]);
   if (
     plan.deployment_profile === "edge-hetzner-v1" &&
-    plan.placeholders.EDGE_CADDYFILE !== "hetzner-public.Caddyfile"
+    new Set([
+      plan.placeholders.PUBLIC_HTTPS_BIND,
+      plan.placeholders.DIRECTORY_PUBLISHER_PRIVATE_BIND,
+      plan.placeholders.DIRECTORY_PUBLISHER_CLIENT_IP,
+    ]).size !== 3
   ) {
-    fail("edge-hetzner-v1 must select hetzner-public.Caddyfile");
+    fail("edge-hetzner-v1 public, publisher-private bind, and publisher-client roles must use distinct addresses");
+  }
+  if (
+    plan.deployment_profile === "edge-hetzner-v1" &&
+    isIP(plan.placeholders.DIRECTORY_PUBLISHER_PRIVATE_BIND) !==
+      isIP(plan.placeholders.DIRECTORY_PUBLISHER_CLIENT_IP)
+  ) {
+    fail("edge-hetzner-v1 publisher private bind and client addresses must use the same IP family");
   }
   if (
     plan.deployment_profile === "edge-rollback-authority-v1" &&
-    plan.placeholders.EDGE_CADDYFILE !== "rollback-authority.Caddyfile"
+    plan.placeholders.ROLLBACK_AUTHORITY_PRIVATE_BIND ===
+      plan.placeholders.ROLLBACK_AUTHORITY_CLIENT_IP
   ) {
-    fail("edge-rollback-authority-v1 must select rollback-authority.Caddyfile");
+    fail("rollback-authority private bind and sole-client addresses must differ");
   }
   if (plan.deployment_profile === "issuer-lightning-signet-v1") {
     const uidValues = ["ISSUER_UID", "LIGHTNING_UID", "CLN_GUARD_UID", "PREFLIGHT_UID"].map(
@@ -1974,12 +2109,58 @@ export function runtimeRequestFromManifest(manifest, manifestSha256) {
       target_path: artifact.target_path,
       uid: artifact.uid,
     }));
+  const runtimePaths = [];
+  if (manifest.deployment_profile === "edge-hetzner-v1") {
+    const sourceFairIdentity = manifest.service_identities.find(
+      (identity) => identity.unit_name === "bitcoinpir-payment-v1-source-fair-edge.service",
+    );
+    if (!sourceFairIdentity) {
+      fail("Hetzner edge runtime request is missing the source-fair service identity");
+    }
+    runtimePaths.push({
+      file_type: "directory",
+      gid: sourceFairIdentity.gid,
+      mode: "0750",
+      target_path: "/run/bitcoinpir-source-fair-edge",
+      uid: sourceFairIdentity.uid,
+    });
+    for (const name of [
+      "directory-public.sock",
+      "directory-publisher.sock",
+      "issuer.sock",
+      "provider.sock",
+    ]) {
+      runtimePaths.push({
+        file_type: "socket",
+        gid: sourceFairIdentity.gid,
+        mode: "0660",
+        target_path: `/run/bitcoinpir-source-fair-edge/${name}`,
+        uid: sourceFairIdentity.uid,
+      });
+    }
+  }
+  if (manifest.deployment_profile === "edge-rollback-authority-v1") {
+    const edgeIdentity = manifest.service_identities.find(
+      (identity) => identity.unit_name === "bitcoinpir-payment-v1-edge.service",
+    );
+    if (!edgeIdentity) {
+      fail("rollback-authority edge runtime request is missing its service identity");
+    }
+    runtimePaths.push({
+      file_type: "directory",
+      gid: edgeIdentity.gid,
+      mode: "0700",
+      target_path: "/run/bitcoinpir-rollback-authority-edge",
+      uid: edgeIdentity.uid,
+    });
+  }
   return {
     approved_plan_sha256: manifest.approved_plan_sha256,
     collector: RUNTIME_COLLECTOR,
     deployment_profile: manifest.deployment_profile,
     installed_files: installedFiles,
     manifest_sha256: manifestSha256,
+    runtime_paths: runtimePaths,
     schema_version: EVIDENCE_SCHEMA_VERSION,
     secret_files: secretFiles,
     service_identities: manifest.service_identities,

--- a/scripts/payment-v1-rendered-artifact-gate.test.mjs
+++ b/scripts/payment-v1-rendered-artifact-gate.test.mjs
@@ -636,7 +636,7 @@ function makeRuntimeEvidence(model) {
     },
     installed_files: clone(model.request.installed_files),
     manifest_sha256: model.manifestSha256,
-    schema_version: 1,
+    schema_version: 2,
     systemd_analyze_verify: {
       argv: clone(model.request.systemd_analyze_argv),
       exit_status: 0,

--- a/scripts/payment-v1-rendered-artifact-gate.test.mjs
+++ b/scripts/payment-v1-rendered-artifact-gate.test.mjs
@@ -33,8 +33,11 @@ import {
 const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
 const REPOSITORY = resolve(SCRIPT_DIRECTORY, "..");
 const GATE = join(SCRIPT_DIRECTORY, "payment-v1-rendered-artifact-gate.mjs");
-const EDGE_UNIT = "deploy/payment-v1/systemd/payment-v1-edge.service.in";
+const EDGE_UNIT = "deploy/payment-v1/systemd/payment-v1-public-edge.service.in";
+const SOURCE_FAIR_UNIT = "deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in";
+const LEGACY_EDGE_UNIT = "deploy/payment-v1/systemd/payment-v1-edge.service.in";
 const EDGE_CONFIG = "deploy/payment-v1/edge/hetzner-public.Caddyfile.in";
+const SOURCE_FAIR_CONFIG = "deploy/payment-v1/edge/source-fair-haproxy.cfg.in";
 const GUARD_UNIT = "deploy/payment-v1/systemd/hetzner-cln-rpc-guard.service.in";
 const PROVIDER_UNIT = "deploy/payment-v1/systemd/hetzner-provider.service.in";
 const ISSUER_TEMPLATES = [
@@ -116,11 +119,12 @@ function renderText(sourceRoot, sourcePath, placeholders) {
   return text;
 }
 
-function addPayload(fixture, targetPath, bytes, index) {
+function addPayload(fixture, targetPath, bytes, index, metadata = {}) {
   const sourcePath = `payload/${String(index).padStart(3, "0")}-${basename(targetPath)}`;
   writeParent(join(fixture.inputRoot, sourcePath), bytes);
   return {
     ...payloadMetadata(targetPath),
+    ...metadata,
     expected_sha256: hashBytes(bytes),
     source_path: sourcePath,
     target_path: targetPath,
@@ -130,35 +134,77 @@ function addPayload(fixture, targetPath, bytes, index) {
 function makeEdgeFixture(t) {
   const fixture = temporaryRoots(t);
   copySource(fixture.sourceRoot, EDGE_UNIT);
+  copySource(fixture.sourceRoot, SOURCE_FAIR_UNIT);
   copySource(fixture.sourceRoot, EDGE_CONFIG);
+  copySource(fixture.sourceRoot, SOURCE_FAIR_CONFIG);
   const caddyBytes = Buffer.from("reviewed-caddy-v2\n");
   const caddySha = hashBytes(caddyBytes);
+  const haproxyBytes = Buffer.from("reviewed-haproxy-v2\n");
+  const haproxySha = hashBytes(haproxyBytes);
   const placeholders = {
     CADDY_SHA256: caddySha,
+    DIRECTORY_PUBLISHER_CLIENT_IP: "10.23.0.6",
+    DIRECTORY_PUBLISHER_HTTPS_HOST: "publisher.example.net",
+    DIRECTORY_PUBLISHER_PRIVATE_BIND: "10.23.0.5",
     DIRECTORY_RELAY_WSS_HOST: "directory.example.net",
-    EDGE_CADDYFILE: "hetzner-public.Caddyfile",
+    HAPROXY_SHA256: haproxySha,
     PAYMENT_ISSUER_HTTPS_HOST: "pay.example.net",
     PROVIDER_WSS_HOST: "pir.example.net",
+    PUBLIC_HTTPS_BIND: "198.51.100.23",
   };
   const renderedConfig = Buffer.from(renderText(fixture.sourceRoot, EDGE_CONFIG, placeholders));
+  const renderedSourceFairConfig = Buffer.from(
+    renderText(fixture.sourceRoot, SOURCE_FAIR_CONFIG, placeholders),
+  );
   const targets = {
-    binary: `/opt/bitcoinpir/caddy/${caddySha}/caddy`,
-    binaryManifest: "/etc/bitcoinpir/payment-v1/edge/caddy.sha256",
+    caddyBinary: `/opt/bitcoinpir/caddy/${caddySha}/caddy`,
+    caddyBinaryManifest: "/etc/bitcoinpir/payment-v1/edge/caddy.sha256",
     config: "/etc/bitcoinpir/payment-v1/edge/hetzner-public.Caddyfile",
     configManifest: "/etc/bitcoinpir/payment-v1/edge/edge-config.sha256",
+    haproxyBinary: `/opt/bitcoinpir/haproxy/${haproxySha}/haproxy`,
+    haproxyBinaryManifest: "/etc/bitcoinpir/payment-v1/source-fair-edge/haproxy.sha256",
+    publisherCertificate: "/etc/bitcoinpir/payment-v1/edge/directory-publisher-server.crt",
+    publisherKey: "/etc/bitcoinpir/payment-v1/edge/directory-publisher-server.key",
+    sourceFairConfig: "/etc/bitcoinpir/payment-v1/source-fair-edge/haproxy.cfg",
+    sourceFairConfigManifest: "/etc/bitcoinpir/payment-v1/source-fair-edge/source-fair-config.sha256",
   };
   const payloads = [
-    [targets.binary, caddyBytes],
-    [targets.binaryManifest, Buffer.from(`${caddySha}  ${targets.binary}\n`)],
+    [targets.caddyBinary, caddyBytes],
+    [targets.caddyBinaryManifest, Buffer.from(`${caddySha}  ${targets.caddyBinary}\n`)],
     [
       targets.configManifest,
       Buffer.from(`${hashBytes(renderedConfig)}  ${targets.config}\n`),
+    ],
+    [targets.haproxyBinary, haproxyBytes],
+    [
+      targets.haproxyBinaryManifest,
+      Buffer.from(`${haproxySha}  ${targets.haproxyBinary}\n`),
+    ],
+    [targets.publisherCertificate, Buffer.from("reviewed-publisher-certificate\n")],
+    [targets.publisherKey, Buffer.from("reviewed-publisher-private-key\n")],
+    [
+      targets.sourceFairConfigManifest,
+      Buffer.from(
+        `${hashBytes(renderedSourceFairConfig)}  ${targets.sourceFairConfig}\n`,
+      ),
     ],
   ];
   const plan = {
     deployment_id: "hetzner-edge-v1-test",
     deployment_profile: "edge-hetzner-v1",
-    payload_artifacts: payloads.map(([target, bytes], index) => addPayload(fixture, target, bytes, index)),
+    payload_artifacts: payloads.map(([target, bytes], index) => {
+      if (target === targets.publisherKey) {
+        return addPayload(fixture, target, bytes, index, {
+          class: "secret", gid: 730, mode: "0400", uid: 729,
+        });
+      }
+      if (target === targets.publisherCertificate) {
+        return addPayload(fixture, target, bytes, index, {
+          class: "config", gid: 730, mode: "0440", uid: 0,
+        });
+      }
+      return addPayload(fixture, target, bytes, index);
+    }),
     placeholders,
     rendered_artifacts: [
       {
@@ -174,18 +220,43 @@ function makeEdgeFixture(t) {
         mode: "0644",
         source_path: EDGE_UNIT,
         source_sha256: hashFile(join(fixture.sourceRoot, EDGE_UNIT)),
-        target_path: "/etc/systemd/system/bitcoinpir-payment-v1-edge.service",
+        target_path: "/etc/systemd/system/bitcoinpir-payment-v1-public-edge.service",
+        uid: 0,
+      },
+      {
+        gid: 732,
+        mode: "0440",
+        source_path: SOURCE_FAIR_CONFIG,
+        source_sha256: hashFile(join(fixture.sourceRoot, SOURCE_FAIR_CONFIG)),
+        target_path: targets.sourceFairConfig,
+        uid: 0,
+      },
+      {
+        gid: 0,
+        mode: "0644",
+        source_path: SOURCE_FAIR_UNIT,
+        source_sha256: hashFile(join(fixture.sourceRoot, SOURCE_FAIR_UNIT)),
+        target_path: "/etc/systemd/system/bitcoinpir-payment-v1-source-fair-edge.service",
         uid: 0,
       },
     ],
     schema_version: 1,
-    service_identities: [{
-      gid: 730,
-      group_name: "bitcoinpir-payment-edge",
-      uid: 729,
-      unit_name: "bitcoinpir-payment-v1-edge.service",
-      user_name: "bitcoinpir-payment-edge",
-    }],
+    service_identities: [
+      {
+        gid: 730,
+        group_name: "bitcoinpir-payment-edge",
+        uid: 729,
+        unit_name: "bitcoinpir-payment-v1-public-edge.service",
+        user_name: "bitcoinpir-payment-edge",
+      },
+      {
+        gid: 732,
+        group_name: "bitcoinpir-source-fair-edge",
+        uid: 731,
+        unit_name: "bitcoinpir-payment-v1-source-fair-edge.service",
+        user_name: "bitcoinpir-source-fair-edge",
+      },
+    ],
   };
   return { ...fixture, plan, targets };
 }
@@ -454,26 +525,41 @@ function makeRollbackEdgeFixture(t) {
   const fixture = temporaryRoots(t);
   const source = "deploy/payment-v1/edge/rollback-authority.Caddyfile.in";
   copySource(fixture.sourceRoot, source);
-  copySource(fixture.sourceRoot, EDGE_UNIT);
+  copySource(fixture.sourceRoot, LEGACY_EDGE_UNIT);
   const binaryBytes = Buffer.from("reviewed-caddy-rollback\n");
   const binarySha = hashBytes(binaryBytes);
   const binaryTarget = `/opt/bitcoinpir/caddy/${binarySha}/caddy`;
   const configTarget = "/etc/bitcoinpir/payment-v1/edge/rollback-authority.Caddyfile";
   const placeholders = {
     CADDY_SHA256: binarySha,
-    EDGE_CADDYFILE: "rollback-authority.Caddyfile",
+    ROLLBACK_AUTHORITY_CLIENT_IP: "10.44.0.2",
     ROLLBACK_AUTHORITY_HTTPS_HOST: "authority.example.net",
+    ROLLBACK_AUTHORITY_PRIVATE_BIND: "10.44.0.3",
   };
   const configSha = hashBytes(renderText(fixture.sourceRoot, source, placeholders));
   const contents = [
     [binaryTarget, binaryBytes],
     ["/etc/bitcoinpir/payment-v1/edge/caddy.sha256", `${binarySha}  ${binaryTarget}\n`],
     ["/etc/bitcoinpir/payment-v1/edge/edge-config.sha256", `${configSha}  ${configTarget}\n`],
+    ["/etc/bitcoinpir/payment-v1/edge/rollback-authority-server.crt", "reviewed rollback server certificate\n"],
+    ["/etc/bitcoinpir/payment-v1/edge/rollback-authority-server.key", "reviewed rollback server private key\n"],
   ];
   const plan = {
     deployment_id: "rollback-edge-v1-test",
     deployment_profile: "edge-rollback-authority-v1",
-    payload_artifacts: contents.map(([target, bytes], index) => addPayload(fixture, target, bytes, index)),
+    payload_artifacts: contents.map(([target, bytes], index) => {
+      if (target.endsWith("rollback-authority-server.key")) {
+        return addPayload(fixture, target, bytes, index, {
+          class: "secret", gid: 730, mode: "0400", uid: 729,
+        });
+      }
+      if (target.endsWith("rollback-authority-server.crt")) {
+        return addPayload(fixture, target, bytes, index, {
+          class: "config", gid: 730, mode: "0440", uid: 0,
+        });
+      }
+      return addPayload(fixture, target, bytes, index);
+    }),
     placeholders,
     rendered_artifacts: [
       {
@@ -487,8 +573,8 @@ function makeRollbackEdgeFixture(t) {
       {
         gid: 0,
         mode: "0644",
-        source_path: EDGE_UNIT,
-        source_sha256: hashFile(join(fixture.sourceRoot, EDGE_UNIT)),
+        source_path: LEGACY_EDGE_UNIT,
+        source_sha256: hashFile(join(fixture.sourceRoot, LEGACY_EDGE_UNIT)),
         target_path: "/etc/systemd/system/bitcoinpir-payment-v1-edge.service",
         uid: 0,
       },
@@ -585,6 +671,17 @@ test("edge bundle is deterministic, externally plan-pinned, and closed", (t) => 
   assert.deepEqual(Object.keys(first.manifest.hash_bindings).sort(), [
     "binary", "config", "hash_manifest", "policy", "secret",
   ]);
+  assert.equal(first.request.units.length, 2);
+  assert.deepEqual(
+    first.request.runtime_paths.map(({ file_type, mode, target_path }) => ({ file_type, mode, target_path })),
+    [
+      { file_type: "directory", mode: "0750", target_path: "/run/bitcoinpir-source-fair-edge" },
+      { file_type: "socket", mode: "0660", target_path: "/run/bitcoinpir-source-fair-edge/directory-public.sock" },
+      { file_type: "socket", mode: "0660", target_path: "/run/bitcoinpir-source-fair-edge/directory-publisher.sock" },
+      { file_type: "socket", mode: "0660", target_path: "/run/bitcoinpir-source-fair-edge/issuer.sock" },
+      { file_type: "socket", mode: "0660", target_path: "/run/bitcoinpir-source-fair-edge/provider.sock" },
+    ],
+  );
   assert.equal(verifyFixture(fixture).manifestSha256, first.manifestSha256);
   const secondRoot = join(fixture.root, "second");
   const second = renderFixture(fixture, secondRoot);
@@ -593,6 +690,87 @@ test("edge bundle is deterministic, externally plan-pinned, and closed", (t) => 
     readdirSync(fixture.bundleRoot, { recursive: true }).sort(),
     readdirSync(secondRoot, { recursive: true }).sort(),
   );
+});
+
+for (const [sourcePath, label] of [
+  [EDGE_UNIT, "public Caddy edge"],
+  [SOURCE_FAIR_UNIT, "source-fair HAProxy edge"],
+]) {
+  for (const directive of ["StandardOutput", "StandardError", "LimitCORE", "MemorySwapMax"]) {
+    const expectedValue = directive.startsWith("Standard") ? "null" : "0";
+    test(`edge profile keeps ${label} ${directive}=${expectedValue}`, (t) => {
+      const fixture = makeEdgeFixture(t);
+      updateTemplate(fixture, sourcePath, (text) =>
+        text.replace(
+          `${directive}=${expectedValue}`,
+          `${directive}=${directive.startsWith("Standard") ? "journal" : "infinity"}`,
+        ),
+      );
+      assert.throws(
+        () => renderFixture(fixture),
+        new RegExp(`${directive}=|request-source state cannot persist`),
+      );
+    });
+  }
+}
+
+for (const directive of ["StandardOutput", "StandardError", "LimitCORE", "MemorySwapMax"]) {
+  test(`rollback edge keeps ${directive} fail-closed`, (t) => {
+    const fixture = makeRollbackEdgeFixture(t);
+    updateTemplate(fixture, LEGACY_EDGE_UNIT, (text) =>
+      text.replace(
+        `${directive}=${directive.startsWith("Standard") ? "null" : "0"}`,
+        `${directive}=${directive.startsWith("Standard") ? "journal" : "infinity"}`,
+      ),
+    );
+    assert.throws(
+      () => renderFixture(fixture),
+      new RegExp(`${directive}=|request-source state cannot persist`),
+    );
+  });
+}
+
+test("rollback edge requires distinct private bind and sole-client addresses", (t) => {
+  for (const [field, value, expected] of [
+    ["ROLLBACK_AUTHORITY_PRIVATE_BIND", "198.51.100.8", /RFC1918|ULA/],
+    ["ROLLBACK_AUTHORITY_CLIENT_IP", "198.51.100.9", /RFC1918|ULA/],
+  ]) {
+    const fixture = makeRollbackEdgeFixture(t);
+    fixture.plan.placeholders[field] = value;
+    assert.throws(() => renderFixture(fixture), expected);
+  }
+  const same = makeRollbackEdgeFixture(t);
+  same.plan.placeholders.ROLLBACK_AUTHORITY_CLIENT_IP =
+    same.plan.placeholders.ROLLBACK_AUTHORITY_PRIVATE_BIND;
+  assert.throws(
+    () => renderFixture(same),
+    /private bind and sole-client addresses must differ/,
+  );
+});
+
+test("Hetzner edge binds one distinct same-family private publisher client", (t) => {
+  for (const field of [
+    "DIRECTORY_PUBLISHER_PRIVATE_BIND",
+    "DIRECTORY_PUBLISHER_CLIENT_IP",
+  ]) {
+    const publicAddress = makeEdgeFixture(t);
+    publicAddress.plan.placeholders[field] = "198.51.100.9";
+    assert.throws(() => renderFixture(publicAddress), /RFC1918|ULA/);
+  }
+
+  const sameAsBind = makeEdgeFixture(t);
+  sameAsBind.plan.placeholders.DIRECTORY_PUBLISHER_CLIENT_IP =
+    sameAsBind.plan.placeholders.DIRECTORY_PUBLISHER_PRIVATE_BIND;
+  assert.throws(() => renderFixture(sameAsBind), /roles must use distinct addresses/);
+
+  const sameAsPublic = makeEdgeFixture(t);
+  sameAsPublic.plan.placeholders.PUBLIC_HTTPS_BIND =
+    sameAsPublic.plan.placeholders.DIRECTORY_PUBLISHER_CLIENT_IP;
+  assert.throws(() => renderFixture(sameAsPublic), /roles must use distinct addresses/);
+
+  const mixedFamily = makeEdgeFixture(t);
+  mixedFamily.plan.placeholders.DIRECTORY_PUBLISHER_CLIENT_IP = "fd23::6";
+  assert.throws(() => renderFixture(mixedFamily), /same IP family/);
 });
 
 test("complete issuer profile closes core, guard, tmpfiles, preflight, issuer, and referenced files", (t) => {
@@ -800,13 +978,13 @@ test("payload class and target metadata are target-derived and secrets cannot be
 test("hash manifests are strict, sorted, complete, and bind actual artifacts", (t) => {
   const wrong = makeEdgeFixture(t);
   const manifest = wrong.plan.payload_artifacts.find((entry) => entry.target_path.endsWith("caddy.sha256"));
-  writeFileSync(join(wrong.inputRoot, manifest.source_path), `${"1".repeat(64)}  ${wrong.targets.binary}\n`);
+  writeFileSync(join(wrong.inputRoot, manifest.source_path), `${"1".repeat(64)}  ${wrong.targets.caddyBinary}\n`);
   manifest.expected_sha256 = hashFile(join(wrong.inputRoot, manifest.source_path));
   assert.throws(() => renderFixture(wrong), /wrong digest/);
 
   const malformed = makeEdgeFixture(t);
   const second = malformed.plan.payload_artifacts.find((entry) => entry.target_path.endsWith("caddy.sha256"));
-  writeFileSync(join(malformed.inputRoot, second.source_path), `${hashBytes("x")} *${malformed.targets.binary}\n`);
+  writeFileSync(join(malformed.inputRoot, second.source_path), `${hashBytes("x")} *${malformed.targets.caddyBinary}\n`);
   second.expected_sha256 = hashFile(join(malformed.inputRoot, second.source_path));
   assert.throws(() => renderFixture(malformed), /strict sha256sum syntax/);
 
@@ -832,6 +1010,15 @@ test("hash manifests are strict, sorted, complete, and bind actual artifacts", (
   writeFileSync(clnPath, `${reversed}\n`);
   clnManifest.expected_sha256 = hashFile(clnPath);
   assert.throws(() => renderFixture(unsorted), /bytewise ASCII sorted/);
+});
+
+test("HAProxy content-address placeholder must equal the selected binary digest", (t) => {
+  const fixture = makeEdgeFixture(t);
+  fixture.plan.placeholders.HAPROXY_SHA256 = "1".repeat(64);
+  assert.throws(
+    () => renderFixture(fixture),
+    /HAPROXY_SHA256 must select|must bind only|dependency is missing|references missing artifact/,
+  );
 });
 
 test("systemd rejects duplicate single-valued directives even without an empty reset", (t) => {

--- a/scripts/payment-v1-source-fair-edge.test.mjs
+++ b/scripts/payment-v1-source-fair-edge.test.mjs
@@ -1,0 +1,1111 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import net from "node:net";
+import { networkInterfaces, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const REPOSITORY = resolve(SCRIPT_DIRECTORY, "..");
+const HAPROXY_TEMPLATE = join(
+  REPOSITORY,
+  "deploy/payment-v1/edge/source-fair-haproxy.cfg.in",
+);
+const CADDY_TEMPLATE = join(
+  REPOSITORY,
+  "deploy/payment-v1/edge/hetzner-public.Caddyfile.in",
+);
+const ROLLBACK_CADDY_TEMPLATE = join(
+  REPOSITORY,
+  "deploy/payment-v1/edge/rollback-authority.Caddyfile.in",
+);
+
+function read(relativePath) {
+  return readFileSync(join(REPOSITORY, relativePath), "utf8");
+}
+
+function commandFromEnvironment(name, candidates) {
+  const explicit = process.env[name];
+  if (explicit !== undefined) {
+    assert.equal(explicit.startsWith("/"), true, `${name} must be an absolute path`);
+    assert.equal(existsSync(explicit), true, `${name} does not exist`);
+    return explicit;
+  }
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  const commandName = {
+    BPIR_CADDY_BIN: "caddy",
+    BPIR_HAPROXY_BIN: "haproxy",
+    BPIR_OPENSSL_BIN: "openssl",
+  }[name];
+  assert.ok(commandName, `unknown binary environment key ${name}`);
+  const found = spawnSync("/usr/bin/env", ["which", commandName], {
+    encoding: "utf8",
+    shell: false,
+  });
+  return found.status === 0 ? found.stdout.trim() : undefined;
+}
+
+const HAPROXY = commandFromEnvironment("BPIR_HAPROXY_BIN", [
+  "/usr/sbin/haproxy",
+  "/usr/local/sbin/haproxy",
+  "/opt/homebrew/bin/haproxy",
+]);
+const CADDY = commandFromEnvironment("BPIR_CADDY_BIN", [
+  "/usr/bin/caddy",
+  "/usr/local/bin/caddy",
+  "/opt/homebrew/bin/caddy",
+]);
+const OPENSSL = commandFromEnvironment("BPIR_OPENSSL_BIN", [
+  "/usr/bin/openssl",
+  "/usr/local/bin/openssl",
+  "/opt/homebrew/bin/openssl",
+]);
+
+function withoutComments(text) {
+  return text
+    .split("\n")
+    .map((line) => line.replace(/\s+#.*$/u, ""))
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .join("\n");
+}
+
+test("source-fair templates close persistence, bypass, and source-header channels", () => {
+  const haproxy = withoutComments(readFileSync(HAPROXY_TEMPLATE, "utf8"));
+  const caddy = withoutComments(readFileSync(CADDY_TEMPLATE, "utf8"));
+  const rollbackCaddy = withoutComments(
+    readFileSync(ROLLBACK_CADDY_TEMPLATE, "utf8"),
+  );
+  const publicUnit = read("deploy/payment-v1/systemd/payment-v1-public-edge.service.in");
+  const sourceFairUnit = read(
+    "deploy/payment-v1/systemd/payment-v1-source-fair-edge.service.in",
+  );
+  const rollbackUnit = read("deploy/payment-v1/systemd/payment-v1-edge.service.in");
+
+  assert.equal((haproxy.match(/^\s*stick-table .* expire 2m nopurge /gmu) ?? []).length, 6);
+  assert.equal((haproxy.match(/^\s*bind .* accept-proxy mode 660$/gmu) ?? []).length, 4);
+  assert.equal((haproxy.match(/^\s*filter bwlim-out /gmu) ?? []).length, 8);
+  assert.equal((haproxy.match(/^\s*http-request set-bandwidth-limit /gmu) ?? []).length, 8);
+  assert.match(haproxy, /stick-table type integer size 1 expire 2m nopurge/u);
+  assert.match(haproxy, /type ipv6 size 64 expire 2m nopurge/u);
+  assert.equal((haproxy.match(/type ipv6 size 4096 expire 2m nopurge/gu) ?? []).length, 4);
+  assert.equal((haproxy.match(/src,ipmask\(32,64\)/gu) ?? []).length >= 14, true);
+  assert.equal(
+    (haproxy.match(/^\s*http-request deny deny_status 429 unless \{ sc0_tracked \}$/gmu) ?? [])
+      .length,
+    4,
+  );
+  assert.equal(
+    (haproxy.match(/^\s*http-request deny deny_status 429 if quote_create !\{ sc[12]_tracked \}$/gmu) ?? [])
+      .length,
+    2,
+  );
+  assert.match(haproxy, /sc1_http_req_rate gt 6/u);
+  assert.match(haproxy, /sc2_http_req_rate gt 60/u);
+  assert.match(haproxy, /^\s*maxconn 320$/mu);
+  assert.match(haproxy, /^\s*no log$/mu);
+  assert.doesNotMatch(
+    haproxy,
+    /^\s*(?:log(?!-format\b)|stats socket|server-state|load-server-state|peers\b|spoe-agent|lua-load)\b/mu,
+  );
+  assert.doesNotMatch(haproxy, /\bsend-proxy(?:-v2)?\b/u);
+  assert.doesNotMatch(haproxy, /^\s*http-request (?:add|set)-header\b/mu);
+  assert.doesNotMatch(haproxy, /127\.0\.0\.1:8099/u);
+  for (const backend of [
+    "127.0.0.1:8191",
+    "127.0.0.1:5610",
+    "127.0.0.1:8080",
+    "127.0.0.1:8081",
+  ]) {
+    assert.match(haproxy, new RegExp(`server [^\\n]+ ${backend.replaceAll(".", "\\.")}`));
+  }
+  for (const header of [
+    "Baggage", "CF-Connecting-IP", "Client-IP", "Fastly-Client-IP",
+    "Fly-Client-IP", "Forwarded", "Traceparent", "Tracestate",
+    "True-Client-IP", "Via", "X-Client-IP", "X-Cluster-Client-IP",
+    "X-Correlation-ID", "X-Envoy-External-Address", "X-Forwarded-For",
+    "X-Forwarded-Host", "X-Forwarded-Proto", "X-Original-Client-IP",
+    "X-Original-Forwarded-For", "X-Real-IP", "X-Request-ID",
+  ]) {
+    assert.equal(
+      (haproxy.match(new RegExp(`^\\s*http-request del-header ${header}$`, "gimu")) ?? []).length,
+      4,
+      header,
+    );
+  }
+
+  assert.equal((caddy.match(/proxy_protocol v2/gu) ?? []).length, 7);
+  assert.equal((caddy.match(/header_up -\*/gu) ?? []).length, 7);
+  assert.doesNotMatch(
+    caddy,
+    /header_up\s+(?:CF-Connecting-IP|Client-IP|Fastly-Client-IP|Fly-Client-IP|Forwarded|True-Client-IP|X-Client-IP|X-Cluster-Client-IP|X-Envoy-External-Address|X-Forwarded(?:-[A-Za-z0-9-]+)?|X-Original-(?:Client-IP|Forwarded-For)|X-Real-IP)\b/iu,
+  );
+  assert.match(caddy, /bind @DIRECTORY_PUBLISHER_PRIVATE_BIND@/u);
+  assert.match(caddy, /remote_ip @DIRECTORY_PUBLISHER_CLIENT_IP@/u);
+  assert.doesNotMatch(caddy, /client_auth|trust_pool|directory-publisher-client-ca\.pem/u);
+  assert.match(
+    haproxy,
+    /http-request deny deny_status 403 unless \{ src @DIRECTORY_PUBLISHER_CLIENT_IP@ \}/u,
+  );
+
+  assert.match(publicUnit, /^Requires=bitcoinpir-payment-v1-source-fair-edge\.service$/mu);
+  assert.match(publicUnit, /^BindsTo=bitcoinpir-payment-v1-source-fair-edge\.service$/mu);
+  assert.match(
+    publicUnit,
+    /^ConditionPathExists=\/etc\/bitcoinpir\/payment-v1\/DIRECTORY-PUBLISHER-PRIVATE-INGRESS-APPROVED$/mu,
+  );
+  assert.match(publicUnit, /^LimitCORE=0$/mu);
+  assert.match(publicUnit, /^MemoryMax=536870912$/mu);
+  assert.match(publicUnit, /^MemorySwapMax=0$/mu);
+  assert.match(publicUnit, /^TasksMax=512$/mu);
+  assert.match(publicUnit, /^StandardOutput=null$/mu);
+  assert.match(publicUnit, /^StandardError=null$/mu);
+  assert.match(sourceFairUnit, /^RuntimeDirectory=bitcoinpir-source-fair-edge$/mu);
+  assert.match(
+    sourceFairUnit,
+    /^ConditionPathExists=\/etc\/bitcoinpir\/payment-v1\/DIRECTORY-PUBLISHER-PRIVATE-INGRESS-APPROVED$/mu,
+  );
+  assert.doesNotMatch(sourceFairUnit, /^StateDirectory=/mu);
+  assert.match(sourceFairUnit, /^LimitCORE=0$/mu);
+  assert.match(sourceFairUnit, /^MemoryMax=268435456$/mu);
+  assert.match(sourceFairUnit, /^MemorySwapMax=0$/mu);
+  assert.match(sourceFairUnit, /^TasksMax=128$/mu);
+  assert.match(sourceFairUnit, /^StandardOutput=null$/mu);
+  assert.match(sourceFairUnit, /^StandardError=null$/mu);
+
+  assert.match(rollbackCaddy, /bind @ROLLBACK_AUTHORITY_PRIVATE_BIND@/u);
+  assert.match(
+    rollbackCaddy,
+    /tls \/etc\/bitcoinpir\/payment-v1\/edge\/rollback-authority-server\.crt \/etc\/bitcoinpir\/payment-v1\/edge\/rollback-authority-server\.key/u,
+  );
+  assert.doesNotMatch(rollbackCaddy, /client_auth|trust_pool/u);
+  assert.match(
+    rollbackUnit,
+    /^ConditionPathExists=\/etc\/bitcoinpir\/payment-v1\/ROLLBACK-AUTHORITY-PRIVATE-INGRESS-APPROVED$/mu,
+  );
+  assert.match(rollbackUnit, /^RuntimeDirectory=bitcoinpir-rollback-authority-edge$/mu);
+  assert.doesNotMatch(rollbackUnit, /^StateDirectory=/mu);
+  assert.match(rollbackUnit, /^IPAddressDeny=any$/mu);
+  assert.match(rollbackUnit, /^IPAddressAllow=localhost @ROLLBACK_AUTHORITY_CLIENT_IP@$/mu);
+  assert.match(rollbackUnit, /^LimitCORE=0$/mu);
+  assert.match(rollbackUnit, /^MemorySwapMax=0$/mu);
+  assert.match(rollbackUnit, /^StandardOutput=null$/mu);
+  assert.match(rollbackUnit, /^StandardError=null$/mu);
+
+  for (const unitPath of [
+    "deploy/payment-v1/systemd/hetzner-provider.service.in",
+    "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+    "deploy/payment-v1/systemd/hetzner-directory-relay.service.in",
+  ]) {
+    assert.match(read(unitPath), /^InaccessiblePaths=.*\/run\/bitcoinpir-source-fair-edge/mu);
+  }
+});
+
+test("the selected HAProxy binary supports systemd readiness", {
+  skip: HAPROXY === undefined,
+}, () => {
+  const version = spawnSync(HAPROXY, ["-vv"], {
+    encoding: "utf8",
+    shell: false,
+  });
+  const output = `${version.stdout}\n${version.stderr}`;
+  assert.equal(version.status, 0, output);
+  assert.match(output, /^HAProxy version 2\.8\./mu);
+  assert.match(output, /(?:^|\s)\+SYSTEMD(?:\s|$)/mu);
+});
+
+test("the selected Caddy binary validates complete IPv4 and IPv6-ULA public templates", {
+  skip: CADDY === undefined || OPENSSL === undefined,
+}, (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "bpir-caddy-template-"));
+  chmodSync(directory, 0o700);
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const certificate = join(directory, "publisher.crt");
+  const key = join(directory, "publisher.key");
+  const generated = spawnSync(OPENSSL, [
+    "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", key,
+    "-out", certificate,
+    "-days", "1",
+    "-subj", "/CN=publisher.example.net",
+  ], { encoding: "utf8", shell: false });
+  assert.equal(generated.status, 0, generated.stderr);
+  const profiles = [
+    {
+      label: "ipv4",
+      publisherClientIp: "10.77.0.1",
+      publisherPrivateBind: "10.77.0.2",
+      publicBind: "127.0.0.1",
+    },
+    {
+      label: "ipv6-ula",
+      publisherClientIp: "fd42:6270:6972:1::1",
+      publisherPrivateBind: "fd42:6270:6972:1::2",
+      publicBind: "2001:db8::10",
+    },
+  ];
+  for (const profile of profiles) {
+    let rendered = readFileSync(CADDY_TEMPLATE, "utf8");
+    for (const [placeholder, value] of Object.entries({
+      DIRECTORY_PUBLISHER_CLIENT_IP: profile.publisherClientIp,
+      DIRECTORY_PUBLISHER_HTTPS_HOST: "publisher.example.net",
+      DIRECTORY_PUBLISHER_PRIVATE_BIND: profile.publisherPrivateBind,
+      DIRECTORY_RELAY_WSS_HOST: "directory.example.net",
+      PAYMENT_ISSUER_HTTPS_HOST: "pay.example.net",
+      PROVIDER_WSS_HOST: "pir.example.net",
+      PUBLIC_HTTPS_BIND: profile.publicBind,
+    })) {
+      rendered = rendered.replaceAll(`@${placeholder}@`, value);
+    }
+    rendered = rendered
+      .replaceAll(
+        "/etc/bitcoinpir/payment-v1/edge/directory-publisher-server.crt",
+        certificate,
+      )
+      .replaceAll(
+        "/etc/bitcoinpir/payment-v1/edge/directory-publisher-server.key",
+        key,
+      );
+    assert.doesNotMatch(rendered, /@[A-Z][A-Z0-9_]+@/u);
+    const config = join(directory, `${profile.label}.Caddyfile`);
+    writeFileSync(config, rendered, { mode: 0o600 });
+    const validation = spawnSync(CADDY, [
+      "validate", "--config", config, "--adapter", "caddyfile",
+    ], { encoding: "utf8", shell: false });
+    assert.equal(
+      validation.status,
+      0,
+      `${profile.label} complete Caddy template validation failed:\n${validation.stdout}\n${validation.stderr}`,
+    );
+  }
+});
+
+test("the selected Caddy binary validates the private rollback template", {
+  skip: CADDY === undefined || OPENSSL === undefined,
+}, (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "bpir-rollback-caddy-template-"));
+  chmodSync(directory, 0o700);
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const certificate = join(directory, "rollback.crt");
+  const key = join(directory, "rollback.key");
+  const generated = spawnSync(OPENSSL, [
+    "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", key,
+    "-out", certificate,
+    "-days", "1",
+    "-subj", "/CN=authority.example.net",
+  ], { encoding: "utf8", shell: false });
+  assert.equal(generated.status, 0, generated.stderr);
+  const rendered = readFileSync(ROLLBACK_CADDY_TEMPLATE, "utf8")
+    .replaceAll("@ROLLBACK_AUTHORITY_HTTPS_HOST@", "authority.example.net")
+    .replaceAll("@ROLLBACK_AUTHORITY_PRIVATE_BIND@", "127.0.0.3")
+    .replaceAll(
+      "/etc/bitcoinpir/payment-v1/edge/rollback-authority-server.crt",
+      certificate,
+    )
+    .replaceAll(
+      "/etc/bitcoinpir/payment-v1/edge/rollback-authority-server.key",
+      key,
+    );
+  assert.doesNotMatch(rendered, /@[A-Z][A-Z0-9_]+@/u);
+  const config = join(directory, "Caddyfile");
+  writeFileSync(config, rendered, { mode: 0o600 });
+  const validation = spawnSync(CADDY, [
+    "validate", "--config", config, "--adapter", "caddyfile",
+  ], { encoding: "utf8", shell: false });
+  assert.equal(
+    validation.status,
+    0,
+    `rollback Caddy template validation failed:\n${validation.stdout}\n${validation.stderr}`,
+  );
+});
+
+function ipv6Bytes(address) {
+  assert.equal(net.isIP(address), 6, `${address} is not IPv6`);
+  const halves = address.split("::");
+  assert.equal(halves.length <= 2, true, `${address} has multiple :: compressions`);
+  const left = halves[0] === "" ? [] : halves[0].split(":");
+  const right = halves.length === 1 || halves[1] === "" ? [] : halves[1].split(":");
+  const omitted = 8 - left.length - right.length;
+  if (halves.length === 1) assert.equal(omitted, 0, `${address} is not full-width IPv6`);
+  else assert.equal(omitted >= 1, true, `${address} has no compressed IPv6 word`);
+  const words = [...left, ...Array(omitted).fill("0"), ...right];
+  assert.equal(words.length, 8);
+  const bytes = Buffer.alloc(16);
+  for (const [index, word] of words.entries()) {
+    assert.match(word, /^[0-9a-f]{1,4}$/iu, `${address} has an invalid IPv6 word`);
+    bytes.writeUInt16BE(Number.parseInt(word, 16), index * 2);
+  }
+  return bytes;
+}
+
+function ipBytes(address, family) {
+  assert.equal(net.isIP(address), family, `${address} does not use IP family ${family}`);
+  if (family === 6) return ipv6Bytes(address);
+  const octets = address.split(".").map(Number);
+  assert.equal(octets.length, 4);
+  assert.equal(octets.every((octet) => Number.isInteger(octet) && octet >= 0 && octet <= 255), true);
+  return Buffer.from(octets);
+}
+
+function proxyV2Header(sourceIp, destinationIp) {
+  const family = net.isIP(sourceIp);
+  assert.equal(family === 4 || family === 6, true, `${sourceIp} is not an IP address`);
+  const effectiveDestination = destinationIp ?? (family === 4 ? "127.0.0.1" : "fd42:6270:6972:ffff::1");
+  const source = ipBytes(sourceIp, family);
+  const destination = ipBytes(effectiveDestination, family);
+  const addressLength = family === 4 ? 12 : 36;
+  const header = Buffer.alloc(16 + addressLength);
+  Buffer.from("\r\n\r\n\0\r\nQUIT\n", "binary").copy(header, 0);
+  header[12] = 0x21;
+  header[13] = family === 4 ? 0x11 : 0x21;
+  header.writeUInt16BE(addressLength, 14);
+  Buffer.from(source).copy(header, 16);
+  Buffer.from(destination).copy(header, 16 + source.length);
+  const portsOffset = 16 + source.length + destination.length;
+  header.writeUInt16BE(40_000, portsOffset);
+  header.writeUInt16BE(443, portsOffset + 2);
+  return header;
+}
+
+function waitFor(predicate, label, timeoutMs = 5_000) {
+  const started = Date.now();
+  return new Promise((resolvePromise, rejectPromise) => {
+    const poll = () => {
+      if (predicate()) {
+        resolvePromise();
+        return;
+      }
+      if (Date.now() - started > timeoutMs) {
+        rejectPromise(new Error(`timed out waiting for ${label}`));
+        return;
+      }
+      setTimeout(poll, 10);
+    };
+    poll();
+  });
+}
+
+function listen(server, host = "127.0.0.1", port = 0) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    server.once("error", rejectPromise);
+    server.listen(port, host, () => {
+      server.off("error", rejectPromise);
+      resolvePromise(server.address());
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolvePromise) => server.close(() => resolvePromise()));
+}
+
+function listenUnix(server, socketPath) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    server.once("error", rejectPromise);
+    server.listen(socketPath, () => {
+      server.off("error", rejectPromise);
+      resolvePromise();
+    });
+  });
+}
+
+function stopProcess(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolvePromise) => {
+    const timer = setTimeout(() => child.kill("SIGKILL"), 2_000);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolvePromise();
+    });
+    child.kill("SIGTERM");
+  });
+}
+
+function backendServer({ hold = false } = {}) {
+  const records = [];
+  const sockets = new Set();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+    let bytes = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      bytes = Buffer.concat([bytes, chunk]);
+      if (!bytes.includes(Buffer.from("\r\n\r\n"))) return;
+      if (records.some((record) => record.socket === socket)) return;
+      const raw = bytes.toString("latin1");
+      records.push({ remoteAddress: socket.remoteAddress, raw, socket });
+      if (!hold) {
+        socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+      }
+    });
+  });
+  return {
+    records,
+    server,
+    destroySockets() {
+      for (const socket of sockets) socket.destroy();
+    },
+  };
+}
+
+function proxyV2BackendServer() {
+  const records = [];
+  const sockets = new Set();
+  const signature = Buffer.from("\r\n\r\n\0\r\nQUIT\n", "binary");
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on("error", () => {});
+    socket.on("close", () => sockets.delete(socket));
+    let bytes = Buffer.alloc(0);
+    socket.on("data", (chunk) => {
+      bytes = Buffer.concat([bytes, chunk]);
+      if (bytes.length < 16 || records.some((record) => record.socket === socket)) return;
+      try {
+        assert.deepEqual(bytes.subarray(0, 12), signature);
+        assert.equal(bytes[12], 0x21);
+        assert.equal(bytes[13], 0x11);
+        const headerLength = bytes.readUInt16BE(14);
+        const payloadOffset = 16 + headerLength;
+        if (bytes.length < payloadOffset) return;
+        const payload = bytes.subarray(payloadOffset);
+        if (!payload.includes(Buffer.from("\r\n\r\n"))) return;
+        const sourceAddress = [...bytes.subarray(16, 20)].join(".");
+        records.push({ raw: payload.toString("latin1"), socket, sourceAddress });
+        socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+      } catch (error) {
+        records.push({ error, raw: "", socket, sourceAddress: "" });
+        socket.destroy();
+      }
+    });
+  });
+  return {
+    records,
+    server,
+    destroySockets() {
+      for (const socket of sockets) socket.destroy();
+    },
+  };
+}
+
+async function openProxyRequest(socketPath, sourceIp, request) {
+  const socket = net.createConnection({ path: socketPath });
+  let response = Buffer.alloc(0);
+  let connected = false;
+  const responsePromise = new Promise((resolvePromise, rejectPromise) => {
+    socket.on("data", (chunk) => {
+      response = Buffer.concat([response, chunk]);
+    });
+    socket.on("end", () => {
+      resolvePromise(response.toString("latin1"));
+    });
+    socket.on("error", (error) => {
+      if (connected) resolvePromise(response.toString("latin1"));
+      else rejectPromise(error);
+    });
+  });
+  await new Promise((resolvePromise, rejectPromise) => {
+    const onError = (error) => rejectPromise(error);
+    socket.once("error", onError);
+    socket.once("connect", () => {
+      socket.off("error", onError);
+      connected = true;
+      resolvePromise();
+    });
+  });
+  socket.write(Buffer.concat([proxyV2Header(sourceIp), Buffer.from(request, "latin1")]));
+  return { responsePromise, socket };
+}
+
+async function requestAndRead(socketPath, sourceIp, request) {
+  const opened = await openProxyRequest(socketPath, sourceIp, request);
+  return opened.responsePromise;
+}
+
+function statusOf(response) {
+  const match = /^HTTP\/1\.[01] ([0-9]{3})\b/u.exec(response);
+  assert.ok(match, `missing HTTP response status: ${JSON.stringify(response.slice(0, 120))}`);
+  return Number(match[1]);
+}
+
+async function createHarness(
+  t,
+  {
+    providerHold = false,
+    providerSourceTableSize = 4096,
+    publisherClientIp = "198.20.0.1",
+  } = {},
+) {
+  assert.ok(HAPROXY, "HAProxy integration requested without an installed binary");
+  assert.equal(Number.isSafeInteger(providerSourceTableSize), true);
+  assert.equal(providerSourceTableSize > 0, true);
+  assert.equal(net.isIP(publisherClientIp) !== 0, true, "publisher client must be an IP address");
+  const directory = mkdtempSync(join(tmpdir(), "bpir-source-fair-"));
+  chmodSync(directory, 0o700);
+  const lanes = {
+    directoryPublic: backendServer(),
+    directoryPublisher: backendServer(),
+    issuer: backendServer(),
+    provider: backendServer({ hold: providerHold }),
+  };
+  const addresses = {};
+  for (const [name, lane] of Object.entries(lanes)) {
+    addresses[name] = await listen(lane.server);
+  }
+  let config = readFileSync(HAPROXY_TEMPLATE, "utf8");
+  const providerTable =
+    "stick-table type ipv6 size 4096 expire 2m nopurge store conn_cur,conn_rate(10s),bytes_out_rate(1s)";
+  assert.equal(config.includes(providerTable), true);
+  config = config.replace(
+    providerTable,
+    providerTable.replace("size 4096", `size ${providerSourceTableSize}`),
+  );
+  config = config.replaceAll("/run/bitcoinpir-source-fair-edge", directory);
+  config = config.replaceAll("@DIRECTORY_PUBLISHER_CLIENT_IP@", publisherClientIp);
+  for (const [original, replacement] of [
+    ["127.0.0.1:8191", `127.0.0.1:${addresses.provider.port}`],
+    ["127.0.0.1:5610", `127.0.0.1:${addresses.issuer.port}`],
+    ["127.0.0.1:8080", `127.0.0.1:${addresses.directoryPublic.port}`],
+    ["127.0.0.1:8081", `127.0.0.1:${addresses.directoryPublisher.port}`],
+  ]) {
+    config = config.replaceAll(original, replacement);
+  }
+  const configPath = join(directory, "haproxy.cfg");
+  writeFileSync(configPath, config, { mode: 0o600 });
+  const validation = spawnSync(HAPROXY, ["-c", "-f", configPath], {
+    encoding: "utf8",
+    shell: false,
+  });
+  assert.equal(
+    validation.status,
+    0,
+    `HAProxy validation failed:\n${validation.stdout}\n${validation.stderr}`,
+  );
+  const child = spawn(HAPROXY, ["-db", "-f", configPath], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  child.stdout.on("data", (chunk) => { output += chunk; });
+  child.stderr.on("data", (chunk) => { output += chunk; });
+  const sockets = {
+    directoryPublic: join(directory, "directory-public.sock"),
+    directoryPublisher: join(directory, "directory-publisher.sock"),
+    issuer: join(directory, "issuer.sock"),
+    provider: join(directory, "provider.sock"),
+  };
+  await waitFor(
+    () => Object.values(sockets).every(existsSync) || child.exitCode !== null,
+    "HAProxy Unix sockets",
+  );
+  assert.equal(child.exitCode, null, `HAProxy exited during startup: ${output}`);
+  t.after(async () => {
+    for (const lane of Object.values(lanes)) lane.destroySockets();
+    await stopProcess(child);
+    await Promise.all(Object.values(lanes).map((lane) => closeServer(lane.server)));
+    rmSync(directory, { recursive: true, force: true });
+  });
+  return { child, directory, lanes, sockets };
+}
+
+const providerRequest =
+  "GET /v1/pir HTTP/1.1\r\nHost: pir.example.net\r\nConnection: close\r\n\r\n";
+const quoteRequest =
+  "POST /v1/quotes/bolt11 HTTP/1.1\r\nHost: pay.example.net\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+const directoryPublisherRequest =
+  "GET /v1/directory HTTP/1.1\r\nHost: publisher.example.net\r\nConnection: close\r\n\r\n";
+
+test("HAProxy enforces per-source upgraded-connection slots without cross-source starvation", {
+  skip: HAPROXY === undefined,
+}, async (t) => {
+  const harness = await createHarness(t, { providerHold: true });
+  const held = [];
+  for (let index = 0; index < 8; index += 1) {
+    held.push(await openProxyRequest(harness.sockets.provider, "198.18.0.1", providerRequest));
+  }
+  await waitFor(() => harness.lanes.provider.records.length === 8, "eight admitted provider streams");
+  const rejected = await requestAndRead(harness.sockets.provider, "198.18.0.1", providerRequest);
+  assert.equal(statusOf(rejected), 429);
+
+  const other = await openProxyRequest(harness.sockets.provider, "198.18.0.2", providerRequest);
+  held.push(other);
+  await waitFor(() => harness.lanes.provider.records.length === 9, "independent-source provider stream");
+  for (const connection of held) connection.socket.destroy();
+});
+
+test("HAProxy fails closed when concurrent new sources race for the final table entry", {
+  skip: HAPROXY === undefined,
+}, async (t) => {
+  const harness = await createHarness(t, { providerSourceTableSize: 1 });
+  const sources = Array.from(
+    { length: 32 },
+    (_, index) => `198.20.0.${index + 1}`,
+  );
+  const responses = await Promise.all(
+    sources.map((source) =>
+      requestAndRead(harness.sockets.provider, source, providerRequest)
+    ),
+  );
+  const statuses = responses.map(statusOf);
+  assert.equal(statuses.filter((status) => status === 200).length, 1);
+  assert.equal(statuses.filter((status) => status === 429).length, sources.length - 1);
+  assert.equal(harness.lanes.provider.records.length, 1);
+
+  const admittedSource = sources[statuses.indexOf(200)];
+  assert.equal(
+    statusOf(await requestAndRead(harness.sockets.provider, admittedSource, providerRequest)),
+    200,
+  );
+  assert.equal(harness.lanes.provider.records.length, 2);
+});
+
+test("HAProxy isolates per-source and global quote budgets", {
+  skip: HAPROXY === undefined,
+}, async (t) => {
+  const sourceHarness = await createHarness(t);
+  for (let index = 0; index < 6; index += 1) {
+    assert.equal(
+      statusOf(await requestAndRead(sourceHarness.sockets.issuer, "198.18.1.1", quoteRequest)),
+      200,
+    );
+  }
+  assert.equal(
+    statusOf(await requestAndRead(sourceHarness.sockets.issuer, "198.18.1.1", quoteRequest)),
+    429,
+  );
+  assert.equal(
+    statusOf(await requestAndRead(sourceHarness.sockets.issuer, "198.18.1.2", quoteRequest)),
+    200,
+  );
+  assert.equal(sourceHarness.lanes.issuer.records.length, 7);
+
+  const globalHarness = await createHarness(t);
+  for (let index = 0; index < 60; index += 1) {
+    const source = `198.19.${Math.floor(index / 250)}.${(index % 250) + 1}`;
+    assert.equal(
+      statusOf(await requestAndRead(globalHarness.sockets.issuer, source, quoteRequest)),
+      200,
+    );
+  }
+  assert.equal(
+    statusOf(await requestAndRead(globalHarness.sockets.issuer, "198.19.1.1", quoteRequest)),
+    429,
+  );
+  assert.equal(globalHarness.lanes.issuer.records.length, 60);
+});
+
+test("HAProxy publisher lane admits only the exact private-route source", {
+  skip: HAPROXY === undefined,
+}, async (t) => {
+  const harness = await createHarness(t);
+  assert.equal(
+    statusOf(
+      await requestAndRead(
+        harness.sockets.directoryPublisher,
+        "198.20.0.2",
+        directoryPublisherRequest,
+      ),
+    ),
+    403,
+  );
+  assert.equal(harness.lanes.directoryPublisher.records.length, 0);
+  assert.equal(
+    statusOf(
+      await requestAndRead(
+        harness.sockets.directoryPublisher,
+        "198.20.0.1",
+        directoryPublisherRequest,
+      ),
+    ),
+    200,
+  );
+  assert.equal(harness.lanes.directoryPublisher.records.length, 1);
+});
+
+test("HAProxy publisher lane uses PROXY v2 to admit only the exact IPv6 ULA source", {
+  skip: HAPROXY === undefined,
+}, async (t) => {
+  const publisherClientIp = "fd42:6270:6972:1::1";
+  const harness = await createHarness(t, { publisherClientIp });
+  assert.equal(
+    statusOf(
+      await requestAndRead(
+        harness.sockets.directoryPublisher,
+        "fd42:6270:6972:1::2",
+        directoryPublisherRequest,
+      ),
+    ),
+    403,
+  );
+  assert.equal(harness.lanes.directoryPublisher.records.length, 0);
+  assert.equal(
+    statusOf(
+      await requestAndRead(
+        harness.sockets.directoryPublisher,
+        publisherClientIp,
+        directoryPublisherRequest,
+      ),
+    ),
+    200,
+  );
+  assert.equal(harness.lanes.directoryPublisher.records.length, 1);
+});
+
+test("HAProxy strips source, auth, and correlation material before business services", {
+  skip: HAPROXY === undefined,
+}, async (t) => {
+  const harness = await createHarness(t);
+  const sourceIp = "203.0.113.77";
+  const request = [
+    "POST /v1/quotes/abc/status HTTP/1.1",
+    "Host: pay.example.net",
+    "Content-Length: 0",
+    "Connection: close",
+    `Forwarded: for=${sourceIp}`,
+    `X-Forwarded-For: ${sourceIp}`,
+    `X-Original-Forwarded-For: ${sourceIp}`,
+    `X-Real-IP: ${sourceIp}`,
+    `CF-Connecting-IP: ${sourceIp}`,
+    `True-Client-IP: ${sourceIp}`,
+    `X-Client-IP: ${sourceIp}`,
+    `X-Envoy-External-Address: ${sourceIp}`,
+    "X-Request-ID: invoice-query-link",
+    "X-Correlation-ID: invoice-query-link",
+    "Traceparent: 00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
+    "Tracestate: vendor=value",
+    "Baggage: invoice=secret",
+    "Authorization: Bearer payer-identity",
+    "Proxy-Authorization: Basic payer-identity",
+    "Cookie: invoice=secret",
+    "Via: identifying-proxy",
+    "",
+    "",
+  ].join("\r\n");
+  assert.equal(statusOf(await requestAndRead(harness.sockets.issuer, sourceIp, request)), 200);
+  assert.equal(harness.lanes.issuer.records.length, 1);
+  const observed = harness.lanes.issuer.records[0];
+  assert.equal(observed.remoteAddress, "127.0.0.1");
+  assert.equal(observed.raw.startsWith("POST "), true);
+  assert.equal(observed.raw.includes(sourceIp), false);
+  for (const forbidden of [
+    "forwarded:",
+    "x-forwarded-",
+    "cf-connecting-ip:",
+    "true-client-ip:",
+    "x-client-ip:",
+    "x-envoy-external-address:",
+    "x-original-forwarded-for:",
+    "x-real-ip:",
+    "x-request-id:",
+    "x-correlation-id:",
+    "traceparent:",
+    "tracestate:",
+    "baggage:",
+    "authorization:",
+    "proxy-authorization:",
+    "cookie:",
+    "via:",
+  ]) {
+    assert.equal(observed.raw.toLowerCase().includes(forbidden), false, forbidden);
+  }
+});
+
+async function unusedTcpPort() {
+  const server = net.createServer();
+  const address = await listen(server);
+  await closeServer(server);
+  return address.port;
+}
+
+function waitForTcpListener(port, child, output, timeoutMs = 5_000) {
+  const started = Date.now();
+  return new Promise((resolvePromise, rejectPromise) => {
+    const attempt = () => {
+      if (child.exitCode !== null) {
+        rejectPromise(new Error(`Caddy exited before listener readiness: ${output()}`));
+        return;
+      }
+      const probe = net.createConnection({ host: "127.0.0.1", port });
+      probe.once("connect", () => {
+        probe.destroy();
+        resolvePromise();
+      });
+      probe.once("error", (error) => {
+        probe.destroy();
+        if (Date.now() - started > timeoutMs) {
+          rejectPromise(new Error(`timed out waiting for Caddy listener: ${error.message}`));
+          return;
+        }
+        setTimeout(attempt, 10);
+      });
+    };
+    attempt();
+  });
+}
+
+function plainHttpRequest(
+  port,
+  localAddress,
+  request = providerRequest,
+  host = "127.0.0.1",
+) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const socket = net.createConnection({ host, port, localAddress });
+    let bytes = "";
+    socket.on("connect", () => {
+      socket.write(request);
+    });
+    socket.on("data", (chunk) => { bytes += chunk.toString("latin1"); });
+    socket.on("end", () => resolvePromise(bytes));
+    socket.on("error", rejectPromise);
+  });
+}
+
+function nonLoopbackIpv4Address() {
+  for (const entries of Object.values(networkInterfaces())) {
+    for (const entry of entries ?? []) {
+      if (!entry.internal && (entry.family === "IPv4" || entry.family === 4)) {
+        return entry.address;
+      }
+    }
+  }
+  return undefined;
+}
+
+test("the selected Caddy binary enforces the exact publisher source address", {
+  skip: CADDY === undefined,
+}, async (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "bpir-caddy-publisher-source-"));
+  chmodSync(directory, 0o700);
+  const port = await unusedTcpPort();
+  const caddyfile = join(directory, "Caddyfile");
+  writeFileSync(caddyfile, `{
+  admin off
+  persist_config off
+  auto_https off
+}
+
+http://:${port} {
+  bind 0.0.0.0
+  @publisher {
+    remote_ip 127.0.0.1
+    method GET
+    path /v1/directory
+    header Host publisher.example.net
+  }
+  handle @publisher {
+    respond "ok" 200
+  }
+  handle {
+    respond "" 404
+  }
+}
+`, { mode: 0o600 });
+  const validation = spawnSync(CADDY, ["validate", "--config", caddyfile, "--adapter", "caddyfile"], {
+    encoding: "utf8",
+    shell: false,
+  });
+  assert.equal(validation.status, 0, `${validation.stdout}\n${validation.stderr}`);
+  const caddy = spawn(CADDY, ["run", "--config", caddyfile, "--adapter", "caddyfile"], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  caddy.stdout.on("data", (chunk) => { output += chunk; });
+  caddy.stderr.on("data", (chunk) => { output += chunk; });
+  t.after(async () => {
+    await stopProcess(caddy);
+    rmSync(directory, { force: true, recursive: true });
+  });
+  await waitForTcpListener(port, caddy, () => output);
+
+  const request =
+    "GET /v1/directory HTTP/1.1\r\nHost: publisher.example.net\r\nX-Forwarded-For: 127.0.0.1\r\nConnection: close\r\n\r\n";
+  const unauthorizedAddress = nonLoopbackIpv4Address();
+  assert.ok(unauthorizedAddress, "test host has no non-loopback IPv4 address");
+  assert.equal(
+    statusOf(
+      await plainHttpRequest(port, unauthorizedAddress, request, unauthorizedAddress),
+    ),
+    404,
+  );
+  assert.equal(statusOf(await plainHttpRequest(port, "127.0.0.1", request)), 200);
+});
+
+test("the selected Caddy binary removes source headers before PROXY v2 Unix handoff", {
+  skip: CADDY === undefined,
+}, async (t) => {
+  const directory = mkdtempSync(join(tmpdir(), "bpir-caddy-source-strip-"));
+  chmodSync(directory, 0o700);
+  const upstreamPath = join(directory, "upstream.sock");
+  const upstream = proxyV2BackendServer();
+  await listenUnix(upstream.server, upstreamPath);
+  const port = await unusedTcpPort();
+  const caddyfile = join(directory, "Caddyfile");
+  writeFileSync(caddyfile, `{
+  admin off
+  persist_config off
+  auto_https off
+}
+
+http://:${port} {
+  bind 127.0.0.1
+  reverse_proxy unix/${upstreamPath} {
+    header_up -*
+    header_up Host pir.example.net
+    transport http {
+      versions 1.1
+      proxy_protocol v2
+      dial_timeout 3s
+      response_header_timeout 3s
+      keepalive off
+      compression off
+    }
+  }
+}
+`, { mode: 0o600 });
+  const validation = spawnSync(CADDY, ["validate", "--config", caddyfile, "--adapter", "caddyfile"], {
+    encoding: "utf8",
+    shell: false,
+  });
+  assert.equal(validation.status, 0, `${validation.stdout}\n${validation.stderr}`);
+  const caddy = spawn(CADDY, ["run", "--config", caddyfile, "--adapter", "caddyfile"], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  caddy.stdout.on("data", (chunk) => { output += chunk; });
+  caddy.stderr.on("data", (chunk) => { output += chunk; });
+  t.after(async () => {
+    await stopProcess(caddy);
+    upstream.destroySockets();
+    await closeServer(upstream.server);
+    rmSync(directory, { force: true, recursive: true });
+  });
+  await waitForTcpListener(port, caddy, () => output);
+
+  const sourceMarker = "198.51.100.92";
+  const response = await plainHttpRequest(port, "127.0.0.1", [
+    "GET /v1/pir HTTP/1.1",
+    "Host: public.example.net",
+    `Forwarded: for=${sourceMarker}`,
+    `X-Forwarded-For: ${sourceMarker}`,
+    `X-Real-IP: ${sourceMarker}`,
+    `CF-Connecting-IP: ${sourceMarker}`,
+    `True-Client-IP: ${sourceMarker}`,
+    "X-Request-ID: source-query-link",
+    "Connection: close",
+    "",
+    "",
+  ].join("\r\n"));
+  assert.equal(statusOf(response), 200);
+  await waitFor(() => upstream.records.length === 1, "Caddy protected Unix handoff");
+  const observed = upstream.records[0];
+  assert.equal(observed.error, undefined);
+  assert.equal(observed.sourceAddress, "127.0.0.1");
+  assert.equal(observed.raw.includes(sourceMarker), false);
+  assert.equal(observed.raw.includes("127.0.0.1"), false);
+  for (const forbidden of [
+    "forwarded:",
+    "x-forwarded-",
+    "x-real-ip:",
+    "cf-connecting-ip:",
+    "true-client-ip:",
+    "x-request-id:",
+  ]) {
+    assert.equal(observed.raw.toLowerCase().includes(forbidden), false, forbidden);
+  }
+});
+
+test("the selected Caddy binary sends PROXY v2 over the protected Unix socket", {
+  skip: HAPROXY === undefined || CADDY === undefined,
+}, async (t) => {
+  const harness = await createHarness(t);
+  const port = await unusedTcpPort();
+  const caddyfile = join(harness.directory, "Caddyfile");
+  writeFileSync(caddyfile, `{
+  admin off
+  persist_config off
+  auto_https off
+}
+
+http://:${port} {
+  bind 127.0.0.1
+  reverse_proxy unix/${harness.sockets.provider} {
+    header_up -*
+    header_up Host pir.example.net
+    transport http {
+      versions 1.1
+      proxy_protocol v2
+      dial_timeout 3s
+      response_header_timeout 3s
+      keepalive off
+      compression off
+    }
+  }
+}
+`, { mode: 0o600 });
+  const validation = spawnSync(CADDY, ["validate", "--config", caddyfile, "--adapter", "caddyfile"], {
+    encoding: "utf8",
+    shell: false,
+  });
+  assert.equal(
+    validation.status,
+    0,
+    `Caddy lacks reviewed Unix+PROXY-v2 support:\n${validation.stdout}\n${validation.stderr}`,
+  );
+  const caddy = spawn(CADDY, ["run", "--config", caddyfile, "--adapter", "caddyfile"], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  caddy.stdout.on("data", (chunk) => { output += chunk; });
+  caddy.stderr.on("data", (chunk) => { output += chunk; });
+  t.after(() => stopProcess(caddy));
+  await waitForTcpListener(port, caddy, () => output);
+  const sourceMarker = "198.51.100.91";
+  const response = await plainHttpRequest(port, "127.0.0.2", [
+    "GET /v1/pir HTTP/1.1",
+    "Host: public.example.net",
+    `Forwarded: for=${sourceMarker}`,
+    `X-Forwarded-For: ${sourceMarker}`,
+    `X-Real-IP: ${sourceMarker}`,
+    "X-Request-ID: source-query-link",
+    "Connection: close",
+    "",
+    "",
+  ].join("\r\n"));
+  assert.equal(statusOf(response), 200);
+  await waitFor(
+    () => Object.values(harness.lanes).some((lane) => lane.records.length >= 1),
+    "Caddy-to-HAProxy request",
+  );
+  assert.equal(
+    harness.lanes.provider.records.length >= 1,
+    true,
+    JSON.stringify(
+      Object.fromEntries(
+        Object.entries(harness.lanes).map(([name, lane]) => [name, lane.records.length]),
+      ),
+    ),
+  );
+  const observed = harness.lanes.provider.records.at(-1);
+  assert.equal(observed.remoteAddress, "127.0.0.1");
+  assert.equal(observed.raw.includes("127.0.0.2"), false);
+  assert.equal(observed.raw.includes(sourceMarker), false);
+  for (const forbidden of [
+    "forwarded:",
+    "x-forwarded-",
+    "x-real-ip:",
+    "x-request-id:",
+  ]) {
+    assert.equal(observed.raw.toLowerCase().includes(forbidden), false, forbidden);
+  }
+});


### PR DESCRIPTION
## Summary
- extend the real two-provider Payment V1 process boundary from DPF to a complete four-frame K-padded Harmony query job
- bind DPF and Harmony to distinct scopes, globally unique offers, and independent receipt keys while keeping each provider independent
- prove wrong-scope non-consumption, terminal operation sequencing, and durable replay rejection after provider restart
- update acceptance, implementation-status, and test-plan documentation

## Validation
- `cargo test --locked --offline -p runtime --test payment_v1_process_e2e` in Rust 1.94.1 Linux container: 2 passed
- `cargo clippy --locked --offline -p runtime --test payment_v1_process_e2e --no-deps -- -D warnings`: passed
- changed-file `rustfmt --check` and `git diff --check`: passed

## Boundaries
This is a no-funds, loopback, NoSevHost process test with deterministic fixture keys. It proves the secure wire, signed provider/workload policy, payment gate, real Harmony query handler, and durable spent boundary. It does not prove production identity/attestation, browser hint acquisition, public Lightning/Cashu interoperability, or production deployment.