### PR TITLE
Stabilize synthetic Harmony query tests

### DIFF
--- a/crates/sdk/client/src/harmony.rs
+++ b/crates/sdk/client/src/harmony.rs
@@ -9211,6 +9211,9 @@ mod tests {
         let db_info = sample_db_info();
         let sent = Arc::new(Mutex::new(Vec::new()));
         let mut client = HarmonyClient::new("mock://hint", "mock://query");
+        // Keep this synthetic 32-bin fixture focused on the expected
+        // fail-closed verification error, not random relocation cycles.
+        client.set_master_key([0x42; 16]);
         client.connect_with_transport(
             Box::new(MockTransport::new("mock://hint")),
             Box::new(ZeroHarmonyQueryTransport::new(sent.clone())),
@@ -9271,6 +9274,10 @@ mod tests {
 
         let sent = Arc::new(Mutex::new(Vec::new()));
         let mut client = HarmonyClient::new("mock://hint", "mock://query");
+        // This test exercises batching, leakage accounting, and the shared
+        // Merkle verdict. Pin the synthetic 32-bin fixture's PRP layout so
+        // unrelated relocation-chain randomness cannot make it flaky.
+        client.set_master_key([0x42; 16]);
         client.connect_with_transport(
             Box::new(MockTransport::new("mock://hint")),
             Box::new(ZeroHarmonyQueryTransport::new(sent.clone())),


### PR DESCRIPTION
## What changed

- Pin the PRP key in the two Harmony tests that execute real query relocation against the synthetic 32-bin fixture.
- Keep the production `HarmonyClient::new` CSPRNG behavior unchanged.

## Root cause

The post-merge Payment workflow failed because these tests combined an intentionally tiny fixture with a fresh random PRP key. Some layouts form a relocation chain that exceeds the fixture's 33-step bound before the assertion under test is reached.

The adjacent malicious-provider test had the same latent issue, so both query-consuming fixtures are made deterministic.

## Validation

- Unpatched exact-tree stress:
  - two-address inspector: 263 failures / 5000 runs
  - malicious-provider omission: 151 failures / 5000 runs
- Patched Linux stress: 0 failures / 5000 runs for each test
- `pir-sdk-client` library suite: 337 passed
- Exact Payment workflow offline package set: passed
- Independent read-only review: no blocking finding

## Follow-up boundary

This PR does not change or suppress the vendor `ChainWalkExceeded` error. Production-sized randomized domain/property testing should be tracked separately; a relocation error remains fail-closed.
