### PR TITLE
Harden GitHub workflow supply chain

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -49,7 +49,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install pinned Rust toolchain
         run: rustup toolchain install --profile minimal

--- a/.github/workflows/build-determinism.yml
+++ b/.github/workflows/build-determinism.yml
@@ -13,8 +13,8 @@ name: Build Reproducibility
 # byte-for-byte.
 #
 # This job is intentionally separate from pir-sdk-integration.yml: that
-# workflow hits live production servers (needs network + secrets), whereas
-# this one is fully hermetic and must stay fast — it only compiles the
+# workflow hits live production servers, whereas every Cargo command here is
+# locked and offline. It only compiles the
 # lightweight `pir-core` crate (no SEAL/onionpir), so a determinism break
 # surfaces as its own isolated red check within seconds.
 
@@ -22,11 +22,21 @@ on:
   push:
     branches: [main]
     paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.cargo/**'
+      - 'vendor/**'
       - 'crates/protocol/core/**'
       - '.github/workflows/build-determinism.yml'
   pull_request:
     branches: [main]
     paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.cargo/**'
+      - 'vendor/**'
       - 'crates/protocol/core/**'
       - '.github/workflows/build-determinism.yml'
   workflow_dispatch:
@@ -44,33 +54,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install pinned Rust toolchain
         run: rustup toolchain install --profile minimal
-
-      - name: Cache Cargo registry + target
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-pir-core-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-pir-core-
 
       # Headline gate: the fixture cross-build determinism + anchor-
       # sensitivity suite. Run it explicitly first so a reproducibility
       # regression is the obvious failure, not buried in the full suite.
       - name: Cross-build determinism fixture
-        run: cargo test -p pir-core --test cross_build_determinism -- --nocapture
+        run: cargo test --locked --offline -p pir-core --test cross_build_determinism -- --nocapture
 
       # Full pir-core unit suite (seeds, cuckoo, hash, merkle, codec) —
       # all hermetic, gives pir-core its own coverage gate on PRs that
       # touch it.
       - name: pir-core unit tests
-        run: cargo test -p pir-core
+        run: cargo test --locked --offline -p pir-core
 
       - name: Clippy (pir-core, incl. tests)
-        run: cargo clippy -p pir-core --tests -- -D warnings
+        run: cargo clippy --locked --offline -p pir-core --tests -- -D warnings

--- a/.github/workflows/generated-proof-lock.yml
+++ b/.github/workflows/generated-proof-lock.yml
@@ -28,11 +28,14 @@ jobs:
 
     steps:
       - name: Checkout BitcoinPIR
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Checkout locked proof registry commit
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: Bitcoin-PIR/proof-registry
           ref: 4e19b0bc675715c88e5c11364ac9e0236c2cb359
           path: proof-registry

--- a/.github/workflows/pir-sdk-integration.yml
+++ b/.github/workflows/pir-sdk-integration.yml
@@ -72,13 +72,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install pinned Rust toolchain
         run: rustup toolchain install --profile minimal
 
       - name: Cache Cargo registry + target
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cargo/registry
@@ -146,7 +148,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install pinned Rust toolchain
         run: rustup toolchain install --profile minimal
@@ -172,7 +176,7 @@ jobs:
           git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 
       - name: Cache Cargo registry + target
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cargo/registry
@@ -234,7 +238,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install pinned Rust toolchain
         run: rustup toolchain install --profile minimal
@@ -251,7 +257,7 @@ jobs:
           git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 
       - name: Cache Cargo registry + target
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -11,12 +11,12 @@ name: Web client build + tests
 #      wasm32 build (e.g., refactor that pulls a native-only API into
 #      shared code) merges silently and surfaces only at deploy time.
 #
-#   2. **TypeScript strict typecheck (`tsc`).** `web/package.json` has
-#      `build` = `tsc` and `build-web` = `vite build`. The deploy
-#      workflow runs `build-web` (esbuild bundler — permissive). `tsc`
-#      strict-mode errors (null-vs-undefined narrows, hand-written
-#      interface drift between `sdk-bridge.ts` and WASM-generated
-#      stubs, etc.) are never gated.
+#   2. **PR-time TypeScript strict typecheck (`tsc`).** `web/package.json`
+#      has `build` = `tsc` and `build-web` = `vite build`. The deploy
+#      workflow now also runs typecheck, unit and Chromium gates before a
+#      manual production render; this workflow gives the same strict-mode
+#      errors (null-vs-undefined narrows, hand-written interface drift between
+#      `sdk-bridge.ts` and WASM-generated stubs, etc.) a pre-merge signal.
 #
 #   3. **vitest unit tests.** `web/src/__tests__/` includes pure-helper
 #      TS-side analogs of the Kani harnesses plus the Payment V1 admission,

--- a/.github/workflows/workflow-supply-chain.yml
+++ b/.github/workflows/workflow-supply-chain.yml
@@ -1,0 +1,60 @@
+name: GitHub workflow supply-chain gate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'scripts/github-workflow-supply-chain-gate.mjs'
+      - 'scripts/github-workflow-supply-chain-gate.test.mjs'
+      - 'web/package.json'
+      - 'web/package-lock.json'
+      - 'web/npm-shrinkwrap.json'
+  # Keep the PR event unfiltered so this job can become a required check
+  # without unrelated PRs remaining permanently Pending.
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-supply-chain:
+    name: Exact action pins and non-persisting checkout credentials
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24.18.0'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      # npm gives npm-shrinkwrap.json precedence over package-lock.json. Reject
+      # any file type here before npm can resolve the YAML parser through it.
+      - name: Reject higher-priority npm shrinkwrap override
+        run: |
+          if [ -e web/npm-shrinkwrap.json ] || [ -L web/npm-shrinkwrap.json ]; then
+            echo 'web/npm-shrinkwrap.json is forbidden; web/package-lock.json is the only parser lock' >&2
+            exit 1
+          fi
+
+      - name: Install locked YAML parser without lifecycle scripts
+        working-directory: web
+        run: npm ci --ignore-scripts
+
+      - name: Validate workflow supply-chain policy
+        run: |
+          node --check scripts/github-workflow-supply-chain-gate.mjs
+          node --check scripts/github-workflow-supply-chain-gate.test.mjs
+          node --test scripts/github-workflow-supply-chain-gate.test.mjs
+          node scripts/github-workflow-supply-chain-gate.mjs

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -514,6 +514,27 @@ operator has activated the path with real money or public infrastructure.
       App token; credential governance and mutable repository/environment
       policy remain deployment gates. No deployment was triggered or
       authorized here.
+- [x] A repository-wide workflow supply-chain gate parses every workflow with
+      the locked YAML parser, rejects anchors/aliases/merge keys, permits only
+      reviewed action-name/40-hex-commit pairs, and requires every checkout to
+      use the YAML boolean `persist-credentials: false`. It rejects the
+      higher-priority `web/npm-shrinkwrap.json` before installing or importing
+      the parser, leaving `web/package-lock.json` as the only npm parser lock.
+      The SDK, generated-proof, audit and build-determinism workflows now use
+      those exact pins. The lightweight pir-core determinism job no longer
+      restores a Cargo/target cache, uses `--locked --offline` for every Cargo
+      command, and is retriggered by its root manifest, lockfile, toolchain,
+      Cargo configuration and vendored-source inputs. Updating an action still
+      requires a reviewed allowlist change in the same checked revision. Its PR
+      trigger is intentionally path-unfiltered and it handles merge groups, so
+      a future required check reports for every protected-main PR and merge-
+      queue candidate instead of remaining Pending.
+      A read-only 2026-07-29 recheck still found no classic branch protection or
+      repository ruleset on `main`; that is an external governance blocker, not
+      something this source change can close. Until a required-check/no-direct-
+      push rule is installed, this in-repository gate can be rewritten or
+      deleted and a push failure is only post-merge detection. It also does not
+      replace GitHub token/PAT/App governance.
 
 ## What the tests currently prove
 

--- a/scripts/github-workflow-supply-chain-gate.mjs
+++ b/scripts/github-workflow-supply-chain-gate.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export const APPROVED_ACTION_COMMITS = Object.freeze({
+  "actions/cache": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+  "actions/checkout": "3d3c42e5aac5ba805825da76410c181273ba90b1",
+  "actions/configure-pages": "45bfe0192ca1faeb007ade9deae92b16b8254a0d",
+  "actions/deploy-pages": "cd2ce8fcbc39b97be8ca5fce6e763baed58fa128",
+  "actions/setup-node": "820762786026740c76f36085b0efc47a31fe5020",
+  "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+  "actions/upload-pages-artifact": "fc324d3547104276b827a68afc52ff2a11cc49c9",
+});
+
+export const SUPPLY_CHAIN_GATE_PUSH_PATHS = Object.freeze([
+  ".github/workflows/**",
+  "scripts/github-workflow-supply-chain-gate.mjs",
+  "scripts/github-workflow-supply-chain-gate.test.mjs",
+  "web/package.json",
+  "web/package-lock.json",
+  "web/npm-shrinkwrap.json",
+]);
+
+function fail(message) {
+  throw new Error(`github-workflow-supply-chain-gate: ${message}`);
+}
+
+function requireCanonicalDirectory(path, label) {
+  const absolute = resolve(path);
+  const stat = lstatSync(absolute);
+  if (!stat.isDirectory() || stat.isSymbolicLink() || realpathSync(absolute) !== absolute) {
+    fail(`${label} must be one canonical non-symlink directory`);
+  }
+  return absolute;
+}
+
+export function validateNpmParserLockBoundary(repositoryRootInput) {
+  const repositoryRoot = requireCanonicalDirectory(repositoryRootInput, "repository root");
+  const shrinkwrapPath = resolve(repositoryRoot, "web/npm-shrinkwrap.json");
+  if (lstatSync(shrinkwrapPath, { throwIfNoEntry: false }) !== undefined) {
+    fail(
+      "web/npm-shrinkwrap.json is forbidden because npm gives it precedence over web/package-lock.json",
+    );
+  }
+}
+
+// This check intentionally runs before loading the YAML package. A malicious
+// higher-priority shrinkwrap must not get a chance to choose the parser module
+// that evaluates the workflows or the parser's own negative tests.
+validateNpmParserLockBoundary(REPOSITORY_ROOT);
+
+let parseDocument;
+let visit;
+try {
+  const requireFromWeb = createRequire(resolve(REPOSITORY_ROOT, "web/package.json"));
+  ({ parseDocument, visit } = requireFromWeb("yaml"));
+} catch {
+  fail("locked YAML parser unavailable; run npm ci in web first");
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseWorkflowSource(source, label) {
+  if (typeof source !== "string" || Buffer.byteLength(source, "utf8") > 2 * 1024 * 1024) {
+    fail(`${label} must be bounded UTF-8 workflow text`);
+  }
+  const document = parseDocument(source, {
+    maxAliasCount: 0,
+    prettyErrors: false,
+    strict: true,
+    uniqueKeys: true,
+  });
+  if (document.errors.length !== 0 || document.warnings.length !== 0) {
+    fail(`${label} is not strict warning-free YAML`);
+  }
+  visit(document, {
+    Alias() {
+      fail(`${label} must not contain YAML aliases`);
+    },
+    Node(_key, node) {
+      if (node?.anchor !== undefined) fail(`${label} must not contain YAML anchors`);
+    },
+    Pair(_key, pair) {
+      if (pair?.key?.value === "<<") fail(`${label} must not contain YAML merge keys`);
+    },
+  });
+  const workflow = document.toJS({ maxAliasCount: 0 });
+  if (!isRecord(workflow)) fail(`${label} root must be a mapping`);
+  return workflow;
+}
+
+function requireExactMappingKeys(value, expectedKeys, label) {
+  if (!isRecord(value)) fail(`${label} must be a mapping`);
+  const actualKeys = Object.keys(value).sort();
+  const sortedExpectedKeys = [...expectedKeys].sort();
+  if (
+    actualKeys.length !== sortedExpectedKeys.length ||
+    actualKeys.some((key, index) => key !== sortedExpectedKeys[index])
+  ) {
+    fail(`${label} must contain exactly: ${sortedExpectedKeys.join(", ")}`);
+  }
+}
+
+function requireExactStringList(value, expectedValues, label) {
+  if (
+    !Array.isArray(value) ||
+    value.length !== expectedValues.length ||
+    value.some((entry, index) => entry !== expectedValues[index])
+  ) {
+    fail(`${label} must match the reviewed ordered list`);
+  }
+}
+
+export function validateSupplyChainGateTriggers(source, label = "workflow supply-chain gate") {
+  const workflow = parseWorkflowSource(source, label);
+  requireExactMappingKeys(
+    workflow.on,
+    ["push", "pull_request", "merge_group", "workflow_dispatch"],
+    `${label}.on`,
+  );
+
+  requireExactMappingKeys(workflow.on.push, ["branches", "paths"], `${label}.on.push`);
+  requireExactStringList(workflow.on.push.branches, ["main"], `${label}.on.push.branches`);
+  requireExactStringList(
+    workflow.on.push.paths,
+    SUPPLY_CHAIN_GATE_PUSH_PATHS,
+    `${label}.on.push.paths`,
+  );
+
+  // A workflow-level PR path filter leaves a required check Pending on
+  // unrelated PRs. Only the protected target branch may narrow this event.
+  requireExactMappingKeys(
+    workflow.on.pull_request,
+    ["branches"],
+    `${label}.on.pull_request`,
+  );
+  requireExactStringList(
+    workflow.on.pull_request.branches,
+    ["main"],
+    `${label}.on.pull_request.branches`,
+  );
+
+  requireExactMappingKeys(
+    workflow.on.merge_group,
+    ["types"],
+    `${label}.on.merge_group`,
+  );
+  requireExactStringList(
+    workflow.on.merge_group.types,
+    ["checks_requested"],
+    `${label}.on.merge_group.types`,
+  );
+  if (workflow.on.workflow_dispatch !== null) {
+    fail(`${label}.on.workflow_dispatch must be an input-free manual trigger`);
+  }
+
+  return { events: 4, pushPaths: SUPPLY_CHAIN_GATE_PUSH_PATHS.length };
+}
+
+function validateActionUse(actionUse, step, label) {
+  if (typeof actionUse !== "string") fail(`${label}.uses must be a string`);
+  const match = /^([0-9A-Za-z_.-]+\/[0-9A-Za-z_.-]+(?:\/[0-9A-Za-z_./-]+)?)@([0-9a-f]{40})$/u.exec(actionUse);
+  if (!match) fail(`${label}.uses must pin one approved action to a lowercase 40-hex commit`);
+  const action = match[1];
+  const approvedCommit = APPROVED_ACTION_COMMITS[action];
+  if (approvedCommit === undefined || match[2] !== approvedCommit) {
+    fail(`${label}.uses is outside the reviewed action/commit allowlist: ${actionUse}`);
+  }
+  if (action === "actions/checkout") {
+    if (!isRecord(step.with) || step.with["persist-credentials"] !== false) {
+      fail(`${label} checkout must set persist-credentials: false as a YAML boolean`);
+    }
+  }
+}
+
+function walkWorkflow(value, label, counters) {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => walkWorkflow(entry, `${label}[${index}]`, counters));
+    return;
+  }
+  if (!isRecord(value)) return;
+  if (Object.hasOwn(value, "uses")) {
+    validateActionUse(value.uses, value, label);
+    counters.actionUses += 1;
+    if (value.uses.startsWith("actions/checkout@")) counters.checkouts += 1;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    walkWorkflow(child, `${label}.${key}`, counters);
+  }
+}
+
+export function validateWorkflowSource(source, label = "workflow") {
+  const workflow = parseWorkflowSource(source, label);
+  const counters = { actionUses: 0, checkouts: 0 };
+  walkWorkflow(workflow, label, counters);
+  if (counters.actionUses < 1 || counters.checkouts < 1) {
+    fail(`${label} must contain at least one approved action and checkout`);
+  }
+  return counters;
+}
+
+export function validateWorkflowDirectory(directoryInput) {
+  const directory = requireCanonicalDirectory(directoryInput, "workflow directory");
+  const entries = readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0);
+  if (entries.length < 1) fail("workflow directory is empty");
+  let actionUses = 0;
+  let checkouts = 0;
+  for (const entry of entries) {
+    if (entry.isSymbolicLink() || !entry.isFile() || !/\.ya?ml$/u.test(entry.name)) {
+      fail(`workflow directory contains an unreviewed entry: ${entry.name}`);
+    }
+    const path = resolve(directory, entry.name);
+    const stat = lstatSync(path);
+    if (
+      !stat.isFile() ||
+      stat.isSymbolicLink() ||
+      stat.nlink !== 1 ||
+      stat.size < 1 ||
+      stat.size > 2 * 1024 * 1024 ||
+      realpathSync(path) !== path
+    ) {
+      fail(`workflow path is not one bounded canonical one-link file: ${entry.name}`);
+    }
+    let source;
+    try {
+      source = new TextDecoder("utf-8", { fatal: true }).decode(readFileSync(path));
+    } catch {
+      fail(`workflow is not canonical UTF-8: ${entry.name}`);
+    }
+    const result = validateWorkflowSource(source, `workflow ${entry.name}`);
+    if (entry.name === "workflow-supply-chain.yml") {
+      validateSupplyChainGateTriggers(source, `workflow ${entry.name}`);
+    }
+    actionUses += result.actionUses;
+    checkouts += result.checkouts;
+  }
+  return { actionUses, checkouts, workflows: entries.length };
+}
+
+const isMain =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isMain) {
+  try {
+    if (process.argv.length > 3) fail("usage: github-workflow-supply-chain-gate.mjs [WORKFLOW_DIRECTORY]");
+    const directory = process.argv[2] ?? resolve(REPOSITORY_ROOT, ".github/workflows");
+    const result = validateWorkflowDirectory(directory);
+    process.stdout.write(
+      `github-workflow-supply-chain-gate=PASS workflows=${result.workflows} actions=${result.actionUses} checkouts=${result.checkouts}\n`,
+    );
+  } catch (error) {
+    process.stderr.write(`github-workflow-supply-chain-gate=FAIL: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/github-workflow-supply-chain-gate.test.mjs
+++ b/scripts/github-workflow-supply-chain-gate.test.mjs
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import {
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  APPROVED_ACTION_COMMITS,
+  SUPPLY_CHAIN_GATE_PUSH_PATHS,
+  validateNpmParserLockBoundary,
+  validateSupplyChainGateTriggers,
+  validateWorkflowDirectory,
+  validateWorkflowSource,
+} from "./github-workflow-supply-chain-gate.mjs";
+
+const checkout = APPROVED_ACTION_COMMITS["actions/checkout"];
+const setupNode = APPROVED_ACTION_COMMITS["actions/setup-node"];
+
+function workflow(stepSource = `
+      - name: Checkout
+        uses: actions/checkout@${checkout}
+        with:
+          persist-credentials: false
+`) {
+  return `
+name: Fixture
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  fixture:
+    runs-on: ubuntu-24.04
+    steps:
+${stepSource}`;
+}
+
+test("accepts exact allowlisted commits and non-persisting checkout credentials", () => {
+  const result = validateWorkflowSource(workflow(`
+      - name: Checkout
+        uses: actions/checkout@${checkout}
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        uses: actions/setup-node@${setupNode}
+`));
+  assert.deepEqual(result, { actionUses: 2, checkouts: 1 });
+});
+
+for (const [label, source, pattern] of [
+  ["mutable tag", workflow(`
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+`), /lowercase 40-hex/u],
+  ["unknown exact action", workflow(`
+      - uses: example/unknown@${"1".repeat(40)}
+`), /allowlist/u],
+  ["wrong checkout commit", workflow(`
+      - uses: actions/checkout@${"1".repeat(40)}
+        with:
+          persist-credentials: false
+`), /allowlist/u],
+  ["missing checkout with", workflow(`
+      - uses: actions/checkout@${checkout}
+`), /persist-credentials/u],
+  ["persisted checkout", workflow(`
+      - uses: actions/checkout@${checkout}
+        with:
+          persist-credentials: true
+`), /persist-credentials/u],
+  ["string false checkout", workflow(`
+      - uses: actions/checkout@${checkout}
+        with:
+          persist-credentials: "false"
+`), /YAML boolean/u],
+  ["expression action", workflow(`
+      - uses: \${{ matrix.action }}
+`), /lowercase 40-hex/u],
+  ["local action bypass", workflow(`
+      - uses: ./unreviewed-action
+`), /lowercase 40-hex/u],
+  ["reusable mutable workflow", workflow(`
+      - uses: owner/repository/.github/workflows/reuse.yml@main
+`), /lowercase 40-hex/u],
+  ["reusable exact workflow", workflow(`
+      - uses: owner/repository/.github/workflows/reuse.yml@${"1".repeat(40)}
+`), /allowlist/u],
+  ["Docker action", workflow(`
+      - uses: docker://alpine:3.22
+`), /lowercase 40-hex/u],
+  ["bare YAML anchor", workflow(`
+      - &checkout
+        uses: actions/checkout@${checkout}
+        with:
+          persist-credentials: false
+`), /anchors/u],
+  ["YAML alias", workflow(`
+      - &checkout
+        uses: actions/checkout@${checkout}
+        with:
+          persist-credentials: false
+      - *checkout
+`), /aliases|anchors/u],
+  ["YAML merge key", workflow(`
+      - <<:
+          uses: actions/checkout@${checkout}
+          with:
+            persist-credentials: false
+`), /merge keys/u],
+  ["duplicate YAML key", workflow(`
+      - uses: actions/checkout@${checkout}
+        uses: actions/checkout@${checkout}
+        with:
+          persist-credentials: false
+`), /strict warning-free YAML/u],
+]) {
+  test(`rejects ${label}`, () => {
+    assert.throws(() => validateWorkflowSource(source, label), pattern);
+  });
+}
+
+test("rejects workflows without an approved checkout", () => {
+  assert.throws(
+    () => validateWorkflowSource(workflow(`
+      - uses: actions/setup-node@${setupNode}
+`)),
+    /checkout/u,
+  );
+});
+
+test("accepts the parser lock boundary without npm-shrinkwrap.json", (t) => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "bitcoinpir-parser-lock-")));
+  t.after(() => rmSync(root, { force: true, recursive: true }));
+  mkdirSync(join(root, "web"), { mode: 0o700 });
+  writeFileSync(join(root, "web", "package-lock.json"), "{}\n", { mode: 0o600 });
+  assert.doesNotThrow(() => validateNpmParserLockBoundary(root));
+});
+
+test("rejects higher-priority npm-shrinkwrap.json parser lock", (t) => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "bitcoinpir-parser-lock-")));
+  t.after(() => rmSync(root, { force: true, recursive: true }));
+  mkdirSync(join(root, "web"), { mode: 0o700 });
+  writeFileSync(join(root, "web", "package-lock.json"), "{}\n", { mode: 0o600 });
+  writeFileSync(join(root, "web", "npm-shrinkwrap.json"), "{}\n", { mode: 0o600 });
+  assert.throws(
+    () => validateNpmParserLockBoundary(root),
+    /forbidden because npm gives it precedence/u,
+  );
+});
+
+test("rejects a dangling npm-shrinkwrap.json symlink", (t) => {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "bitcoinpir-parser-lock-")));
+  t.after(() => rmSync(root, { force: true, recursive: true }));
+  mkdirSync(join(root, "web"), { mode: 0o700 });
+  symlinkSync("missing-lock", join(root, "web", "npm-shrinkwrap.json"));
+  assert.throws(
+    () => validateNpmParserLockBoundary(root),
+    /forbidden because npm gives it precedence/u,
+  );
+});
+
+function supplyChainGateTriggerFixture({ mergeGroup = true, pullRequestPaths = false } = {}) {
+  const pushPaths = SUPPLY_CHAIN_GATE_PUSH_PATHS
+    .map((path) => `      - '${path}'`)
+    .join("\n");
+  const pullRequestPathFilter = pullRequestPaths
+    ? "    paths: ['.github/workflows/**']\n"
+    : "";
+  const mergeGroupTrigger = mergeGroup
+    ? "  merge_group:\n    types: [checks_requested]\n"
+    : "";
+  return `
+name: GitHub workflow supply-chain gate
+on:
+  push:
+    branches: [main]
+    paths:
+${pushPaths}
+  pull_request:
+    branches: [main]
+${pullRequestPathFilter}${mergeGroupTrigger}  workflow_dispatch:
+`;
+}
+
+test("accepts always-reporting PR and merge-queue gate triggers", () => {
+  assert.deepEqual(validateSupplyChainGateTriggers(supplyChainGateTriggerFixture()), {
+    events: 4,
+    pushPaths: SUPPLY_CHAIN_GATE_PUSH_PATHS.length,
+  });
+});
+
+test("rejects a PR path filter that can strand a required check", () => {
+  assert.throws(
+    () => validateSupplyChainGateTriggers(
+      supplyChainGateTriggerFixture({ pullRequestPaths: true }),
+    ),
+    /on\.pull_request must contain exactly/u,
+  );
+});
+
+test("rejects a gate without merge-group coverage", () => {
+  assert.throws(
+    () => validateSupplyChainGateTriggers(supplyChainGateTriggerFixture({ mergeGroup: false })),
+    /on must contain exactly/u,
+  );
+});
+
+function workflowDirectory(t) {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "bitcoinpir-workflow-gate-")));
+  t.after(() => rmSync(root, { force: true, recursive: true }));
+  const directory = join(root, "workflows");
+  mkdirSync(directory, { mode: 0o700 });
+  writeFileSync(join(directory, "fixture.yml"), workflow(), { mode: 0o600 });
+  return directory;
+}
+
+test("accepts a canonical directory of one-link workflow files", (t) => {
+  assert.deepEqual(validateWorkflowDirectory(workflowDirectory(t)), {
+    actionUses: 1,
+    checkouts: 1,
+    workflows: 1,
+  });
+});
+
+test("rejects an extra non-workflow directory entry", (t) => {
+  const directory = workflowDirectory(t);
+  writeFileSync(join(directory, "README"), "unreviewed\n");
+  assert.throws(() => validateWorkflowDirectory(directory), /unreviewed entry/u);
+});
+
+test("rejects a symlinked workflow", (t) => {
+  const directory = workflowDirectory(t);
+  symlinkSync(join(directory, "fixture.yml"), join(directory, "linked.yml"));
+  assert.throws(() => validateWorkflowDirectory(directory), /unreviewed entry/u);
+});
+
+test("rejects hardlinked workflows", (t) => {
+  const directory = workflowDirectory(t);
+  linkSync(join(directory, "fixture.yml"), join(directory, "linked.yml"));
+  assert.throws(() => validateWorkflowDirectory(directory), /one-link/u);
+});
+
+test("rejects non-UTF-8 workflow bytes", (t) => {
+  const directory = workflowDirectory(t);
+  writeFileSync(join(directory, "fixture.yml"), Buffer.from([0xff, 0xfe, 0xfd]));
+  assert.throws(() => validateWorkflowDirectory(directory), /canonical UTF-8/u);
+});


### PR DESCRIPTION
## Summary

- pin every existing GitHub Action use to its reviewed 40-hex commit and disable persisted checkout credentials
- add a repository-wide strict-YAML workflow gate with an exact action allowlist and fail-closed anchor, alias, merge-key, local/reusable/Docker action checks
- make the gate report for every pull request and merge-queue candidate, while rejecting `npm-shrinkwrap.json` before the locked YAML parser is installed
- make the lightweight `pir-core` determinism job cache-free, `--locked --offline`, and sensitive to all of its Cargo, toolchain, configuration, and vendored-source inputs
- document that absent branch protection/rulesets remain an external production-governance blocker

## Why

Mutable action tags, persisted checkout credentials, parser lock precedence, and path-filtered required checks left avoidable supply-chain and governance gaps. The new gate validates the complete workflow directory from the checked revision and makes action updates explicit review events.

## Validation

- `node --test scripts/github-workflow-supply-chain-gate.test.mjs` — 28/28 pass
- `node scripts/github-workflow-supply-chain-gate.mjs` — PASS, 10 workflows / 31 action uses / 16 checkouts
- `node --check` for both gate scripts
- `git diff --check`
- all seven allowlisted commits independently matched their official action tag refs

No deployment, remote-host mutation, key use, or Lightning operation is included.
