### PR TITLE
Harden Lightning runtime preflight

### DIFF
--- a/apps/admin/src/lightning_staging.rs
+++ b/apps/admin/src/lightning_staging.rs
@@ -203,8 +203,10 @@ enum CoreRpcCookieAccessPolicyV1 {
     #[default]
     SameUidOwnerOnly,
     /// Split-UID layout: a short-lived preflight unit traverses an exact
-    /// bitcoind-owner/cookie-group mode-0710 directory and reads a 0640 cookie.
-    CrossUidSharedGroup,
+    /// bitcoind-owner/cookie-group mode-2710 setgid directory and reads a 0640
+    /// cookie. The explicit policy name prevents an old mode-0710 config from
+    /// silently acquiring the new directory-inheritance semantics.
+    CrossUidSetgidSharedGroup,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -497,15 +499,18 @@ struct ClnGetInfoV1 {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ClnPluginListV1 {
     command: String,
     plugins: Vec<ClnPluginV1>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
 struct ClnPluginV1 {
     name: String,
     active: bool,
+    dynamic: bool,
 }
 
 #[derive(Deserialize)]
@@ -572,7 +577,7 @@ struct PreflightSnapshotV1 {
     cln_version: String,
     cln_network: String,
     cln_blockheight: u64,
-    plugins: Vec<(String, bool)>,
+    plugins: Vec<ClnPluginV1>,
     peer_channels: Vec<ClnPeerChannelV1>,
     gossip_channels: Vec<ClnGossipChannelV1>,
     scb_digest: [u8; 32],
@@ -593,7 +598,7 @@ struct BootstrapPreflightSnapshotV1 {
     cln_version: String,
     cln_network: String,
     cln_blockheight: u64,
-    plugins: Vec<(String, bool)>,
+    plugins: Vec<ClnPluginV1>,
     peer_channel_count: usize,
     onchain_output_count: usize,
     funding_channel_count: usize,
@@ -1477,10 +1482,10 @@ fn validate_core_rpc_cookie_access_policy_v1(
             check,
             "cross-uid-fields-with-same-uid-policy",
         )),
-        (CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup, None) => {
+        (CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup, None) => {
             Err(PreflightFailureV1::new(check, "missing-cross-uid-fields"))
         }
-        (CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup, Some(cross_uid)) => {
+        (CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup, Some(cross_uid)) => {
             if cross_uid.protected_parent_expected_uid != 0
                 || cross_uid.protected_parent_expected_gid != 0
                 || cross_uid.preflight_expected_uid == 0
@@ -1504,7 +1509,7 @@ fn validate_preflight_identity_separation_v1(
     let check = "config.preflight-identities";
     let core_preflight_uid = match config.bitcoin.rpc_cookie.access_policy {
         CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly => config.bitcoin.rpc_cookie.expected_uid,
-        CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup => {
+        CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup => {
             config
                 .bitcoin
                 .rpc_cookie
@@ -1530,7 +1535,8 @@ fn validate_preflight_identity_separation_v1(
     if core_preflight_uid != lightning_preflight_uid {
         return Err(PreflightFailureV1::new(check, "preflight-uid-conflict"));
     }
-    if config.bitcoin.rpc_cookie.access_policy == CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup
+    if config.bitcoin.rpc_cookie.access_policy
+        == CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup
         && (config.bitcoin.rpc_cookie.expected_uid == config.lightning.expected_uid
             || config.bitcoin.rpc_cookie.expected_gid == config.lightning.expected_gid)
     {
@@ -1865,7 +1871,9 @@ fn validate_protected_config_runtime_group_set_for_identity_v1(
         return Err(PreflightFailureV1::new(check, "runtime-uid-mismatch"));
     }
     let mut expected = BTreeSet::from([config_expected_gid]);
-    if config.bitcoin.rpc_cookie.access_policy == CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup {
+    if config.bitcoin.rpc_cookie.access_policy
+        == CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup
+    {
         expected.insert(config.bitcoin.rpc_cookie.expected_gid);
     }
     if config.lightning.rpc_access_policy == LightningRpcAccessPolicyV1::CrossUidSharedGroup {
@@ -2190,7 +2198,7 @@ fn validate_core_rpc_cookie_runtime_identity_v1(
                 return Err(PreflightFailureV1::new(check, "runtime-uid-mismatch"));
             }
         }
-        CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup => {
+        CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup => {
             let cross_uid = config
                 .cross_uid_access
                 .as_ref()
@@ -2257,7 +2265,7 @@ fn validate_core_rpc_cookie_file_metadata_v1(
 ) -> Result<(), PreflightFailureV1> {
     let expected_mode = match config.access_policy {
         CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly => 0o600,
-        CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup => 0o640,
+        CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup => 0o640,
     };
     if metadata.kind != CoreRpcCookieBoundaryKindV1::RegularFile
         || metadata.uid != config.expected_uid
@@ -2280,7 +2288,7 @@ fn validate_core_rpc_cookie_boundary_metadata_v1(
     cookie: CoreRpcCookieBoundaryMetadataV1,
     check: &'static str,
 ) -> Result<(), PreflightFailureV1> {
-    if config.access_policy == CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup {
+    if config.access_policy == CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup {
         let cross_uid = config
             .cross_uid_access
             .as_ref()
@@ -2295,7 +2303,7 @@ fn validate_core_rpc_cookie_boundary_metadata_v1(
     }
     let expected_final_mode = match config.access_policy {
         CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly => 0o700,
-        CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup => 0o710,
+        CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup => 0o2710,
     };
     if final_parent.kind != CoreRpcCookieBoundaryKindV1::Directory
         || final_parent.uid != config.expected_uid
@@ -2327,7 +2335,7 @@ fn validate_canonical_core_rpc_cookie_layout_v1(
         || !components
             .iter()
             .all(|component| matches!(component, Component::Normal(_)))
-        || (config.access_policy == CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup
+        || (config.access_policy == CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup
             && components.len() != 2)
     {
         return Err(PreflightFailureV1::new(check, "invalid-cookie-layout"));
@@ -2386,16 +2394,24 @@ fn validate_core_rpc_cookie_namespace_v1(
         core_rpc_cookie_boundary_metadata_v1(cookie),
         check,
     )?;
-    let shared_gid = match config.access_policy {
-        CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly => None,
-        CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup => Some(config.expected_gid),
-    };
-    let checked_path = pir_private_files::prepare_private_unix_socket_parent_v1(
-        &config.path,
-        config.expected_uid,
-        shared_gid,
-        "Core RPC cookie",
-    )
+    let checked_path = match config.access_policy {
+        CoreRpcCookieAccessPolicyV1::SameUidOwnerOnly => {
+            pir_private_files::prepare_private_unix_socket_parent_v1(
+                &config.path,
+                config.expected_uid,
+                None,
+                "Core RPC cookie",
+            )
+        }
+        CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup => {
+            pir_private_files::prepare_private_setgid_group_file_parent_v1(
+                &config.path,
+                config.expected_uid,
+                config.expected_gid,
+                "Core RPC cookie",
+            )
+        }
+    }
     .map_err(|_| PreflightFailureV1::new(check, "unsafe-parent-boundary"))?;
     if checked_path != config.path || config.path.parent() != Some(final_parent) {
         return Err(PreflightFailureV1::new(check, "path-changed"));
@@ -3454,11 +3470,7 @@ async fn collect_bootstrap_snapshot_v1<R: CommandRunnerV1>(
         cln_version: getinfo.version,
         cln_network: getinfo.network,
         cln_blockheight: getinfo.blockheight,
-        plugins: plugin_list
-            .plugins
-            .into_iter()
-            .map(|plugin| (plugin.name, plugin.active))
-            .collect(),
+        plugins: plugin_list.plugins,
         peer_channel_count: peer_channels.channels.len(),
         onchain_output_count: funds.outputs.len(),
         funding_channel_count: funds.channels.len(),
@@ -3571,11 +3583,7 @@ async fn collect_snapshot_v1<R: CommandRunnerV1>(
         cln_version: getinfo.version,
         cln_network: getinfo.network,
         cln_blockheight: getinfo.blockheight,
-        plugins: plugin_list
-            .plugins
-            .into_iter()
-            .map(|plugin| (plugin.name, plugin.active))
-            .collect(),
+        plugins: plugin_list.plugins,
         peer_channels: peer_channels.channels,
         gossip_channels,
         scb_digest,
@@ -3804,7 +3812,7 @@ struct RuntimeSnapshotViewV1<'a> {
     cln_version: &'a str,
     cln_network: &'a str,
     cln_blockheight: u64,
-    plugins: &'a [(String, bool)],
+    plugins: &'a [ClnPluginV1],
 }
 
 fn validate_runtime_snapshot_v1(
@@ -3975,7 +3983,7 @@ fn validate_snapshot_v1(
 
 fn validate_plugins_v1(
     config: &LightningStagingConfigV1,
-    actual: &[(String, bool)],
+    actual: &[ClnPluginV1],
 ) -> Result<(), PreflightFailureV1> {
     if actual.len() > MAX_PLUGIN_COUNT_V1 {
         return Err(PreflightFailureV1::new(
@@ -3990,8 +3998,12 @@ fn validate_plugins_v1(
         .map(|plugin| plugin.name.as_str())
         .collect();
     let mut observed = BTreeMap::new();
-    for (name, active) in actual {
-        if name.len() > 4096 || observed.insert(name.as_str(), *active).is_some() {
+    for plugin in actual {
+        if plugin.name.len() > 4096
+            || observed
+                .insert(plugin.name.as_str(), (plugin.active, plugin.dynamic))
+                .is_some()
+        {
             return Err(PreflightFailureV1::new(
                 "lightning.plugins",
                 "invalid-plugin-list",
@@ -4004,7 +4016,13 @@ fn validate_plugins_v1(
             "allowlist-mismatch",
         ));
     }
-    if observed.values().any(|active| !active) {
+    if observed.values().any(|(_, dynamic)| *dynamic) {
+        return Err(PreflightFailureV1::new(
+            "lightning.plugins",
+            "plugin-dynamic",
+        ));
+    }
+    if observed.values().any(|(active, _)| !active) {
         return Err(PreflightFailureV1::new(
             "lightning.plugins",
             "plugin-inactive",
@@ -4295,7 +4313,8 @@ mod tests {
 
     fn fully_cross_uid_config(role: StagingRoleV1) -> LightningStagingConfigV1 {
         let mut value = cross_uid_config(role);
-        value.bitcoin.rpc_cookie.access_policy = CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup;
+        value.bitcoin.rpc_cookie.access_policy =
+            CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup;
         value.bitcoin.rpc_cookie.cross_uid_access = Some(CoreRpcCookieCrossUidAccessV1 {
             preflight_expected_uid: 1001,
             protected_parent_expected_uid: 0,
@@ -4374,6 +4393,14 @@ mod tests {
         }
     }
 
+    fn plugin(name: &str, active: bool, dynamic: bool) -> ClnPluginV1 {
+        ClnPluginV1 {
+            name: name.to_owned(),
+            active,
+            dynamic,
+        }
+    }
+
     fn gossip(left: &str, right: &str, scid: &str) -> Vec<ClnGossipChannelV1> {
         vec![
             ClnGossipChannelV1 {
@@ -4419,7 +4446,7 @@ mod tests {
             cln_version: "v26.06.6".to_owned(),
             cln_network: "signet".to_owned(),
             cln_blockheight: 999,
-            plugins: vec![(PLUGIN.to_owned(), true)],
+            plugins: vec![plugin(PLUGIN, true, false)],
             peer_channels,
             gossip_channels,
             scb_digest: [9u8; 32],
@@ -4446,7 +4473,7 @@ mod tests {
             cln_version: "v26.06.6".to_owned(),
             cln_network: "signet".to_owned(),
             cln_blockheight: 999,
-            plugins: vec![(PLUGIN.to_owned(), true)],
+            plugins: vec![plugin(PLUGIN, true, false)],
             peer_channel_count: 0,
             onchain_output_count: 0,
             funding_channel_count: 0,
@@ -4568,13 +4595,68 @@ mod tests {
         let mut unexpected_plugin = bootstrap_snapshot(StagingRoleV1::Issuer);
         unexpected_plugin
             .plugins
-            .push(("/tmp/untrusted".to_owned(), true));
+            .push(plugin("/tmp/untrusted", true, false));
         assert_eq!(
             validate_bootstrap_snapshot_v1(&config, &ids, &unexpected_plugin)
                 .unwrap_err()
                 .check,
             "lightning.plugins"
         );
+    }
+
+    #[test]
+    fn cln_plugin_list_requires_static_plugins_and_a_closed_item_shape() {
+        let config = config(StagingRoleV1::Issuer);
+        let valid: ClnPluginListV1 = serde_json::from_value(serde_json::json!({
+            "command": "list",
+            "plugins": [{"name": PLUGIN, "active": true, "dynamic": false}]
+        }))
+        .unwrap();
+        validate_plugins_v1(&config, &valid.plugins).unwrap();
+
+        let dynamic: ClnPluginListV1 = serde_json::from_value(serde_json::json!({
+            "command": "list",
+            "plugins": [{"name": PLUGIN, "active": true, "dynamic": true}]
+        }))
+        .unwrap();
+        assert_eq!(
+            validate_plugins_v1(&config, &dynamic.plugins)
+                .unwrap_err()
+                .reason,
+            "plugin-dynamic"
+        );
+
+        for malformed in [
+            serde_json::json!({
+                "command": "list",
+                "plugins": [{"name": PLUGIN, "active": true}]
+            }),
+            serde_json::json!({
+                "command": "list",
+                "plugins": [{"name": PLUGIN, "dynamic": false}]
+            }),
+            serde_json::json!({
+                "command": "list",
+                "plugins": [{
+                    "name": PLUGIN,
+                    "active": true,
+                    "dynamic": false,
+                    "autostart": true
+                }]
+            }),
+            serde_json::json!({
+                "command": "list",
+                "plugins": [{"name": PLUGIN, "active": true, "dynamic": "false"}]
+            }),
+            serde_json::json!({"command": "list", "plugins": [PLUGIN]}),
+            serde_json::json!({
+                "command": "list",
+                "plugins": [{"name": PLUGIN, "active": true, "dynamic": false}],
+                "unknown_top_level": true
+            }),
+        ] {
+            assert!(serde_json::from_value::<ClnPluginListV1>(malformed).is_err());
+        }
     }
 
     #[test]
@@ -4637,6 +4719,7 @@ mod tests {
             HeightLag,
             UnexpectedPlugin,
             InactivePlugin,
+            DynamicPlugin,
             PrivateChannel,
             DisconnectedChannel,
             MissingLiquidity,
@@ -4658,6 +4741,7 @@ mod tests {
             (Mutation::HeightLag, "lightning.height"),
             (Mutation::UnexpectedPlugin, "lightning.plugins"),
             (Mutation::InactivePlugin, "lightning.plugins"),
+            (Mutation::DynamicPlugin, "lightning.plugins"),
             (Mutation::PrivateChannel, "lightning.peer-channels"),
             (Mutation::DisconnectedChannel, "lightning.peer-channels"),
             (Mutation::MissingLiquidity, "lightning.liquidity"),
@@ -4682,9 +4766,10 @@ mod tests {
                 Mutation::WrongClnNetwork => snapshot.cln_network = "testnet4".to_owned(),
                 Mutation::HeightLag => snapshot.cln_blockheight = 900,
                 Mutation::UnexpectedPlugin => {
-                    snapshot.plugins.push(("/tmp/unknown".to_owned(), true));
+                    snapshot.plugins.push(plugin("/tmp/unknown", true, false));
                 }
-                Mutation::InactivePlugin => snapshot.plugins[0].1 = false,
+                Mutation::InactivePlugin => snapshot.plugins[0].active = false,
+                Mutation::DynamicPlugin => snapshot.plugins[0].dynamic = true,
                 Mutation::PrivateChannel => snapshot.peer_channels[0].private = Some(true),
                 Mutation::DisconnectedChannel => {
                     snapshot.peer_channels[0].peer_connected = false;
@@ -4844,7 +4929,7 @@ mod tests {
 
         let mut missing_fields = legacy.clone();
         missing_fields.bitcoin.rpc_cookie.access_policy =
-            CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup;
+            CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup;
         assert_eq!(
             validate_static_config_v1(&missing_fields)
                 .unwrap_err()
@@ -5012,7 +5097,7 @@ mod tests {
             kind: CoreRpcCookieBoundaryKindV1::Directory,
             uid: cookie_config.expected_uid,
             gid: cookie_config.expected_gid,
-            mode: 0o710,
+            mode: 0o2710,
             nlink: 2,
             size: 0,
         };
@@ -5082,7 +5167,25 @@ mod tests {
             (
                 protected_parent,
                 CoreRpcCookieBoundaryMetadataV1 {
+                    mode: 0o710,
+                    ..final_parent
+                },
+                cookie,
+                "unsafe-directory",
+            ),
+            (
+                protected_parent,
+                CoreRpcCookieBoundaryMetadataV1 {
                     mode: 0o711,
+                    ..final_parent
+                },
+                cookie,
+                "unsafe-directory",
+            ),
+            (
+                protected_parent,
+                CoreRpcCookieBoundaryMetadataV1 {
+                    mode: 0o3710,
                     ..final_parent
                 },
                 cookie,
@@ -5503,7 +5606,7 @@ mod tests {
         let parsed = toml::from_str::<LightningStagingConfigV1>(template).unwrap();
         assert_eq!(
             parsed.bitcoin.rpc_cookie.access_policy,
-            CoreRpcCookieAccessPolicyV1::CrossUidSharedGroup
+            CoreRpcCookieAccessPolicyV1::CrossUidSetgidSharedGroup
         );
         assert_eq!(parsed.bitcoin.rpc_cookie.expected_uid, 990);
         assert_eq!(parsed.bitcoin.rpc_cookie.expected_gid, 994);
@@ -5598,6 +5701,13 @@ mod tests {
         );
         assert!(
             toml::from_str::<LightningStagingConfigV1>(&with_unknown_core_cross_uid_field).is_err()
+        );
+        let with_obsolete_core_cookie_policy = template.replace(
+            "access_policy = \"cross-uid-setgid-shared-group\"",
+            "access_policy = \"cross-uid-shared-group\"",
+        );
+        assert!(
+            toml::from_str::<LightningStagingConfigV1>(&with_obsolete_core_cookie_policy).is_err()
         );
         let with_unknown_backup_field = format!("{template}\nunexpected = true\n");
         assert!(toml::from_str::<LightningStagingConfigV1>(&with_unknown_backup_field).is_err());

--- a/crates/security/private-files/Cargo.toml
+++ b/crates/security/private-files/Cargo.toml
@@ -13,4 +13,5 @@ rustix = { version = "1", features = ["fs", "process"] }
 zeroize = "1"
 
 [dev-dependencies]
+rustix = { version = "1", features = ["thread"] }
 tempfile = "3"

--- a/crates/security/private-files/src/lib.rs
+++ b/crates/security/private-files/src/lib.rs
@@ -241,10 +241,54 @@ pub fn prepare_private_unix_socket_parent_v1(
     expected_group_gid: Option<u32>,
     label: &str,
 ) -> Result<PathBuf, String> {
+    prepare_private_service_parent_v1(
+        path,
+        expected_owner_uid,
+        PrivateServiceParentPolicyV1::UnixSocket { expected_group_gid },
+        label,
+    )
+}
+
+/// Validate the parent of a cross-UID, group-readable private file.
+///
+/// The final parent must be owned by the expected daemon UID and trusted
+/// reader GID with exact mode 2710. The setgid bit is mandatory so a daemon
+/// that deliberately does not hold the reader group still creates the file
+/// with that group. As with the Unix-socket validator, every component is
+/// opened with `O_NOFOLLOW` and writable or untrusted ancestors fail closed.
+#[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+pub fn prepare_private_setgid_group_file_parent_v1(
+    path: &Path,
+    expected_owner_uid: u32,
+    expected_group_gid: u32,
+    label: &str,
+) -> Result<PathBuf, String> {
+    prepare_private_service_parent_v1(
+        path,
+        expected_owner_uid,
+        PrivateServiceParentPolicyV1::SetgidGroupFile { expected_group_gid },
+        label,
+    )
+}
+
+#[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+#[derive(Clone, Copy)]
+enum PrivateServiceParentPolicyV1 {
+    UnixSocket { expected_group_gid: Option<u32> },
+    SetgidGroupFile { expected_group_gid: u32 },
+}
+
+#[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+fn prepare_private_service_parent_v1(
+    path: &Path,
+    expected_owner_uid: u32,
+    policy: PrivateServiceParentPolicyV1,
+    label: &str,
+) -> Result<PathBuf, String> {
     let file_name = path
         .file_name()
         .filter(|name| !name.is_empty())
-        .ok_or_else(|| format!("{label} must name a socket: {}", path.display()))?
+        .ok_or_else(|| format!("{label} must name a protected entry: {}", path.display()))?
         .to_os_string();
     let configured_parent = path
         .parent()
@@ -306,7 +350,7 @@ pub fn prepare_private_unix_socket_parent_v1(
                 &current,
                 &opened_path,
                 expected_owner_uid,
-                expected_group_gid,
+                policy,
                 label,
             )?;
         } else {
@@ -325,6 +369,18 @@ pub fn prepare_private_unix_socket_parent_v1(
 ) -> Result<PathBuf, String> {
     Err(format!(
         "{label} protected Unix-socket operations require Linux or macOS"
+    ))
+}
+
+#[cfg(not(all(unix, any(target_os = "linux", target_os = "macos"))))]
+pub fn prepare_private_setgid_group_file_parent_v1(
+    _path: &Path,
+    _expected_owner_uid: u32,
+    _expected_group_gid: u32,
+    label: &str,
+) -> Result<PathBuf, String> {
+    Err(format!(
+        "{label} protected group-file operations require Linux or macOS"
     ))
 }
 
@@ -360,23 +416,31 @@ fn validate_socket_final_parent_fd_v1(
     directory: &File,
     path: &Path,
     expected_owner_uid: u32,
-    expected_group_gid: Option<u32>,
+    policy: PrivateServiceParentPolicyV1,
     label: &str,
 ) -> Result<(), String> {
     let stat = rustix::fs::fstat(directory)
         .map_err(|error| format!("inspect {label} final parent {}: {error}", path.display()))?;
     let euid = rustix::process::geteuid().as_raw();
     let permissions = (stat.st_mode & 0o7777) as u32;
-    let valid_identity_and_mode = if expected_owner_uid == euid {
-        stat.st_uid == euid && permissions == 0o700
-    } else {
-        expected_group_gid.is_some_and(|gid| {
-            stat.st_uid == expected_owner_uid && stat.st_gid == gid && permissions == 0o710
-        })
+    let valid_identity_and_mode = match policy {
+        PrivateServiceParentPolicyV1::UnixSocket { .. } if expected_owner_uid == euid => {
+            stat.st_uid == euid && permissions == 0o700
+        }
+        PrivateServiceParentPolicyV1::UnixSocket { expected_group_gid } => expected_group_gid
+            .is_some_and(|gid| {
+                stat.st_uid == expected_owner_uid && stat.st_gid == gid && permissions == 0o710
+            }),
+        PrivateServiceParentPolicyV1::SetgidGroupFile { expected_group_gid } => {
+            expected_owner_uid != euid
+                && stat.st_uid == expected_owner_uid
+                && stat.st_gid == expected_group_gid
+                && permissions == 0o2710
+        }
     };
     if !rustix::fs::FileType::from_raw_mode(stat.st_mode).is_dir() || !valid_identity_and_mode {
         return Err(format!(
-            "{label} final parent must be same-UID mode 0700 or cross-UID owner/group mode 0710: {}",
+            "{label} final parent does not match its exact owner/group/mode policy: {}",
             path.display()
         ));
     }
@@ -915,6 +979,154 @@ mod tests {
             prepare_private_unix_socket_parent_v1(&path, another_uid, None, "test RPC socket")
                 .is_err()
         );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn setgid_group_file_creation_linux_child() {
+        use rustix::process::{Gid, Uid};
+        use std::io::Write as _;
+        use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
+
+        let Ok(path) = std::env::var("BPIR_SETGID_FILE_CHILD_PATH") else {
+            return;
+        };
+        let uid = std::env::var("BPIR_SETGID_FILE_CHILD_UID")
+            .unwrap()
+            .parse::<u32>()
+            .unwrap();
+        let primary_gid = std::env::var("BPIR_SETGID_FILE_CHILD_PRIMARY_GID")
+            .unwrap()
+            .parse::<u32>()
+            .unwrap();
+        let inherited_gid = std::env::var("BPIR_SETGID_FILE_CHILD_INHERITED_GID")
+            .unwrap()
+            .parse::<u32>()
+            .unwrap();
+
+        rustix::thread::set_thread_groups(&[]).unwrap();
+        rustix::thread::set_thread_gid(Gid::from_raw(primary_gid)).unwrap();
+        rustix::thread::set_thread_uid(Uid::from_raw(uid)).unwrap();
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o640)
+            .open(&path)
+            .unwrap();
+        file.write_all(
+            b"__cookie__:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+        )
+        .unwrap();
+        file.sync_all().unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+        let metadata = file.metadata().unwrap();
+        assert_eq!(metadata.uid(), uid);
+        assert_eq!(metadata.gid(), inherited_gid);
+        assert_eq!(metadata.mode() & 0o7777, 0o640);
+        assert_eq!(metadata.nlink(), 1);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn setgid_group_file_parent_requires_exact_cross_uid_2710_shape() {
+        use rustix::fs::chown;
+        use rustix::process::{Gid, Uid};
+        use std::os::unix::fs::MetadataExt as _;
+        use std::process::Command;
+
+        if !rustix::process::geteuid().is_root() {
+            return;
+        }
+
+        const OWNER_UID: u32 = 60_101;
+        const READER_GID: u32 = 60_102;
+        let directory = private_tempdir();
+        chown(
+            directory.path(),
+            Some(Uid::from_raw(OWNER_UID)),
+            Some(Gid::from_raw(READER_GID)),
+        )
+        .unwrap();
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o2710))
+            .unwrap();
+        let path = directory.path().join(".cookie");
+
+        assert_eq!(
+            prepare_private_setgid_group_file_parent_v1(
+                &path,
+                OWNER_UID,
+                READER_GID,
+                "test Core RPC cookie",
+            )
+            .unwrap()
+            .file_name(),
+            path.file_name()
+        );
+
+        const DAEMON_PRIMARY_GID: u32 = 60_103;
+        let output = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("tests::setgid_group_file_creation_linux_child")
+            .arg("--nocapture")
+            .env("BPIR_SETGID_FILE_CHILD_PATH", &path)
+            .env("BPIR_SETGID_FILE_CHILD_UID", OWNER_UID.to_string())
+            .env(
+                "BPIR_SETGID_FILE_CHILD_PRIMARY_GID",
+                DAEMON_PRIMARY_GID.to_string(),
+            )
+            .env(
+                "BPIR_SETGID_FILE_CHILD_INHERITED_GID",
+                READER_GID.to_string(),
+            )
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "setgid child failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        let inherited = std::fs::metadata(&path).unwrap();
+        assert_eq!(inherited.uid(), OWNER_UID);
+        assert_eq!(inherited.gid(), READER_GID);
+        assert_eq!(inherited.mode() & 0o7777, 0o640);
+        assert_eq!(inherited.nlink(), 1);
+
+        for mode in [0o710, 0o2700, 0o2711, 0o3710] {
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(mode))
+                .unwrap();
+            assert!(prepare_private_setgid_group_file_parent_v1(
+                &path,
+                OWNER_UID,
+                READER_GID,
+                "test Core RPC cookie",
+            )
+            .is_err());
+        }
+
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o2710))
+            .unwrap();
+        assert!(prepare_private_setgid_group_file_parent_v1(
+            &path,
+            OWNER_UID + 1,
+            READER_GID,
+            "test Core RPC cookie",
+        )
+        .is_err());
+        assert!(prepare_private_setgid_group_file_parent_v1(
+            &path,
+            OWNER_UID,
+            READER_GID + 1,
+            "test Core RPC cookie",
+        )
+        .is_err());
+        assert!(prepare_private_setgid_group_file_parent_v1(
+            &path,
+            rustix::process::geteuid().as_raw(),
+            READER_GID,
+            "test Core RPC cookie",
+        )
+        .is_err());
     }
 
     #[test]

--- a/docs/payment/LIGHTNING_STAGING.md
+++ b/docs/payment/LIGHTNING_STAGING.md
@@ -121,15 +121,19 @@ The Core RPC cookie has an access policy independent of the CLN socket
 policy. Omitting `bitcoin.rpc_cookie.access_policy` preserves schema V1's
 `same-uid-owner-only` layout: the preflight EUID must equal the bitcoind UID,
 the final cookie directory is exact mode 0700, and the single-link cookie is
-exact mode 0600. `cross-uid-shared-group` requires the separate
+exact mode 0600. `cross-uid-setgid-shared-group` requires the separate
 `bitcoin.rpc_cookie.cross_uid_access` table, a root:root mode-0755 broad
 parent (normally `/srv/bitcoin`), exactly one directly nested
-bitcoind-UID/cookie-GID mode-0710 network directory, and a
+bitcoind-UID/cookie-GID mode-2710 setgid network directory, and a
 bitcoind-UID/cookie-GID mode-0640 cookie with link count one. The preflight
 must run under its separately pinned EUID and have that cookie GID as its
 effective or supplementary group. Configure bitcoind with
 `rpccookieperms=group` and the cookie-only group so it creates the required
-0640 file; the preflight never changes ownership or permissions. Bitcoin
+0640 file. Bitcoind keeps its separate primary group and does not receive the
+cookie group; the setgid directory supplies the cookie's group inheritance.
+The preflight never changes ownership or permissions. The obsolete
+`cross-uid-shared-group` cookie-policy spelling and its mode-0710 directory
+shape are rejected rather than silently reinterpreted. Bitcoin
 Core documents that cookie read access is a powerful RPC trust boundary and
 supports `owner`, `group`, or `all` via
 [`rpccookieperms`](https://github.com/bitcoin/bitcoin/blob/master/src/init.cpp).
@@ -163,6 +167,13 @@ layout. If CLN is already split-UID while Core names a different bitcoind UID,
 the two required preflight EUIDs conflict and static validation fails; the
 operator must add the explicit Core cross-UID table rather than obtaining an
 implicit policy downgrade.
+
+The CLN plugin snapshot is also closed: every `plugin list` item must contain
+exactly `name`, `active` and `dynamic` with the expected JSON types. The
+observed path set must equal the pinned executable allowlist, every plugin must
+be active, and every plugin must report `dynamic=false`. Missing or unknown
+item fields, duplicate or unexpected paths, dynamically managed plugins and
+response-shape drift all fail closed.
 
 The CLN adapter's timeout is one process-local monotonic budget covering
 socket metadata validation, connect, complete request write and complete
@@ -368,7 +379,7 @@ following before emitting one bounded `result=PASS` line:
   EUID, a mode-0700 final directory and a mode-0600 single-link cookie.
   Cross-UID mode requires the exact preflight EUID plus effective or
   supplementary cookie-only GID, root:root 0755 on the broad parent, exactly
-  one bitcoind-UID/cookie-GID 0710 network directory below it, and a
+  one bitcoind-UID/cookie-GID setgid 2710 network directory below it, and a
   bitcoind-UID/cookie-GID 0640 single-link cookie. The cookie path is canonical
   and `O_NOFOLLOW`-opened, its parents and ACL policy are checked, and the same
   descriptor's identity/size plus two matching bounded content reads and the
@@ -380,7 +391,8 @@ following before emitting one bounded `result=PASS` line:
 - Core v29+, exact configured subversion, `chain=signet`, the exact default
   challenge and genesis, `initialblockdownload=false`, and bounded header lag;
 - exact CLN role identity, version, `network=signet`, height lag and an exact
-  active plugin allowlist whose executable hashes are also pinned;
+  active, `dynamic=false` plugin allowlist whose executable hashes are also
+  pinned; the plugin response and each item have closed JSON shapes;
 - a canonical `lightning-rpc` path with no symlinked component, exact runtime
   EUID and (for cross-UID) effective/supplementary shared-group membership.
   Same-UID staging requires an owner/GID-pinned non-writable tree, exact 0700

--- a/docs/payment/LIGHTNING_STAGING_PREFLIGHT.toml.example
+++ b/docs/payment/LIGHTNING_STAGING_PREFLIGHT.toml.example
@@ -62,10 +62,11 @@ expected_subversion = "/Satoshi:29.0.0/"
 [bitcoin.rpc_cookie]
 path = "/srv/bitcoin/signet/.cookie"
 protected_parent = "/srv/bitcoin"
-access_policy = "cross-uid-shared-group"
+access_policy = "cross-uid-setgid-shared-group"
 # Cookie/final-network-directory owner (bitcoind UID) and the distinct,
-# CLN/preflight-only cookie group. Cross-UID mode requires 0710 on
-# `/srv/bitcoin/signet` and 0640 with link count one on `.cookie`.
+# CLN/preflight-only cookie group. This versioned cross-UID policy requires
+# setgid mode 2710 on `/srv/bitcoin/signet` and 0640 with link count one on
+# `.cookie`; the old non-setgid 0710 shape fails closed.
 expected_uid = 990
 expected_gid = 994
 


### PR DESCRIPTION
## What changed

- require every Core Lightning `plugin list` item to be active and non-dynamic, with a closed JSON shape
- replace the Core RPC cookie cross-UID policy with an explicitly versioned setgid-group policy
- require an exact `2710` bitcoind-owned/cookie-group directory and `0640` cookie
- add real Linux UID/GID inheritance coverage for cookie creation
- update the staging contract and example configuration

## Why

The production CLN closure relies on exactly two static built-in plugins, and the bitcoind process does not hold the preflight reader group. The old checks did not bind the CLN `dynamic` field and mode `0710` did not guarantee that a newly created cookie inherited the reader group.

## Validation

- Linux arm64 Docker, Rust 1.94.1, read-only source with target and Cargo state on tmpfs
- `bpir-admin`: 142/142 tests passed
- `pir-private-files`: 9/9 tests passed, including a real root-spawned UID/GID/setgid inheritance proof
- scoped `cargo clippy --all-targets --no-deps -- -D warnings` passed
- `rustfmt --check`, `git diff --check`, and post-rebase scope checks passed

A workspace-wide dependency lint still encounters the pre-existing `pir-identity::signing_preimage` `too_many_arguments` warning; the changed packages pass the scoped lint.
