### PR TITLE
Add exact-pinned storeless Free-PoW admission

### DIFF
--- a/apps/server/src/bin/unified_server.rs
+++ b/apps/server/src/bin/unified_server.rs
@@ -9562,7 +9562,7 @@ async fn main() {
         }
         if runtime.provider_store.is_none() {
             println!(
-                "  Storeless Free-PoW: exact measured policy digest; no provider store or rollback authority"
+                "  Storeless Free-PoW: exact policy digest pin active; no provider store or rollback authority"
             );
         }
         AdmissionEnforcementV1::Enforced

--- a/apps/server/src/bin/unified_server.rs
+++ b/apps/server/src/bin/unified_server.rs
@@ -23,9 +23,10 @@ use pir_runtime_core::service_admission::{
     ServiceWireRequestV1,
 };
 use pir_runtime_core::service_policy_runtime::{
-    activate_retained_service_policy_v1, activate_service_policy_v1,
-    validate_policy_method_coverage_v1, validate_retained_policy_method_coverage_v1,
-    ActivatedRetainedServicePolicyV1, ActivatedServicePolicyV1,
+    activate_exact_storeless_free_pow_policy_v1, activate_retained_service_policy_v1,
+    activate_service_policy_v1, validate_policy_method_coverage_v1,
+    validate_retained_policy_method_coverage_v1, ActivatedRetainedServicePolicyV1,
+    ActivatedServicePolicyV1,
 };
 use runtime::config::ServerConfig;
 use runtime::db_proof::load_database_proof_bundle;
