### PR TITLE
Add shared issuer clearing operator tooling

### DIFF
--- a/.github/workflows/payment-platform.yml
+++ b/.github/workflows/payment-platform.yml
@@ -250,7 +250,12 @@ jobs:
             --features test-only-fake-lightning \
             --bin payment-issuer \
             --target-dir "$issuer_e2e_target_dir"
+          cargo build --locked --offline \
+            -p bpir-admin \
+            --bin bpir-admin \
+            --target-dir "$issuer_e2e_target_dir"
           BITCOINPIR_PAYMENT_ISSUER_BIN="$issuer_e2e_target_dir/debug/payment-issuer" \
+          BITCOINPIR_BPIR_ADMIN_BIN="$issuer_e2e_target_dir/debug/bpir-admin" \
             cargo test --locked --offline \
               -p runtime \
               --features shared-issuer-process-e2e \

--- a/apps/admin/src/payment_artifact.rs
+++ b/apps/admin/src/payment_artifact.rs
@@ -13,14 +13,17 @@ use pir_service_protocol::{
     paid_receipt_key_id, AuthScheme, Bolt11QuoteKeyDelegationV1, CashuDenominationKeyV1,
     CashuKeysetBindingV1, CashuRequiredNutsV1, CredentialKeyBindingClaimsV1,
     CredentialKeyBindingExpectationV1, CredentialKeyBindingV1, CredentialUnitV1,
-    LightningNetworkV1, StandardCashuMintExpectationV1, StandardCashuMintManifestV1,
-    MAX_CREDENTIAL_KEY_ID_LEN,
+    IssuerClearingApprovalV1, LightningNetworkV1, ProviderClearingAuthorizationClaimsV1,
+    ProviderClearingAuthorizationV1, SettlementModesV1, SettlementRuleV1, SettlementUnitV1,
+    StandardCashuMintExpectationV1, StandardCashuMintManifestV1, MAX_CREDENTIAL_KEY_ID_LEN,
 };
 use serde::Deserialize;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 const MAX_MANIFEST_CONFIG_BYTES: u64 = 1024 * 1024;
