### PR TITLE
fix(payment): parse real busctl GetAll dictionary shape

### DIFF
--- a/scripts/payment-v1-core-pattern-ceremony.mjs
+++ b/scripts/payment-v1-core-pattern-ceremony.mjs
@@ -3517,16 +3517,19 @@ export function parseBusctlGetAll(text, label) {
   }
   const envelope = parseLosslessJson(text, label);
   exactKeys(envelope, ["data", "type"], label + " envelope");
-  if (envelope.type !== "a{sv}" || !isPlainObject(envelope.data)) {
+  // busctl renders a D-Bus dictionary array as one JSON object inside an array.
+  if (envelope.type !== "a{sv}" || !Array.isArray(envelope.data) ||
+      envelope.data.length !== 1 || !isPlainObject(envelope.data[0])) {
     fail(label + " signature differs from a{sv}");
   }
-  for (const [property, variant] of Object.entries(envelope.data)) {
+  const properties = envelope.data[0];
+  for (const [property, variant] of Object.entries(properties)) {
     exactKeys(variant, ["data", "type"], label + "." + property);
     if (typeof variant.type !== "string" || variant.type.length === 0) {
       fail(label + "." + property + " has an invalid variant signature");
     }
   }
-  return envelope.data;
+  return properties;
 }
 
 function busctlGetAll(path, iface) {

--- a/scripts/payment-v1-core-pattern-ceremony.test.mjs
+++ b/scripts/payment-v1-core-pattern-ceremony.test.mjs
@@ -1471,8 +1471,8 @@ test("production canonical and D-Bus parsers reject non-canonical, duplicate, an
 
 test("GetAll parsing and manager fences reject duplicate, torn, queued, PID, job, and reload evidence", () => {
   const getAll = parseBusctlGetAll(
-    '{"type":"a{sv}","data":{"NeedDaemonReload":{"type":"b","data":false},' +
-      '"Huge":{"type":"t","data":18446744073709551615}}}',
+    '{"type":"a{sv}","data":[{"NeedDaemonReload":{"type":"b","data":false},' +
+      '"Huge":{"type":"t","data":18446744073709551615}}]}',
     "GetAll",
   );
   assert.equal(getAll.NeedDaemonReload.data, false);
@@ -1480,13 +1480,26 @@ test("GetAll parsing and manager fences reject duplicate, torn, queued, PID, job
   assert.throws(
     function () {
       parseBusctlGetAll(
-        '{"type":"a{sv}","data":{"Id":{"type":"s","data":"a"},' +
-          '"Id":{"type":"s","data":"a"}}}',
+        '{"type":"a{sv}","data":[{"Id":{"type":"s","data":"a"},' +
+          '"Id":{"type":"s","data":"a"}}]}',
         "GetAll",
       );
     },
     /duplicate JSON key/u,
   );
+  for (const malformedData of [
+    '{}',
+    '[]',
+    '[{},{}]',
+    '[[]]',
+  ]) {
+    assert.throws(
+      function () {
+        parseBusctlGetAll('{"type":"a{sv}","data":' + malformedData + '}', "GetAll");
+      },
+      /signature differs from a\{sv\}/u,
+    );
+  }
   const objectPath = "/org/freedesktop/systemd1/unit/apport_2eservice";
   const row = [APPORT_UNIT, "Apport", "loaded", "active", "exited", "", objectPath, 0, "", "/"];
   const variant = function (type, data) { return { data, type }; };


### PR DESCRIPTION
## Summary

- accept the exact singleton-object array emitted by `busctl --json=short` for `a{sv}`
- retain lossless uint64 and duplicate-key handling
- reject bare objects, empty/multiple arrays, and non-object elements fail closed

## Verification

- target Hetzner Manager `GetAll` capture parses and yields the exact 12-entry UnitPath
- Linux read-only container: 97/97 core-pattern tests and 2/2 independent gate tests
- independent security review approved exact commit `c71a787b828d47f73534c3cfdb5810fb9d8b3bab`
- no sysctl, systemd, service, route, or production listener changes