### PR TITLE
Test concurrent Cashu recovery ordering

### DIFF
--- a/crates/payment/cashu-client/src/tests.rs
+++ b/crates/payment/cashu-client/src/tests.rs
@@ -1214,14 +1214,21 @@ fn concurrent_callers_issue_one_swap_and_one_grant() {
     // The durable PREPARED -> SUBMITTED transition intentionally happens
     // before the sole NUT-03 call. A concurrent observer may therefore reach
     // NUT-09/NUT-07 before the winning call has committed at the mint and get
-    // a transient, fail-closed RecoveryPending result. It must never submit a
-    // second output set, and it converges through the persisted intent after
-    // the winner completes.
+    // a transient, fail-closed RecoveryPending result. A second valid ordering
+    // is NUT-09 observing no promises immediately before the winner commits,
+    // followed by NUT-07 observing the now-spent inputs. That observer must
+    // report the exact spent-without-promises attention state; it still must
+    // never submit a second output set, and the shared persisted intent
+    // converges after the winner completes.
     assert!(results.iter().all(|result| matches!(
         result,
         CashuSwapProgressV1::Grant(_)
             | CashuSwapProgressV1::AlreadyGranted { .. }
             | CashuSwapProgressV1::RecoveryPending { .. }
+            | CashuSwapProgressV1::AttentionRequired {
+                observation: CashuRecoveryObservationV1::InputsSpentButPromisesMissing,
+                ..
+            }
     )));
     assert_eq!(mint.calls().0, 1);
     assert!(matches!(


### PR DESCRIPTION
## Summary

- model the second valid concurrent Cashu recovery ordering
- keep the observer fail closed on `InputsSpentButPromisesMissing`
- retain the one-mint-call and durable convergence assertions

## Why

A concurrent observer can complete an empty NUT-09 restore immediately before
the winning NUT-03 call commits, then observe spent inputs through NUT-07. That
does not imply a second swap or lost durable state; it is the exact
spent-without-promises attention state already defined by the client.

## Verification

- targeted Linux Docker test passed
- copied Linux test binary passed 200 consecutive invocations
- exactly one grant and one mint call remain asserted
- final resume still converges to `AlreadyGranted`
- `git diff --check`

No production or remote-host state was changed.