+const MAX_CLEARING_CONFIG_BYTES: u64 = 1024 * 1024;
+const MAX_CLEARING_AUTHORIZATION_BYTES: u64 = 64 * 1024;
 
 #[derive(Args, Debug)]
 pub struct PaymentArtifactArgs {
@@ -39,6 +42,12 @@ enum PaymentArtifactCommand {
     /// Build and self-verify a canonical standard Cashu mint manifest.
     #[command(name = "cashu-manifest")]
     CashuManifest(CashuManifestArgs),
+    /// Operator-sign and self-verify one production ledger-only provider authorization.
+    #[command(name = "clearing-authorization")]
+    ClearingAuthorization(ClearingAuthorizationArgs),
+    /// Issuer-sign and self-verify one exact provider clearing authorization.
+    #[command(name = "clearing-approval")]
+    ClearingApproval(ClearingApprovalArgs),
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -160,6 +169,75 @@ struct CashuManifestArgs {
     force: bool,
 }
 
+#[derive(Args, Debug)]
+struct ClearingAuthorizationArgs {
+    /// Owner-only 32-byte provider-operator Ed25519 seed.
+    #[arg(long)]
+    operator_signing_key: PathBuf,
+    /// Strict TOML source for one auth-credit, ledger-only authorization.
+    #[arg(long)]
+    config: PathBuf,
+    #[arg(long)]
+    out: PathBuf,
+    #[arg(long)]
+    force: bool,
+}
+
+#[derive(Args, Debug)]
+struct ClearingApprovalArgs {
+    /// Canonical operator-signed ProviderClearingAuthorizationV1 bytes.
+    #[arg(long)]
+    authorization: PathBuf,
+    /// Owner-only 32-byte issuer-settlement Ed25519 seed.
+    #[arg(long)]
+    issuer_settlement_signing_key: PathBuf,
+    /// Digest printed by the independently run clearing-authorization ceremony.
+    #[arg(long)]
+    expected_authorization_digest_hex: String,
+    #[arg(long)]
+    expected_provider_id_hex: String,
+    #[arg(long)]
+    expected_issuer_id_hex: String,
+    #[arg(long)]
+    expected_operator_key_hex: String,
+    #[arg(long)]
+    minimum_authorization_epoch: u64,
+    #[arg(long)]
+    approved_at: u64,
+    #[arg(long)]
+    not_after: u64,
+    #[arg(long)]
+    out: PathBuf,
+    #[arg(long)]
+    force: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ClearingAuthorizationConfig {
+    authorization_id_hex: String,
+    authorization_epoch: u64,
+    provider_id_hex: String,
+    issuer_id_hex: String,
+    redeem_endpoint: String,
+    redeem_leaf_spki_sha256_pins_hex: Vec<String>,
+    settlement_account_id_hex: String,
+    clearing_verifying_key_hex: String,
+    not_before: u64,
+    not_after: u64,
+    rules: Vec<LedgerClearingRuleConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LedgerClearingRuleConfig {
+    credential_binding_digest_hex: String,
+    accepted_value: u64,
+    provider_credit: u64,
+    issuer_fee: u64,
+    denomination_profile: u32,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct CashuManifestConfig {
@@ -199,6 +277,8 @@ pub fn run(args: PaymentArtifactArgs) -> Result<(), String> {
         PaymentArtifactCommand::QuoteDelegation(args) => build_quote_delegation(args),
         PaymentArtifactCommand::CredentialBinding(args) => build_credential_binding(args),
         PaymentArtifactCommand::CashuManifest(args) => build_cashu_manifest(args),
+        PaymentArtifactCommand::ClearingAuthorization(args) => build_clearing_authorization(args),
+        PaymentArtifactCommand::ClearingApproval(args) => build_clearing_approval(args),
     }
 }
 
@@ -333,6 +413,227 @@ fn build_credential_binding(args: CredentialBindingArgs) -> Result<(), String> {
         )
     );
     println!("out={}", args.out.display());
+    Ok(())
+}
+
+fn build_clearing_authorization(args: ClearingAuthorizationArgs) -> Result<(), String> {
+    let operator_key = crate::keygen::read_secret_key(&args.operator_signing_key)?;
+    let config_bytes = read_bounded_public_file(&args.config, MAX_CLEARING_CONFIG_BYTES)?;
+    let config: ClearingAuthorizationConfig = toml::from_str(
+        std::str::from_utf8(&config_bytes)
+            .map_err(|_| format!("{} is not UTF-8", args.config.display()))?,
+    )
+    .map_err(|error| format!("parse {}: {error}", args.config.display()))?;
+    if config.not_before == 0 || config.authorization_epoch == 0 {
+        return Err("clearing authorization epoch and not_before must be non-zero".to_owned());
+    }
+    let clearing_verifying_key = parse_hex_exact::<32>(
+        "clearing_verifying_key_hex",
+        &config.clearing_verifying_key_hex,
+    )?;
+    VerifyingKey::from_bytes(&clearing_verifying_key)
+        .map_err(|_| "clearing_verifying_key_hex is not a valid Ed25519 key".to_owned())?;
+    if clearing_verifying_key == operator_key.verifying_key().to_bytes() {
+        return Err("operator and provider clearing keys must be distinct".to_owned());
+    }
+    let rules = config
+        .rules
+        .iter()
+        .map(|rule| {
+            Ok(SettlementRuleV1 {
+                credential_binding_digest: parse_hex_exact::<32>(
+                    "credential_binding_digest_hex",
+                    &rule.credential_binding_digest_hex,
+                )?,
+                unit: SettlementUnitV1::AuthCredit,
+                accepted_value: rule.accepted_value,
+                provider_credit: rule.provider_credit,
+                issuer_fee: rule.issuer_fee,
+                denomination_profile: rule.denomination_profile,
+                settlement_modes: SettlementModesV1::from_bits(SettlementModesV1::LEDGER_CREDIT)
+                    .map_err(|error| format!("construct ledger-only settlement mode: {error}"))?,
+                blind_output_minimum_validity_seconds: 0,
+                blind_output_keyset: None,
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let authorization = ProviderClearingAuthorizationV1::sign(
+        ProviderClearingAuthorizationClaimsV1 {
+            authorization_id: parse_hex_exact::<16>(
+                "authorization_id_hex",
+                &config.authorization_id_hex,
+            )?,
+            authorization_epoch: config.authorization_epoch,
+            provider_id: parse_hex_exact::<32>("provider_id_hex", &config.provider_id_hex)?,
+            issuer_id: parse_hex_exact::<32>("issuer_id_hex", &config.issuer_id_hex)?,
+            redeem_endpoint: config.redeem_endpoint,
+            redeem_leaf_spki_sha256_pins: config
+                .redeem_leaf_spki_sha256_pins_hex
+                .iter()
+                .map(|pin| parse_hex_exact::<32>("redeem leaf SPKI SHA-256 pin", pin))
+                .collect::<Result<Vec<_>, _>>()?,
+            settlement_account_id: parse_hex_exact::<32>(
+                "settlement_account_id_hex",
+                &config.settlement_account_id_hex,
+            )?,
+            clearing_verifying_key,
+            not_before: config.not_before,
+            not_after: config.not_after,
+            rules,
+        },
+        &operator_key,
+    )
+    .map_err(|error| format!("construct provider clearing authorization: {error}"))?;
+    let encoded = authorization
+        .encode()
+        .map_err(|error| format!("encode provider clearing authorization: {error}"))?;
+    let decoded = ProviderClearingAuthorizationV1::decode(&encoded)
+        .map_err(|error| format!("decode generated provider clearing authorization: {error}"))?;
+    if decoded != authorization
+        || decoded
+            .encode()
+            .map_err(|error| format!("re-encode provider clearing authorization: {error}"))?
+            != encoded
+    {
+        return Err("generated provider clearing authorization is not canonical".to_owned());
+    }
+    decoded
+        .verify_for(
+            &decoded.claims.provider_id,
+            &decoded.claims.issuer_id,
+            &operator_key.verifying_key(),
+            decoded.claims.not_before,
+            config.authorization_epoch,
+        )
+        .map_err(|error| format!("self-verify provider clearing authorization: {error}"))?;
+    ensure_auth_credit_ledger_only(&decoded)?;
+    let digest = decoded
+        .authorization_digest()
+        .map_err(|error| format!("digest provider clearing authorization: {error}"))?;
+    write_public_artifact(&args.out, &encoded, args.force)?;
+    println!("provider_id={}", hex::encode(decoded.claims.provider_id));
+    println!("issuer_id={}", hex::encode(decoded.claims.issuer_id));
+    println!(
+        "operator_key={}",
+        hex::encode(decoded.operator_verifying_key)
+    );
+    println!(
+        "clearing_key={}",
+        hex::encode(decoded.claims.clearing_verifying_key)
+    );
+    println!("authorization_digest={}", hex::encode(digest));
+    println!("out={}", args.out.display());
+    Ok(())
+}
+
+fn build_clearing_approval(args: ClearingApprovalArgs) -> Result<(), String> {
+    if args.minimum_authorization_epoch == 0 || args.approved_at == 0 {
+        return Err("minimum authorization epoch and approved_at must be non-zero".to_owned());
+    }
+    let exact = read_bounded_public_file(&args.authorization, MAX_CLEARING_AUTHORIZATION_BYTES)?;
+    let authorization = ProviderClearingAuthorizationV1::decode(&exact)
+        .map_err(|error| format!("decode provider clearing authorization: {error}"))?;
+    if authorization
+        .encode()
+        .map_err(|error| format!("re-encode provider clearing authorization: {error}"))?
+        != exact
+    {
+        return Err("provider clearing authorization is not canonical".to_owned());
+    }
+    let expected_digest = parse_hex_exact::<32>(
+        "--expected-authorization-digest-hex",
+        &args.expected_authorization_digest_hex,
+    )?;
+    if authorization
+        .authorization_digest()
+        .map_err(|error| format!("digest provider clearing authorization: {error}"))?
+        != expected_digest
+    {
+        return Err(
+            "provider clearing authorization digest does not match ceremony input".to_owned(),
+        );
+    }
+    let expected_provider =
+        parse_hex_exact::<32>("--expected-provider-id-hex", &args.expected_provider_id_hex)?;
+    let expected_issuer =
+        parse_hex_exact::<32>("--expected-issuer-id-hex", &args.expected_issuer_id_hex)?;
+    let expected_operator_bytes = parse_hex_exact::<32>(
+        "--expected-operator-key-hex",
+        &args.expected_operator_key_hex,
+    )?;
+    let expected_operator = VerifyingKey::from_bytes(&expected_operator_bytes)
+        .map_err(|_| "--expected-operator-key-hex is not a valid Ed25519 key".to_owned())?;
+    authorization
+        .verify_for(
+            &expected_provider,
+            &expected_issuer,
+            &expected_operator,
+            args.approved_at,
+            args.minimum_authorization_epoch,
+        )
+        .map_err(|error| format!("verify provider clearing authorization: {error}"))?;
+    ensure_auth_credit_ledger_only(&authorization)?;
+
+    let settlement_key = crate::keygen::read_secret_key(&args.issuer_settlement_signing_key)?;
+    let settlement_verifying_key = settlement_key.verifying_key().to_bytes();
+    if settlement_verifying_key == authorization.operator_verifying_key
+        || settlement_verifying_key == authorization.claims.clearing_verifying_key
+    {
+        return Err(
+            "issuer settlement, provider operator, and provider clearing keys must be distinct"
+                .to_owned(),
+        );
+    }
+    let approval = IssuerClearingApprovalV1::sign(
+        &authorization,
+        args.approved_at,
+        args.not_after,
+        &settlement_key,
+    )
+    .map_err(|error| format!("construct issuer clearing approval: {error}"))?;
+    let encoded = approval.encode();
+    let decoded = IssuerClearingApprovalV1::decode(&encoded)
+        .map_err(|error| format!("decode generated issuer clearing approval: {error}"))?;
+    if decoded != approval || decoded.encode() != encoded {
+        return Err("generated issuer clearing approval is not canonical".to_owned());
+    }
+    decoded
+        .verify_for(
+            &authorization,
+            &settlement_key.verifying_key(),
+            args.approved_at,
+            args.minimum_authorization_epoch,
+        )
+        .map_err(|error| format!("self-verify issuer clearing approval: {error}"))?;
+    write_public_artifact(&args.out, &encoded, args.force)?;
+    println!(
+        "authorization_digest={}",
+        hex::encode(decoded.authorization_digest)
+    );
+    println!(
+        "issuer_settlement_key_id={}",
+        hex::encode(decoded.issuer_settlement_key_id)
+    );
+    println!("authorization_epoch={}", decoded.authorization_epoch);
+    println!("out={}", args.out.display());
+    Ok(())
+}
+
+fn ensure_auth_credit_ledger_only(
+    authorization: &ProviderClearingAuthorizationV1,
+) -> Result<(), String> {
+    if authorization.claims.rules.is_empty()
+        || authorization.claims.rules.iter().any(|rule| {
+            rule.unit != SettlementUnitV1::AuthCredit
+                || rule.settlement_modes.bits() != SettlementModesV1::LEDGER_CREDIT
+                || rule.blind_output_minimum_validity_seconds != 0
+                || rule.blind_output_keyset.is_some()
+        })
+    {
+        return Err(
+            "production clearing artifacts must contain auth-credit ledger-only rules".to_owned(),
+        );
+    }
     Ok(())
 }
 
@@ -654,6 +955,42 @@ mod tests {
         crate::keygen::write_secret_bytes_unix(path, bytes).unwrap();
     }
 
+    fn clearing_config(
+        operator: &SigningKey,
+        clearing: &SigningKey,
+        authorization_epoch: u64,
+    ) -> String {
+        assert_ne!(
+            operator.verifying_key().to_bytes(),
+            clearing.verifying_key().to_bytes()
+        );
+        format!(
+            "authorization_id_hex = \"{}\"\n\
+             authorization_epoch = {authorization_epoch}\n\
+             provider_id_hex = \"{}\"\n\
+             issuer_id_hex = \"{}\"\n\
+             redeem_endpoint = \"https://issuer.example\"\n\
+             redeem_leaf_spki_sha256_pins_hex = [\"{}\"]\n\
+             settlement_account_id_hex = \"{}\"\n\
+             clearing_verifying_key_hex = \"{}\"\n\
+             not_before = 1700000000\n\
+             not_after = 1900000000\n\
+             [[rules]]\n\
+             credential_binding_digest_hex = \"{}\"\n\
+             accepted_value = 10\n\
+             provider_credit = 9\n\
+             issuer_fee = 1\n\
+             denomination_profile = 7\n",
+            hex::encode([0x51; 16]),
+            hex::encode([0x52; 32]),
+            hex::encode([0x53; 32]),
+            hex::encode([0x54; 32]),
+            hex::encode([0x55; 32]),
+            hex::encode(clearing.verifying_key().to_bytes()),
+            hex::encode([0x56; 32]),
+        )
+    }
+
     #[test]
     fn quote_delegation_command_writes_self_verified_roundtrip() {
         let directory = private_tempdir().unwrap();
@@ -685,6 +1022,140 @@ mod tests {
                 .unwrap(),
             bytes
         );
+    }
+
+    #[test]
+    fn clearing_authorization_and_independent_approval_are_canonical_and_self_verified() {
+        let directory = private_tempdir().unwrap();
+        let operator = SigningKey::from_bytes(&[0x41; 32]);
+        let clearing = SigningKey::from_bytes(&[0x42; 32]);
+        let settlement = SigningKey::from_bytes(&[0x43; 32]);
+        let operator_path = directory.path().join("operator.key");
+        let settlement_path = directory.path().join("settlement.key");
+        let config_path = directory.path().join("clearing.toml");
+        let authorization_path = directory.path().join("authorization.bin");
+        let approval_path = directory.path().join("approval.bin");
+        write_secret(&operator_path, &operator.to_bytes());
+        write_secret(&settlement_path, &settlement.to_bytes());
+        std::fs::write(&config_path, clearing_config(&operator, &clearing, 7)).unwrap();
+
+        build_clearing_authorization(ClearingAuthorizationArgs {
+            operator_signing_key: operator_path,
+            config: config_path,
+            out: authorization_path.clone(),
+            force: false,
+        })
+        .unwrap();
+        let authorization_bytes = std::fs::read(&authorization_path).unwrap();
+        let authorization = ProviderClearingAuthorizationV1::decode(&authorization_bytes).unwrap();
+        assert_eq!(authorization.encode().unwrap(), authorization_bytes);
+        assert_eq!(
+            authorization.claims.clearing_verifying_key,
+            clearing.verifying_key().to_bytes()
+        );
+        let authorization_digest = authorization.authorization_digest().unwrap();
+
+        build_clearing_approval(ClearingApprovalArgs {
+            authorization: authorization_path,
+            issuer_settlement_signing_key: settlement_path,
+            expected_authorization_digest_hex: hex::encode(authorization_digest),
+            expected_provider_id_hex: hex::encode(authorization.claims.provider_id),
+            expected_issuer_id_hex: hex::encode(authorization.claims.issuer_id),
+            expected_operator_key_hex: hex::encode(operator.verifying_key().to_bytes()),
+            minimum_authorization_epoch: 7,
+            approved_at: 1_700_000_000,
+            not_after: 1_900_000_000,
+            out: approval_path.clone(),
+            force: false,
+        })
+        .unwrap();
+        let approval_bytes = std::fs::read(approval_path).unwrap();
+        let approval = IssuerClearingApprovalV1::decode(&approval_bytes).unwrap();
+        assert_eq!(approval.encode(), approval_bytes);
+        approval
+            .verify_for(
+                &authorization,
+                &settlement.verifying_key(),
+                1_700_000_000,
+                7,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn clearing_artifact_builders_reject_key_reuse_unknown_fields_and_swapped_digest() {
+        let directory = private_tempdir().unwrap();
+        let operator = SigningKey::from_bytes(&[0x61; 32]);
+        let clearing = SigningKey::from_bytes(&[0x62; 32]);
+        let settlement = SigningKey::from_bytes(&[0x63; 32]);
+        let operator_path = directory.path().join("operator.key");
+        let settlement_path = directory.path().join("settlement.key");
+        write_secret(&operator_path, &operator.to_bytes());
+        write_secret(&settlement_path, &settlement.to_bytes());
+
+        let reused_config = directory.path().join("reused.toml");
+        std::fs::write(
+            &reused_config,
+            clearing_config(&clearing, &operator, 1).replace(
+                &hex::encode(clearing.verifying_key().to_bytes()),
+                &hex::encode(operator.verifying_key().to_bytes()),
+            ),
+        )
+        .unwrap();
+        assert!(build_clearing_authorization(ClearingAuthorizationArgs {
+            operator_signing_key: operator_path.clone(),
+            config: reused_config,
+            out: directory.path().join("must-not-exist.bin"),
+            force: false,
+        })
+        .unwrap_err()
+        .contains("must be distinct"));
+
+        let unknown_config = directory.path().join("unknown.toml");
+        std::fs::write(
+            &unknown_config,
+            format!(
+                "{}\nunreviewed_mode = true\n",
+                clearing_config(&operator, &clearing, 1)
+            ),
+        )
+        .unwrap();
+        assert!(build_clearing_authorization(ClearingAuthorizationArgs {
+            operator_signing_key: operator_path.clone(),
+            config: unknown_config,
+            out: directory.path().join("must-not-exist-2.bin"),
+            force: false,
+        })
+        .is_err());
+
+        let config_path = directory.path().join("valid.toml");
+        let authorization_path = directory.path().join("authorization.bin");
+        std::fs::write(&config_path, clearing_config(&operator, &clearing, 3)).unwrap();
+        build_clearing_authorization(ClearingAuthorizationArgs {
+            operator_signing_key: operator_path,
+            config: config_path,
+            out: authorization_path.clone(),
+            force: false,
+        })
+        .unwrap();
+        let authorization =
+            ProviderClearingAuthorizationV1::decode(&std::fs::read(&authorization_path).unwrap())
+                .unwrap();
+        let error = build_clearing_approval(ClearingApprovalArgs {
+            authorization: authorization_path,
+            issuer_settlement_signing_key: settlement_path,
+            expected_authorization_digest_hex: hex::encode([0x99; 32]),
+            expected_provider_id_hex: hex::encode(authorization.claims.provider_id),
+            expected_issuer_id_hex: hex::encode(authorization.claims.issuer_id),
+            expected_operator_key_hex: hex::encode(operator.verifying_key().to_bytes()),
+            minimum_authorization_epoch: 3,
+            approved_at: 1_700_000_000,
+            not_after: 1_900_000_000,
+            out: directory.path().join("must-not-exist-3.bin"),
+            force: false,
+        })
+        .unwrap_err();
+        assert!(error.contains("digest does not match"));
     }
 
     #[test]

--- a/apps/admin/src/service_keygen.rs
+++ b/apps/admin/src/service_keygen.rs
@@ -24,6 +24,8 @@ pub enum ServiceKeyRole {
     AnonymousTicketEd25519,
     /// Provider/issuer clearing Ed25519 key.
     ClearingEd25519,
+    /// Provider payout-recovery/status request Ed25519 key; never a clearing key.
+    ProviderRequestEd25519,
     /// Central directory Nostr BIP340 key.
     DirectoryNostr,
     /// BIP340 claim/recovery key (normally browser generated).
@@ -76,7 +78,8 @@ pub fn run(args: ServiceKeygenArgs) -> Result<crate::keygen::SecretWriteCompleti
             | ServiceKeyRole::QuoteEd25519
             | ServiceKeyRole::ReceiptEd25519
             | ServiceKeyRole::AnonymousTicketEd25519
-            | ServiceKeyRole::ClearingEd25519 => Some(hex::encode(
+            | ServiceKeyRole::ClearingEd25519
+            | ServiceKeyRole::ProviderRequestEd25519 => Some(hex::encode(
                 Ed25519SigningKey::from_bytes(&secret)
                     .verifying_key()
                     .to_bytes(),
@@ -184,6 +187,7 @@ mod tests {
             ServiceKeyRole::ReceiptEd25519,
             ServiceKeyRole::AnonymousTicketEd25519,
             ServiceKeyRole::ClearingEd25519,
+            ServiceKeyRole::ProviderRequestEd25519,
             ServiceKeyRole::DirectoryNostr,
             ServiceKeyRole::Bip340Claim,
             ServiceKeyRole::CashuBat,
@@ -235,7 +239,8 @@ mod tests {
                 | ServiceKeyRole::QuoteEd25519
                 | ServiceKeyRole::ReceiptEd25519
                 | ServiceKeyRole::AnonymousTicketEd25519
-                | ServiceKeyRole::ClearingEd25519 => {
+                | ServiceKeyRole::ClearingEd25519
+                | ServiceKeyRole::ProviderRequestEd25519 => {
                     let seed: [u8; 32] = bytes.try_into().unwrap();
                     Ed25519SigningKey::from_bytes(&seed);
                 }

--- a/apps/payment-issuer/README.md
+++ b/apps/payment-issuer/README.md
@@ -24,8 +24,12 @@ payout mode or target, fee, or intent-TTL flag. The store's legacy non-zero
 payout-target column receives one fixed domain-separated disabled sentinel,
 never operator or request input. The issuer settlement signing key remains
 required for redeem and balance signatures. Retained settlement verifying keys
-remain optional because exact committed redeem/approval replay after signing-key
-rotation also needs them; they are not payout-only keys. Production TLS, node
+remain optional because exact committed issuer-side replay and verification
+after signing-key rotation may need them; they are not payout-only keys. This
+does not give `unified_server` retained clearing authorizations: the shipped
+provider runtime loads one authorization/approval and cannot recover an
+outcome-unknown old redeem after replacing it. V1 operators must drain and
+reconcile shared-issuer admission before such a rotation. Production TLS, node
 custody, payout execution, real-funds activation and remote deployment remain
 separate approval gates.
 

--- a/apps/payment-issuer/README.md
+++ b/apps/payment-issuer/README.md
@@ -29,6 +29,17 @@ rotation also needs them; they are not payout-only keys. Production TLS, node
 custody, payout execution, real-funds activation and remote deployment remain
 separate approval gates.
 
+Each `--clearing-authorization` and `--clearing-approval` pair must have one
+same-position `--clearing-provider-request-verifying-key` file containing a raw
+32-byte Ed25519 public key. Startup rejects a missing/invalid key and rejects
+reuse among the provider request, provider clearing, provider operator and
+current/retained issuer settlement roles. Ledger-only balance requests continue to use the
+authorized clearing key; the request key is registered separately for future
+payout recovery/status compatibility and is never replaced by a schema filler.
+Generate the signed artifacts with the two independent, self-verifying
+`bpir-admin payment-artifact clearing-*` ceremonies documented in
+`docs/payment/OFFLINE_OPERATOR_TOOLING.md`.
+
 `init-store`, `check-store`, and every available serving mode require exactly
 one floor boundary:
 

--- a/apps/payment-issuer/src/main.rs
+++ b/apps/payment-issuer/src/main.rs
@@ -310,6 +310,12 @@ struct ServeCommonArgs {
     /// Repeat one matching issuer approval, in the same order as authorization.
     #[arg(long = "clearing-approval")]
     clearing_approvals: Vec<PathBuf>,
+    /// Repeat one raw 32-byte provider-request Ed25519 verifying key, in the
+    /// same order as authorization. This key is reserved for payout
+    /// recovery/status and MUST differ from the provider clearing key even in
+    /// production ledger-only mode.
+    #[arg(long = "clearing-provider-request-verifying-key")]
+    clearing_provider_request_verifying_keys: Vec<PathBuf>,
     /// Issuer Ed25519 settlement signing key; required when clearing is enabled.
     #[arg(long)]
     issuer_settlement_signing_key: Option<PathBuf>,
@@ -1753,6 +1759,7 @@ fn load_ledger_clearing(
 ) -> Result<Option<SharedIssuerClearingServiceV1>, String> {
     let any_configured = !args.clearing_authorizations.is_empty()
         || !args.clearing_approvals.is_empty()
+        || !args.clearing_provider_request_verifying_keys.is_empty()
         || args.issuer_settlement_signing_key.is_some()
         || !args.retained_issuer_settlement_verifying_keys.is_empty()
         || args.redeem_response_derivation_key.is_some();
@@ -1761,9 +1768,10 @@ fn load_ledger_clearing(
     }
     if args.clearing_authorizations.is_empty()
         || args.clearing_authorizations.len() != args.clearing_approvals.len()
+        || args.clearing_authorizations.len() != args.clearing_provider_request_verifying_keys.len()
     {
         return Err(
-            "clearing requires the same non-zero number of --clearing-authorization and --clearing-approval files"
+            "clearing requires the same non-zero number of --clearing-authorization, --clearing-approval and --clearing-provider-request-verifying-key files"
                 .to_owned(),
         );
     }
@@ -1804,6 +1812,7 @@ fn load_ledger_clearing(
         authorization: ProviderClearingAuthorizationV1,
         approval: IssuerClearingApprovalV1,
         operator_key: VerifyingKey,
+        provider_request_verifying_key: [u8; 32],
     }
 
     let identity = store
@@ -1811,10 +1820,11 @@ fn load_ledger_clearing(
         .map_err(|error| format!("read issuer identity failed: {error}"))?;
     let mut prepared = Vec::with_capacity(args.clearing_authorizations.len());
     let mut seen_providers = BTreeMap::new();
-    for (authorization_path, approval_path) in args
+    for ((authorization_path, approval_path), provider_request_key_path) in args
         .clearing_authorizations
         .iter()
         .zip(&args.clearing_approvals)
+        .zip(&args.clearing_provider_request_verifying_keys)
     {
         let authorization_bytes = read_public_file(
             authorization_path,
@@ -1859,6 +1869,22 @@ fn load_ledger_clearing(
         }
         let operator_key = VerifyingKey::from_bytes(&authorization.operator_verifying_key)
             .map_err(|_| "provider operator key is invalid".to_owned())?;
+        let provider_request_key_bytes = read_public_file(
+            provider_request_key_path,
+            32,
+            "provider request verifying key",
+        )?;
+        let provider_request_verifying_key: [u8; 32] = provider_request_key_bytes
+            .try_into()
+            .map_err(|_| "provider request verifying key must be 32 bytes".to_owned())?;
+        VerifyingKey::from_bytes(&provider_request_verifying_key)
+            .map_err(|_| "provider request verifying key is invalid".to_owned())?;
+        validate_clearing_role_key_separation_v1(
+            &authorization,
+            &provider_request_verifying_key,
+            &settlement_verifying_key,
+            &retained_settlement_verifying_keys,
+        )?;
         authorization
             .verify_for(
                 &authorization.claims.provider_id,
@@ -1905,6 +1931,7 @@ fn load_ledger_clearing(
             authorization,
             approval,
             operator_key,
+            provider_request_verifying_key,
         });
     }
 
@@ -1923,11 +1950,11 @@ fn load_ledger_clearing(
                 registration_epoch: claims.authorization_epoch,
                 provider_id: claims.provider_id,
                 settlement_account_id: claims.settlement_account_id,
-                provider_request_verifying_key: claims.clearing_verifying_key,
-                // The schema predates ledger-only mode and requires a non-zero
-                // target. Production has no target CLI: this domain-separated
-                // constant is a non-routable schema sentinel, never request
-                // input and never interpreted while the service is ledger-only.
+                provider_request_verifying_key: provider.provider_request_verifying_key,
+                // The schema requires a non-zero target. Production has no
+                // target CLI: this domain-separated constant is a non-routable
+                // schema sentinel, never request input and never interpreted
+                // while the service is ledger-only.
                 payout_target_id: LEDGER_ONLY_DISABLED_PAYOUT_TARGET_ID_V1,
                 not_before: claims.not_before,
                 not_after: claims.not_after,
@@ -1962,6 +1989,38 @@ fn load_ledger_clearing(
     )
     .map(Some)
     .map_err(|error| format!("build shared issuer clearing service failed: {error}"))
+}
+
+fn validate_clearing_role_key_separation_v1(
+    authorization: &ProviderClearingAuthorizationV1,
+    provider_request_verifying_key: &[u8; 32],
+    issuer_settlement_verifying_key: &VerifyingKey,
+    retained_issuer_settlement_verifying_keys: &[VerifyingKey],
+) -> Result<(), String> {
+    let settlement_key = issuer_settlement_verifying_key.to_bytes();
+    let clearing_key = authorization.claims.clearing_verifying_key;
+    let operator_key = authorization.operator_verifying_key;
+    let mut settlement_lineage = std::collections::BTreeSet::from([settlement_key]);
+    if *provider_request_verifying_key == authorization.claims.clearing_verifying_key
+        || *provider_request_verifying_key == operator_key
+        || *provider_request_verifying_key == settlement_key
+        || clearing_key == operator_key
+        || clearing_key == settlement_key
+        || operator_key == settlement_key
+        || retained_issuer_settlement_verifying_keys.iter().any(|key| {
+            let bytes = key.to_bytes();
+            bytes == *provider_request_verifying_key
+                || bytes == clearing_key
+                || bytes == operator_key
+                || !settlement_lineage.insert(bytes)
+        })
+    {
+        return Err(
+            "provider request, provider clearing, provider operator and issuer settlement key lineage must be distinct"
+                .to_owned(),
+        );
+    }
+    Ok(())
 }
 
 struct ConnectionCountGuard(Arc<AtomicUsize>);
@@ -3173,6 +3232,70 @@ mod tests {
                 now_unix_override: Some(now_unix_override),
                 test_only_payout_http,
             })
+        }
+    }
+
+    #[test]
+    fn production_clearing_registration_requires_four_distinct_key_roles() {
+        let fixture = SettlementHttpFixture::new();
+        let settlement = SigningKey::from_bytes(&SETTLEMENT_HTTP_SIGNING_KEY).verifying_key();
+        let provider_request = SigningKey::from_bytes(&SETTLEMENT_HTTP_PROVIDER_REQUEST_KEY)
+            .verifying_key()
+            .to_bytes();
+        validate_clearing_role_key_separation_v1(
+            &fixture.authorization,
+            &provider_request,
+            &settlement,
+            &[],
+        )
+        .expect("four distinct key roles");
+        for reused in [
+            fixture.authorization.claims.clearing_verifying_key,
+            fixture.authorization.operator_verifying_key,
+            settlement.to_bytes(),
+        ] {
+            assert!(validate_clearing_role_key_separation_v1(
+                &fixture.authorization,
+                &reused,
+                &settlement,
+                &[],
+            )
+            .is_err());
+        }
+        let mut collapsed = fixture.authorization.clone();
+        collapsed.claims.clearing_verifying_key = collapsed.operator_verifying_key;
+        assert!(validate_clearing_role_key_separation_v1(
+            &collapsed,
+            &provider_request,
+            &settlement,
+            &[],
+        )
+        .is_err());
+        let operator_as_settlement =
+            VerifyingKey::from_bytes(&fixture.authorization.operator_verifying_key)
+                .expect("operator verifying key");
+        assert!(validate_clearing_role_key_separation_v1(
+            &fixture.authorization,
+            &provider_request,
+            &operator_as_settlement,
+            &[],
+        )
+        .is_err());
+
+        for reused in [
+            provider_request,
+            fixture.authorization.claims.clearing_verifying_key,
+            fixture.authorization.operator_verifying_key,
+            settlement.to_bytes(),
+        ] {
+            let retained = [VerifyingKey::from_bytes(&reused).expect("retained verifying key")];
+            assert!(validate_clearing_role_key_separation_v1(
+                &fixture.authorization,
+                &provider_request,
+                &settlement,
+                &retained,
+            )
+            .is_err());
         }
     }
 

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -67,7 +67,10 @@ standard-cashu-process-e2e = ["pir-strict-https/test-only-webpki-root"]
 # the exact Standard-Cashu private-root injection surface so `unified_server`
 # has only one test-only WebPKI escape hatch; `pir-strict-https` rejects that
 # hook in release builds.
-shared-issuer-process-e2e = ["standard-cashu-process-e2e"]
+shared-issuer-process-e2e = [
+  "standard-cashu-process-e2e",
+  "pir-provider-clearing-client/test-only-webpki-root",
+]
 # Privacy-dangerous query-detail logging for local tests only. The build script
 # rejects this feature outside Cargo's debug profile; normal dev/release
 # binaries do not compile or recognize its CLI switch.

--- a/apps/server/tests/payment_v1_shared_issuer_process_e2e.rs
+++ b/apps/server/tests/payment_v1_shared_issuer_process_e2e.rs
@@ -30,6 +30,10 @@ use pir_issuer_store::{
 };
 use pir_lightning_backend::FakeLightningNodeV1;
 use pir_payment_crypto::{cashu_hash_to_curve_v1, K256CashuMintKeyringV1};
+use pir_provider_clearing_client::{
+    ProviderLedgerBalanceClientV1, ProviderLedgerBalanceTrustV1,
+    StrictHttpsProviderSettlementTransportV1,
+};
 use pir_runtime_core::protocol::{BatchQuery, Request, Response};
 use pir_sdk_client::attest::{attest_with_eph_binding, SevStatus};
 use pir_sdk_client::channel::{establish, SecureChannelTransport};
@@ -93,11 +97,14 @@ enum ProviderMethod {
 }
 
 struct SharedProviderConfig {
+    authorization_epoch: u64,
     authorization_path: PathBuf,
     approval_path: PathBuf,
+    operator_key_path: PathBuf,
     operator_verifying_key: VerifyingKey,
     issuer_settlement_verifying_key: VerifyingKey,
     clearing_key_path: PathBuf,
+    provider_request_verifying_key_path: PathBuf,
     idempotency_key_path: PathBuf,
     proof: BitcoinPirCashuBatProofV1,
     account_id: [u8; 32],
@@ -142,6 +149,7 @@ impl ProviderFixture {
 
 struct IssuerMaterial {
     binary: PathBuf,
+    admin_binary: PathBuf,
     issuer_id: [u8; 32],
     issuer_root: SigningKey,
     settlement_signing_key: SigningKey,
@@ -154,6 +162,7 @@ struct IssuerMaterial {
     fake_lightning_signing_key_path: PathBuf,
     fake_lightning_derivation_seed_path: PathBuf,
     issuer_settlement_signing_key_path: PathBuf,
+    retained_issuer_settlement_verifying_key_paths: Vec<PathBuf>,
     redeem_response_derivation_key_path: PathBuf,
     bat_keyring: Arc<K256CashuMintKeyringV1>,
 }
@@ -288,10 +297,10 @@ async fn shared_issuer_real_process_tls_e2e() {
     let edge_port = distinct_unused_port(&[issuer_port]);
     let offline_port = distinct_unused_port(&[issuer_port, edge_port]);
     let redeem_endpoint = format!("https://localhost:{edge_port}");
-    let issuer = build_issuer_material(root.path(), unix_now());
+    let mut issuer = build_issuer_material(root.path(), unix_now());
     let now = unix_now();
 
-    let paid = build_provider(
+    let mut paid = build_provider(
         root.path(),
         0,
         ProviderMethod::SharedIssuerBat,
@@ -346,9 +355,9 @@ async fn shared_issuer_real_process_tls_e2e() {
     // provider that can reach `/v1/redeems`. This also preserves the issuer
     // store invariant that one BAT public key has one immutable lineage.
     let shared_providers = [&paid];
-
     init_issuer_store(&issuer);
-    let payment_issuer = spawn_payment_issuer(root.path(), issuer_port, &issuer, &shared_providers);
+    let payment_issuer =
+        spawn_payment_issuer(root.path(), issuer_port, &issuer, &shared_providers);
     let forward_counter = root.path().join("tls-edge-forwarded.log");
     let transcript_path = root.path().join("tls-edge-transcript-digests.bin");
     let drop_success_once_path = root.path().join("tls-edge-drop-success-once.marker");
@@ -410,6 +419,33 @@ async fn shared_issuer_real_process_tls_e2e() {
         .await
         .expect("peer provider must independently accept Free/Open");
 
+    let initial_balance = read_signed_ledger_balance(&paid, &tls.root, [0x11; 32], Vec::new());
+    assert_eq!(
+        (
+            initial_balance.available_value,
+            initial_balance.reserved_value
+        ),
+        (9, 0)
+    );
+
+    // A real issuer restart reopens the same rollback-protected store and the
+    // independently generated authorization/approval/request-key artifacts.
+    // The next balance is freshly signed and revalidated; no payout fixture or
+    // in-memory registration is accepted as a substitute.
+    let (issuer_stdout_first, issuer_stderr_first) = payment_issuer.stop();
+    assert!(issuer_stdout_first.contains("payment-issuer fake service listening"));
+    assert!(issuer_stdout_first.contains("issuer_store_startup_check=ok"));
+    assert!(!issuer_stderr_first.contains("secret_raw"));
+    let payment_issuer = spawn_payment_issuer(root.path(), issuer_port, &issuer, &[&paid]);
+    let restarted_balance = read_signed_ledger_balance(&paid, &tls.root, [0x12; 32], Vec::new());
+    assert_eq!(
+        (
+            restarted_balance.available_value,
+            restarted_balance.reserved_value
+        ),
+        (9, 0)
+    );
+
     let (paid_stdout_first, paid_stderr_first) = paid_server.stop();
     let (free_stdout, free_stderr) = free_server.stop();
     assert_server_log(&paid_stdout_first, &paid_stderr_first, paid_port, &paid);
@@ -436,8 +472,50 @@ async fn shared_issuer_real_process_tls_e2e() {
 
     let forwarded_after_replay = forwarded_request_count(&forward_counter);
     assert!(
-        (2..=3).contains(&forwarded_after_replay),
-        "loss recovery must forward twice; a later spent replay may be rejected locally or replayed at the issuer"
+        (4..=5).contains(&forwarded_after_replay),
+        "two identical recovery redeems and two signed balance reads must be forwarded; the later spent replay may be rejected locally or replayed at the issuer"
+    );
+
+    // Rotate both the authorization epoch and issuer settlement signing key.
+    // The issuer retains the old public key only for historical recovery, while
+    // the newly generated approval is bound to epoch 2 and the new key. The
+    // real provider restarts on those files; its already-spent credential
+    // remains spent and the signed ledger balance survives unchanged.
+    let (issuer_stdout_restart, issuer_stderr_restart) = payment_issuer.stop();
+    assert!(issuer_stdout_restart.contains("issuer_store_startup_check=ok"));
+    assert!(!issuer_stderr_restart.contains("secret_raw"));
+    let old_settlement_key = rotate_shared_clearing_artifacts(&mut issuer, &mut paid, unix_now());
+    let payment_issuer = spawn_payment_issuer(root.path(), issuer_port, &issuer, &[&paid]);
+    let rotated_balance =
+        read_signed_ledger_balance(&paid, &tls.root, [0x13; 32], vec![old_settlement_key]);
+    assert_eq!(
+        (
+            rotated_balance.available_value,
+            rotated_balance.reserved_value
+        ),
+        (9, 0)
+    );
+    assert_ne!(
+        initial_balance.issuer_settlement_key_id,
+        rotated_balance.issuer_settlement_key_id
+    );
+    let rotated_provider =
+        spawn_provider(root.path(), &db_path, &paid, paid_port, 2, Some(&tls.root));
+    let rotated_replay = authorize_only(paid_port, &paid, manifest_root)
+        .await
+        .expect_err("credential spent before clearing rotation must remain spent");
+    assert!(
+        rotated_replay.contains("invalid-or-spent"),
+        "unexpected rotated replay: {rotated_replay}"
+    );
+    let (rotated_stdout, rotated_stderr) = rotated_provider.stop();
+    assert_server_log(&rotated_stdout, &rotated_stderr, paid_port, &paid);
+    assert_eq!(provider_local_claim_count(&paid), 1);
+    let forwarded_after_rotation = forwarded_request_count(&forward_counter);
+    assert!(
+        (forwarded_after_replay + 1..=forwarded_after_replay + 2)
+            .contains(&forwarded_after_rotation),
+        "rotated signed balance must be forwarded once; rotated spent proof may be rejected locally or by the issuer"
     );
 
     // Every trust failure uses a fresh provider process/store. The signed
@@ -459,7 +537,7 @@ async fn shared_issuer_real_process_tls_e2e() {
         assert_provider_spend_inventory(fixture, 0);
         assert_eq!(
             forwarded_request_count(&forward_counter),
-            forwarded_after_replay,
+            forwarded_after_rotation,
             "TLS trust/offline failure must not reach the issuer HTTP application"
         );
     }
@@ -474,6 +552,7 @@ async fn shared_issuer_real_process_tls_e2e() {
 
 fn build_issuer_material(root: &Path, now: u64) -> IssuerMaterial {
     let binary = required_payment_issuer_binary();
+    let admin_binary = required_bpir_admin_binary();
     let issuer_root_dir = root.join("payment-issuer");
     let store_dir = issuer_root_dir.join("store-domain");
     let rollback_dir = issuer_root_dir.join("rollback-domain");
@@ -544,6 +623,7 @@ fn build_issuer_material(root: &Path, now: u64) -> IssuerMaterial {
 
     IssuerMaterial {
         binary,
+        admin_binary,
         issuer_id,
         issuer_root,
         settlement_signing_key,
@@ -556,6 +636,7 @@ fn build_issuer_material(root: &Path, now: u64) -> IssuerMaterial {
         fake_lightning_signing_key_path,
         fake_lightning_derivation_seed_path,
         issuer_settlement_signing_key_path,
+        retained_issuer_settlement_verifying_key_paths: Vec::new(),
         redeem_response_derivation_key_path,
         bat_keyring: Arc::new(
             K256CashuMintKeyringV1::from_secret_keys([bat_key])
@@ -669,47 +750,9 @@ fn build_provider(
                 .expect("known shared-issuer privacy flags"),
             };
             let clearing = SigningKey::from_bytes(&[0x80u8.wrapping_add(index); 32]);
+            let provider_request = SigningKey::from_bytes(&[0x90u8.wrapping_add(index); 32]);
             let idempotency_key = [0xa0u8.wrapping_add(index); 32];
             let account_id = [0xb0u8.wrapping_add(index); 32];
-            let authorization = ProviderClearingAuthorizationV1::sign(
-                ProviderClearingAuthorizationClaimsV1 {
-                    authorization_id: [0xd0u8.wrapping_add(index); 16],
-                    authorization_epoch: 1,
-                    provider_id,
-                    issuer_id: issuer.issuer_id,
-                    redeem_endpoint: redeem_endpoint.to_owned(),
-                    redeem_leaf_spki_sha256_pins: redeem_pins,
-                    settlement_account_id: account_id,
-                    clearing_verifying_key: clearing.verifying_key().to_bytes(),
-                    not_before: issued_at,
-                    not_after: expires_at,
-                    rules: vec![SettlementRuleV1 {
-                        credential_binding_digest: binding
-                            .binding_digest()
-                            .expect("shared BAT binding digest"),
-                        unit: SettlementUnitV1::AuthCredit,
-                        accepted_value: 10,
-                        provider_credit: 9,
-                        issuer_fee: 1,
-                        denomination_profile: 1,
-                        settlement_modes: SettlementModesV1::from_bits(
-                            SettlementModesV1::LEDGER_CREDIT,
-                        )
-                        .expect("ledger-credit-only settlement"),
-                        blind_output_minimum_validity_seconds: 0,
-                        blind_output_keyset: None,
-                    }],
-                },
-                &operator,
-            )
-            .expect("sign provider clearing authorization");
-            let approval = IssuerClearingApprovalV1::sign(
-                &authorization,
-                issued_at,
-                expires_at,
-                &issuer.settlement_signing_key,
-            )
-            .expect("sign issuer clearing approval");
             let secret_raw = [0xe0u8.wrapping_add(index); 32];
             let hashed = cashu_hash_to_curve_v1(&secret_raw).expect("hash BAT secret to curve");
             let signed = issuer
@@ -727,25 +770,129 @@ fn build_provider(
 
             let authorization_path = provider_root.join("clearing-authorization.bin");
             let approval_path = provider_root.join("issuer-approval.bin");
+            let operator_key_path = provider_root.join("operator.key");
+            let authorization_config_path = provider_root.join("clearing-authorization.toml");
             let clearing_key_path = provider_root.join("clearing.key");
+            let provider_request_verifying_key_path =
+                provider_root.join("provider-request-verifying.key");
             let idempotency_key_path = provider_root.join("redeem-idempotency.key");
-            write_public_file(
-                &authorization_path,
-                &authorization
-                    .encode()
-                    .expect("encode clearing authorization"),
-            );
-            write_public_file(&approval_path, &approval.encode());
+            write_private_file(&operator_key_path, &operator.to_bytes());
             write_private_file(&clearing_key_path, &clearing.to_bytes());
+            write_public_file(
+                &provider_request_verifying_key_path,
+                &provider_request.verifying_key().to_bytes(),
+            );
             write_private_file(&idempotency_key_path, &idempotency_key);
+            let authorization_config = format!(
+                "authorization_id_hex = \"{}\"\n\
+                 authorization_epoch = 1\n\
+                 provider_id_hex = \"{}\"\n\
+                 issuer_id_hex = \"{}\"\n\
+                 redeem_endpoint = \"{}\"\n\
+                 redeem_leaf_spki_sha256_pins_hex = [{}]\n\
+                 settlement_account_id_hex = \"{}\"\n\
+                 clearing_verifying_key_hex = \"{}\"\n\
+                 not_before = {}\n\
+                 not_after = {}\n\
+                 [[rules]]\n\
+                 credential_binding_digest_hex = \"{}\"\n\
+                 accepted_value = 10\n\
+                 provider_credit = 9\n\
+                 issuer_fee = 1\n\
+                 denomination_profile = 1\n",
+                hex::encode([0xd0u8.wrapping_add(index); 16]),
+                hex::encode(provider_id),
+                hex::encode(issuer.issuer_id),
+                redeem_endpoint,
+                redeem_pins
+                    .iter()
+                    .map(|pin| format!("\"{}\"", hex::encode(pin)))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                hex::encode(account_id),
+                hex::encode(clearing.verifying_key().to_bytes()),
+                issued_at,
+                expires_at,
+                hex::encode(binding.binding_digest().expect("shared BAT binding digest")),
+            );
+            write_public_file(&authorization_config_path, authorization_config.as_bytes());
+            let authorization_output = Command::new(&issuer.admin_binary)
+                .args([
+                    OsString::from("payment-artifact"),
+                    OsString::from("clearing-authorization"),
+                    OsString::from("--operator-signing-key"),
+                    operator_key_path.as_os_str().to_owned(),
+                    OsString::from("--config"),
+                    authorization_config_path.as_os_str().to_owned(),
+                    OsString::from("--out"),
+                    authorization_path.as_os_str().to_owned(),
+                ])
+                .stdin(Stdio::null())
+                .output()
+                .expect("run bpir-admin clearing-authorization");
+            assert_command_success("bpir-admin clearing-authorization", &authorization_output);
+            let authorization = ProviderClearingAuthorizationV1::decode(
+                &fs::read(&authorization_path).expect("read generated clearing authorization"),
+            )
+            .expect("decode generated clearing authorization");
+            let approval_output = Command::new(&issuer.admin_binary)
+                .args([
+                    OsString::from("payment-artifact"),
+                    OsString::from("clearing-approval"),
+                    OsString::from("--authorization"),
+                    authorization_path.as_os_str().to_owned(),
+                    OsString::from("--issuer-settlement-signing-key"),
+                    issuer
+                        .issuer_settlement_signing_key_path
+                        .as_os_str()
+                        .to_owned(),
+                    OsString::from("--expected-authorization-digest-hex"),
+                    OsString::from(hex::encode(
+                        authorization
+                            .authorization_digest()
+                            .expect("generated authorization digest"),
+                    )),
+                    OsString::from("--expected-provider-id-hex"),
+                    OsString::from(hex::encode(provider_id)),
+                    OsString::from("--expected-issuer-id-hex"),
+                    OsString::from(hex::encode(issuer.issuer_id)),
+                    OsString::from("--expected-operator-key-hex"),
+                    OsString::from(hex::encode(operator.verifying_key().to_bytes())),
+                    OsString::from("--minimum-authorization-epoch"),
+                    OsString::from("1"),
+                    OsString::from("--approved-at"),
+                    OsString::from(issued_at.to_string()),
+                    OsString::from("--not-after"),
+                    OsString::from(expires_at.to_string()),
+                    OsString::from("--out"),
+                    approval_path.as_os_str().to_owned(),
+                ])
+                .stdin(Stdio::null())
+                .output()
+                .expect("run bpir-admin clearing-approval");
+            assert_command_success("bpir-admin clearing-approval", &approval_output);
+            IssuerClearingApprovalV1::decode(
+                &fs::read(&approval_path).expect("read generated clearing approval"),
+            )
+            .expect("decode generated clearing approval")
+            .verify_for(
+                &authorization,
+                &issuer.settlement_signing_key.verifying_key(),
+                issued_at,
+                1,
+            )
+            .expect("self-verified CLI clearing approval");
             (
                 offer,
                 Some(SharedProviderConfig {
+                    authorization_epoch: 1,
                     authorization_path,
                     approval_path,
+                    operator_key_path,
                     operator_verifying_key: operator.verifying_key(),
                     issuer_settlement_verifying_key: issuer.settlement_signing_key.verifying_key(),
                     clearing_key_path,
+                    provider_request_verifying_key_path,
                     idempotency_key_path,
                     proof,
                     account_id,
@@ -848,6 +995,163 @@ fn build_provider(
     }
 }
 
+fn rotate_shared_clearing_artifacts(
+    issuer: &mut IssuerMaterial,
+    fixture: &mut ProviderFixture,
+    now: u64,
+) -> VerifyingKey {
+    let shared = fixture.shared.as_mut().expect("shared provider config");
+    let old_settlement_key = issuer.settlement_signing_key.verifying_key();
+    assert_eq!(old_settlement_key, shared.issuer_settlement_verifying_key);
+    let old_authorization = ProviderClearingAuthorizationV1::decode(
+        &fs::read(&shared.authorization_path).expect("read old clearing authorization"),
+    )
+    .expect("decode old clearing authorization");
+    assert_eq!(old_authorization.claims.rules.len(), 1);
+    let old_rule = &old_authorization.claims.rules[0];
+
+    let issuer_root = issuer
+        .issuer_settlement_signing_key_path
+        .parent()
+        .expect("issuer settlement key parent");
+    let retained_path = issuer_root.join("settlement-verifying-v1.pub");
+    write_public_file(&retained_path, &old_settlement_key.to_bytes());
+    issuer
+        .retained_issuer_settlement_verifying_key_paths
+        .push(retained_path);
+    let rotated_settlement = SigningKey::from_bytes(&[0x39; 32]);
+    assert_ne!(
+        rotated_settlement.verifying_key().to_bytes(),
+        old_settlement_key.to_bytes()
+    );
+    let rotated_settlement_path = issuer_root.join("settlement-signing-v2.key");
+    write_private_file(&rotated_settlement_path, &rotated_settlement.to_bytes());
+
+    let provider_root = shared
+        .authorization_path
+        .parent()
+        .expect("provider authorization parent");
+    let config_path = provider_root.join("clearing-authorization-v2.toml");
+    let authorization_path = provider_root.join("clearing-authorization-v2.bin");
+    let approval_path = provider_root.join("issuer-approval-v2.bin");
+    let issued_at = now.saturating_sub(1);
+    let not_after = old_authorization.claims.not_after;
+    let config = format!(
+        "authorization_id_hex = \"{}\"\n\
+         authorization_epoch = 2\n\
+         provider_id_hex = \"{}\"\n\
+         issuer_id_hex = \"{}\"\n\
+         redeem_endpoint = \"{}\"\n\
+         redeem_leaf_spki_sha256_pins_hex = [{}]\n\
+         settlement_account_id_hex = \"{}\"\n\
+         clearing_verifying_key_hex = \"{}\"\n\
+         not_before = {}\n\
+         not_after = {}\n\
+         [[rules]]\n\
+         credential_binding_digest_hex = \"{}\"\n\
+         accepted_value = {}\n\
+         provider_credit = {}\n\
+         issuer_fee = {}\n\
+         denomination_profile = {}\n",
+        hex::encode([0xd2; 16]),
+        hex::encode(old_authorization.claims.provider_id),
+        hex::encode(old_authorization.claims.issuer_id),
+        old_authorization.claims.redeem_endpoint,
+        old_authorization
+            .claims
+            .redeem_leaf_spki_sha256_pins
+            .iter()
+            .map(|pin| format!("\"{}\"", hex::encode(pin)))
+            .collect::<Vec<_>>()
+            .join(", "),
+        hex::encode(old_authorization.claims.settlement_account_id),
+        hex::encode(old_authorization.claims.clearing_verifying_key),
+        issued_at,
+        not_after,
+        hex::encode(old_rule.credential_binding_digest),
+        old_rule.accepted_value,
+        old_rule.provider_credit,
+        old_rule.issuer_fee,
+        old_rule.denomination_profile,
+    );
+    write_public_file(&config_path, config.as_bytes());
+    let authorization_output = Command::new(&issuer.admin_binary)
+        .args([
+            OsString::from("payment-artifact"),
+            OsString::from("clearing-authorization"),
+            OsString::from("--operator-signing-key"),
+            shared.operator_key_path.as_os_str().to_owned(),
+            OsString::from("--config"),
+            config_path.as_os_str().to_owned(),
+            OsString::from("--out"),
+            authorization_path.as_os_str().to_owned(),
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("run rotated bpir-admin clearing-authorization");
+    assert_command_success(
+        "bpir-admin rotated clearing-authorization",
+        &authorization_output,
+    );
+    let authorization = ProviderClearingAuthorizationV1::decode(
+        &fs::read(&authorization_path).expect("read rotated clearing authorization"),
+    )
+    .expect("decode rotated clearing authorization");
+    let approval_output = Command::new(&issuer.admin_binary)
+        .args([
+            OsString::from("payment-artifact"),
+            OsString::from("clearing-approval"),
+            OsString::from("--authorization"),
+            authorization_path.as_os_str().to_owned(),
+            OsString::from("--issuer-settlement-signing-key"),
+            rotated_settlement_path.as_os_str().to_owned(),
+            OsString::from("--expected-authorization-digest-hex"),
+            OsString::from(hex::encode(
+                authorization
+                    .authorization_digest()
+                    .expect("rotated authorization digest"),
+            )),
+            OsString::from("--expected-provider-id-hex"),
+            OsString::from(hex::encode(fixture.provider_id)),
+            OsString::from("--expected-issuer-id-hex"),
+            OsString::from(hex::encode(issuer.issuer_id)),
+            OsString::from("--expected-operator-key-hex"),
+            OsString::from(hex::encode(shared.operator_verifying_key.to_bytes())),
+            OsString::from("--minimum-authorization-epoch"),
+            OsString::from("2"),
+            OsString::from("--approved-at"),
+            OsString::from(issued_at.to_string()),
+            OsString::from("--not-after"),
+            OsString::from(not_after.to_string()),
+            OsString::from("--out"),
+            approval_path.as_os_str().to_owned(),
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("run rotated bpir-admin clearing-approval");
+    assert_command_success("bpir-admin rotated clearing-approval", &approval_output);
+    let approval = IssuerClearingApprovalV1::decode(
+        &fs::read(&approval_path).expect("read rotated issuer clearing approval"),
+    )
+    .expect("decode rotated issuer clearing approval");
+    approval
+        .verify_for(
+            &authorization,
+            &rotated_settlement.verifying_key(),
+            issued_at,
+            2,
+        )
+        .expect("verify rotated issuer clearing approval");
+
+    issuer.settlement_signing_key = rotated_settlement;
+    issuer.issuer_settlement_signing_key_path = rotated_settlement_path;
+    shared.authorization_epoch = 2;
+    shared.authorization_path = authorization_path;
+    shared.approval_path = approval_path;
+    shared.issuer_settlement_verifying_key = issuer.settlement_signing_key.verifying_key();
+    old_settlement_key
+}
+
 fn init_issuer_store(issuer: &IssuerMaterial) {
     let output = Command::new(&issuer.binary)
         .args([
@@ -921,6 +1225,12 @@ fn spawn_payment_issuer(
         OsString::from("--mutation-rate-per-minute"),
         OsString::from("1000"),
     ];
+    for retained_key_path in &issuer.retained_issuer_settlement_verifying_key_paths {
+        args.extend([
+            OsString::from("--retained-issuer-settlement-verifying-key"),
+            retained_key_path.as_os_str().to_owned(),
+        ]);
+    }
     for fixture in providers {
         let shared = fixture.shared.as_ref().expect("shared issuer provider");
         args.extend([
@@ -934,6 +1244,11 @@ fn spawn_payment_issuer(
             shared.authorization_path.as_os_str().to_owned(),
             OsString::from("--clearing-approval"),
             shared.approval_path.as_os_str().to_owned(),
+            OsString::from("--clearing-provider-request-verifying-key"),
+            shared
+                .provider_request_verifying_key_path
+                .as_os_str()
+                .to_owned(),
         ]);
     }
 
@@ -1017,7 +1332,7 @@ fn spawn_provider(
             "--service-shared-idempotency-key".to_owned(),
             shared.idempotency_key_path.to_string_lossy().into_owned(),
             "--service-shared-minimum-authorization-epoch".to_owned(),
-            "1".to_owned(),
+            shared.authorization_epoch.to_string(),
             "--test-only-service-https-root-pem".to_owned(),
             test_root.to_string_lossy().into_owned(),
         ]);
@@ -1357,6 +1672,53 @@ fn assert_issuer_ledger(
     assert_eq!(inventory.payout_rows, 0);
 }
 
+fn read_signed_ledger_balance(
+    fixture: &ProviderFixture,
+    test_root: &Path,
+    nonce: [u8; 32],
+    retained_issuer_settlement_keys: Vec<VerifyingKey>,
+) -> pir_service_protocol::IssuerBalanceResponseV1 {
+    let shared = fixture.shared.as_ref().expect("shared provider config");
+    let authorization_bytes = fs::read(&shared.authorization_path)
+        .expect("read generated provider clearing authorization");
+    let authorization = ProviderClearingAuthorizationV1::decode(&authorization_bytes)
+        .expect("decode generated provider clearing authorization");
+    assert_eq!(authorization.encode().unwrap(), authorization_bytes);
+    let approval_bytes =
+        fs::read(&shared.approval_path).expect("read generated issuer clearing approval");
+    let approval = IssuerClearingApprovalV1::decode(&approval_bytes)
+        .expect("decode generated issuer clearing approval");
+    assert_eq!(approval.encode(), approval_bytes);
+    let clearing_bytes: [u8; 32] = fs::read(&shared.clearing_key_path)
+        .expect("read provider clearing signing key")
+        .try_into()
+        .expect("provider clearing signing key length");
+    let transport = StrictHttpsProviderSettlementTransportV1::new_with_test_only_webpki_root_pem(
+        authorization.claims.redeem_endpoint.clone(),
+        Duration::from_secs(2),
+        Duration::from_secs(5),
+        &authorization.claims.redeem_leaf_spki_sha256_pins,
+        &fs::read(test_root).expect("read private test WebPKI root"),
+    )
+    .expect("construct pinned test-only ledger transport");
+    let client = ProviderLedgerBalanceClientV1::new(
+        ProviderLedgerBalanceTrustV1 {
+            authorization,
+            issuer_approval: approval,
+            operator_verifying_key: shared.operator_verifying_key,
+            minimum_authorization_epoch: shared.authorization_epoch,
+            current_issuer_settlement_key: shared.issuer_settlement_verifying_key,
+            retained_issuer_settlement_keys,
+        },
+        SigningKey::from_bytes(&clearing_bytes),
+        &transport,
+    )
+    .expect("construct ledger-only balance client from generated artifacts");
+    client
+        .balance(nonce, unix_now())
+        .expect("fetch and verify issuer-signed ledger balance")
+}
+
 fn assert_server_log(stdout: &str, stderr: &str, port: u16, fixture: &ProviderFixture) {
     assert!(stdout.contains(&format!("Listening on ws://127.0.0.1:{port}")));
     assert!(stdout.contains("Service admission V1: enforced"));
@@ -1496,7 +1858,17 @@ fn serve_one_tls_edge_request(
     let connection = ServerConnection::new(config).map_err(io::Error::other)?;
     let mut tls = StreamOwned::new(connection, socket);
     let request = read_bounded_http_request(&mut tls)?;
-    let transcript = validate_canonical_redeem_request(&request)?;
+    let is_redeem = request.starts_with(b"POST /v1/redeems HTTP/1.1\r\n");
+    let is_balance = request.starts_with(b"POST /v1/settlement/balance HTTP/1.1\r\n");
+    if !is_redeem && !is_balance {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "TLS edge accepts only issuer redeem and signed balance routes",
+        ));
+    }
+    let transcript = is_redeem
+        .then(|| validate_canonical_redeem_request(&request))
+        .transpose()?;
 
     let mut upstream = TcpStream::connect_timeout(&upstream_address, TLS_IO_TIMEOUT)?;
     upstream.set_read_timeout(Some(TLS_IO_TIMEOUT))?;
@@ -1516,17 +1888,19 @@ fn serve_one_tls_edge_request(
             "issuer response is empty or exceeded the proxy bound",
         ));
     }
-    let canonical_success =
-        validate_canonical_redeem_success_response(&response, &transcript.request_digest)?;
-    append_redeem_transcript_digests(transcript_path, transcript)?;
-    if canonical_success && mark_drop_success_response_once(drop_success_once_path)? {
-        // The complete issuer success response proves the redeem commit escaped
-        // the application boundary. Drop the downstream TLS stream without
-        // forwarding one response, modeling an outcome-unknown network loss.
-        return Err(io::Error::new(
-            io::ErrorKind::ConnectionAborted,
-            "test-only committed issuer response loss",
-        ));
+    if let Some(transcript) = transcript {
+        let canonical_success =
+            validate_canonical_redeem_success_response(&response, &transcript.request_digest)?;
+        append_redeem_transcript_digests(transcript_path, transcript)?;
+        if canonical_success && mark_drop_success_response_once(drop_success_once_path)? {
+            // The complete issuer success response proves the redeem commit escaped
+            // the application boundary. Drop the downstream TLS stream without
+            // forwarding one response, modeling an outcome-unknown network loss.
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionAborted,
+                "test-only committed issuer response loss",
+            ));
+        }
     }
     tls.write_all(&response)?;
     tls.flush()?;
@@ -1848,6 +2222,23 @@ fn required_payment_issuer_binary() -> PathBuf {
         0,
         "payment-issuer is not executable"
     );
+    path
+}
+
+fn required_bpir_admin_binary() -> PathBuf {
+    let path = PathBuf::from(
+        env::var_os("BITCOINPIR_BPIR_ADMIN_BIN")
+            .expect("BITCOINPIR_BPIR_ADMIN_BIN must name a debug bpir-admin binary"),
+    );
+    assert!(
+        path.is_absolute(),
+        "BITCOINPIR_BPIR_ADMIN_BIN must be absolute"
+    );
+    let metadata = fs::symlink_metadata(&path)
+        .unwrap_or_else(|error| panic!("inspect bpir-admin binary {}: {error}", path.display()));
+    assert!(!metadata.file_type().is_symlink());
+    assert!(metadata.file_type().is_file());
+    assert_ne!(metadata.mode() & 0o111, 0, "bpir-admin is not executable");
     path
 }
 

--- a/apps/server/tests/payment_v1_shared_issuer_process_e2e.rs
+++ b/apps/server/tests/payment_v1_shared_issuer_process_e2e.rs
@@ -47,10 +47,9 @@ use pir_service_protocol::{
     Bolt11QuoteKeyDelegationV1, CredentialKeyBindingClaimsV1, CredentialKeyBindingV1,
     CredentialUnitV1, DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1,
     FreeAuthorizationProofV1, FreeModeV1, IssuerClearingApprovalV1, LightningNetworkV1,
-    OperationStartV1, PriceV1, PrivacyLeakageV1, ProviderClearingAuthorizationClaimsV1,
-    ProviderClearingAuthorizationV1, ProviderRedeemEnvelopeV1, ProviderRedeemResponseV1,
-    ServiceOfferV1, ServicePolicyV1, ServiceScopePolicyV1, ServiceScopeV1, SettlementModesV1,
-    SettlementRuleV1, SettlementUnitV1, VerificationMode, WorkloadId,
+    OperationStartV1, PriceV1, PrivacyLeakageV1, ProviderClearingAuthorizationV1,
+    ProviderRedeemEnvelopeV1, ProviderRedeemResponseV1, ServiceOfferV1, ServicePolicyV1,
+    ServiceScopePolicyV1, ServiceScopeV1, SettlementUnitV1, VerificationMode, WorkloadId,
 };
 use pir_service_store::{
     ProviderStore, SqliteRollbackFloorAuthorityV1, StoreOptions as ProviderStoreOptions,
@@ -356,8 +355,7 @@ async fn shared_issuer_real_process_tls_e2e() {
     // store invariant that one BAT public key has one immutable lineage.
     let shared_providers = [&paid];
     init_issuer_store(&issuer);
-    let payment_issuer =
-        spawn_payment_issuer(root.path(), issuer_port, &issuer, &shared_providers);
+    let payment_issuer = spawn_payment_issuer(root.path(), issuer_port, &issuer, &shared_providers);
     let forward_counter = root.path().join("tls-edge-forwarded.log");
     let transcript_path = root.path().join("tls-edge-transcript-digests.bin");
     let drop_success_once_path = root.path().join("tls-edge-drop-success-once.marker");
@@ -451,7 +449,11 @@ async fn shared_issuer_real_process_tls_e2e() {
     assert_server_log(&paid_stdout_first, &paid_stderr_first, paid_port, &paid);
     assert_server_log(&free_stdout, &free_stderr, free_port, &free);
     assert_provider_spend_inventory(&paid, 1);
-    assert_eq!(forwarded_request_count(&forward_counter), 2);
+    assert_eq!(
+        forwarded_request_count(&forward_counter),
+        4,
+        "two recovery redeems and two signed balance reads must reach the issuer"
+    );
     assert_private_regular_file(&transcript_path);
     assert_first_two_forwarded_requests_are_identical(&transcript_path);
 
@@ -510,7 +512,7 @@ async fn shared_issuer_real_process_tls_e2e() {
     );
     let (rotated_stdout, rotated_stderr) = rotated_provider.stop();
     assert_server_log(&rotated_stdout, &rotated_stderr, paid_port, &paid);
-    assert_eq!(provider_local_claim_count(&paid), 1);
+    assert_provider_spend_inventory(&paid, 1);
     let forwarded_after_rotation = forwarded_request_count(&forward_counter);
     assert!(
         (forwarded_after_replay + 1..=forwarded_after_replay + 2)

--- a/crates/payment/cashu-client/src/tests.rs
+++ b/crates/payment/cashu-client/src/tests.rs
@@ -1211,10 +1211,31 @@ fn concurrent_callers_issue_one_swap_and_one_grant() {
             .count(),
         1
     );
+    // The durable PREPARED -> SUBMITTED transition intentionally happens
+    // before the sole NUT-03 call. A concurrent observer may therefore reach
+    // NUT-09/NUT-07 before the winning call has committed at the mint and get
+    // a transient, fail-closed RecoveryPending result. It must never submit a
+    // second output set, and it converges through the persisted intent after
+    // the winner completes.
     assert!(results.iter().all(|result| matches!(
         result,
-        CashuSwapProgressV1::Grant(_) | CashuSwapProgressV1::AlreadyGranted { .. }
+        CashuSwapProgressV1::Grant(_)
+            | CashuSwapProgressV1::AlreadyGranted { .. }
+            | CashuSwapProgressV1::RecoveryPending { .. }
     )));
+    assert_eq!(mint.calls().0, 1);
+    assert!(matches!(
+        client(store.as_ref(), &mint, &cipher)
+            .resume_swap(
+                &fixture.spend,
+                &fixture.checked,
+                &fixture.verified_offer(),
+                &fixture.manifest,
+                200,
+            )
+            .unwrap(),
+        CashuSwapProgressV1::AlreadyGranted { .. }
+    ));
     assert_eq!(mint.calls().0, 1);
 }
 

--- a/crates/payment/provider-clearing-client/Cargo.toml
+++ b/crates/payment/provider-clearing-client/Cargo.toml
@@ -8,6 +8,12 @@ description = "Provider-side shared issuer redemption adapter for BitcoinPIR adm
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Bitcoin-PIR/Bitcoin-PIR"
 
+[features]
+default = []
+# Non-default debug/test-only private WebPKI root injection. The underlying
+# strict HTTPS crate compile-errors if this feature reaches a release build.
+test-only-webpki-root = ["pir-strict-https/test-only-webpki-root"]
+
 [dependencies]
 ed25519-dalek = "2"
 getrandom = "0.2"

--- a/crates/payment/provider-clearing-client/src/https_transport.rs
+++ b/crates/payment/provider-clearing-client/src/https_transport.rs
@@ -57,6 +57,30 @@ impl StrictHttpsProviderSettlementTransportV1 {
         })
     }
 
+    /// Debug/test-only constructor for real-process tests behind a private CA.
+    /// The production release boundary is enforced again by `pir-strict-https`.
+    #[cfg(feature = "test-only-webpki-root")]
+    pub fn new_with_test_only_webpki_root_pem(
+        issuer_endpoint: String,
+        connect_timeout: Duration,
+        io_timeout: Duration,
+        leaf_spki_sha256_pins: &[[u8; 32]],
+        test_only_root_pem: &[u8],
+    ) -> Result<Self, String> {
+        StrictHttpsClientV1::validate_base_endpoint(&issuer_endpoint)?;
+        let client =
+            StrictHttpsClientV1::new_with_leaf_spki_sha256_pins_and_test_only_webpki_root_pem(
+                connect_timeout,
+                io_timeout,
+                leaf_spki_sha256_pins,
+                test_only_root_pem,
+            )?;
+        Ok(Self {
+            issuer_endpoint,
+            client,
+        })
+    }
+
     pub fn issuer_endpoint(&self) -> &str {
         &self.issuer_endpoint
     }

--- a/crates/payment/provider-clearing-client/src/lib.rs
+++ b/crates/payment/provider-clearing-client/src/lib.rs
@@ -44,8 +44,9 @@ use pir_service_protocol::{
     ProviderPayoutIntentRequestV1, ProviderPayoutRequestV1, ProviderPayoutStatusEnvelopeV1,
     ProviderPayoutStatusRequestV1, ProviderRedeemRequestV1,
     ProviderSettlementRegistrationExpectationV1, ProviderSettlementRequestAuthV1,
-    ServiceProtocolError, SettlementDestinationV1, SettlementUnitV1, SharedIssuerProviderSecretV1,
-    VerificationMode, VerifiedPayoutSnapshotV1, MAX_EXECUTABLE_SETTLEMENT_HTTP_ENVELOPE_LEN_V1,
+    ServiceProtocolError, SettlementDestinationV1, SettlementModesV1, SettlementUnitV1,
+    SharedIssuerProviderSecretV1, VerificationMode, VerifiedPayoutSnapshotV1,
+    MAX_EXECUTABLE_SETTLEMENT_HTTP_ENVELOPE_LEN_V1,
 };
 use pir_service_store::{ProviderStore, StoreError};
 use sha2::{Digest, Sha256};
@@ -736,6 +737,213 @@ impl VerifiedProviderPayoutStateV1 {
                 .transpose()?,
             rollback_floor: self.rollback_floor(),
         })
+    }
+}
+
+/// Minimal trust bundle for the production ledger-only balance surface.
+///
+/// It deliberately contains no payout registration, payout target, or
+/// provider-request key. Balance requests are authenticated by the clearing
+/// key already authorized for ledger accrual. The distinct provider-request
+/// key remains reserved for payout recovery/status and is provisioned at the
+/// issuer even while payout routes are disabled.
+pub struct ProviderLedgerBalanceTrustV1 {
+    pub authorization: ProviderClearingAuthorizationV1,
+    pub issuer_approval: IssuerClearingApprovalV1,
+    pub operator_verifying_key: VerifyingKey,
+    pub minimum_authorization_epoch: u64,
+    pub current_issuer_settlement_key: VerifyingKey,
+    pub retained_issuer_settlement_keys: Vec<VerifyingKey>,
+}
+
+impl fmt::Debug for ProviderLedgerBalanceTrustV1 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderLedgerBalanceTrustV1")
+            .field("provider_id", &self.authorization.claims.provider_id)
+            .field("issuer_id", &self.authorization.claims.issuer_id)
+            .field(
+                "minimum_authorization_epoch",
+                &self.minimum_authorization_epoch,
+            )
+            .field(
+                "retained_issuer_settlement_key_count",
+                &self.retained_issuer_settlement_keys.len(),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+/// Provider client for the production ledger-only signed balance route.
+///
+/// The transport must be constructed from the authorization's exact canonical
+/// HTTPS origin and signed leaf-SPKI pins. [`StrictHttpsProviderSettlementTransportV1`]
+/// provides that production adapter; tests may inject a transport-neutral
+/// implementation.
+pub struct ProviderLedgerBalanceClientV1<'a> {
+    trust: ProviderLedgerBalanceTrustV1,
+    clearing_signing_key: SigningKey,
+    transport: &'a dyn ProviderSettlementTransportV1,
+}
+
+impl fmt::Debug for ProviderLedgerBalanceClientV1<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderLedgerBalanceClientV1")
+            .field("trust", &self.trust)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> ProviderLedgerBalanceClientV1<'a> {
+    pub fn new(
+        trust: ProviderLedgerBalanceTrustV1,
+        clearing_signing_key: SigningKey,
+        transport: &'a dyn ProviderSettlementTransportV1,
+    ) -> Result<Self, ProviderSettlementClientErrorV1> {
+        let claims = &trust.authorization.claims;
+        let clearing_key = clearing_signing_key.verifying_key().to_bytes();
+        let operator_key = trust.operator_verifying_key.to_bytes();
+        let current_issuer_key = trust.current_issuer_settlement_key.to_bytes();
+        let mut retained = std::collections::BTreeSet::new();
+        if trust.minimum_authorization_epoch == 0
+            || claims.clearing_verifying_key != clearing_key
+            || clearing_key == operator_key
+            || clearing_key == current_issuer_key
+            || operator_key == current_issuer_key
+            || trust.retained_issuer_settlement_keys.iter().any(|key| {
+                let bytes = key.to_bytes();
+                bytes == current_issuer_key
+                    || bytes == clearing_key
+                    || bytes == operator_key
+                    || !retained.insert(bytes)
+            })
+            || claims.rules.is_empty()
+            || claims.rules.iter().any(|rule| {
+                rule.unit != SettlementUnitV1::AuthCredit
+                    || rule.settlement_modes.bits() != SettlementModesV1::LEDGER_CREDIT
+                    || rule.blind_output_minimum_validity_seconds != 0
+                    || rule.blind_output_keyset.is_some()
+            })
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "ProviderLedgerBalanceClientV1.trust",
+                reason: "ledger-only rules, rollback floor, or domain-separated keys mismatch",
+            }
+            .into());
+        }
+        let keyring = IssuerSettlementKeyringExpectationV1 {
+            issuer_id: &claims.issuer_id,
+            current_key: &trust.current_issuer_settlement_key,
+            retained_keys: &trust.retained_issuer_settlement_keys,
+        };
+        let approval_key = keyring.resolve_for_issuer(
+            &claims.issuer_id,
+            &trust.issuer_approval.issuer_settlement_key_id,
+        )?;
+        let validation_time = claims.not_before.max(trust.issuer_approval.approved_at);
+        trust.authorization.verify_for(
+            &claims.provider_id,
+            &claims.issuer_id,
+            &trust.operator_verifying_key,
+            validation_time,
+            trust.minimum_authorization_epoch,
+        )?;
+        trust.issuer_approval.verify_for(
+            &trust.authorization,
+            approval_key,
+            validation_time,
+            trust.minimum_authorization_epoch,
+        )?;
+        Ok(Self {
+            trust,
+            clearing_signing_key,
+            transport,
+        })
+    }
+
+    pub fn balance(
+        &self,
+        fresh_request_nonce: [u8; 32],
+        now_unix: u64,
+    ) -> Result<IssuerBalanceResponseV1, ProviderSettlementClientErrorV1> {
+        self.verify_authority_at(now_unix)?;
+        let authorization_digest = self.trust.authorization.authorization_digest()?;
+        let claims = &self.trust.authorization.claims;
+        let request = ProviderBalanceRequestV1 {
+            authorization_digest,
+            issuer_id: claims.issuer_id,
+            provider_id: claims.provider_id,
+            account_id: claims.settlement_account_id,
+            unit: SettlementUnitV1::AuthCredit,
+            idempotency_key: fresh_request_nonce,
+        };
+        let request_auth = ProviderClearingRequestAuthV1::sign(
+            authorization_digest,
+            request.request_digest()?,
+            &self.clearing_signing_key,
+        );
+        let body = ProviderBalanceEnvelopeV1 {
+            request: request.clone(),
+            request_auth,
+        }
+        .encode()?;
+        let bytes = self.transport.post(
+            ProviderSettlementHttpRequestV1 {
+                endpoint: PROVIDER_BALANCE_ENDPOINT_V1,
+                canonical_body: &body,
+            },
+            MAX_PROVIDER_SETTLEMENT_RESPONSE_BYTES_V1,
+        )?;
+        let response = decode_canonical_response(
+            &bytes,
+            IssuerBalanceResponseV1::decode,
+            IssuerBalanceResponseV1::encode,
+        )?;
+        let keyring = IssuerSettlementKeyringExpectationV1 {
+            issuer_id: &claims.issuer_id,
+            current_key: &self.trust.current_issuer_settlement_key,
+            retained_keys: &self.trust.retained_issuer_settlement_keys,
+        };
+        let response_key =
+            keyring.resolve_for_issuer(&claims.issuer_id, &response.issuer_settlement_key_id)?;
+        response.verify_for_exact_request(&request, response_key)?;
+        Ok(response)
+    }
+
+    fn verify_authority_at(&self, now_unix: u64) -> Result<(), ProviderSettlementClientErrorV1> {
+        let claims = &self.trust.authorization.claims;
+        let keyring = IssuerSettlementKeyringExpectationV1 {
+            issuer_id: &claims.issuer_id,
+            current_key: &self.trust.current_issuer_settlement_key,
+            retained_keys: &self.trust.retained_issuer_settlement_keys,
+        };
+        let approval_key = keyring.resolve_for_issuer(
+            &claims.issuer_id,
+            &self.trust.issuer_approval.issuer_settlement_key_id,
+        )?;
+        self.trust.authorization.verify_for(
+            &claims.provider_id,
+            &claims.issuer_id,
+            &self.trust.operator_verifying_key,
+            now_unix,
+            self.trust.minimum_authorization_epoch,
+        )?;
+        self.trust.issuer_approval.verify_for(
+            &self.trust.authorization,
+            approval_key,
+            now_unix,
+            self.trust.minimum_authorization_epoch,
+        )?;
+        Ok(())
+    }
+
+    pub fn authorized_issuer_endpoint(&self) -> &str {
+        &self.trust.authorization.claims.redeem_endpoint
+    }
+
+    pub fn authorized_leaf_spki_sha256_pins(&self) -> &[[u8; 32]] {
+        &self.trust.authorization.claims.redeem_leaf_spki_sha256_pins
     }
 }
 

--- a/crates/payment/provider-clearing-client/src/settlement_client_tests.rs
+++ b/crates/payment/provider-clearing-client/src/settlement_client_tests.rs
@@ -133,6 +133,27 @@ impl Fixture {
         )
         .expect("provider client")
     }
+
+    fn ledger_client<'a>(
+        &self,
+        current_issuer_settlement_key: VerifyingKey,
+        retained_issuer_settlement_keys: Vec<VerifyingKey>,
+        transport: &'a dyn ProviderSettlementTransportV1,
+    ) -> ProviderLedgerBalanceClientV1<'a> {
+        ProviderLedgerBalanceClientV1::new(
+            ProviderLedgerBalanceTrustV1 {
+                authorization: self.authorization.clone(),
+                issuer_approval: self.approval.clone(),
+                operator_verifying_key: self.operator.verifying_key(),
+                minimum_authorization_epoch: 1,
+                current_issuer_settlement_key,
+                retained_issuer_settlement_keys,
+            },
+            self.clearing.clone(),
+            transport,
+        )
+        .expect("provider ledger-only balance client")
+    }
 }
 
 #[derive(Default)]
@@ -742,6 +763,109 @@ impl PayoutStatusCompareAndSwapStoreV1 for AlwaysCommitStatus {
     ) -> Result<bool, Self::Error> {
         Ok(true)
     }
+}
+
+#[test]
+fn ledger_only_balance_client_needs_no_payout_registration_and_handles_key_rotation() {
+    let fixture = Fixture::new();
+    let issuer = FakeIssuer::new(&fixture);
+    issuer.commit_verified_redeem_credit(10, 9, 1);
+
+    let current = fixture.ledger_client(
+        fixture.issuer_settlement.verifying_key(),
+        Vec::new(),
+        &issuer,
+    );
+    assert_eq!(
+        current.authorized_issuer_endpoint(),
+        fixture.authorization.claims.redeem_endpoint
+    );
+    assert_eq!(
+        current.authorized_leaf_spki_sha256_pins(),
+        fixture.authorization.claims.redeem_leaf_spki_sha256_pins
+    );
+    let balance = current
+        .balance([0x48; 32], NOW)
+        .expect("signed ledger balance");
+    assert_eq!((balance.available_value, balance.reserved_value), (9, 0));
+
+    // During an issuer settlement-key rotation, an approval/response signed by
+    // the historical key remains verifiable only when that exact key is
+    // explicitly retained. No payout registration or provider-request key is
+    // synthesized for this read-only path.
+    let rotated = fixture.ledger_client(
+        fixture.rotated_issuer_settlement.verifying_key(),
+        vec![fixture.issuer_settlement.verifying_key()],
+        &issuer,
+    );
+    rotated
+        .balance([0x49; 32], NOW)
+        .expect("retained issuer key verifies signed balance");
+
+    issuer.corrupt_next_balance_response();
+    assert!(matches!(
+        rotated.balance([0x4a; 32], NOW),
+        Err(ProviderSettlementClientErrorV1::Protocol(_))
+    ));
+
+    assert!(matches!(
+        rotated.balance([0x4b; 32], 2_001),
+        Err(ProviderSettlementClientErrorV1::Protocol(_))
+    ));
+}
+
+#[test]
+fn ledger_only_balance_client_rejects_key_reuse_and_missing_rotation_pin() {
+    let fixture = Fixture::new();
+    let issuer = FakeIssuer::new(&fixture);
+    let trust = || ProviderLedgerBalanceTrustV1 {
+        authorization: fixture.authorization.clone(),
+        issuer_approval: fixture.approval.clone(),
+        operator_verifying_key: fixture.operator.verifying_key(),
+        minimum_authorization_epoch: 1,
+        current_issuer_settlement_key: fixture.issuer_settlement.verifying_key(),
+        retained_issuer_settlement_keys: Vec::new(),
+    };
+    assert!(
+        ProviderLedgerBalanceClientV1::new(trust(), fixture.operator.clone(), &issuer,).is_err()
+    );
+
+    let mut no_floor = trust();
+    no_floor.minimum_authorization_epoch = 0;
+    assert!(
+        ProviderLedgerBalanceClientV1::new(no_floor, fixture.clearing.clone(), &issuer).is_err()
+    );
+
+    let missing_old_key = ProviderLedgerBalanceTrustV1 {
+        current_issuer_settlement_key: fixture.rotated_issuer_settlement.verifying_key(),
+        ..trust()
+    };
+    assert!(
+        ProviderLedgerBalanceClientV1::new(missing_old_key, fixture.clearing.clone(), &issuer,)
+            .is_err()
+    );
+
+    let issuer_reuses_operator = ProviderLedgerBalanceTrustV1 {
+        current_issuer_settlement_key: fixture.operator.verifying_key(),
+        ..trust()
+    };
+    assert!(ProviderLedgerBalanceClientV1::new(
+        issuer_reuses_operator,
+        fixture.clearing.clone(),
+        &issuer,
+    )
+    .is_err());
+
+    let retained_reuses_operator = ProviderLedgerBalanceTrustV1 {
+        retained_issuer_settlement_keys: vec![fixture.operator.verifying_key()],
+        ..trust()
+    };
+    assert!(ProviderLedgerBalanceClientV1::new(
+        retained_reuses_operator,
+        fixture.clearing.clone(),
+        &issuer,
+    )
+    .is_err());
 }
 
 #[test]

--- a/deploy/payment-v1/README.md
+++ b/deploy/payment-v1/README.md
@@ -35,7 +35,10 @@ The templates divide responsibilities as follows:
   authenticated provider-balance lookup; payout-intent, payout and
   payout-status routes are not part of the V1 production product. Its command
   has no payout target, fee, or intent-TTL argument; the source gate rejects
-  reintroducing any of those flags.
+  reintroducing any of those flags. Every clearing authorization/approval pair
+  also names one distinct provider-request public-key file; this future
+  payout-recovery/status identity is never filled with the clearing key even
+  though current production serving is ledger-only.
 - `systemd/rollback-authority.service.in` is instantiated only on a separately
   administered authority host. Provider 0, Provider 1, and the issuer each need
   their own host, keys, database, TLS edge, administrator, logs, and backup

--- a/deploy/payment-v1/systemd/hetzner-payment-issuer.service.in
+++ b/deploy/payment-v1/systemd/hetzner-payment-issuer.service.in
@@ -42,6 +42,7 @@ ExecStart=/opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@/payment-issuer 
     --bat-key /etc/bitcoinpir/payment-v1/issuer/cashu-bat.key \
     --clearing-authorization /etc/bitcoinpir/payment-v1/issuer/provider-clearing-authorization.bin \
     --clearing-approval /etc/bitcoinpir/payment-v1/issuer/provider-clearing-approval.bin \
+    --clearing-provider-request-verifying-key /etc/bitcoinpir/payment-v1/issuer/provider-request-verifying.key \
     --issuer-settlement-signing-key /etc/bitcoinpir/payment-v1/issuer/issuer-settlement-signing.key \
     --redeem-response-derivation-key /etc/bitcoinpir/payment-v1/issuer/redeem-response-derivation.key \
     --cln-rpc-socket /run/bitcoinpir-cln-rpc-guard/issuer/issuer-rpc \

--- a/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
+++ b/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
@@ -148,6 +148,18 @@ row in place: either initialize the first production ledger-only store with the
 reviewed sentinel-bearing build, or design and review a separate authenticated
 offline migration before preserving such a prototype store.
 
+The rendered issuer unit also requires
+`provider-request-verifying.key`, the raw public half of a provider-owned
+`provider-request-ed25519` key. It is deliberately separate from the online
+clearing, provider-operator and issuer-settlement keys. For each provider,
+install authorization, approval and request public key in the same CLI order;
+any count mismatch, invalid key or key reuse aborts startup. The provider keeps
+the request secret offline while V1 remains ledger-only. Authorization and
+approval bytes must come from the independent `bpir-admin payment-artifact
+clearing-authorization` and `clearing-approval` ceremonies; rotation advances
+the authorization epoch and retains only reviewed historical issuer settlement
+public keys.
+
 `BITCOINPIR_WEB_ORIGIN` is one complete canonical HTTPS origin. Every
 `*_PUBKEY_HEX` placeholder is public verification material, never a private
 seed. The renderer must type- and length-check these values and reject any

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -224,7 +224,14 @@ operator has activated the path with real money or public infrastructure.
       return `NotFound` before input decoding or store access in this mode. The
       settlement signing key remains necessary for redeem/balance signatures,
       and retained verifying keys remain available for exact committed redeem
-      and approval recovery after rotation. A private Rust unit-fixture
+      and approval recovery after rotation. Production registration now
+      requires a separate provider-request public key for every authorization;
+      startup rejects count mismatch, invalid keys and reuse with clearing,
+      operator or issuer-settlement roles. Offline `bpir-admin` builders create
+      and self-verify the operator authorization and independent issuer
+      approval, while `ProviderLedgerBalanceClientV1` reads the signed
+      auth-credit balance without inventing a payout registration or target.
+      A private Rust unit-fixture
       switch retains the raw loopback payout/status roundtrip solely to test the
       transport-neutral state machines, store reopen, exact response replay
       after authorization/registration expiry and provider request-key

--- a/docs/payment/LOCAL_ACCEPTANCE.md
+++ b/docs/payment/LOCAL_ACCEPTANCE.md
@@ -663,7 +663,12 @@ cargo build --locked --offline \
   --features test-only-fake-lightning \
   --bin payment-issuer \
   --target-dir "$issuer_e2e_target_dir"
+cargo build --locked --offline \
+  -p bpir-admin \
+  --bin bpir-admin \
+  --target-dir "$issuer_e2e_target_dir"
 BITCOINPIR_PAYMENT_ISSUER_BIN="$issuer_e2e_target_dir/debug/payment-issuer" \
+BITCOINPIR_BPIR_ADMIN_BIN="$issuer_e2e_target_dir/debug/bpir-admin" \
   cargo test --locked --offline \
     -p runtime \
     --features shared-issuer-process-e2e \
@@ -679,12 +684,21 @@ digests. The provider fails closed without a local claim. Restarting both issuer
 and provider against their original stores/floors and replaying the exact proof
 must reproduce all three digests, recover exactly one provider-local grant and
 leave exactly one issuer ledger credit/sequence; a later replay cannot create a
-second grant. Wrong-CA, wrong-pin and offline dependencies fail closed without
-invoice creation or real funds. It does not prove public source-fair ingress,
-independent production rollback domains, real Lightning, automated payout, or
-target-host systemd state. The source is wired into CI, but this preparation
-branch must not record a pass until the Linux cell has run on the exact candidate
-commit.
+second grant. The same run invokes the production `bpir-admin` builders for
+both clearing artifacts, provisions a distinct provider-request public key,
+verifies freshly signed balances before and after an issuer restart, then—only
+after the lost-response operation reaches a known local-delivery result—rotates
+the authorization epoch and issuer settlement key with explicit old-key
+retention. The restarted provider keeps the credential at-most-once. This does
+not claim that V1 recovers an outcome-unknown redeem across authorization
+rotation; operators must drain and reconcile before rotating. Wrong-CA,
+wrong-pin and offline issuer
+dependencies fail before the issuer HTTP application without invoice creation
+or real funds. It does not prove public
+source-fair ingress, independent production rollback domains, real Lightning,
+automated payout, or target-host systemd state. The source is wired into CI,
+but this preparation branch must not record a pass until the Linux cell has run
+on the exact candidate commit.
 
 ## Standard Cashu custody boundary
 

--- a/docs/payment/OFFLINE_OPERATOR_TOOLING.md
+++ b/docs/payment/OFFLINE_OPERATOR_TOOLING.md
@@ -34,14 +34,16 @@ bpir-admin service-keygen --role free-ip-hmac --out free-ip-hmac.key
 bpir-admin service-keygen --role cashu-recovery-aead --out cashu-recovery-1.key
 bpir-admin service-keygen --role cashu-custody-aead --out cashu-custody-1.key
 bpir-admin service-keygen --role provider-shared-idempotency-hmac --out shared-idempotency.key
+bpir-admin service-keygen --role clearing-ed25519 --out provider-clearing.key
+bpir-admin service-keygen --role provider-request-ed25519 --out provider-request.key
 bpir-admin service-keygen --role receipt-ed25519 --out receipt.key
 bpir-admin service-keygen --role cashu-bat --out bat.key
 bpir-admin service-keygen --role cashu-ecash --out cashu-denomination.key
 bpir-admin service-keygen --role arc-experimental --out arc.key
 ```
 
-Other supported roles are `policy-ed25519`, `anonymous-ticket-ed25519`,
-`clearing-ed25519`, and `directory-nostr`. The six symmetric or derivation
+Other supported roles are `policy-ed25519`, `anonymous-ticket-ed25519`, and
+`directory-nostr`. The six symmetric or derivation
 roles (`credential-derivation`, `redeem-derivation`, and the four roles added
 above) print only a domain-separated operator fingerprint, never a public key
 or secret. Do not
@@ -207,6 +209,86 @@ bpir-admin payment-artifact cashu-manifest \
   --config cashu-manifest.toml \
   --out standard-cashu-mint-manifest-v1.bin
 ```
+
+## Shared-issuer clearing authorization and approval
+
+The provider operator and issuer run separate offline ceremonies. The provider
+first prepares a strict TOML authorization source. V1 tooling intentionally
+constructs only `AuthCredit` plus `LEDGER_CREDIT`; blind settlement and payout
+cannot be enabled by adding a TOML field. Unknown fields fail closed.
+
+```toml
+authorization_id_hex = "<32 lowercase hex>"
+authorization_epoch = 1
+provider_id_hex = "<64 lowercase hex>"
+issuer_id_hex = "<64 lowercase hex>"
+redeem_endpoint = "https://issuer.example"
+redeem_leaf_spki_sha256_pins_hex = ["<64 lowercase hex>"]
+settlement_account_id_hex = "<64 lowercase hex>"
+clearing_verifying_key_hex = "<64 lowercase hex>"
+not_before = 1700000000
+not_after = 1900000000
+
+[[rules]]
+credential_binding_digest_hex = "<64 lowercase hex>"
+accepted_value = 10
+provider_credit = 9
+issuer_fee = 1
+denomination_profile = 1
+```
+
+```sh
+bpir-admin payment-artifact clearing-authorization \
+  --operator-signing-key provider-operator.key \
+  --config clearing-authorization.toml \
+  --out provider-clearing-authorization.bin
+```
+
+The builder checks value conservation, canonical endpoint and pins, unique
+binding digests, validity, exact roundtrip and operator signature before it
+writes. It rejects reuse of the operator key as the online clearing key. Record
+the printed `authorization_digest` through an independent channel before the
+issuer ceremony.
+
+```sh
+bpir-admin payment-artifact clearing-approval \
+  --authorization provider-clearing-authorization.bin \
+  --issuer-settlement-signing-key issuer-settlement.key \
+  --expected-authorization-digest-hex "$AUTHORIZATION_DIGEST" \
+  --expected-provider-id-hex "$PROVIDER_ID" \
+  --expected-issuer-id-hex "$ISSUER_ID" \
+  --expected-operator-key-hex "$PROVIDER_OPERATOR_PUBLIC_KEY" \
+  --minimum-authorization-epoch 1 \
+  --approved-at 1700000000 \
+  --not-after 1900000000 \
+  --out provider-clearing-approval.bin
+```
+
+The issuer command verifies all out-of-band expectations and the exact digest
+before signing. It rejects settlement-key reuse with either provider key, then
+decodes and verifies its own canonical approval before writing. Rotation uses
+a strictly higher authorization epoch and a new approval; an approval cannot
+be replaced under the same authorization digest in the durable issuer store.
+
+Provision a fourth, distinct public key beside the two artifacts:
+
+```sh
+# `service-keygen` prints this public key while retaining the provider secret.
+bpir-admin service-keygen \
+  --role provider-request-ed25519 \
+  --out provider-request.key
+```
+
+Install only its raw 32-byte public half at the issuer and pass it once per
+matching authorization with
+`--clearing-provider-request-verifying-key`. The clearing key signs redemption
+and balance requests. The provider-request key is reserved for payout recovery
+and status; ledger-only mode does not use it, but production registration still
+keeps the domains distinct so a future payout client cannot inherit a
+same-key registration. Provider code that only reads the identified ledger can
+use `ProviderLedgerBalanceClientV1`; it validates the authorization, approval,
+epoch floor, current/retained issuer settlement keys, canonical signed response
+and exact nonce without inventing a payout registration or target.
 
 ## Provider store initialization
 

--- a/docs/payment/OPERATOR_RUNBOOK.md
+++ b/docs/payment/OPERATOR_RUNBOOK.md
@@ -355,6 +355,25 @@ workflow cannot inherit collapsed signature domains. Rotation requires a
 strictly higher authorization epoch and a new issuer approval; retain an old
 issuer settlement public key only for exact historical recovery.
 
+This retained issuer key is not a retained provider authorization. The shipped
+`unified_server` constructs one `SharedIssuerAdmissionCommitterV1` from the one
+current clearing authorization, approval and issuer endpoint/pin tuple; it has
+no keyring of old clearing authorizations and cannot reconstruct an
+outcome-unknown redeem made under an authorization that has since been
+replaced. The issuer can replay exact previously committed request bytes under
+their original idempotency key, but that server-side property is useful only
+while the provider can still reproduce and authenticate that exact request.
+Therefore V1 clearing-authorization, clearing-key or settlement-key rotation is
+a drain boundary: stop new shared-issuer admission, let every in-flight redeem
+reach a known local-delivery result, reconcile every ambiguous operation, and
+only then replace the authorization/approval and restart. If an outcome remains
+unknown, keep the old provider instance and complete its exact recovery before
+rotation or fail closed and handle it as an accounting incident. Do not claim
+that retained settlement keys make rolling shared-authorization rotation or
+cross-rotation provider recovery safe. A future retained-authorization client
+requires a separately reviewed bounded keyring, endpoint/pin lifetime rules and
+tests; V1 does not provide it.
+
 Certificate-key rotation at the same issuer origin must use a newly
 operator-signed and issuer-approved two-pin overlap, followed by removal of the
 old pin in a later higher authorization epoch. Do not change the signed issuer

--- a/docs/payment/OPERATOR_RUNBOOK.md
+++ b/docs/payment/OPERATOR_RUNBOOK.md
@@ -345,6 +345,16 @@ as needed), or publish a deliberately reviewed future protocol version with an
 authenticated policy-key succession proof.
 
 V1 also loads only one shared-issuer clearing authorization per provider.
+Create it with the offline provider-operator builder, transfer its printed
+digest independently, and have the issuer run the separate approval builder.
+Provision a fourth, raw provider-request public key in the same list position;
+it must differ from clearing, operator and issuer-settlement keys. Ledger-only
+balance reads use the clearing key and need no payout registration, but the
+issuer still persists the distinct request key so a future payout/status
+workflow cannot inherit collapsed signature domains. Rotation requires a
+strictly higher authorization epoch and a new issuer approval; retain an old
+issuer settlement public key only for exact historical recovery.
+
 Certificate-key rotation at the same issuer origin must use a newly
 operator-signed and issuer-approved two-pin overlap, followed by removal of the
 old pin in a later higher authorization epoch. Do not change the signed issuer

--- a/docs/payment/PERSISTENCE.md
+++ b/docs/payment/PERSISTENCE.md
@@ -604,6 +604,18 @@ exactly-once behavior across a crash.
 
 ## Provider settlement payout workflow
 
+Ledger-only balance reads do not create provider payout state.
+`ProviderLedgerBalanceClientV1` authenticates with the operator-authorized
+clearing key and verifies the exact issuer-signed response against the current
+or explicitly retained settlement key. Every send rechecks the authorization
+and approval against the caller's current Unix time before transport. It
+requires no registration digest,
+payout target, provider-request secret, detailed payout SQLite, or payout floor.
+Issuer production startup nevertheless registers a distinct provider-request
+public key for every authorization. Reusing the clearing key for that column is
+rejected: it would make the stored registration unusable by the full settlement
+client and collapse the redemption versus payout-recovery signature domains.
+
 `pir-provider-clearing-client` includes a concrete
 `SqliteProviderSettlementStateStoreV1` for the provider's exact payout workflow.
 It persists the canonical intent request/response, payout request, initial and

--- a/docs/payment/PERSISTENCE.md
+++ b/docs/payment/PERSISTENCE.md
@@ -543,8 +543,14 @@ looks up an exact previously committed `(idempotency digest, request digest)`:
 - same key and different digest: conflict;
 - no row: validate current authority and create a new operation.
 
-This ordering lets a client recover a committed response after key rotation or
-expiry without authorizing new debt under stale authority.
+This ordering lets the issuer replay a committed response after key rotation or
+expiry without authorizing new debt under stale authority, provided the client
+can reproduce the exact original request and idempotency key. The shipped
+provider runtime retains neither an old clearing authorization/approval nor the
+old authenticated issuer tuple, so it cannot perform that recovery after its
+single configured shared-issuer authorization has been replaced. Production V1
+must drain and reconcile every outcome-unknown redeem before that rotation; the
+issuer replay rule is not a rolling-rotation guarantee for providers.
 
 ### Atomic redeem
 

--- a/docs/payment/PROTOCOL.md
+++ b/docs/payment/PROTOCOL.md
@@ -944,6 +944,19 @@ balance. Any actual payout is an operator/product action outside the query path
 and requires a separately reviewed executor or manual reconciliation design
 plus explicit production/funds approval.
 
+The registration's `provider_request_verifying_key` is not a ledger-only
+sentinel and is never copied from `clearing_verifying_key`. Production startup
+requires an independently provisioned Ed25519 public key and rejects reuse with
+the clearing, operator, or issuer-settlement roles. The clearing key signs
+redeem and balance requests; the provider-request key remains reserved for
+payout recovery/status. `ProviderLedgerBalanceClientV1` therefore verifies the
+signed balance directly from the operator authorization, issuer approval,
+clearing key and current/retained settlement-key lineage without manufacturing
+a payout registration digest or disabled target. It rechecks both signed
+validity windows at the caller-supplied current time before every send. The broader
+`ProviderSettlementClientV1` still requires the exact distinct-key registration
+before any payout workflow.
+
 Every retained settlement Cashu keyset registry is local trusted context bound
 to one `issuer_id`; a matching keyset ID from a different issuer lineage is
 rejected before note verification or ledger credit. Settlement-signature keys

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -265,7 +265,12 @@ cargo build --locked --offline \
   --features test-only-fake-lightning \
   --bin payment-issuer \
   --target-dir "$issuer_e2e_target_dir"
+cargo build --locked --offline \
+  -p bpir-admin \
+  --bin bpir-admin \
+  --target-dir "$issuer_e2e_target_dir"
 BITCOINPIR_PAYMENT_ISSUER_BIN="$issuer_e2e_target_dir/debug/payment-issuer" \
+BITCOINPIR_BPIR_ADMIN_BIN="$issuer_e2e_target_dir/debug/bpir-admin" \
   cargo test --locked --offline \
     -p runtime \
     --features shared-issuer-process-e2e \
@@ -273,7 +278,7 @@ BITCOINPIR_PAYMENT_ISSUER_BIN="$issuer_e2e_target_dir/debug/payment-issuer" \
     shared_issuer_real_process_tls_e2e -- --exact
 ```
 
-It launches a real `payment-issuer`, a redeem-only private WebPKI TLS edge, one
+It launches a real `payment-issuer`, a redeem/balance-only private WebPKI TLS edge, one
 real shared-BAT `unified_server`, and an independently selected Free/Open peer.
 After reading one complete canonical issuer HTTP 200 bound to the redeem request
 digest, the test edge persists a one-shot test marker and deliberately drops
@@ -285,13 +290,21 @@ request and idempotency-key SHA-256 digests, recover exactly one local grant and
 leave the issuer ledger at one credit/sequence; a later replay cannot create a
 second grant. The digest transcript is a fixed-size, test-local oracle and does
 not persist the raw envelope, credential, idempotency key, HTTP metadata, peer
-address or timing. Wrong CA, wrong signed pin and offline issuer fail before
-issuer HTTP application handling and create no local claim or ledger account.
-CI additionally denies warnings for the exact runtime/test targets and proves
-the test-only WebPKI feature cannot compile in a release profile. The current
-preparation branch has static source evidence only until that Linux CI cell
-passes; it is not public ingress, production rollback-authority, real Lightning
-or payout-executor evidence.
+address or timing. The same run uses `bpir-admin` to build both clearing
+artifacts and installs a distinct
+provider-request public key, verifies signed balances across issuer restart,
+then—after exact response-loss recovery reaches a known local-delivery
+result—rotates the authorization epoch and issuer settlement key with explicit
+old-key retention. Provider restart/replay after rotation cannot create a
+second grant. The test is not evidence for recovering an outcome-unknown
+operation across rotation; V1 requires a drain/reconciliation boundary. Wrong
+CA, wrong signed pin
+and offline issuer fail before issuer HTTP application handling and create no
+local claim or ledger account. CI additionally denies warnings for the exact
+runtime/test targets and proves the test-only WebPKI feature cannot compile in
+a release profile. The current preparation branch has static source evidence
+only until that Linux CI cell passes; it is not public ingress, production
+rollback-authority, real Lightning or payout-executor evidence.
 
 ### First-version executable path ledger
 

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -46,7 +46,7 @@ export const REVIEWED_PREPARATION_HASHES = Object.freeze({
   "deploy/payment-v1/systemd/hetzner-lightning-preflight.service.in":
     "e0fa6b1213ae660f74a541d086a16f0c20b8b8eac91f7afe780ffb4ff67ed2ee",
   "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in":
-    "c9557f8d547bc4b800593452f5308d91d65419603e5a5f046f5d06af9033b4e9",
+    "a5edd86ad88d5ecd792d11f4bcbd1bb4eccdc80c1da73477ca7eafb211f30ade",
   "deploy/payment-v1/systemd/payment-v1-edge.service.in":
     "49edab939937c98d420e6a6bef6ad3a834effa502630deb666229272993ca841",
 });
@@ -654,6 +654,7 @@ function validateHetznerIssuer(text) {
       ["--bat-key", "/etc/bitcoinpir/payment-v1/issuer/cashu-bat.key"],
       ["--clearing-authorization", "/etc/bitcoinpir/payment-v1/issuer/provider-clearing-authorization.bin"],
       ["--clearing-approval", "/etc/bitcoinpir/payment-v1/issuer/provider-clearing-approval.bin"],
+      ["--clearing-provider-request-verifying-key", "/etc/bitcoinpir/payment-v1/issuer/provider-request-verifying.key"],
       ["--issuer-settlement-signing-key", "/etc/bitcoinpir/payment-v1/issuer/issuer-settlement-signing.key"],
       ["--redeem-response-derivation-key", "/etc/bitcoinpir/payment-v1/issuer/redeem-response-derivation.key"],
       ["--cln-rpc-socket", "/run/bitcoinpir-cln-rpc-guard/issuer/issuer-rpc"],

--- a/scripts/payment-v1-deployment-template-gate.test.mjs
+++ b/scripts/payment-v1-deployment-template-gate.test.mjs
@@ -211,6 +211,18 @@ test("production templates reject ARC, fake, local and proxied Free-IP flags", (
       /--clearing-approval/,
     );
   });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/systemd/hetzner-payment-issuer.service.in",
+      (text) => text.replace(/^.*--clearing-provider-request-verifying-key.*\n/m, ""),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /--clearing-provider-request-verifying-key/,
+    );
+  });
 });
 
 test("issuer and authority origins must remain loopback", () => {

--- a/scripts/payment-v1-local-check.sh
+++ b/scripts/payment-v1-local-check.sh
@@ -299,7 +299,12 @@ cargo build --locked --offline \
   --features test-only-fake-lightning \
   --bin payment-issuer \
   --target-dir "$issuer_e2e_target_dir"
+cargo build --locked --offline \
+  -p bpir-admin \
+  --bin bpir-admin \
+  --target-dir "$issuer_e2e_target_dir"
 BITCOINPIR_PAYMENT_ISSUER_BIN="$issuer_e2e_target_dir/debug/payment-issuer" \
+BITCOINPIR_BPIR_ADMIN_BIN="$issuer_e2e_target_dir/debug/bpir-admin" \
   cargo test --locked --offline \
     -p runtime \
     --features shared-issuer-process-e2e \

--- a/scripts/payment-v1-rendered-artifact-gate.test.mjs
+++ b/scripts/payment-v1-rendered-artifact-gate.test.mjs
@@ -260,6 +260,7 @@ function makeIssuerFixture(t) {
     "/etc/bitcoinpir/payment-v1/issuer/issuer-settlement-signing.key": "settlement-key\n",
     "/etc/bitcoinpir/payment-v1/issuer/provider-clearing-approval.bin": "approval\n",
     "/etc/bitcoinpir/payment-v1/issuer/provider-clearing-authorization.bin": "authorization\n",
+    "/etc/bitcoinpir/payment-v1/issuer/provider-request-verifying.key": "provider-request-key\n",
     "/etc/bitcoinpir/payment-v1/issuer/quote-delegation.bin": "delegation\n",
     "/etc/bitcoinpir/payment-v1/issuer/quote-signing.key": "quote-key\n",
     "/etc/bitcoinpir/payment-v1/issuer/redeem-response-derivation.key": "redeem-key\n",


### PR DESCRIPTION
## Summary
- add offline, self-verifying provider clearing authorization and issuer approval ceremonies
- provision distinct provider operator, clearing, provider-request and issuer settlement key roles, including retained settlement lineage checks
- add a ledger-only signed balance client with authorization/approval/epoch/time revalidation on every request
- extend payment-issuer startup, systemd/deployment gates, operator docs, and real provider/issuer TLS process coverage
- keep V1 ledger-only: no payout executor or blind-output production route

## Validation
- bpir-admin: 120 tests
- provider-clearing-client: 35 tests
- payment-issuer: 25 tests
- deployment/template Node gates: 54 tests
- all changed Rust targets and exact runtime target: clippy with -D warnings
- release test-root compile guard: passed
- real issuer/provider pinned-TLS process E2E: 1 passed, including redeem, signed balance, restart, settlement-key rotation, wrong CA/pin and outage

## Boundaries
The process test uses fake Lightning, a private test CA and NoSevHost. V1 accrues an authenticated ledger balance for manual reconciliation only; it does not execute payouts. Production callers must construct the strict HTTPS transport from the authorization's exact canonical issuer endpoint and SPKI pins and provide a trustworthy current Unix time. No deployment, remote host or real funds are involved.