@@ -273,6 +274,11 @@ struct CliArgs {
     /// live; V1 deliberately has no unauthenticated historical-key list.
     service_provider_id_hex: Option<String>,
     service_policy_key_hex: Option<String>,
+    /// Exact canonical ServicePolicyV1 digest for the measured, storeless
+    /// Free-PoW-only deployment mode. The pin must be part of the measured
+    /// launch configuration; it replaces durable policy rollback state only
+    /// for this deliberately narrow policy shape.
+    service_storeless_free_pow_policy_digest_hex: Option<String>,
     /// Existing provider spend database. The rollback authority must be exactly
     /// one local development/test SQLite file or one production remote config;
     /// startup never creates or silently substitutes either.
@@ -537,6 +543,7 @@ fn parse_args_from(args: Vec<String>) -> CliArgs {
     let mut service_retained_policy_paths: Vec<PathBuf> = Vec::new();
     let mut service_provider_id_hex: Option<String> = None;
     let mut service_policy_key_hex: Option<String> = None;
+    let mut service_storeless_free_pow_policy_digest_hex: Option<String> = None;
     let mut service_store_path: Option<PathBuf> = None;
     let mut service_rollback_authority_path: Option<PathBuf> = None;
     let mut service_remote_rollback_authority_config_path: Option<PathBuf> = None;
@@ -730,6 +737,23 @@ fn parse_args_from(args: Vec<String>) -> CliArgs {
             }
             "--service-policy-key-hex" => {
                 service_policy_key_hex = args.get(i + 1).cloned();
+                i += 1;
+            }
+            "--service-storeless-free-pow-policy-digest-hex" => {
+                if service_storeless_free_pow_policy_digest_hex.is_some() {
+                    fatal_cli(
+                        "--service-storeless-free-pow-policy-digest-hex must not be repeated",
+                    );
+                }
+                service_storeless_free_pow_policy_digest_hex = Some(
+                    args.get(i + 1)
+                        .unwrap_or_else(|| {
+                            fatal_cli(
+                                "--service-storeless-free-pow-policy-digest-hex requires a digest",
+                            )
+                        })
+                        .clone(),
+                );
                 i += 1;
             }
             "--service-store" => {
@@ -1090,6 +1114,7 @@ fn parse_args_from(args: Vec<String>) -> CliArgs {
         service_retained_policy_paths,
         service_provider_id_hex,
         service_policy_key_hex,
+        service_storeless_free_pow_policy_digest_hex,
         service_store_path,
         service_rollback_authority_path,
         service_remote_rollback_authority_config_path,
@@ -4017,7 +4042,10 @@ struct UnifiedServerData {
 struct StrictServiceAdmissionRuntimeV1 {
     policy: ActivatedServicePolicyV1,
     retained_policies: BTreeMap<[u8; 32], ActivatedRetainedServicePolicyV1>,
-    provider_store: ProviderStore,
+    /// Absent only for the exact-digest-pinned, Free-PoW-only measured mode.
+    /// Every durable quota, credential, payment, Cashu, ARC, retained-policy,
+    /// or shared-issuer route requires this store at startup.
+    provider_store: Option<ProviderStore>,
     free_rate_limits: Arc<FreeRateLimitStateV1>,
     free_ip_subject_key: Option<FreeIpSubjectKeyV1>,
     trust_direct_peer_ip: bool,
@@ -4284,28 +4312,33 @@ impl StrictServiceAdmissionRuntimeV1 {
 
     fn supports(&self, route: AdmissionMethodRouteV1) -> bool {
         match route {
-            AdmissionMethodRouteV1::FreeOpenBestEffort
-            | AdmissionMethodRouteV1::FreeProofOfWork
-            | AdmissionMethodRouteV1::FreeAnonymousTicketProviderLocal
-            | AdmissionMethodRouteV1::Bolt11DirectReceiptProviderLocal => true,
+            AdmissionMethodRouteV1::FreeOpenBestEffort => self.provider_store.is_some(),
+            AdmissionMethodRouteV1::FreeProofOfWork => true,
+            AdmissionMethodRouteV1::FreeAnonymousTicketProviderLocal
+            | AdmissionMethodRouteV1::Bolt11DirectReceiptProviderLocal => {
+                self.provider_store.is_some()
+            }
             AdmissionMethodRouteV1::FreeIpRateLimited => {
                 self.free_ip_subject_key.is_some()
                     && self.trust_direct_peer_ip
                     && self.free_rate_limits.is_persistent()
             }
-            AdmissionMethodRouteV1::BitcoinPirCashuBatProviderLocal => self.bat_keyring.is_some(),
+            AdmissionMethodRouteV1::BitcoinPirCashuBatProviderLocal => {
+                self.provider_store.is_some() && self.bat_keyring.is_some()
+            }
             AdmissionMethodRouteV1::ArcProviderLocalExperimental => {
-                self.experimental_arc_keyring.is_some()
+                self.provider_store.is_some() && self.experimental_arc_keyring.is_some()
             }
             AdmissionMethodRouteV1::StandardCashuMintOnline => {
-                self.cashu_recovery_cipher.is_some()
+                self.provider_store.is_some()
+                    && self.cashu_recovery_cipher.is_some()
                     && self.cashu_custody_cipher.is_some()
                     && !self.cashu_exposure_limits.is_empty()
             }
             AdmissionMethodRouteV1::FreeAnonymousTicketSharedIssuerOnline
             | AdmissionMethodRouteV1::BitcoinPirCashuBatSharedIssuerOnline
             | AdmissionMethodRouteV1::ArcSharedIssuerOnlineExperimental => {
-                self.shared_issuer.is_some()
+                self.provider_store.is_some() && self.shared_issuer.is_some()
             }
         }
     }
@@ -7378,6 +7411,7 @@ fn load_strict_service_admission_v1(
         || !args.service_retained_policy_paths.is_empty()
         || args.service_provider_id_hex.is_some()
         || args.service_policy_key_hex.is_some()
+        || args.service_storeless_free_pow_policy_digest_hex.is_some()
         || args.service_store_path.is_some()
         || args.service_rollback_authority_path.is_some()
         || args.service_remote_rollback_authority_config_path.is_some()
@@ -7450,6 +7484,54 @@ fn load_strict_service_admission_v1(
         SERVICE_CONFIG_FILE_LIMIT_V1,
         "signed service policy",
     )?;
+    let storeless_free_pow_policy_digest = args
+        .service_storeless_free_pow_policy_digest_hex
+        .as_deref()
+        .map(|value| {
+            decode_fixed_hex_v1::<32>(value, "--service-storeless-free-pow-policy-digest-hex")
+        })
+        .transpose()?;
+    if storeless_free_pow_policy_digest.is_some()
+        && (!args.service_retained_policy_paths.is_empty()
+            || args.arc_key_path.is_some()
+            || !args.cashu_keysets.is_empty()
+            || args.service_store_path.is_some()
+            || args.service_rollback_authority_path.is_some()
+            || args.service_remote_rollback_authority_config_path.is_some()
+            || args.allow_local_service_rollback_authority_dev
+            || args.service_free_ip_key_path.is_some()
+            || args.service_trust_direct_peer_ip
+            || !args.service_bat_key_paths.is_empty()
+            || !args.service_arc_key_specs.is_empty()
+            || args.allow_experimental_arc
+            || !args.service_cashu_recovery_key_specs.is_empty()
+            || args.service_cashu_recovery_active_epoch.is_some()
+            || !args.service_cashu_custody_key_specs.is_empty()
+            || args.service_cashu_custody_active_epoch.is_some()
+            || !args.service_cashu_exposure_limit_specs.is_empty()
+            || args.service_shared_authorization_path.is_some()
+            || args.service_shared_issuer_approval_path.is_some()
+            || args.service_shared_operator_key_hex.is_some()
+            || args.service_shared_issuer_settlement_key_hex.is_some()
+            || args.service_shared_clearing_key_path.is_some()
+            || args.service_shared_idempotency_key_path.is_some()
+            || args.service_shared_minimum_authorization_epoch.is_some()
+            || {
+                #[cfg(feature = "standard-cashu-process-e2e")]
+                {
+                    test_only_service_https_configured
+                }
+                #[cfg(not(feature = "standard-cashu-process-e2e"))]
+                {
+                    false
+                }
+            })
+    {
+        return Err(
+            "storeless Free-PoW mode forbids retained policies, stores, rollback authorities, Free IP quota, credential/payment keys, legacy or V1 Cashu/ARC, shared issuer, and test HTTPS configuration"
+                .to_owned(),
+        );
+    }
     let mut experimental_arc_usage =
         inspect_experimental_arc_policy_v1(&signed_policy, "signed service policy")?;
     let mut retained_policy_inputs = Vec::with_capacity(args.service_retained_policy_paths.len());
@@ -7475,55 +7557,64 @@ fn load_strict_service_admission_v1(
             "!!! WARNING: EXPERIMENTAL ARC ENABLED FOR THIS PIR SERVER; THE PINNED DRAFT-01 IMPLEMENTATION IS UNAUDITED AND MUST NOT BE USED IN PRODUCTION !!!"
         );
     }
-    let provider_store_path = args
-        .service_store_path
-        .as_deref()
-        .ok_or_else(|| "--service-store is required".to_owned())?;
-    let rollback_source = service_rollback_authority_source_v1(
-        args.service_rollback_authority_path.as_deref(),
-        args.service_remote_rollback_authority_config_path
-            .as_deref(),
-        args.allow_local_service_rollback_authority_dev,
-    )?;
-    let canonical_store =
-        validate_existing_private_sqlite_path_v1(provider_store_path, "provider spend store")?;
+    let provider_store = if storeless_free_pow_policy_digest.is_some() {
+        None
+    } else {
+        let provider_store_path = args
+            .service_store_path
+            .as_deref()
+            .ok_or_else(|| "--service-store is required".to_owned())?;
+        let rollback_source = service_rollback_authority_source_v1(
+            args.service_rollback_authority_path.as_deref(),
+            args.service_remote_rollback_authority_config_path
+                .as_deref(),
+            args.allow_local_service_rollback_authority_dev,
+        )?;
+        let canonical_store =
+            validate_existing_private_sqlite_path_v1(provider_store_path, "provider spend store")?;
 
-    let options = StoreOptions::default();
-    let store_startup_check_started = Instant::now();
-    let rollback_authority: Arc<dyn RollbackFloorAuthorityV1> = match rollback_source {
-        ServiceRollbackAuthoritySourceV1::LocalSqlite(path) => {
-            let canonical_rollback =
-                validate_existing_private_sqlite_path_v1(path, "provider rollback authority")?;
-            if private_sqlite_paths_alias_v1(&canonical_store, &canonical_rollback)? {
-                return Err(
-                    "provider store and rollback authority must be different files/inodes"
-                        .to_owned(),
+        let options = StoreOptions::default();
+        let store_startup_check_started = Instant::now();
+        let rollback_authority: Arc<dyn RollbackFloorAuthorityV1> = match rollback_source {
+            ServiceRollbackAuthoritySourceV1::LocalSqlite(path) => {
+                let canonical_rollback =
+                    validate_existing_private_sqlite_path_v1(path, "provider rollback authority")?;
+                if private_sqlite_paths_alias_v1(&canonical_store, &canonical_rollback)? {
+                    return Err(
+                        "provider store and rollback authority must be different files/inodes"
+                            .to_owned(),
+                    );
+                }
+                eprintln!(
+                    "!!! WARNING: LOCAL SQLITE SERVICE ROLLBACK AUTHORITY IS DEVELOPMENT/TEST ONLY; USE --service-remote-rollback-authority-config FOR PRODUCTION !!!"
                 );
-            }
-            eprintln!(
-                "!!! WARNING: LOCAL SQLITE SERVICE ROLLBACK AUTHORITY IS DEVELOPMENT/TEST ONLY; USE --service-remote-rollback-authority-config FOR PRODUCTION !!!"
-            );
-            Arc::new(
-                SqliteRollbackFloorAuthorityV1::open_existing(
-                    &canonical_rollback,
-                    options.busy_timeout,
+                Arc::new(
+                    SqliteRollbackFloorAuthorityV1::open_existing(
+                        &canonical_rollback,
+                        options.busy_timeout,
+                    )
+                    .map_err(|error| format!("failed to open rollback authority: {error}"))?,
                 )
-                .map_err(|error| format!("failed to open rollback authority: {error}"))?,
-            )
-        }
-        ServiceRollbackAuthoritySourceV1::RemoteConfig(path) => {
-            open_remote_service_rollback_authority_v1(provider_id, path)?
-        }
+            }
+            ServiceRollbackAuthoritySourceV1::RemoteConfig(path) => {
+                open_remote_service_rollback_authority_v1(provider_id, path)?
+            }
+        };
+        let store = ProviderStore::open_existing(
+            &canonical_store,
+            provider_id,
+            options,
+            rollback_authority,
+        )
+        .map_err(|error| format!("failed to open provider spend store: {error}"))?;
+        let _store_inventory = store.operational_inventory().map_err(|error| {
+            format!("failed to read provider store operational inventory: {error}")
+        })?;
+        let startup_line =
+            provider_store_startup_log_line_v1(store_startup_check_started.elapsed().as_millis());
+        println!("{startup_line}");
+        Some(store)
     };
-    let provider_store =
-        ProviderStore::open_existing(&canonical_store, provider_id, options, rollback_authority)
-            .map_err(|error| format!("failed to open provider spend store: {error}"))?;
-    let _store_inventory = provider_store
-        .operational_inventory()
-        .map_err(|error| format!("failed to read provider store operational inventory: {error}"))?;
-    let startup_line =
-        provider_store_startup_log_line_v1(store_startup_check_started.elapsed().as_millis());
-    println!("{startup_line}");
 
     let free_ip_subject_key = match args.service_free_ip_key_path.as_deref() {
         Some(path) => Some(
@@ -7781,7 +7872,12 @@ fn load_strict_service_admission_v1(
             )
             .map_err(|error| format!("shared issuer HTTPS trust is invalid: {error}"))?;
         shared
-            .committer(&provider_store, &http_transport)
+            .committer(
+                provider_store.as_ref().ok_or_else(|| {
+                    "shared issuer configuration requires a provider store".to_owned()
+                })?,
+                &http_transport,
+            )
             .map_err(|error| format!("shared issuer clearing configuration is invalid: {error}"))?;
         shared
             .authorization
@@ -7804,16 +7900,27 @@ fn load_strict_service_admission_v1(
             .map_err(|error| format!("issuer clearing approval is not current: {error}"))?;
     }
 
-    let policy = activate_service_policy_v1(
-        &signed_policy,
-        provider_id,
-        verifying_key,
-        &provider_store,
-        now_unix,
-        experimental_arc_keyring
-            .as_ref()
-            .map(|keyring| keyring as &dyn pir_service_store::ArcExclusiveKeyLineageVerifierV1),
-    )
+    let policy = match storeless_free_pow_policy_digest {
+        Some(expected_digest) => activate_exact_storeless_free_pow_policy_v1(
+            &signed_policy,
+            provider_id,
+            verifying_key,
+            expected_digest,
+            now_unix,
+        ),
+        None => activate_service_policy_v1(
+            &signed_policy,
+            provider_id,
+            verifying_key,
+            provider_store
+                .as_ref()
+                .ok_or_else(|| "provider store is unavailable".to_owned())?,
+            now_unix,
+            experimental_arc_keyring
+                .as_ref()
+                .map(|keyring| keyring as &dyn pir_service_store::ArcExclusiveKeyLineageVerifierV1),
+        ),
+    }
     .map_err(|error| format!("failed to activate signed service policy: {error}"))?;
     let mut retained_policies = BTreeMap::new();
     for (retained_path, retained_bytes) in retained_policy_inputs {
@@ -7834,10 +7941,15 @@ fn load_strict_service_admission_v1(
             ));
         }
     }
-    let free_rate_limits = Arc::new(FreeRateLimitStateV1::provider_store(
-        provider_store.clone(),
-        pir_runtime_core::free_admission::DEFAULT_MAX_FREE_RATE_LIMIT_BUCKETS_V1,
-    ));
+    let free_rate_limits = Arc::new(match provider_store.as_ref() {
+        Some(store) => FreeRateLimitStateV1::provider_store(
+            store.clone(),
+            pir_runtime_core::free_admission::DEFAULT_MAX_FREE_RATE_LIMIT_BUCKETS_V1,
+        ),
+        None => FreeRateLimitStateV1::new(
+            pir_runtime_core::free_admission::DEFAULT_MAX_FREE_RATE_LIMIT_BUCKETS_V1,
+        ),
+    });
     let runtime = StrictServiceAdmissionRuntimeV1 {
         policy,
         retained_policies,
@@ -7888,6 +8000,8 @@ fn load_strict_service_admission_v1(
                     })?;
                 let readiness = runtime
                     .provider_store
+                    .as_ref()
+                    .ok_or_else(|| "retained policy requires a provider store".to_owned())?
                     .verify_existing_verified_offer_namespace_v1(
                         &verified_offer,
                         retained.policy().issued_at,
@@ -8039,6 +8153,8 @@ fn validate_cashu_runtime_configuration_v1(
             })?;
         let inventory = runtime
             .provider_store
+            .as_ref()
+            .ok_or_else(|| "standard Cashu requires a provider store".to_owned())?
             .cashu_custody_inventory_v1(mint_id, unit)
             .map_err(|error| {
                 format!(
@@ -9444,6 +9560,11 @@ async fn main() {
         if runtime.trust_direct_peer_ip {
             println!("  Free IP quotas: direct TCP peer explicitly trusted");
         }
+        if runtime.provider_store.is_none() {
+            println!(
+                "  Storeless Free-PoW: exact measured policy digest; no provider store or rollback authority"
+            );
+        }
         AdmissionEnforcementV1::Enforced
     } else {
         println!(
@@ -10602,26 +10723,29 @@ async fn main() {
                                                     },
                                                 )
                                             } else {
-                                                let mut provider_local = ProviderStoreBearerCommitterV1::new(
-                                                    &runtime.provider_store,
-                                                    runtime
-                                                        .bat_keyring
-                                                        .as_ref()
-                                                        .map(|keyring| keyring as &dyn pir_service_store::CashuBatProofVerifierV1),
-                                                );
-                                                if let Some(keyring) =
-                                                    runtime.experimental_arc_keyring.as_ref()
-                                                {
-                                                    provider_local = provider_local
-                                                        .with_arc_adapter_v1(keyring);
-                                                }
+                                                let provider_local = runtime.provider_store.as_ref().map(|store| {
+                                                    let committer = ProviderStoreBearerCommitterV1::new(
+                                                        store,
+                                                        runtime
+                                                            .bat_keyring
+                                                            .as_ref()
+                                                            .map(|keyring| keyring as &dyn pir_service_store::CashuBatProofVerifierV1),
+                                                    );
+                                                    match runtime.experimental_arc_keyring.as_ref() {
+                                                        Some(keyring) => committer.with_arc_adapter_v1(keyring),
+                                                        None => committer,
+                                                    }
+                                                });
                                                 let mut composite =
-                                                    CompositeAdmissionMethodCommitterV1::new()
-                                                        .with_provider_local(&provider_local);
+                                                    CompositeAdmissionMethodCommitterV1::new();
+                                                if let Some(committer) = provider_local.as_ref() {
+                                                    composite = composite.with_provider_local(committer);
+                                                }
                                                 if let Some(free) = free_admission.as_ref() {
                                                     composite = composite.with_free(free);
                                                 }
                                                 let standard_cashu = match (
+                                                    runtime.provider_store.as_ref(),
                                                     runtime.cashu_recovery_cipher.as_ref(),
                                                     runtime.cashu_custody_cipher.as_ref(),
                                                     verified_offer
@@ -10630,6 +10754,7 @@ async fn main() {
                                                         .as_ref(),
                                                 ) {
                                                     (
+                                                        Some(store),
                                                         Some(recovery),
                                                         Some(custody),
                                                         Some(manifest),
@@ -10643,7 +10768,7 @@ async fn main() {
                                                         .map(|limits| {
                                                             StandardCashuAdmissionCommitterV1::new(
                                                                 StandardCashuClientV1::new(
-                                                                    &runtime.provider_store,
+                                                                    store,
                                                                     &runtime.http_transport,
                                                                     recovery,
                                                                     custody,
@@ -10660,10 +10785,11 @@ async fn main() {
                                                 let shared_issuer = runtime
                                                     .shared_issuer
                                                     .as_ref()
-                                                    .and_then(|config| {
+                                                    .zip(runtime.provider_store.as_ref())
+                                                    .and_then(|(config, store)| {
                                                         config
                                                             .committer(
-                                                                &runtime.provider_store,
+                                                                store,
                                                                 &runtime.http_transport,
                                                             )
                                                             .ok()
@@ -13308,6 +13434,20 @@ mod service_admission_dispatch_tests {
             "3".to_owned(),
         ]);
         assert_eq!(args.service_max_concurrent_online_v2full_auth, Some(3));
+    }
+
+    #[test]
+    fn cli_parser_accepts_exact_storeless_free_pow_policy_digest() {
+        let digest = "42".repeat(32);
+        let args = parse_args_from(vec![
+            "unified_server".to_owned(),
+            "--service-storeless-free-pow-policy-digest-hex".to_owned(),
+            digest.clone(),
+        ]);
+        assert_eq!(
+            args.service_storeless_free_pow_policy_digest_hex.as_deref(),
+            Some(digest.as_str())
+        );
     }
 
     #[cfg(feature = "test-only-unsafe-query-logging")]

--- a/apps/server/tests/payment_v1_process_e2e.rs
+++ b/apps/server/tests/payment_v1_process_e2e.rs
@@ -36,19 +36,22 @@ use pir_sdk_client::dangerous_unpaired_accept_service_authorization_response_v1;
 use pir_sdk_client::{
     dangerous_unpaired_authorize_service_operation_v1,
     dangerous_unpaired_build_authorization_proof_v1, fetch_verified_service_policy_v1,
-    AcceptedServicePolicyV1, PirTransport, ServicePolicyCheckpointV1, WsConnection,
+    request_pow_challenge_v1, AcceptedServicePolicyV1, PirTransport, ServicePolicyCheckpointV1,
+    WsConnection,
 };
 use pir_service_protocol::{
-    derive_provider_id, paid_receipt_key_id, AcquisitionMethod, AuthPaddingClassV1, AuthScheme,
-    BackendId, CredentialKeyBindingClaimsV1, CredentialKeyBindingV1, CredentialUnitV1,
-    DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1, FreeModeV1, OperationStartV1,
-    PaidReceiptBindingV1, PaidReceiptV1, PriceV1, PrivacyLeakageV1, ServiceOfferV1,
+    derive_provider_id, paid_receipt_key_id, pow_solution_meets_difficulty_v1, AcquisitionMethod,
+    AuthPaddingClassV1, AuthScheme, BackendId, CredentialKeyBindingClaimsV1,
+    CredentialKeyBindingV1, CredentialUnitV1, DatasetBindingV1, DeploymentStatus,
+    EntitlementLimitsV1, FreeModeV1, FreePowProofV1, OperationStartV1, PaidReceiptBindingV1,
+    PaidReceiptV1, PowChallengeResponseV1, PriceV1, PrivacyLeakageV1, ServiceOfferV1,
     ServicePolicyV1, ServiceScopePolicyV1, ServiceScopeV1, VerificationMode, WorkloadId,
 };
 #[cfg(feature = "standard-cashu-process-e2e")]
 use pir_service_protocol::{AuthBeginV1, AuthorizationProofV1, REQ_AUTH_BEGIN_V1};
 use pir_service_store::{ProviderStore, SqliteRollbackFloorAuthorityV1, StoreOptions};
 use std::fs::{self, File};
+use std::io::Read;
 use std::net::{TcpListener, TcpStream};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -82,6 +85,15 @@ struct ProviderFixture {
     issued_at: u64,
     receipt_not_after: u64,
     harmony_method_matrix: Option<MethodMatrixFixture>,
+}
+
+#[derive(Debug)]
+struct StorelessFreePowFixture {
+    provider_id: [u8; 32],
+    policy_signing_key: SigningKey,
+    policy_path: PathBuf,
+    dpf_scope_id: [u8; 32],
+    policy_digest: [u8; 32],
 }
 
 impl ProviderFixture {
@@ -187,6 +199,37 @@ impl ServerProcess {
         server
     }
 
+    fn spawn_storeless_free_pow(
+        root: &Path,
+        db_path: &Path,
+        fixture: &StorelessFreePowFixture,
+        port: u16,
+    ) -> Self {
+        let stdout_path = root.join("storeless-free-pow-stdout.log");
+        let stderr_path = root.join("storeless-free-pow-stderr.log");
+        let stdout = File::create(&stdout_path).expect("create storeless server stdout log");
+        let stderr = File::create(&stderr_path).expect("create storeless server stderr log");
+        let child = Command::new(env!("CARGO_BIN_EXE_unified_server"))
+            .args(storeless_free_pow_server_args(
+                db_path,
+                fixture,
+                port,
+                fixture.policy_digest,
+            ))
+            .stdin(Stdio::null())
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .spawn()
+            .expect("spawn storeless Free-PoW unified_server");
+        let mut server = Self {
+            child,
+            stdout_path,
+            stderr_path,
+        };
+        server.wait_until_listening(port);
+        server
+    }
+
     fn wait_until_listening(&mut self, port: u16) {
         let deadline = Instant::now() + Duration::from_secs(30);
         loop {
@@ -220,6 +263,226 @@ impl ServerProcess {
         let _ = self.child.wait();
         (read_log(&self.stdout_path), read_log(&self.stderr_path))
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exact_pinned_storeless_free_pow_challenge_authorizes_one_real_query() {
+    let root = tempfile::tempdir().expect("test root");
+    chmod(root.path(), 0o700);
+    let (db_path, manifest_root) = write_tiny_manifest_database(root.path());
+    let fixture = build_storeless_free_pow_provider(root.path(), manifest_root, unix_now());
+    let port = unused_loopback_port();
+    let server = ServerProcess::spawn_storeless_free_pow(root.path(), &db_path, &fixture, port);
+    let request = valid_tiny_dpf_request();
+
+    let (mut secure, accepted) = open_verified_session_exact(
+        port,
+        fixture.provider_id,
+        &fixture.policy_signing_key,
+        fixture.policy_digest,
+        0,
+        manifest_root,
+        &request,
+    )
+    .await;
+    let first_exporter = secure
+        .service_authorization_exporter_v1()
+        .expect("first secure channel exposes an authorization exporter");
+    let operation = OperationStartV1::DpfQuery { db_id: 0 };
+    let challenge = request_pow_challenge_v1(
+        &mut secure,
+        &accepted,
+        fixture.dpf_scope_id,
+        DPF_OFFER_ID,
+        operation.clone(),
+        unix_now(),
+    )
+    .await
+    .expect("request exact secure-channel-bound Free-PoW challenge");
+    assert_eq!(challenge.secure_channel_exporter, first_exporter);
+    let solution = solve_pow(&challenge);
+    let proof = dangerous_unpaired_build_authorization_proof_v1(
+        &accepted,
+        &fixture.dpf_scope_id,
+        DPF_OFFER_ID,
+        &solution.encode().unwrap(),
+    )
+    .unwrap();
+    let grant = dangerous_unpaired_authorize_service_operation_v1(
+        &mut secure,
+        &accepted,
+        fixture.dpf_scope_id,
+        DPF_OFFER_ID,
+        operation.clone(),
+        proof,
+    )
+    .await
+    .expect("storeless Free-PoW proof must authorize its exact operation");
+    assert_eq!(grant.scope_id, fixture.dpf_scope_id);
+    assert_eq!(grant.enforced_profile, ENTITLEMENT_PROFILE);
+
+    match Response::decode(&secure.roundtrip(&request).await.unwrap()).unwrap() {
+        Response::IndexBatch(result) => {
+            assert_eq!(result.results.len(), 2);
+            assert!(result.results.iter().all(|group| group.len() == 2));
+        }
+        other => panic!("authorized storeless DPF frame did not reach handler: {other:?}"),
+    }
+    expect_error_response(
+        &secure.roundtrip(&request).await.unwrap(),
+        "service entitlement limit exceeded",
+    );
+    secure.close().await.unwrap();
+
+    // A challenge is connection/exporter-bound. A new connection has no
+    // outstanding challenge state and must reject the old proof rather than
+    // treating storeless mode as an unbounded bearer grant.
+    let (mut replay, replay_policy) = open_verified_session_exact(
+        port,
+        fixture.provider_id,
+        &fixture.policy_signing_key,
+        fixture.policy_digest,
+        0,
+        manifest_root,
+        &request,
+    )
+    .await;
+    let replay_exporter = replay
+        .service_authorization_exporter_v1()
+        .expect("second secure channel exposes an authorization exporter");
+    assert_ne!(replay_exporter, first_exporter);
+    assert_ne!(replay_exporter, challenge.secure_channel_exporter);
+    let replay_proof = dangerous_unpaired_build_authorization_proof_v1(
+        &replay_policy,
+        &fixture.dpf_scope_id,
+        DPF_OFFER_ID,
+        &solution.encode().unwrap(),
+    )
+    .unwrap();
+    let replay_error = dangerous_unpaired_authorize_service_operation_v1(
+        &mut replay,
+        &replay_policy,
+        fixture.dpf_scope_id,
+        DPF_OFFER_ID,
+        operation,
+        replay_proof,
+    )
+    .await
+    .expect_err("cross-connection Free-PoW replay must fail closed");
+    assert!(
+        replay_error.to_string().contains("invalid-or-spent"),
+        "{replay_error}"
+    );
+    replay.close().await.unwrap();
+
+    let (stdout, stderr) = server.stop();
+    assert_loopback_listener(0, port, &stdout, &stderr);
+    assert!(stdout.contains("Storeless Free-PoW: exact measured policy digest"));
+    assert!(!stdout.contains("Provider store startup_check=ok"));
+    assert!(
+        !tree_contains_provider_state(root.path()),
+        "storeless process fixture unexpectedly created provider/rollback SQLite, WAL, or SHM state"
+    );
+}
+
+#[test]
+fn storeless_free_pow_startup_rejects_wrong_pin_broader_policy_and_stateful_flags() {
+    let root = tempfile::tempdir().expect("test root");
+    chmod(root.path(), 0o700);
+    let (db_path, manifest_root) = write_tiny_manifest_database(root.path());
+    let fixture = build_storeless_free_pow_provider(root.path(), manifest_root, unix_now());
+
+    assert_storeless_startup_fails(
+        root.path(),
+        &db_path,
+        &fixture,
+        [0x42; 32],
+        &[],
+        "exact storeless policy digest pin",
+    );
+
+    let broader_path = root.path().join("open-free-policy.bin");
+    let broader = build_open_free_policy(&fixture, manifest_root, unix_now());
+    fs::write(&broader_path, broader.encode().unwrap()).unwrap();
+    chmod(&broader_path, 0o644);
+    assert_storeless_startup_fails_with_policy(
+        root.path(),
+        &db_path,
+        &fixture,
+        &broader_path,
+        broader.policy_digest().unwrap(),
+        &[],
+        "must contain only provider-local Free proof-of-work offers",
+    );
+
+    for extra in [
+        vec!["--service-store", "/nonexistent/provider.sqlite3"],
+        vec!["--service-rollback-authority", "/nonexistent/floor.sqlite3"],
+        vec!["--service-free-ip-key", "/nonexistent/free-ip.key"],
+        vec!["--service-bat-key", "/nonexistent/bat.key"],
+        vec![
+            "--service-arc-key",
+            "01=/nonexistent/arc.key",
+            "--allow-experimental-arc",
+        ],
+        vec!["--cashu-keyset", "fixture:00"],
+        vec![
+            "--service-cashu-recovery-key",
+            "1=/nonexistent/cashu-recovery.key",
+        ],
+        vec![
+            "--service-shared-authorization",
+            "/nonexistent/shared-authorization.bin",
+        ],
+        vec![
+            "--service-retained-policy",
+            fixture.policy_path.to_str().unwrap(),
+        ],
+    ] {
+        assert_storeless_startup_fails(
+            root.path(),
+            &db_path,
+            &fixture,
+            fixture.policy_digest,
+            &extra,
+            "storeless Free-PoW mode forbids",
+        );
+    }
+
+    assert_storeless_startup_fails(
+        root.path(),
+        &db_path,
+        &fixture,
+        fixture.policy_digest,
+        &["--arc-key", "/nonexistent/legacy-arc.key"],
+        "legacy experimental ARC configuration requires explicit --allow-experimental-arc",
+    );
+
+    let digest_hex = hex::encode(fixture.policy_digest);
+    assert_storeless_startup_fails(
+        root.path(),
+        &db_path,
+        &fixture,
+        fixture.policy_digest,
+        &[
+            "--service-storeless-free-pow-policy-digest-hex",
+            digest_hex.as_str(),
+        ],
+        "--service-storeless-free-pow-policy-digest-hex must not be repeated",
+    );
+
+    #[cfg(feature = "standard-cashu-process-e2e")]
+    assert_storeless_startup_fails(
+        root.path(),
+        &db_path,
+        &fixture,
+        fixture.policy_digest,
+        &[
+            "--test-only-service-https-root-pem",
+            "/nonexistent/test-https-root.pem",
+        ],
+        "storeless Free-PoW mode forbids",
+    );
 }
 
 impl Drop for ServerProcess {
@@ -770,6 +1033,30 @@ async fn open_verified_session(
     SecureChannelTransport<WsConnection>,
     AcceptedServicePolicyV1,
 ) {
+    open_verified_session_exact(
+        port,
+        fixture.provider_id,
+        &fixture.policy_signing_key,
+        fixture.policy_digest,
+        fixture.index,
+        manifest_root,
+        backend_request,
+    )
+    .await
+}
+
+async fn open_verified_session_exact(
+    port: u16,
+    provider_id: [u8; 32],
+    policy_signing_key: &SigningKey,
+    policy_digest: [u8; 32],
+    provider_index: u8,
+    manifest_root: [u8; 32],
+    backend_request: &[u8],
+) -> (
+    SecureChannelTransport<WsConnection>,
+    AcceptedServicePolicyV1,
+) {
     let url = format!("ws://127.0.0.1:{port}");
     let mut raw = WsConnection::connect_once(&url)
         .await
@@ -779,8 +1066,8 @@ async fn open_verified_session(
     // the server independently rejects a cleartext expensive backend frame.
     let local_reject = fetch_verified_service_policy_v1(
         &mut raw,
-        fixture.provider_id,
-        &fixture.policy_signing_key.verifying_key(),
+        provider_id,
+        &policy_signing_key.verifying_key(),
         unix_now(),
         &ServicePolicyCheckpointV1::initial(),
     )
@@ -795,9 +1082,9 @@ async fn open_verified_session(
     // Keep deterministic fixtures without reusing client ephemeral material
     // across the multiple real connections opened by this test.
     let session_id = SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let mut eph_seed = [0x20u8.wrapping_add(fixture.index); 32];
-    let mut random = [0x40u8.wrapping_add(fixture.index); 32];
-    let mut handshake_nonce = [0x60u8.wrapping_add(fixture.index); 32];
+    let mut eph_seed = [0x20u8.wrapping_add(provider_index); 32];
+    let mut random = [0x40u8.wrapping_add(provider_index); 32];
+    let mut handshake_nonce = [0x60u8.wrapping_add(provider_index); 32];
     eph_seed[..8].copy_from_slice(&session_id.to_le_bytes());
     random[..8].copy_from_slice(&session_id.wrapping_add(0x1000).to_le_bytes());
     handshake_nonce[..8].copy_from_slice(&session_id.wrapping_add(0x2000).to_le_bytes());
@@ -825,14 +1112,14 @@ async fn open_verified_session(
     .expect("secure-channel upgrade");
     let accepted = fetch_verified_service_policy_v1(
         &mut secure,
-        fixture.provider_id,
-        &fixture.policy_signing_key.verifying_key(),
+        provider_id,
+        &policy_signing_key.verifying_key(),
         unix_now(),
         &ServicePolicyCheckpointV1::initial(),
     )
     .await
     .expect("verify exact signed provider policy");
-    assert_eq!(accepted.policy_digest(), fixture.policy_digest);
+    assert_eq!(accepted.policy_digest(), policy_digest);
     assert_eq!(accepted.checkpoint().rollback_guard().highest_epoch, 1);
 
     expect_error_response(
@@ -840,6 +1127,342 @@ async fn open_verified_session(
         "authorization required",
     );
     (secure, accepted)
+}
+
+fn storeless_free_pow_server_args(
+    db_path: &Path,
+    fixture: &StorelessFreePowFixture,
+    port: u16,
+    expected_policy_digest: [u8; 32],
+) -> Vec<String> {
+    storeless_free_pow_server_args_with_policy(
+        db_path,
+        fixture,
+        &fixture.policy_path,
+        port,
+        expected_policy_digest,
+    )
+}
+
+fn storeless_free_pow_server_args_with_policy(
+    db_path: &Path,
+    fixture: &StorelessFreePowFixture,
+    policy_path: &Path,
+    port: u16,
+    expected_policy_digest: [u8; 32],
+) -> Vec<String> {
+    vec![
+        "--bind-address".to_owned(),
+        "127.0.0.1".to_owned(),
+        "--port".to_owned(),
+        port.to_string(),
+        "--data-dir".to_owned(),
+        db_path.display().to_string(),
+        "--role".to_owned(),
+        "secondary".to_owned(),
+        "--disable-onion".to_owned(),
+        "--serve-queries".to_owned(),
+        "--require-service-auth-v1".to_owned(),
+        "--service-policy".to_owned(),
+        policy_path.display().to_string(),
+        "--service-provider-id-hex".to_owned(),
+        hex::encode(fixture.provider_id),
+        "--service-policy-key-hex".to_owned(),
+        hex::encode(fixture.policy_signing_key.verifying_key().to_bytes()),
+        "--service-storeless-free-pow-policy-digest-hex".to_owned(),
+        hex::encode(expected_policy_digest),
+        "--max-connections".to_owned(),
+        "16".to_owned(),
+        "--service-max-concurrent-auth".to_owned(),
+        "4".to_owned(),
+        "--websocket-handshake-timeout-ms".to_owned(),
+        "1000".to_owned(),
+        "--connection-idle-timeout-ms".to_owned(),
+        "60000".to_owned(),
+        "--service-pre-auth-timeout-ms".to_owned(),
+        "60000".to_owned(),
+    ]
+}
+
+fn assert_storeless_startup_fails(
+    root: &Path,
+    db_path: &Path,
+    fixture: &StorelessFreePowFixture,
+    expected_policy_digest: [u8; 32],
+    extra_args: &[&str],
+    expected_error: &str,
+) {
+    assert_storeless_startup_fails_with_policy(
+        root,
+        db_path,
+        fixture,
+        &fixture.policy_path,
+        expected_policy_digest,
+        extra_args,
+        expected_error,
+    );
+}
+
+fn assert_storeless_startup_fails_with_policy(
+    root: &Path,
+    db_path: &Path,
+    fixture: &StorelessFreePowFixture,
+    policy_path: &Path,
+    expected_policy_digest: [u8; 32],
+    extra_args: &[&str],
+    expected_error: &str,
+) {
+    let port = unused_loopback_port();
+    let mut args = storeless_free_pow_server_args_with_policy(
+        db_path,
+        fixture,
+        policy_path,
+        port,
+        expected_policy_digest,
+    );
+    args.extend(extra_args.iter().map(|value| (*value).to_owned()));
+    let mut child = Command::new(env!("CARGO_BIN_EXE_unified_server"))
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rejected storeless configuration");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if child
+            .try_wait()
+            .expect("poll rejected storeless configuration")
+            .is_some()
+        {
+            break;
+        }
+        if TcpStream::connect_timeout(
+            &format!("127.0.0.1:{port}").parse().unwrap(),
+            Duration::from_millis(50),
+        )
+        .is_ok()
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("rejected storeless configuration opened a listener");
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("rejected storeless configuration did not terminate");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    let output = child
+        .wait_with_output()
+        .expect("collect rejected storeless configuration output");
+    assert!(!output.status.success());
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        combined.contains(expected_error),
+        "expected startup error {expected_error:?}, got:\n{combined}"
+    );
+    assert!(
+        TcpStream::connect(("127.0.0.1", port)).is_err(),
+        "rejected storeless configuration left a listener"
+    );
+    assert!(root.exists());
+}
+
+fn build_storeless_free_pow_provider(
+    root: &Path,
+    manifest_root: [u8; 32],
+    now: u64,
+) -> StorelessFreePowFixture {
+    let provider_root = root.join("storeless-free-pow-provider");
+    fs::create_dir(&provider_root).unwrap();
+    chmod(&provider_root, 0o700);
+    let operator_key = SigningKey::from_bytes(&[0x71; 32]);
+    let policy_signing_key = SigningKey::from_bytes(&[0x72; 32]);
+    let provider_id = derive_provider_id(
+        &operator_key.verifying_key().to_bytes(),
+        "payment-v1-storeless-free-pow-provider",
+    );
+    let scope = ServiceScopeV1 {
+        provider_id,
+        backend: BackendId::DpfPirV1,
+        workload: WorkloadId::DpfEvaluateJobV1,
+        protocol_version: 1,
+        dataset: DatasetBindingV1::ManifestRoot {
+            root: manifest_root,
+        },
+        operation_profile: OPERATION_PROFILE,
+        entitlement_profile: ENTITLEMENT_PROFILE,
+    };
+    let dpf_scope_id = scope.scope_id();
+    let policy = sign_free_policy(
+        provider_id,
+        scope,
+        FreeModeV1::ProofOfWork,
+        8,
+        now,
+        &policy_signing_key,
+    );
+    let policy_digest = policy.policy_digest().unwrap();
+    let policy_path = provider_root.join("service-policy-v1.bin");
+    fs::write(&policy_path, policy.encode().unwrap()).unwrap();
+    chmod(&policy_path, 0o644);
+    StorelessFreePowFixture {
+        provider_id,
+        policy_signing_key,
+        policy_path,
+        dpf_scope_id,
+        policy_digest,
+    }
+}
+
+fn build_open_free_policy(
+    fixture: &StorelessFreePowFixture,
+    manifest_root: [u8; 32],
+    now: u64,
+) -> ServicePolicyV1 {
+    sign_free_policy(
+        fixture.provider_id,
+        ServiceScopeV1 {
+            provider_id: fixture.provider_id,
+            backend: BackendId::DpfPirV1,
+            workload: WorkloadId::DpfEvaluateJobV1,
+            protocol_version: 1,
+            dataset: DatasetBindingV1::ManifestRoot {
+                root: manifest_root,
+            },
+            operation_profile: OPERATION_PROFILE,
+            entitlement_profile: ENTITLEMENT_PROFILE,
+        },
+        FreeModeV1::OpenBestEffort,
+        0,
+        now,
+        &fixture.policy_signing_key,
+    )
+}
+
+fn sign_free_policy(
+    provider_id: [u8; 32],
+    scope: ServiceScopeV1,
+    free_mode: FreeModeV1,
+    free_pow_difficulty_bits: u8,
+    now: u64,
+    signing_key: &SigningKey,
+) -> ServicePolicyV1 {
+    ServicePolicyV1::sign(
+        provider_id,
+        1,
+        now.saturating_sub(60),
+        now.checked_add(3_600).unwrap(),
+        AuthPaddingClassV1::Class16KiB,
+        vec![ServiceScopePolicyV1 {
+            scope,
+            limits: EntitlementLimitsV1 {
+                max_logical_inputs: 1,
+                max_frames: 1,
+                max_request_bytes: 16 * 1024,
+                max_response_bytes: 4 * 1024,
+                max_wall_time_ms: 10_000,
+                max_concurrent_sockets: 1,
+                max_hint_groups: 0,
+                max_work_units: 4,
+            },
+            offers: vec![ServiceOfferV1 {
+                offer_id: DPF_OFFER_ID,
+                acquisition: AcquisitionMethod::FreeV1,
+                free_mode,
+                free_quota: 0,
+                free_window_seconds: 0,
+                free_pow_difficulty_bits,
+                priority_class: 1,
+                authorization: AuthScheme::FreeV1,
+                verification: VerificationMode::ProviderLocal,
+                deployment_status: DeploymentStatus::Stable,
+                price: PriceV1::Free,
+                issuer_id: [0; 32],
+                key_id: Vec::new(),
+                credential_binding: None,
+                cashu_mint_manifest: None,
+                endpoint: String::new(),
+                invoice_expiry_seconds: 0,
+                claim_window_seconds: 0,
+                minimum_credential_validity_seconds: 1,
+                retired_policy_grace_seconds: 0,
+                credential_count: 1,
+                credential_presentation_limit: 1,
+                privacy_leakage: PrivacyLeakageV1::NONE,
+            }],
+        }],
+        signing_key,
+    )
+    .unwrap()
+}
+
+fn solve_pow(challenge: &PowChallengeResponseV1) -> FreePowProofV1 {
+    for nonce in 0..=u64::MAX {
+        let solution = FreePowProofV1 {
+            challenge_id: challenge.challenge_id,
+            nonce,
+        };
+        if pow_solution_meets_difficulty_v1(challenge, &solution).unwrap() {
+            return solution;
+        }
+    }
+    unreachable!("bounded test difficulty has a solution")
+}
+
+fn tree_contains_provider_state(root: &Path) -> bool {
+    fs::read_dir(root)
+        .unwrap_or_else(|error| {
+            panic!("inspect storeless runtime tree {}: {error}", root.display())
+        })
+        .map(|entry| {
+            entry.unwrap_or_else(|error| {
+                panic!(
+                    "inspect entry under storeless runtime tree {}: {error}",
+                    root.display()
+                )
+            })
+        })
+        .any(|entry| {
+            let path = entry.path();
+            if path.is_dir() {
+                tree_contains_provider_state(&path)
+            } else {
+                let suspicious_name =
+                    path.file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| {
+                            name.contains(".sqlite")
+                                || name.ends_with("-wal")
+                                || name.ends_with("-shm")
+                                || name.contains("rollback")
+                                || name == "provider.db"
+                        });
+                suspicious_name || file_has_sqlite_header(&path)
+            }
+        })
+}
+
+fn file_has_sqlite_header(path: &Path) -> bool {
+    let mut file = File::open(path).unwrap_or_else(|error| {
+        panic!("inspect storeless runtime file {}: {error}", path.display())
+    });
+    let mut header = [0u8; 16];
+    let mut filled = 0;
+    while filled < header.len() {
+        match file.read(&mut header[filled..]) {
+            Ok(0) => break,
+            Ok(read) => filled += read,
+            Err(error) => panic!("read storeless runtime file {}: {error}", path.display()),
+        }
+    }
+    filled == header.len() && &header == b"SQLite format 3\0"
 }
 
 fn build_provider(

--- a/apps/server/tests/payment_v1_process_e2e.rs
+++ b/apps/server/tests/payment_v1_process_e2e.rs
@@ -377,7 +377,7 @@ async fn exact_pinned_storeless_free_pow_challenge_authorizes_one_real_query() {
 
     let (stdout, stderr) = server.stop();
     assert_loopback_listener(0, port, &stdout, &stderr);
-    assert!(stdout.contains("Storeless Free-PoW: exact measured policy digest"));
+    assert!(stdout.contains("Storeless Free-PoW: exact policy digest pin active"));
     assert!(!stdout.contains("Provider store startup_check=ok"));
     assert!(
         !tree_contains_provider_state(root.path()),

--- a/crates/protocol/runtime/src/service_policy_runtime.rs
+++ b/crates/protocol/runtime/src/service_policy_runtime.rs
@@ -11,10 +11,10 @@ use std::fmt;
 
 use ed25519_dalek::VerifyingKey;
 use pir_service_protocol::{
-    AuthScheme, CashuManifestEpochFloorV1, CredentialKeysetEpochFloorV1, FreeModeV1,
-    PolicyRollbackGuardV1, ProviderId, ServiceOfferV1, ServicePolicyEpochFloorsV1,
-    ServicePolicyResponseV1, ServicePolicyV1, ServiceProtocolError, VerifiedCurrentPolicyV1,
-    VerifiedRetiredOfferV1, VerifiedServiceOfferV1,
+    AcquisitionMethod, AuthScheme, CashuManifestEpochFloorV1, CredentialKeysetEpochFloorV1,
+    FreeModeV1, PolicyRollbackGuardV1, PriceV1, ProviderId, ServiceOfferV1,
+    ServicePolicyEpochFloorsV1, ServicePolicyResponseV1, ServicePolicyV1, ServiceProtocolError,
+    VerificationMode, VerifiedCurrentPolicyV1, VerifiedRetiredOfferV1, VerifiedServiceOfferV1,
 };
 use pir_service_store::{
     ArcExclusiveKeyLineageVerifierV1, ProviderStore, StoreError,
@@ -34,6 +34,8 @@ pub enum ServicePolicyActivationErrorV1 {
     RetainedPolicyIsCurrent,
     RetainedPolicyIsNotOlder,
     RetainedPolicyHasNoCredentialOffers,
+    ExactPolicyDigestMismatch,
+    StorelessPolicyIsNotFreeProofOfWorkOnly,
     MissingMethodAdapter(AdmissionMethodRouteV1),
 }
 
@@ -63,6 +65,11 @@ impl fmt::Display for ServicePolicyActivationErrorV1 {
             ),
             Self::RetainedPolicyHasNoCredentialOffers => formatter
                 .write_str("retained service policy has no provider-bound credential offers"),
+            Self::ExactPolicyDigestMismatch => formatter
+                .write_str("service policy does not match the exact storeless policy digest pin"),
+            Self::StorelessPolicyIsNotFreeProofOfWorkOnly => formatter.write_str(
+                "storeless service policy must contain only provider-local Free proof-of-work offers",
+            ),
             Self::MissingMethodAdapter(route) => {
                 write!(
                     formatter,
@@ -85,6 +92,8 @@ impl std::error::Error for ServicePolicyActivationErrorV1 {
             | Self::RetainedPolicyIsCurrent
             | Self::RetainedPolicyIsNotOlder
             | Self::RetainedPolicyHasNoCredentialOffers
+            | Self::ExactPolicyDigestMismatch
+            | Self::StorelessPolicyIsNotFreeProofOfWorkOnly
             | Self::MissingMethodAdapter(_) => None,
         }
     }
@@ -361,6 +370,97 @@ pub fn activate_retained_service_policy_v1(
     })
 }
 
+/// Activate one exact, signed, provider-local Free proof-of-work policy without
+/// opening a ProviderStore or rollback authority.
+///
+/// This deliberately narrow mode exists for measured, immutable deployments
+/// whose command line pins the exact canonical policy digest. The digest pin is
+/// the rollback/fork boundary: accepting an operator key, epoch floor, or
+/// mutable policy path alone would let a hostile host replay an older signed
+/// free policy. Paid methods, durable IP quota, anonymous tickets, retained
+/// policies, and every credential-bearing offer still require the ordinary
+/// rollback-aware [`activate_service_policy_v1`] path.
+pub fn activate_exact_storeless_free_pow_policy_v1(
+    canonical_signed_policy: &[u8],
+    expected_provider_id: ProviderId,
+    verifying_key: VerifyingKey,
+    expected_policy_digest: [u8; 32],
+    now_unix: u64,
+) -> Result<ActivatedServicePolicyV1, ServicePolicyActivationErrorV1> {
+    if canonical_signed_policy.is_empty() {
+        return Err(ServicePolicyActivationErrorV1::EmptyPolicy);
+    }
+    if canonical_signed_policy.len() > MAX_SIGNED_POLICY_BYTES {
+        return Err(ServicePolicyActivationErrorV1::PolicyTooLarge {
+            len: canonical_signed_policy.len(),
+        });
+    }
+
+    let policy = ServicePolicyV1::decode(canonical_signed_policy)?;
+    if policy.encode()?.as_slice() != canonical_signed_policy {
+        return Err(ServicePolicyActivationErrorV1::NonCanonicalPolicy);
+    }
+    let policy_digest = policy.policy_digest()?;
+    if expected_policy_digest.iter().all(|byte| *byte == 0)
+        || policy_digest != expected_policy_digest
+    {
+        return Err(ServicePolicyActivationErrorV1::ExactPolicyDigestMismatch);
+    }
+    if policy.scopes.is_empty()
+        || policy.scopes.iter().any(|scope| scope.offers.is_empty())
+        || policy
+            .scopes
+            .iter()
+            .flat_map(|scope| &scope.offers)
+            .any(|offer| {
+                offer.acquisition != AcquisitionMethod::FreeV1
+                    || offer.authorization != AuthScheme::FreeV1
+                    || offer.free_mode != FreeModeV1::ProofOfWork
+                    || offer.verification != VerificationMode::ProviderLocal
+                    || offer.price != PriceV1::Free
+                    || offer.issuer_id != [0; 32]
+                    || !offer.key_id.is_empty()
+                    || offer.credential_binding.is_some()
+                    || offer.cashu_mint_manifest.is_some()
+                    || !offer.endpoint.is_empty()
+                    || offer.invoice_expiry_seconds != 0
+                    || offer.claim_window_seconds != 0
+                    || offer.minimum_credential_validity_seconds != 1
+                    || offer.retired_policy_grace_seconds != 0
+                    || offer.credential_count != 1
+                    || offer.credential_presentation_limit != 1
+                    || offer.privacy_leakage != pir_service_protocol::PrivacyLeakageV1::NONE
+            })
+    {
+        return Err(ServicePolicyActivationErrorV1::StorelessPolicyIsNotFreeProofOfWorkOnly);
+    }
+
+    // The exact digest pin supplies both the epoch and same-epoch fork guard.
+    // Credential/mint floors are empty because the policy shape above forbids
+    // all credential and Cashu material.
+    let rollback_guard = PolicyRollbackGuardV1 {
+        highest_epoch: policy.policy_epoch,
+        digest_at_highest_epoch: policy_digest,
+    };
+    let epoch_floors = ServicePolicyEpochFloorsV1::initial();
+    policy.verify_current_for_acquisition(
+        &expected_provider_id,
+        now_unix,
+        &rollback_guard,
+        &epoch_floors,
+        &verifying_key,
+    )?;
+
+    Ok(ActivatedServicePolicyV1 {
+        policy,
+        provider_id: expected_provider_id,
+        verifying_key,
+        rollback_guard,
+        epoch_floors,
+        policy_digest,
+    })
+}
+
 /// Decode, verify, durably advance rollback state, install provider-local
 /// bearer namespaces, and only then return an activatable policy.
 pub fn activate_service_policy_v1(
@@ -623,6 +723,28 @@ mod tests {
         .unwrap()
     }
 
+    fn free_pow_policy(
+        signing: &SigningKey,
+        provider_id: ProviderId,
+        epoch: u64,
+    ) -> ServicePolicyV1 {
+        let template = free_policy(signing, provider_id, epoch);
+        let mut scopes = template.scopes;
+        let offer = &mut scopes[0].offers[0];
+        offer.free_mode = FreeModeV1::ProofOfWork;
+        offer.free_pow_difficulty_bits = 8;
+        ServicePolicyV1::sign(
+            provider_id,
+            epoch,
+            template.issued_at,
+            template.expires_at,
+            template.auth_padding_class,
+            scopes,
+            signing,
+        )
+        .unwrap()
+    }
+
     fn retained_receipt_policy(
         signing: &SigningKey,
         provider_id: ProviderId,
@@ -765,6 +887,187 @@ mod tests {
             None,
         )
         .is_err());
+    }
+
+    #[test]
+    fn exact_storeless_free_pow_activation_needs_no_store_and_keeps_exact_pin() {
+        let provider_id = [9; 32];
+        let signing = SigningKey::from_bytes(&[3; 32]);
+        let policy = free_pow_policy(&signing, provider_id, 2);
+        let bytes = policy.encode().unwrap();
+        let digest = policy.policy_digest().unwrap();
+
+        let activated = activate_exact_storeless_free_pow_policy_v1(
+            &bytes,
+            provider_id,
+            signing.verifying_key(),
+            digest,
+            150,
+        )
+        .unwrap();
+        assert_eq!(activated.policy_digest(), digest);
+        assert!(activated.verify_current(150).is_ok());
+
+        let wrong_digest = [0x42; 32];
+        assert!(matches!(
+            activate_exact_storeless_free_pow_policy_v1(
+                &bytes,
+                provider_id,
+                signing.verifying_key(),
+                wrong_digest,
+                150,
+            ),
+            Err(ServicePolicyActivationErrorV1::ExactPolicyDigestMismatch)
+        ));
+        assert!(matches!(
+            activate_exact_storeless_free_pow_policy_v1(
+                &bytes,
+                provider_id,
+                signing.verifying_key(),
+                [0; 32],
+                150,
+            ),
+            Err(ServicePolicyActivationErrorV1::ExactPolicyDigestMismatch)
+        ));
+    }
+
+    #[test]
+    fn exact_storeless_free_pow_rejects_every_broader_policy_shape() {
+        let provider_id = [9; 32];
+        let signing = SigningKey::from_bytes(&[3; 32]);
+
+        let open = free_policy(&signing, provider_id, 2);
+        let open_bytes = open.encode().unwrap();
+        assert!(matches!(
+            activate_exact_storeless_free_pow_policy_v1(
+                &open_bytes,
+                provider_id,
+                signing.verifying_key(),
+                open.policy_digest().unwrap(),
+                150,
+            ),
+            Err(ServicePolicyActivationErrorV1::StorelessPolicyIsNotFreeProofOfWorkOnly)
+        ));
+
+        let paid = retained_receipt_policy(&signing, provider_id, 2).0;
+        let paid_bytes = paid.encode().unwrap();
+        assert!(matches!(
+            activate_exact_storeless_free_pow_policy_v1(
+                &paid_bytes,
+                provider_id,
+                signing.verifying_key(),
+                paid.policy_digest().unwrap(),
+                110,
+            ),
+            Err(ServicePolicyActivationErrorV1::StorelessPolicyIsNotFreeProofOfWorkOnly)
+        ));
+
+        let policy = free_pow_policy(&signing, provider_id, 2);
+        let mut trailing = policy.encode().unwrap();
+        trailing.push(0);
+        assert!(activate_exact_storeless_free_pow_policy_v1(
+            &trailing,
+            provider_id,
+            signing.verifying_key(),
+            policy.policy_digest().unwrap(),
+            150,
+        )
+        .is_err());
+        assert!(activate_exact_storeless_free_pow_policy_v1(
+            &policy.encode().unwrap(),
+            [8; 32],
+            signing.verifying_key(),
+            policy.policy_digest().unwrap(),
+            150,
+        )
+        .is_err());
+        assert!(activate_exact_storeless_free_pow_policy_v1(
+            &policy.encode().unwrap(),
+            provider_id,
+            SigningKey::from_bytes(&[4; 32]).verifying_key(),
+            policy.policy_digest().unwrap(),
+            150,
+        )
+        .is_err());
+
+        let empty = ServicePolicyV1::sign(
+            provider_id,
+            2,
+            100,
+            200,
+            AuthPaddingClassV1::Class16KiB,
+            Vec::new(),
+            &signing,
+        )
+        .unwrap();
+        assert!(matches!(
+            activate_exact_storeless_free_pow_policy_v1(
+                &empty.encode().unwrap(),
+                provider_id,
+                signing.verifying_key(),
+                empty.policy_digest().unwrap(),
+                150,
+            ),
+            Err(ServicePolicyActivationErrorV1::StorelessPolicyIsNotFreeProofOfWorkOnly)
+        ));
+
+        let template = free_pow_policy(&signing, provider_id, 2);
+        let mut empty_offer_scopes = template.scopes;
+        empty_offer_scopes[0].offers.clear();
+        let empty_offer_scope = ServicePolicyV1::sign(
+            provider_id,
+            2,
+            template.issued_at,
+            template.expires_at,
+            template.auth_padding_class,
+            empty_offer_scopes,
+            &signing,
+        )
+        .unwrap();
+        assert!(matches!(
+            activate_exact_storeless_free_pow_policy_v1(
+                &empty_offer_scope.encode().unwrap(),
+                provider_id,
+                signing.verifying_key(),
+                empty_offer_scope.policy_digest().unwrap(),
+                150,
+            ),
+            Err(ServicePolicyActivationErrorV1::StorelessPolicyIsNotFreeProofOfWorkOnly)
+        ));
+
+        for mutate in [
+            |offer: &mut ServiceOfferV1| offer.endpoint = "https://issuer.invalid".to_owned(),
+            |offer: &mut ServiceOfferV1| offer.minimum_credential_validity_seconds = 2,
+            |offer: &mut ServiceOfferV1| offer.retired_policy_grace_seconds = 1,
+            |offer: &mut ServiceOfferV1| {
+                offer.privacy_leakage =
+                    PrivacyLeakageV1::from_bits(PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING).unwrap()
+            },
+        ] {
+            let template = free_pow_policy(&signing, provider_id, 2);
+            let mut scopes = template.scopes;
+            mutate(&mut scopes[0].offers[0]);
+            let decorated = ServicePolicyV1::sign(
+                provider_id,
+                2,
+                template.issued_at,
+                template.expires_at,
+                template.auth_padding_class,
+                scopes,
+                &signing,
+            )
+            .unwrap();
+            assert!(matches!(
+                activate_exact_storeless_free_pow_policy_v1(
+                    &decorated.encode().unwrap(),
+                    provider_id,
+                    signing.verifying_key(),
+                    decorated.policy_digest().unwrap(),
+                    150,
+                ),
+                Err(ServicePolicyActivationErrorV1::StorelessPolicyIsNotFreeProofOfWorkOnly)
+            ));
+        }
     }
 
     #[test]

--- a/deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in
+++ b/deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in
@@ -4,13 +4,13 @@
 # Never execute, source, or install this file by itself.
 #
 # The frozen signed policy MUST contain only current FreeV1 / ProofOfWork offers.
-# Inspect its canonical contents and sha256 during the UKI ceremony.
+# Inspect its canonical contents, exact protocol digest and sha256 during the
+# UKI ceremony. The digest argument itself must be measured as part of the UKI.
 
 --require-service-auth-v1
 --service-policy /home/pir/data/payment-v1/vpsbg-free-pow-only-policy.bin
 --service-provider-id-hex @VPSBG_PROVIDER_ID_HEX@
 --service-policy-key-hex @VPSBG_POLICY_PUBKEY_HEX@
---service-store /home/pir/data/payment-v1/provider.sqlite3
---service-remote-rollback-authority-config /home/pir/data/payment-v1/remote-rollback-authority.toml
+--service-storeless-free-pow-policy-digest-hex @VPSBG_FREE_POW_POLICY_DIGEST_HEX@
 --service-max-concurrent-auth 16
 --service-pre-auth-timeout-ms 60000

--- a/docs/payment/DEPLOYMENT_INPUT_MATRIX.md
+++ b/docs/payment/DEPLOYMENT_INPUT_MATRIX.md
@@ -81,6 +81,15 @@ reboot and client-pin migration retain their separate ceremony. Do not place a
 Hetzner issuer, mint, relay or rollback authority into that failure domain just
 to simplify the plan.
 
+That VPSBG fragment selects only the exact-pinned storeless Free-PoW runtime.
+Record both the ordinary policy-file SHA-256 and the distinct
+`ServicePolicyV1::policy_digest()` over complete signed canonical bytes. The
+latter must be a literal measured launch input; policy renewal, expiry extension,
+difficulty, scope, dataset, limit or any signed-byte change requires a new UKI,
+fresh attestation measurement and client pin migration. No ProviderStore,
+rollback client, retained policy, Free-IP state or payment/credential input is
+valid in this profile.
+
 ## 4. Non-secret input register
 
 The following values are safe to review as public or operational metadata, but

--- a/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
+++ b/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
@@ -42,11 +42,11 @@ needs to know the other's identity or payment method.
   Hetzner payment issuer + CLN -- pinned HTTPS/CAS --> issuer authority host
   Hetzner directory Relay A + same-host TLS edges
 
-  VPSBG Tier 3 provider       -- pinned HTTPS/CAS --> provider-1 authority host
+  VPSBG Tier 3 provider       -- no payment store/rollback authority
     existing PIR process + enforced V1 + Free/PoW only
     no issuer, relay or mint
 
-  The three authority hosts above are separately administered failure domains.
+  The two stateful authority hosts above are separately administered failure domains.
 
   independent Relay B failure domain
   +----------------------+
@@ -54,11 +54,13 @@ needs to know the other's identity or payment method.
   +----------------------+
 ```
 
-The rollback authorities are not extra processes on the Hetzner provider or
-VPSBG detailed-store hosts. Provider 0, Provider 1, and the issuer require
-separate authority hosts, service accounts, TLS keys, Ed25519 keys, namespaces,
-administrators, logs, and backup/restore domains. Co-location is permitted only
-for an explicitly non-production exercise.
+The rollback authorities are not extra processes on the stateful Hetzner
+provider or issuer hosts. Provider 0 and the issuer require separate authority
+hosts, service accounts, TLS keys, Ed25519 keys, namespaces, administrators,
+logs, and backup/restore domains. Co-location is permitted only for an
+explicitly non-production exercise. The exact-pinned VPSBG Free-PoW profile is
+the narrow storeless exception described below; adding any stateful method to
+it creates a new authority requirement.
 
 Relay A and Relay B likewise require genuinely independent host, network,
 administrator, log and backup/restore domains; a second hostname on the Hetzner
@@ -427,9 +429,15 @@ behavior remains authoritative.
 The frozen VPSBG policy must contain only current `FreeV1` ProofOfWork offers.
 It may expose multiple backend-specific scopes, but every offer has
 `free_mode = proof-of-work`, a non-zero bounded difficulty, no issuer/key
-binding, and a zero price. Before baking, inspect the canonical signed policy
-and verify its SHA-256 against the UKI manifest. The CLI alone cannot prove the
-contents of a signed policy.
+binding, an empty endpoint/privacy-leakage declaration, and a zero price. Before
+baking, inspect the canonical signed policy, compute its domain-separated
+`ServicePolicyV1::policy_digest()` over the complete signed canonical bytes,
+place that exact non-zero value in
+`--service-storeless-free-pow-policy-digest-hex`, and separately verify the
+file's ordinary SHA-256 against the UKI manifest. Those are different digests.
+The exact protocol digest argument and the script that supplies it MUST be
+inside the measured UKI; an unmeasured host argument or mutable environment
+variable does not replace a rollback floor.
 
 The VPSBG template deliberately has no:
 
@@ -440,36 +448,34 @@ The VPSBG template deliberately has no:
 - online-authority method material; a Free-PoW-only policy creates no online
   V2Full authorization route and needs no V2Full override flag.
 
-### P1 activation blocker: VPSBG hostile-host secrecy
+### Storeless measured-policy boundary
 
-The existing Tier 3 `/home/pir/data` is supplied by a host-visible rootfs. The
-repository does not yet implement SEV-SNP sealing, a vTPM, or
-attestation-gated key release for this data. An effective-user-owned mode-0700
-subtree and single-link mode-0600 files protect only against ordinary accounts
-inside the guest. They do not protect against the VPSBG operator: the VPSBG
-host can read or copy the ProviderStore and the remote rollback client's
-Ed25519 seed/value-root key material.
+The VPSBG Free-PoW profile now uses the deliberately narrow storeless runtime
+path. Startup opens no ProviderStore or rollback authority and accepts no
+retained policy, Free-IP quota/key, payment or credential key, direct receipt,
+Cashu, BAT, ARC, shared issuer, legacy credential gate, or test HTTPS root.
+Policy activation rejects an empty policy, an empty scope, any non-Free-PoW
+offer, and unused credential/issuer/endpoint/privacy fields. Runtime admission
+keeps only one fresh challenge in the secure connection; the solution is bound
+to provider, exact policy/scope/offer/operation, random challenge and that
+connection's secure-channel exporter. Closing or restarting loses the
+challenge and cannot turn it into a reusable bearer credential.
 
-This is an activation blocker even for the Free-PoW canary while it requires a
-ProviderStore. Before production activation, the user must explicitly approve
-one of two designs:
+This removes the earlier ProviderStore/remote-authority secret from the VPSBG
+Free-PoW canary; it does not claim that a host-visible rootfs is sealed. The
+signed policy is public and may remain on host-visible storage because its
+signature, provider/key pins and measured exact digest reject replacement.
+Any later stateful method, retained redemption, durable quota or payment method
+must leave this profile and restore the ordinary ProviderStore plus independent
+rollback-authority design; no automatic fallback exists.
 
-1. implement and review attestation-gated key release or equivalent sealing; or
-2. expand the trust boundary and accept that the VPSBG host can steal these
-   availability/rollback credentials.
+The digest pin is immutable for one measurement. Changing policy epoch,
+validity, expiry, scope, dataset, limit, difficulty, priority or any other signed
+byte changes the protocol digest and therefore requires a new measured UKI.
+Plan renewal before `expires_at`; expiry fails closed and cannot be repaired by
+editing the host policy file or command line.
 
-The second choice also abandons the remote authority's anti-rollback guarantee
-*against the VPSBG host itself*: a host that steals the client signing and
-value-root keys can create correctly signed Read/CAS traffic that the
-independent authority cannot distinguish from the guest. The authority still
-separates other failure and administration domains, but it no longer protects
-the detailed store from a malicious VPSBG operator.
-
-Owner-only permissions remain required defense in depth, but must never be
-presented as hostile-host secrecy. The provider rollback authority itself
-remains on an independently administered remote host.
-
-Any binary, policy, run-script or initramfs change requires a new UKI, preserved
+Any binary, policy digest, run-script or initramfs change requires a new UKI, preserved
 previous known-good UKI, portal upload, reboot, fresh SEV-SNP measurement,
 binary hash, attestation verification and client pin update. Those are remote
 activation actions and require separate approval.
@@ -697,5 +703,7 @@ Hetzner rollback changes routing back to the previously verified process and
 preserves both detailed stores and remote authority floors; it never restores a
 stale store snapshot or lowers an authority. VPSBG rollback selects the
 preserved previous known-good UKI through the portal and restores the matching
-client measurement/binary pins. It does not edit the measured run script in
-place.
+client measurement/binary pins and that image's matching exact Free-PoW policy
+digest. This VPSBG profile has no payment ProviderStore, WAL/SHM or rollback
+authority to restore. It does not edit the measured run script, digest argument
+or policy in place.

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # Payment platform implementation status
 
-Status snapshot: 2026-07-29. This document describes repository code and local
+Status snapshot: 2026-07-30. This document describes repository code and local
 tests, not a production deployment. “Implemented” means that a code path exists;
 “tested” names the boundary actually exercised. It does not mean that an
 operator has activated the path with real money or public infrastructure.
@@ -56,6 +56,18 @@ operator has activated the path with real money or public infrastructure.
       pre-existing durable provider spend state.
 - [x] Signed policy activation with provider identity, policy epoch/fork,
       credential-keyset and Cashu-manifest rollback floors.
+- [x] A separate exact-digest storeless activation path exists only for a
+      measured Free-PoW provider. It rejects empty policies/scopes and every
+      non-provider-local Free proof-of-work or decorated issuer/credential
+      offer, and `unified_server` refuses retained policies, ProviderStore,
+      rollback, Free-IP, payment, Cashu/BAT/ARC/shared-issuer, legacy keyset and
+      test-root inputs in that mode. A real loopback child-process test performs
+      secure-channel challenge, PoW solution, AUTH and one protected DPF frame,
+      rejects the same solution on a second secure-channel exporter with no
+      outstanding challenge, and confirms that no provider/rollback
+      SQLite/WAL/SHM appears. This is source/test evidence, not a built or
+      uploaded VPSBG UKI. The exact policy digest must be measured; any policy
+      renewal or signed-byte change requires a new UKI and client pin ceremony.
 - [x] ProviderStore schema v7 with global provider-local spend uniqueness,
       BAT raw-key lineage, durable Free IP quota state, standard-Cashu swap
       recovery intents, finite per-mint/unit custody exposure, encrypted
@@ -991,6 +1003,13 @@ findings and must not be collapsed into that count.
    empty private pool directory, and rollback must use the preserved old or a
    different empty directory. Old and new binaries must never share one
    pool-directory state domain.
+   The VPSBG storeless Free-PoW profile is not a shortcut for these stateful
+   roles: it is eligible only because it has no store or retained/payment
+   method. Its separate release gate is a newly built/uploaded measured UKI
+   containing the literal exact signed-policy digest, followed by fresh
+   attestation/binary/client-pin acceptance. Policy expiry/renewal, difficulty,
+   scope, limit or dataset changes all require another UKI; host-side edits fail
+   closed.
 5. **Reproducible network E2E.** A committed deterministic no-funds fixture
    assembles two independent providers, all five workloads/methods and issuer
    artifacts. The current acceptance additionally launches two independent

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -56,7 +56,7 @@ operator has activated the path with real money or public infrastructure.
       pre-existing durable provider spend state.
 - [x] Signed policy activation with provider identity, policy epoch/fork,
       credential-keyset and Cashu-manifest rollback floors.
-- [x] A separate exact-digest storeless activation path exists only for a
+- [x] A separate exact-digest storeless activation path is intended for a
       measured Free-PoW provider. It rejects empty policies/scopes and every
       non-provider-local Free proof-of-work or decorated issuer/credential
       offer, and `unified_server` refuses retained policies, ProviderStore,
@@ -65,9 +65,12 @@ operator has activated the path with real money or public infrastructure.
       secure-channel challenge, PoW solution, AUTH and one protected DPF frame,
       rejects the same solution on a second secure-channel exporter with no
       outstanding challenge, and confirms that no provider/rollback
-      SQLite/WAL/SHM appears. This is source/test evidence, not a built or
-      uploaded VPSBG UKI. The exact policy digest must be measured; any policy
-      renewal or signed-byte change requires a new UKI and client pin ceremony.
+      SQLite/WAL/SHM appears. This is source/test evidence, not proof that a
+      VPSBG UKI has been built, uploaded, or measured. A deployment may claim
+      measurement only after its exact policy digest and startup arguments are
+      covered by independently verified UKI/attestation evidence; any policy
+      renewal or signed-byte change then requires a new UKI and client pin
+      ceremony.
 - [x] ProviderStore schema v7 with global provider-local spend uniqueness,
       BAT raw-key lineage, durable Free IP quota state, standard-Cashu swap
       recovery intents, finite per-mint/unit custody exposure, encrypted

--- a/docs/payment/LOCAL_ACCEPTANCE.md
+++ b/docs/payment/LOCAL_ACCEPTANCE.md
@@ -599,7 +599,7 @@ the complete vendor tree as an incidental Payment change.
 
 | Method | Focused command/boundary | What it proves | What it does not prove |
 |---|---|---|---|
-| Free | `cargo test --offline -p pir-service-store free_ip_rate_limit`, the runtime matrix, the feature-gated non-receipt process matrix, `payment_v1_methods_process_e2e`, and `npm run test:e2e:payment-two-provider` | open and durable IP-quota authorization through real DPF, Harmony hint/query, Onion and TEE-ORAM provider processes, including wrong-operation non-burn and restart-persistent quota rejection; the Chromium variant additionally joins an exact signed quota-1/window-3600 IP-rate-limited offer and verified DPF/Merkle execution | public-IP attribution behind a real proxy, a generated-browser PoW case, or production DDoS resistance |
+| Free | `cargo test --offline -p pir-service-store free_ip_rate_limit`, the runtime matrix, the feature-gated non-receipt process matrix, `payment_v1_process_e2e`, `payment_v1_methods_process_e2e`, and `npm run test:e2e:payment-two-provider` | open and durable IP-quota authorization through real DPF, Harmony hint/query, Onion and TEE-ORAM provider processes, including wrong-operation non-burn and restart-persistent quota rejection; the default process test additionally boots exact-pinned storeless Free-PoW with no store/authority, completes challenge/solution/AUTH/real DPF and rejects cross-exporter replay; the Chromium variant joins an exact signed quota-1/window-3600 IP-rate-limited offer and verified DPF/Merkle execution | public-IP attribution behind a real proxy, a generated-browser PoW case, production SEV/UKI measurement, or production DDoS resistance |
 | Direct BOLT11 receipt | `cargo test --offline -p pir-lightning-backend`, issuer lifecycle tests, `direct_receipt_production_committer_spend_survives_store_restart`, and optional `scripts/payment-v1-cln-regtest-e2e.sh --acknowledge-local-regtest-only` | fake lifecycle/state tests, signed receipt admission and replay rejection across ProviderStore restart, plus a real local CLN socket and generated-WASM acquisition path; the final current-tree opt-in run passed the forced payer -> router -> issuer route and joined verified provider queries | a public-network or real-value wallet payment, production ingress, or production Lightning operations |
 | Standard Cashu eCash | `cargo test --offline -p pir-cashu-client`, `cargo test --offline -p pir-cashu-custody`, ProviderStore custody tests, the runtime matrix, optional `scripts/payment-v1-cdk-regtest-e2e.sh`, and the feature-gated Standard-Cashu/non-receipt process commands below | exact swap/recovery/grant-to-custody state machine, generated-JS/WASM plus real-CDK NUT-03/NUT-12, and strict-TLS NUT-03 swap through real DPF, Harmony hint/query, Onion and TEE-ORAM provider processes; wrong-operation and replay rejection do not make an extra mint request | an approved external public-WebPKI mint, an independent production rollback floor, admin retirement against real CDK, public-mint interoperability, real-value custody or payout |
 | Cashu BAT | `cargo test --offline -p pir-payment-crypto --features provider-store --test provider_store_bat_adapter`, the runtime matrix, `payment_v1_methods_process_e2e`, and the feature-gated non-receipt process matrix | real blind/DLEQ/unblind proofs through DPF, Harmony hint/query, Onion and TEE-ORAM provider processes, plus provider-local durable serial rejection after restart | a public/shared Cashu service or production key custody |
@@ -658,12 +658,13 @@ cargo test --locked --offline -p runtime --features cuckoo-oram \
   --test payment_v1_tee_oram_process_e2e
 ```
 
-The first two no-funds tests launch two independent logical providers as real
-OS child processes and communicate over real TCP/WebSocket connections. Each
-provider has a distinct provider ID, policy key, method keys, ProviderStore and rollback
-authority. Both listeners are explicitly `127.0.0.1`-only, and the first test
-also proves that a misspelled `--bind-addres` flag exits non-zero before opening
-a listener.
+The first two no-funds tests launch real OS child processes and communicate over
+real TCP/WebSocket connections. Their stateful two-provider fixtures give each
+provider a distinct provider ID, policy key, method keys, ProviderStore and
+rollback authority. The first test binary also has a distinct single-provider
+storeless Free-PoW fixture with no ProviderStore or authority. Every listener
+is explicitly `127.0.0.1`-only, and the first test also proves that a misspelled
+`--bind-addres` flag exits non-zero before opening a listener.
 
 The direct-receipt test covers cleartext backend rejection, ephemeral-bound
 attestation exchange, secure-channel upgrade, exact signed manifest-root
@@ -678,6 +679,20 @@ provider-1 DPF receipt is first rejected by provider 0 and then succeeds at
 provider 1, proving that the wrong-provider rejection neither burns it nor
 consults a shared cross-provider spent set. No hint server is configured or
 named by this query-provider test.
+
+The same process binary now exercises the narrow VPSBG-oriented storeless
+mode. It pins the exact domain-separated digest of one canonical signed policy
+containing only provider-local Free-PoW, starts `unified_server` without a
+ProviderStore or rollback argument, obtains a server-fresh challenge on the
+encrypted channel, solves it, receives `AUTH_GRANTED`, and reaches one real DPF
+handler frame. A second connection has a different secure-channel exporter and
+no outstanding challenge, so replaying the old solution is rejected. The
+temporary runtime tree is checked for provider/rollback SQLite, WAL and SHM
+files. Startup negatives cover the wrong digest, an otherwise valid Free-open
+policy, retained/store/rollback/Free-IP/BAT/shared inputs and legacy ARC/Cashu
+keys. This does not prove a measured UKI: the exact digest must be included in
+that UKI, and every signed policy update requires a new UKI/measurement/client
+pin ceremony.
 
 The method-adapter test repeats the real wire and DPF execution boundary for
 Free open, durable provider-local IP quota, provider-local Cashu BAT and

--- a/docs/payment/OPERATOR_RUNBOOK.md
+++ b/docs/payment/OPERATOR_RUNBOOK.md
@@ -263,13 +263,23 @@ container images, CI artifacts or directory events.
 
 ## 3. Persistence and backup domains
 
-Every logical provider has its own ProviderStore. Independent providers must
+Every stateful logical provider has its own ProviderStore. Independent providers must
 not share the database, WAL, spent set or remote spend service. Replicas sharing
 one `provider_id` and keysets are one logical provider and need one linearizable
 spend authority. Payment V1 does not support independent ProviderStore
 databases as active/active replicas. A common external rollback-floor CAS can
 fence an exact cloned-state race to one winner, but it is not detailed-state
 replication and does not make the losing database safe to serve.
+
+The sole V1 exception is a measured, exact-digest-pinned storeless profile whose
+signed policy contains only provider-local Free proof-of-work offers. It creates
+no ProviderStore, WAL/SHM, rollback client or retained-policy surface. Its exact
+domain-separated signed-policy digest, provider ID and policy verification key
+must be compiled into the measured UKI launch inputs. Any policy renewal or
+change requires a new UKI and client measurement/pin ceremony; do not edit the
+host policy or append an unmeasured digest argument. Adding any stateful quota,
+credential, payment or retained method exits this exception and requires the
+ordinary independent store/authority ceremony before startup.
 
 The provider/issuer SQLite database and its rollback-floor authority must be in
 **independent backup and restore domains**. Merely using two filenames on one

--- a/docs/payment/SECURITY.md
+++ b/docs/payment/SECURITY.md
@@ -86,7 +86,10 @@ Status: release-gating checklist. `MUST` items are fail-closed requirements.
 31. Proof-level Cashu DLEQ fields and wallet blinding scalars never cross the
     PIR wire. Standard Cashu imports are normalized before authorization.
 32. Accepted policy, credential-keyset, Cashu-manifest, clearing-authorization,
-    and directory epochs have durable monotonic rollback floors.
+    and directory epochs have durable monotonic rollback floors. The only
+    provider-policy exception is the measured storeless Free-PoW profile in
+    invariant 71: its exact complete signed policy digest is the immutable
+    floor for one UKI measurement.
 33. Blind clearing commits to one issuer-approved settlement keyset and its
     recovery horizon before the provider reveals blinded outputs.
 34. A quote intent binds the exact issuer-root-signed quote-key delegation,
@@ -137,9 +140,11 @@ Status: release-gating checklist. `MUST` items are fail-closed requirements.
     signature and exact lowercase canonical encoding, reject amountless/zero
     invoices and simnet, and obtain the payee from `n` or signature recovery.
     Caller-asserted invoice facts are never a fallback.
-42. Both provider and issuer databases are checked against an authority stored
-    outside the SQLite backup domain. A missing or lower restore floor fails
-    closed; an operator cannot resume from a stale internally consistent copy.
+42. Every stateful provider database and every issuer database is checked
+    against an authority stored outside the SQLite backup domain. A missing or
+    lower restore floor fails closed; an operator cannot resume from a stale
+    internally consistent copy. Invariant 71's exact-pinned Free-PoW profile is
+    stateless and must not create either database.
 43. Directory clients retain monotonic per-provider state and compare signed
     catalog checkpoints across configured relays. A same-sequence fork is a
     split-view failure; silent first-seen-wins behavior is forbidden.
@@ -323,6 +328,20 @@ Status: release-gating checklist. `MUST` items are fail-closed requirements.
     binding. Product code must first freeze the independently selected DPF
     server pair or Harmony hint/query payment context. This rule does not apply
     to the genuinely single-provider Onion and TEE-ORAM backends.
+71. Storeless service admission is permitted only for a nonempty canonical
+    signed policy with no empty scope and only provider-local
+    `FreeV1`/`ProofOfWork`/zero-price offers with no issuer, key, credential,
+    Cashu manifest, endpoint, retained grace or privacy-leakage field. Startup
+    requires the exact nonzero domain-separated digest of the complete signed
+    policy and rejects every ProviderStore, rollback authority, retained policy,
+    Free-IP quota/key, payment/Cashu/BAT/ARC/shared-issuer, legacy credential or
+    test-root input. The digest argument and provider/policy-key pins MUST be in
+    the measured UKI. Each challenge is random, single-outstanding,
+    connection-local, short-lived and bound to the secure-channel exporter plus
+    exact provider/policy/scope/offer/operation. A policy-byte change, including
+    renewal or difficulty/limit change, requires a new UKI measurement and
+    client pin update; expiry or mismatch fails closed without a stateful or
+    legacy fallback.
 
 ## TLS revocation residual
 

--- a/docs/payment/SECURITY_REVIEW_2026-07-29_DEPLOYMENT.md
+++ b/docs/payment/SECURITY_REVIEW_2026-07-29_DEPLOYMENT.md
@@ -297,15 +297,20 @@ account, TLS/key material, administrator, log stream and backup/restore domain.
 Co-location removes the independent anti-rollback and non-collusion failure
 boundary even though authority values are opaque.
 
-### VPSBG hostile-host state custody
+### VPSBG hostile-host state custody (resolved for the storeless Free-PoW scope)
 
-The prepared VPSBG change is only a non-executable Free/PoW service-auth
-argument fragment. Its ProviderStore and remote-authority client secrets would
-still reside in host-visible `/home/pir/data`; ordinary file modes do not hide
-them from the VPSBG operator. Production activation therefore requires either
-attestation-gated key release/sealing or explicit user acceptance that the
-VPSBG host joins this trust boundary. Until that decision, the live VPSBG
-service and measured UKI remain unchanged.
+This finding applied to the earlier ProviderStore-based VPSBG proposal. The
+current fragment selects an exact-digest-pinned, storeless runtime that accepts
+only provider-local `FreeV1` proof-of-work offers and opens no ProviderStore,
+WAL/SHM or rollback-authority client. There is consequently no payment-store or
+authority secret for attestation-gated release in this narrow profile. The
+provider ID, policy verification key, exact domain-separated policy digest and
+launch arguments must instead be measured in the UKI; changing any signed
+policy byte requires a newly measured UKI and client pins. Adding a retained
+policy, durable quota, payment, Cashu, BAT, ARC or shared-issuer method revives
+the original P1 custody finding and requires the ordinary independent store
+and rollback-authority design. The live VPSBG service and measured UKI remain
+unchanged until the separately approved UKI ceremony.
 
 ### Real staging evidence and resource isolation
 

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -55,15 +55,21 @@ Mixed-provider scenarios:
 
 `cargo test --offline -p runtime --test payment_v1_process_e2e` and
 `cargo test --offline -p runtime --test payment_v1_methods_process_e2e`
-launch two independent provider child processes on explicit `127.0.0.1`
-listeners. Both perform the real WebSocket and encrypted-channel handshake,
+launch real provider child processes on explicit `127.0.0.1` listeners. The
+stateful cases use two independent providers; the first binary also launches a
+single exact-pinned storeless Free-PoW provider. All perform the real WebSocket
+and encrypted-channel handshake,
 verify each provider's exact signed manifest-root policy, execute a valid DPF
 frame, enforce the signed frame limit and reject replay after restart.
 
 The first test covers provider-specific direct receipts. The same provider-1
 receipt is rejected at provider 0 and subsequently accepted at provider 1, so
 it detects accidental cross-provider burn/shared spent state; a misspelled
-bind flag must also exit before listening. The second covers Free open,
+bind flag must also exit before listening. Its storeless case proves a fresh
+secure-channel-bound PoW challenge can authorize one protected DPF frame with
+no ProviderStore/rollback SQLite, rejects the solution on a new exporter with
+no outstanding challenge, and rejects wrong digest, Free-open policy and every
+stateful/payment/credential input before listening. The second covers Free open,
 provider-local durable IP quota, an actual Cashu BAT blind/DLEQ/unblind proof,
 and real experimental ARC issuance/presentation. It verifies independent
 provider keys/quotas, cross-provider BAT/ARC rejection, and durable quota,

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -1812,8 +1812,7 @@ function validateVpsbgFreePow(text, mode) {
       ["--service-policy", "/home/pir/data/payment-v1/vpsbg-free-pow-only-policy.bin"],
       ["--service-provider-id-hex", "@VPSBG_PROVIDER_ID_HEX@"],
       ["--service-policy-key-hex", "@VPSBG_POLICY_PUBKEY_HEX@"],
-      ["--service-store", "/home/pir/data/payment-v1/provider.sqlite3"],
-      ["--service-remote-rollback-authority-config", "/home/pir/data/payment-v1/remote-rollback-authority.toml"],
+      ["--service-storeless-free-pow-policy-digest-hex", "@VPSBG_FREE_POW_POLICY_DIGEST_HEX@"],
       ["--service-max-concurrent-auth", "16"],
       ["--service-pre-auth-timeout-ms", "60000"],
     ],
@@ -2300,8 +2299,10 @@ export function validateDeploymentTree(rootInput) {
   );
   for (const required of [
     "P1 activation blocker",
-    "attestation-gated key release",
-    "host can read or copy",
+    "Storeless measured-policy boundary",
+    "exact protocol digest argument and the script that supplies it MUST be",
+    "requires a new measured UKI",
+    "opens no ProviderStore or rollback authority",
   ]) {
     requireText(deploymentDoc.text, required, "Hetzner/VPSBG deployment document");
   }

--- a/scripts/payment-v1-deployment-template-gate.test.mjs
+++ b/scripts/payment-v1-deployment-template-gate.test.mjs
@@ -442,7 +442,7 @@ test("issuer and authority origins must remain loopback", () => {
   });
 });
 
-test("VPSBG fragment remains service-auth-only, Free-PoW-only and remote-authority-only", () => {
+test("VPSBG fragment remains service-auth-only, exact-pinned and storeless Free-PoW-only", () => {
   for (const flag of [
     "--serve-hints",
     "--service-bat-key /home/pir/data/bat.key",
@@ -455,7 +455,28 @@ test("VPSBG fragment remains service-auth-only, Free-PoW-only and remote-authori
         "deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in",
         (text) => `${text}\n${flag}\n`,
       );
-      assert.throws(() => validateDeploymentTree(root), /unreviewed|canonical order/);
+      assert.throws(
+        () => validateDeploymentTree(root),
+        /unreviewed|canonical order|forbidden Free IP/,
+      );
+    });
+  }
+
+  for (const forbidden of [
+    "--service-store /home/pir/data/provider.sqlite3",
+    "--service-remote-rollback-authority-config /home/pir/data/authority.toml",
+    "--service-free-ip-key /home/pir/data/free-ip.key",
+  ]) {
+    withFixture((root) => {
+      mutate(
+        root,
+        "deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in",
+        (text) => `${text}\n${forbidden}\n`,
+      );
+      assert.throws(
+        () => validateDeploymentTree(root),
+        /unreviewed|canonical order|forbidden Free IP/,
+      );
     });
   }
 


### PR DESCRIPTION
## Summary

- add an exact-policy-digest storeless Free-PoW admission mode for the measured VPSBG provider profile
- reject every stateful, issuer-backed, paid, retained-policy, Free-IP, Cashu, BAT, and experimental ARC input in that mode
- bind each challenge to provider, policy, scope, offer, operation, and secure-channel exporter, and authorize exactly one protected backend request
- add fail-closed VPSBG argument templates, deployment gates, process tests, security boundaries, and operator documentation

## Security boundary

This change does not claim that a UKI has been built, uploaded, or measured. The server reports only that the exact policy digest pin is active. A production measurement claim still requires an independently verified UKI and attestation ceremony, and any signed policy-byte change requires a new image and client pin migration.

No production service, remote server, wallet, Nostr publication, or Lightning funds are touched by this PR. ARC remains experimental.

## Verification

- deployment-template gate: 24/24
- exact storeless runtime unit tests: 2/2
- real process startup rejection and Free-PoW to AUTH to protected DPF query: 2/2
- unified_server and process-test clippy with warnings denied
- independent security review of pre-main-merge implementation: P0 0, P1 0, P2 0

The branch was merged with main commit 42da5b236c72817d2ef5c6dc8de096f8e8d57c36 and the checks above were rerun on exact head 23c5e20a92c4bd22b659569f439cced70fc5f29a.