### PR TITLE
Harden runtime file evidence against in-place races

### DIFF
--- a/scripts/payment-v1-linux-runtime-evidence.mjs
+++ b/scripts/payment-v1-linux-runtime-evidence.mjs
@@ -181,15 +181,7 @@ function validateUuid(value, label) {
 }
 
 function readOneLinkRegular(path, label, maxBytes = MAX_JSON_BYTES) {
-  const stat = lstatSync(path);
-  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1) {
-    fail(`${label} must be a one-link regular file: ${path}`);
-  }
-  if (realpathSync(path) !== path) fail(`${label} resolves through a symlink: ${path}`);
-  if (!Number.isSafeInteger(stat.size) || stat.size < 0 || stat.size > maxBytes) {
-    fail(`${label} exceeds its size limit: ${path}`);
-  }
-  return readFileSync(path);
+  return readOneLinkRegularBoundToDescriptor(path, label, maxBytes).bytes;
 }
 
 function strictJsonBytes(bytes, label) {
@@ -273,16 +265,185 @@ function inspectTrustedCommand(path) {
   };
 }
 
+function statInteger(value, label) {
+  const number = typeof value === "bigint" ? Number(value) : value;
+  if (!Number.isSafeInteger(number) || number < 0) {
+    fail(`${label} is outside the safe evidence integer range`);
+  }
+  return number;
+}
+
+function statMode(stat) {
+  const mode = typeof stat.mode === "bigint"
+    ? Number(stat.mode & 0o7777n)
+    : stat.mode & 0o7777;
+  return mode.toString(8).padStart(4, "0");
+}
+
+function statNanoseconds(stat, field) {
+  const nanoseconds = stat[`${field}Ns`];
+  if (typeof nanoseconds === "bigint") return nanoseconds.toString();
+  const milliseconds = stat[`${field}Ms`];
+  if (!Number.isFinite(milliseconds) || milliseconds < 0) {
+    fail(`installed artifact ${field} timestamp is invalid`);
+  }
+  return BigInt(Math.trunc(milliseconds * 1_000_000)).toString();
+}
+
 function stableStat(stat) {
   return {
     dev: stat.dev.toString(),
-    gid: stat.gid,
+    gid: statInteger(stat.gid, "installed artifact GID"),
     ino: stat.ino.toString(),
-    mode: (stat.mode & 0o7777).toString(8).padStart(4, "0"),
-    nlink: stat.nlink,
-    size: stat.size,
-    uid: stat.uid,
+    mode: statMode(stat),
+    nlink: statInteger(stat.nlink, "installed artifact link count"),
+    size: statInteger(stat.size, "installed artifact size"),
+    uid: statInteger(stat.uid, "installed artifact UID"),
   };
+}
+
+function preciseInstalledStat(stat) {
+  return {
+    ...stableStat(stat),
+    ctime_ns: statNanoseconds(stat, "ctime"),
+    mtime_ns: statNanoseconds(stat, "mtime"),
+  };
+}
+
+function readExactDescriptorBytes(fd, expectedSize, label, path) {
+  const size = statInteger(expectedSize, `${label} size`);
+  const bytes = Buffer.alloc(size);
+  let offset = 0;
+  while (offset < bytes.length) {
+    const count = readSync(fd, bytes, offset, bytes.length - offset, offset);
+    if (count === 0) fail(`${label} became truncated during descriptor read: ${path}`);
+    offset += count;
+  }
+  const trailing = Buffer.alloc(1);
+  if (readSync(fd, trailing, 0, 1, bytes.length) !== 0) {
+    fail(`${label} grew during descriptor read: ${path}`);
+  }
+  return bytes;
+}
+
+function assertOneLinkCanonicalRegular(path, stat, label, maxBytes) {
+  if (
+    !stat.isFile() ||
+    stat.isSymbolicLink() ||
+    statInteger(stat.nlink, `${label} link count`) !== 1 ||
+    realpathSync(path) !== path
+  ) {
+    fail(`${label} must be a canonical one-link regular file: ${path}`);
+  }
+  const size = statInteger(stat.size, `${label} size`);
+  if (size > maxBytes) fail(`${label} exceeds its size limit: ${path}`);
+}
+
+function collectFinalOneLinkRegularSnapshot(
+  path,
+  label,
+  expectedBytes,
+  maxBytes,
+  testHooks = undefined,
+) {
+  const before = lstatSync(path, { bigint: true });
+  assertOneLinkCanonicalRegular(path, before, label, maxBytes);
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_NOFOLLOW | (constants.O_CLOEXEC ?? 0),
+  );
+  try {
+    const opened = fstatSync(fd, { bigint: true });
+    assertSameInstalledFileSnapshot(before, opened, `${label} final path and descriptor`, path);
+    assertSamePreciseInstalledFileSnapshot(
+      before,
+      opened,
+      `${label} final path and descriptor`,
+      path,
+    );
+    runInstalledFileTestHook(testHooks, "afterFinalPathOpen");
+    const bytes = readExactDescriptorBytes(fd, opened.size, label, path);
+    const after = fstatSync(fd, { bigint: true });
+    assertSameInstalledFileSnapshot(opened, after, `${label} final descriptor snapshots`, path);
+    assertSamePreciseInstalledFileSnapshot(
+      opened,
+      after,
+      `${label} final descriptor snapshots`,
+      path,
+    );
+    if (!bytes.equals(expectedBytes)) fail(`${label} changed before its final descriptor read: ${path}`);
+    const pathAfter = lstatSync(path, { bigint: true });
+    assertOneLinkCanonicalRegular(path, pathAfter, `${label} final confirmation`, maxBytes);
+    assertSameInstalledFileSnapshot(after, pathAfter, `${label} final descriptor and path`, path);
+    assertSamePreciseInstalledFileSnapshot(
+      after,
+      pathAfter,
+      `${label} final descriptor and path`,
+      path,
+    );
+    return { stat: after };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function readOneLinkRegularBoundToDescriptor(
+  path,
+  label,
+  maxBytes = MAX_JSON_BYTES,
+  testHooks = undefined,
+) {
+  const before = lstatSync(path, { bigint: true });
+  assertOneLinkCanonicalRegular(path, before, label, maxBytes);
+  const fd = openSync(
+    path,
+    constants.O_RDONLY | constants.O_NOFOLLOW | (constants.O_CLOEXEC ?? 0),
+  );
+  try {
+    const opened = fstatSync(fd, { bigint: true });
+    assertSameInstalledFileSnapshot(before, opened, `${label} initial path and descriptor`, path);
+    assertSamePreciseInstalledFileSnapshot(
+      before,
+      opened,
+      `${label} initial path and descriptor`,
+      path,
+    );
+    runInstalledFileTestHook(testHooks, "afterOpen");
+    const bytes = readExactDescriptorBytes(fd, opened.size, label, path);
+    const afterRead = fstatSync(fd, { bigint: true });
+    assertSameInstalledFileSnapshot(opened, afterRead, `${label} descriptor read`, path);
+    assertSamePreciseInstalledFileSnapshot(opened, afterRead, `${label} descriptor read`, path);
+    runInstalledFileTestHook(testHooks, "afterFirstRead");
+    const finalSnapshot = collectFinalOneLinkRegularSnapshot(
+      path,
+      label,
+      bytes,
+      maxBytes,
+      testHooks,
+    );
+    assertSameInstalledFileSnapshot(
+      afterRead,
+      finalSnapshot.stat,
+      `${label} initial and final descriptors`,
+      path,
+    );
+    assertSamePreciseInstalledFileSnapshot(
+      afterRead,
+      finalSnapshot.stat,
+      `${label} initial and final descriptors`,
+      path,
+    );
+    return {
+      bytes,
+      fingerprint: preciseInstalledStat(finalSnapshot.stat),
+    };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+export function readOneLinkRegularForTestV1(path, label, maxBytes, testHooks) {
+  return readOneLinkRegularBoundToDescriptor(path, label, maxBytes, testHooks).bytes;
 }
 
 function collectExtendedMetadata(
@@ -305,8 +466,9 @@ function collectExtendedMetadata(
     socket: "socket",
   }[expectedType];
   if (statType === undefined) fail(`unreviewed extended metadata type: ${expectedType}`);
-  const expectedStatLine = `${expectedNodeStat.dev}:${expectedNodeStat.ino}:${expectedNodeStat.uid}:${expectedNodeStat.gid}:${(
-    expectedNodeStat.mode & 0o7777
+  const expectedStatLine = `${expectedNodeStat.dev}:${expectedNodeStat.ino}:${expectedNodeStat.uid}:${expectedNodeStat.gid}:${Number.parseInt(
+    statMode(expectedNodeStat),
+    8,
   ).toString(8)}:${expectedNodeStat.nlink}:${expectedNodeStat.size}:${statType}\n`;
   if (statRecord.stdout !== expectedStatLine) fail(`independent stat mismatch for ${path}`);
 
@@ -343,6 +505,12 @@ function assertSameInstalledFileSnapshot(left, right, label, path) {
   }
 }
 
+function assertSamePreciseInstalledFileSnapshot(left, right, label, path) {
+  if (canonicalJson(preciseInstalledStat(left)) !== canonicalJson(preciseInstalledStat(right))) {
+    fail(`installed artifact ${label} changed precise metadata: ${path}`);
+  }
+}
+
 function assertCanonicalInstalledFile(path, stat, label) {
   if (!stat.isFile() || stat.isSymbolicLink() || realpathSync(path) !== path) {
     fail(`installed artifact ${label} is not a canonical regular file: ${path}`);
@@ -355,30 +523,71 @@ function runInstalledFileTestHook(testHooks, phase) {
   if (hook !== undefined) hook();
 }
 
-function collectFinalInstalledPathDescriptor(path) {
-  const finalPathBeforeOpen = lstatSync(path);
+// Preserve the externally verified v4 evidence shape while retaining the
+// precise collector-local fingerprint needed to detect a same-inode
+// write-and-restore between repeated secret checks. Offline evidence never
+// gets to manufacture or replace this process-local comparison state.
+const installedFilePreciseFingerprints = new WeakMap();
+
+function collectFinalInstalledPathDescriptor(path, expectedBytes, testHooks = undefined) {
+  const finalPathBeforeOpen = lstatSync(path, { bigint: true });
   assertCanonicalInstalledFile(path, finalPathBeforeOpen, "final path");
   const finalFd = openSync(
     path,
     constants.O_RDONLY | constants.O_NOFOLLOW | (constants.O_CLOEXEC ?? 0),
   );
   try {
-    const finalOpened = fstatSync(finalFd);
+    const finalOpened = fstatSync(finalFd, { bigint: true });
     assertSameInstalledFileSnapshot(
       finalPathBeforeOpen,
       finalOpened,
       "final path snapshot and final descriptor",
       path,
     );
-    const finalPathAfterOpen = lstatSync(path);
-    assertCanonicalInstalledFile(path, finalPathAfterOpen, "final path confirmation");
+    assertSamePreciseInstalledFileSnapshot(
+      finalPathBeforeOpen,
+      finalOpened,
+      "final path snapshot and final descriptor",
+      path,
+    );
+    runInstalledFileTestHook(testHooks, "afterFinalPathOpen");
+    const finalBytes = readExactDescriptorBytes(
+      finalFd,
+      finalOpened.size,
+      "installed artifact final path",
+      path,
+    );
+    const finalAfterRead = fstatSync(finalFd, { bigint: true });
     assertSameInstalledFileSnapshot(
       finalOpened,
+      finalAfterRead,
+      "final descriptor read snapshots",
+      path,
+    );
+    assertSamePreciseInstalledFileSnapshot(
+      finalOpened,
+      finalAfterRead,
+      "final descriptor read snapshots",
+      path,
+    );
+    if (!finalBytes.equals(expectedBytes)) {
+      fail(`installed artifact final path content changed: ${path}`);
+    }
+    const finalPathAfterOpen = lstatSync(path, { bigint: true });
+    assertCanonicalInstalledFile(path, finalPathAfterOpen, "final path confirmation");
+    assertSameInstalledFileSnapshot(
+      finalAfterRead,
       finalPathAfterOpen,
       "final descriptor and final path confirmation",
       path,
     );
-    return finalOpened;
+    assertSamePreciseInstalledFileSnapshot(
+      finalAfterRead,
+      finalPathAfterOpen,
+      "final descriptor and final path confirmation",
+      path,
+    );
+    return { stat: finalAfterRead };
   } finally {
     closeSync(finalFd);
   }
@@ -386,18 +595,33 @@ function collectFinalInstalledPathDescriptor(path) {
 
 function collectInstalledFileBoundToDescriptor(expected, testHooks = undefined) {
   const path = expected.target_path;
-  const before = lstatSync(path);
+  const before = lstatSync(path, { bigint: true });
   assertCanonicalInstalledFile(path, before, "initial path");
   const fd = openSync(
     path,
     constants.O_RDONLY | constants.O_NOFOLLOW | (constants.O_CLOEXEC ?? 0),
   );
   try {
-    const opened = fstatSync(fd);
+    const opened = fstatSync(fd, { bigint: true });
     assertSameInstalledFileSnapshot(before, opened, "initial path and opened descriptor", path);
+    assertSamePreciseInstalledFileSnapshot(
+      before,
+      opened,
+      "initial path and opened descriptor",
+      path,
+    );
     runInstalledFileTestHook(testHooks, "afterOpen");
 
-    const bytes = readFileSync(fd);
+    const bytes = readExactDescriptorBytes(
+      fd,
+      opened.size,
+      "installed artifact initial path",
+      path,
+    );
+    const afterFirstRead = fstatSync(fd, { bigint: true });
+    assertSameInstalledFileSnapshot(opened, afterFirstRead, "initial descriptor read", path);
+    assertSamePreciseInstalledFileSnapshot(opened, afterFirstRead, "initial descriptor read", path);
+    runInstalledFileTestHook(testHooks, "afterFirstRead");
     const descriptorPath = `/proc/${process.pid}/fd/${fd}`;
     const descriptorSha256 = hashBytes(bytes);
     const canonicalSha256Output = `${descriptorSha256} *${path}\n`;
@@ -417,16 +641,36 @@ function collectInstalledFileBoundToDescriptor(expected, testHooks = undefined) 
     const extendedMetadata = collectExtendedMetadata(descriptorPath, "regular", {
       dereferenceStat: true,
       evidencePath: path,
-      nodeStat: opened,
+      nodeStat: afterFirstRead,
     });
     runInstalledFileTestHook(testHooks, "afterMetadataProbe");
 
-    const after = fstatSync(fd);
-    assertSameInstalledFileSnapshot(opened, after, "opened descriptor snapshots", path);
-    const finalPathDescriptor = collectFinalInstalledPathDescriptor(path);
+    {
+      const confirmationBytes = readExactDescriptorBytes(
+        fd,
+        afterFirstRead.size,
+        "installed artifact confirmation",
+        path,
+      );
+      if (!confirmationBytes.equals(bytes)) {
+        fail(`installed artifact content changed during descriptor reread: ${path}`);
+      }
+    }
+
+    const after = fstatSync(fd, { bigint: true });
+    assertSameInstalledFileSnapshot(afterFirstRead, after, "opened descriptor snapshots", path);
+    assertSamePreciseInstalledFileSnapshot(afterFirstRead, after, "opened descriptor snapshots", path);
+    runInstalledFileTestHook(testHooks, "beforeFinalPathOpen");
+    const finalPathSnapshot = collectFinalInstalledPathDescriptor(path, bytes, testHooks);
     assertSameInstalledFileSnapshot(
       after,
-      finalPathDescriptor,
+      finalPathSnapshot.stat,
+      "opened descriptor and final path descriptor",
+      path,
+    );
+    assertSamePreciseInstalledFileSnapshot(
+      after,
+      finalPathSnapshot.stat,
       "opened descriptor and final path descriptor",
       path,
     );
@@ -445,6 +689,10 @@ function collectInstalledFileBoundToDescriptor(expected, testHooks = undefined) 
     for (const key of ["gid", "mode", "nlink", "sha256", "uid"]) {
       if (observed[key] !== expected[key]) fail(`installed artifact ${key} mismatch: ${path}`);
     }
+    installedFilePreciseFingerprints.set(
+      observed,
+      preciseInstalledStat(finalPathSnapshot.stat),
+    );
     return observed;
   } finally {
     closeSync(fd);
@@ -460,6 +708,27 @@ function collectInstalledFile(expected) {
 // security-sensitive collection boundaries.
 export function collectInstalledFileForTestV1(expected, testHooks) {
   return collectInstalledFileBoundToDescriptor(expected, testHooks);
+}
+
+function assertInstalledFileCollectionsUnchanged(before, after, stage, path) {
+  const beforePrecise = installedFilePreciseFingerprints.get(before);
+  const afterPrecise = installedFilePreciseFingerprints.get(after);
+  if (
+    beforePrecise === undefined ||
+    afterPrecise === undefined ||
+    canonicalJson(before) !== canonicalJson(after) ||
+    canonicalJson(beforePrecise) !== canonicalJson(afterPrecise)
+  ) {
+    fail(`installed artifact metadata or content changed ${stage}: ${path}`);
+  }
+}
+
+export function confirmInstalledFileAcrossCollectionsForTestV1(expected, betweenHook) {
+  const before = collectInstalledFileBoundToDescriptor(expected);
+  betweenHook();
+  const after = collectInstalledFileBoundToDescriptor(expected);
+  assertInstalledFileCollectionsUnchanged(before, after, "between test collections", expected.target_path);
+  return true;
 }
 
 function validateNssName(value, label) {
@@ -4080,9 +4349,7 @@ function confirmSecretFilesUnchanged(installedFiles, request, stage) {
       fail(`secret is absent from installed-file closure: ${secret.target_path}`);
     }
     const after = collectInstalledFile(expected);
-    if (canonicalJson(before) !== canonicalJson(after)) {
-      fail(`secret metadata or content changed ${stage}: ${secret.target_path}`);
-    }
+    assertInstalledFileCollectionsUnchanged(before, after, stage, secret.target_path);
   }
 }
 

--- a/scripts/payment-v1-linux-runtime-evidence.test.mjs
+++ b/scripts/payment-v1-linux-runtime-evidence.test.mjs
@@ -5,12 +5,14 @@ import {
   chmodSync,
   existsSync,
   lstatSync,
+  linkSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
   renameSync,
   rmSync,
+  unlinkSync,
   utimesSync,
   writeFileSync,
 } from "node:fs";
@@ -28,6 +30,7 @@ import {
   NSS_ENUMERATION_KIND,
   PROTECTED_PROCESS_ENUMERATION_KIND,
   collectInstalledFileForTestV1,
+  confirmInstalledFileAcrossCollectionsForTestV1,
   collectSecretParentDirectoryForTestV1,
   confirmSecretParentDirectoryAcrossCollectionsForTestV1,
   collectProtectedCredentialProcessClosureV1,
@@ -38,6 +41,7 @@ import {
   parseLockedServiceAccountPolicyV1,
   parsePasswdEnumerationV2,
   parseProcStatus,
+  readOneLinkRegularForTestV1,
   systemdUnitObjectPathV1,
   validateNonRootEdgeCapabilitiesV1,
   validateLiveRuntimeEvidence,
@@ -73,6 +77,7 @@ const INSTALLED_FILE_PROBE_COMMANDS = [
   "/usr/bin/getfattr",
   "/usr/bin/sha256sum",
   "/usr/bin/stat",
+  "/usr/bin/touch",
   "/usr/sbin/getcap",
 ];
 const CAN_EXERCISE_INSTALLED_FILE_PROBES =
@@ -87,15 +92,34 @@ function clone(value) {
 }
 
 function installedFileExpectation(path, bytes) {
-  const stat = lstatSync(path);
+  const stat = lstatSync(path, { bigint: true });
   return {
-    gid: stat.gid,
-    mode: (stat.mode & 0o7777).toString(8).padStart(4, "0"),
-    nlink: stat.nlink,
+    gid: Number(stat.gid),
+    mode: Number(stat.mode & 0o7777n).toString(8).padStart(4, "0"),
+    nlink: Number(stat.nlink),
     sha256: hash(bytes),
     target_path: path,
-    uid: stat.uid,
+    uid: Number(stat.uid),
   };
+}
+
+function createExactTimestampReference(root, target) {
+  const reference = join(root, "timestamp-reference");
+  writeFileSync(reference, "timestamp reference\n", { mode: 0o600 });
+  const result = spawnSync("/usr/bin/touch", ["-r", target, "--", reference], {
+    encoding: "utf8",
+    shell: false,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return reference;
+}
+
+function restoreExactTimestamps(reference, target) {
+  const result = spawnSync("/usr/bin/touch", ["-r", reference, "--", target], {
+    encoding: "utf8",
+    shell: false,
+  });
+  assert.equal(result.status, 0, result.stderr);
 }
 
 function createExactDirectory(path, mode = 0o700) {
@@ -1016,6 +1040,99 @@ test("final NSS policy confirmation rejects identity or policy drift after enume
 });
 
 test(
+  "Linux one-link reader seals a transient same-inode rewrite before its final descriptor read",
+  { skip: !CAN_EXERCISE_INSTALLED_FILE_PROBES },
+  () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "bitcoinpir-one-link-")));
+    try {
+      const target = join(root, "artifact");
+      const bytes = Buffer.from("descriptor-bound-original\n");
+      const replacement = Buffer.from("descriptor-bound-replaced\n");
+      assert.equal(replacement.length, bytes.length);
+      writeFileSync(target, bytes, { mode: 0o640 });
+      chmodSync(target, 0o640);
+      const timestampReference = createExactTimestampReference(root, target);
+      const initial = lstatSync(target, { bigint: true });
+
+      assert.throws(
+        () => readOneLinkRegularForTestV1(target, "test artifact", 4096, {
+          afterFirstRead: () => {
+            writeFileSync(target, replacement);
+            writeFileSync(target, bytes);
+            chmodSync(target, 0o640);
+            restoreExactTimestamps(timestampReference, target);
+            const restored = lstatSync(target, { bigint: true });
+            assert.equal(restored.mtimeNs, initial.mtimeNs);
+            assert.notEqual(restored.ctimeNs, initial.ctimeNs);
+          },
+        }),
+        /changed precise metadata/,
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+for (const phase of ["afterOpen", "afterFirstRead", "afterFinalPathOpen"]) {
+  test(
+    `Linux one-link reader rejects pathname replacement ${phase}`,
+    { skip: !CAN_EXERCISE_INSTALLED_FILE_PROBES },
+    () => {
+      const root = realpathSync(mkdtempSync(join(tmpdir(), "bitcoinpir-one-link-path-")));
+      try {
+        const target = join(root, "artifact");
+        const replacement = join(root, "replacement");
+        const parked = join(root, "parked");
+        const bytes = Buffer.from("same-content-and-metadata\n");
+        for (const path of [target, replacement]) {
+          writeFileSync(path, bytes, { mode: 0o640 });
+          chmodSync(path, 0o640);
+        }
+        assert.throws(
+          () => readOneLinkRegularForTestV1(target, "test artifact", 4096, {
+            [phase]: () => {
+              renameSync(target, parked);
+              renameSync(replacement, target);
+            },
+          }),
+          /changed precise metadata|do not name the same stable file/,
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    },
+  );
+}
+
+for (const [label, mutation] of [
+  ["truncation", Buffer.from("short\n")],
+  ["growth", Buffer.from("descriptor-bound-original-with-growth\n")],
+]) {
+  test(
+    `Linux one-link reader rejects descriptor ${label}`,
+    { skip: !CAN_EXERCISE_INSTALLED_FILE_PROBES },
+    () => {
+      const root = realpathSync(mkdtempSync(join(tmpdir(), "bitcoinpir-one-link-size-")));
+      try {
+        const target = join(root, "artifact");
+        const bytes = Buffer.from("descriptor-bound-original\n");
+        writeFileSync(target, bytes, { mode: 0o640 });
+        chmodSync(target, 0o640);
+        assert.throws(
+          () => readOneLinkRegularForTestV1(target, "test artifact", 4096, {
+            afterFirstRead: () => writeFileSync(target, mutation),
+          }),
+          /changed precise metadata|do not name the same stable file|final descriptor read/,
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    },
+  );
+}
+
+test(
   "Linux installed-file probes bind content and metadata to one open descriptor",
   { skip: !CAN_EXERCISE_INSTALLED_FILE_PROBES },
   () => {
@@ -1027,7 +1144,7 @@ test(
       chmodSync(target, 0o640);
       const expected = installedFileExpectation(target, bytes);
       const observed = collectInstalledFileForTestV1(expected, {});
-      const stat = lstatSync(target);
+      const stat = lstatSync(target, { bigint: true });
 
       assert.equal(observed.dev, stat.dev.toString());
       assert.equal(observed.ino, stat.ino.toString());
@@ -1053,7 +1170,13 @@ test(
   },
 );
 
-for (const phase of ["afterOpen", "afterMetadataProbe"]) {
+for (const phase of [
+  "afterOpen",
+  "afterFirstRead",
+  "afterMetadataProbe",
+  "beforeFinalPathOpen",
+  "afterFinalPathOpen",
+]) {
   test(
     `Linux installed-file binding rejects same-metadata pathname replacement ${phase}`,
     { skip: !CAN_EXERCISE_INSTALLED_FILE_PROBES },
@@ -1083,7 +1206,7 @@ for (const phase of ["afterOpen", "afterMetadataProbe"]) {
               renameSync(replacement, target);
             },
           }),
-          /opened descriptor and final path descriptor do not name the same stable file/,
+          /changed precise metadata|do not name the same stable file/,
         );
       } finally {
         rmSync(root, { force: true, recursive: true });
@@ -1091,6 +1214,138 @@ for (const phase of ["afterOpen", "afterMetadataProbe"]) {
     },
   );
 }
+
+test(
+  "Linux installed-file binding rejects a same-inode content rewrite after metadata probes",
+  { skip: !CAN_EXERCISE_INSTALLED_FILE_PROBES },
+  () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "bitcoinpir-installed-inplace-")));
+    try {
+      const target = join(root, "artifact");
+      const bytes = Buffer.from("descriptor-bound-original\n");
+      const replacement = Buffer.from("descriptor-bound-replaced\n");
+      assert.equal(replacement.length, bytes.length);
+      writeFileSync(target, bytes, { mode: 0o640 });
+      chmodSync(target, 0o640);
+      const expected = installedFileExpectation(target, bytes);
+      const timestampReference = createExactTimestampReference(root, target);
+      const initial = lstatSync(target, { bigint: true });
+
+      assert.throws(
+        () => collectInstalledFileForTestV1(expected, {
+          afterMetadataProbe: () => {
+            writeFileSync(target, replacement);
+            chmodSync(target, 0o640);
+            restoreExactTimestamps(timestampReference, target);
+            const restored = lstatSync(target, { bigint: true });
+            assert.equal(restored.mtimeNs, initial.mtimeNs);
+          },
+        }),
+        /content changed during descriptor reread|changed precise metadata/,
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "Linux installed-file binding seals ctime across a transient same-inode rewrite",
+  { skip: !CAN_EXERCISE_INSTALLED_FILE_PROBES },
+  () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "bitcoinpir-installed-ctime-")));
+    try {
+      const target = join(root, "artifact");
+      const bytes = Buffer.from("descriptor-bound-original\n");
+      const replacement = Buffer.from("descriptor-bound-replaced\n");
+      assert.equal(replacement.length, bytes.length);
+      writeFileSync(target, bytes, { mode: 0o640 });
+      chmodSync(target, 0o640);
+      const expected = installedFileExpectation(target, bytes);
+      const timestampReference = createExactTimestampReference(root, target);
+      const initial = lstatSync(target, { bigint: true });
+
+      assert.throws(
+        () => collectInstalledFileForTestV1(expected, {
+          afterMetadataProbe: () => {
+            writeFileSync(target, replacement);
+            writeFileSync(target, bytes);
+            chmodSync(target, 0o640);
+            restoreExactTimestamps(timestampReference, target);
+            const restored = lstatSync(target, { bigint: true });
+            assert.equal(restored.mtimeNs, initial.mtimeNs);
+            assert.notEqual(restored.ctimeNs, initial.ctimeNs);
+          },
+        }),
+        /changed precise metadata/,
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "Linux installed-file binding seals transient hardlink creation and removal",
+  { skip: !CAN_EXERCISE_INSTALLED_FILE_PROBES },
+  () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "bitcoinpir-installed-nlink-")));
+    try {
+      const target = join(root, "artifact");
+      const alias = join(root, "transient-hardlink");
+      const bytes = Buffer.from("descriptor-bound-original\n");
+      writeFileSync(target, bytes, { mode: 0o640 });
+      chmodSync(target, 0o640);
+      const expected = installedFileExpectation(target, bytes);
+
+      assert.throws(
+        () => collectInstalledFileForTestV1(expected, {
+          afterMetadataProbe: () => {
+            linkSync(target, alias);
+            unlinkSync(alias);
+          },
+        }),
+        /changed precise metadata/,
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
+
+test(
+  "Linux repeated installed-file collections retain a private precise fingerprint",
+  { skip: !CAN_EXERCISE_INSTALLED_FILE_PROBES },
+  () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "bitcoinpir-installed-cross-pass-")));
+    try {
+      const target = join(root, "artifact");
+      const bytes = Buffer.from("descriptor-bound-original\n");
+      const replacement = Buffer.from("descriptor-bound-replaced\n");
+      assert.equal(replacement.length, bytes.length);
+      writeFileSync(target, bytes, { mode: 0o640 });
+      chmodSync(target, 0o640);
+      const expected = installedFileExpectation(target, bytes);
+      const timestampReference = createExactTimestampReference(root, target);
+      const initial = lstatSync(target, { bigint: true });
+
+      assert.throws(
+        () => confirmInstalledFileAcrossCollectionsForTestV1(expected, () => {
+          writeFileSync(target, replacement);
+          writeFileSync(target, bytes);
+          chmodSync(target, 0o640);
+          restoreExactTimestamps(timestampReference, target);
+          const restored = lstatSync(target, { bigint: true });
+          assert.equal(restored.mtimeNs, initial.mtimeNs);
+          assert.notEqual(restored.ctimeNs, initial.ctimeNs);
+        }),
+        /metadata or content changed between test collections/,
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);
 
 test(
   "Linux secret-parent evidence walks and probes one descriptor-bound directory chain",


### PR DESCRIPTION
Stacked security fix for Payment V1 runtime evidence.\n\n- binds initial, confirmation, and fresh final pathname descriptors with BigInt nanosecond metadata\n- performs positional full reads with truncate/grow detection and final pathname content comparison\n- retains a collector-local precise fingerprint across repeated secret checks without changing the v4 wire evidence\n- hardens the generic one-link reader used for manifests, requests, fragments, and offline evidence\n- adds deterministic Linux regressions for same-inode rewrite/restore, exact mtime restoration, hardlinks, pathname replacement, truncation, and growth\n\nIndependent review found no P0/P1. Local Linux Node 22 runtime suite: 85/85. This PR intentionally targets the provider-profile branch so the security diff is reviewed separately before updating PR #101.