### PR TITLE
Fix portable CLN regtest payment E2E

### DIFF
--- a/apps/admin/src/lightning_staging.rs
+++ b/apps/admin/src/lightning_staging.rs
@@ -1204,10 +1204,14 @@ fn systemd_notify_to_v1(
         SocketAddrUnix::new(notify_socket)
             .map_err(|_| PreflightFailureV1::new(check, "invalid-notify-socket"))?
     };
+    #[cfg(target_os = "linux")]
+    let socket_flags = SocketFlags::CLOEXEC;
+    #[cfg(not(target_os = "linux"))]
+    let socket_flags = SocketFlags::empty();
     let socket = socket_with(
         AddressFamily::UNIX,
         SocketType::DGRAM,
-        SocketFlags::CLOEXEC,
+        socket_flags,
         None,
     )
     .map_err(|_| PreflightFailureV1::new(check, "notify-failed"))?;

--- a/scripts/payment-v1-cln-regtest-e2e.sh
+++ b/scripts/payment-v1-cln-regtest-e2e.sh
@@ -215,6 +215,10 @@ allocate_loopback_port
 readonly ROUTER_CLN_PORT="$ALLOCATED_PORT"
 allocate_loopback_port
 readonly PAYER_CLN_PORT="$ALLOCATED_PORT"
+allocate_loopback_port
+readonly REGTEST_WEB_PORT="$ALLOCATED_PORT"
+allocate_loopback_port
+readonly JOINED_WEB_PORT="$ALLOCATED_PORT"
 
 process_is_live() {
   local pid="$1"
@@ -582,6 +586,8 @@ export BITCOINPIR_PAYMENT_CLN_RPC_SOCKET="$ISSUER_RPC_SOCKET"
 export BITCOINPIR_PAYMENT_CLN_PAYEE_PUBKEY="$ISSUER_NODE_ID"
 export BITCOINPIR_PAYMENT_CLN_PAYER_DIR="$PAYER_CLN_DIR"
 export BITCOINPIR_PAYMENT_CLN_CLI="$LIGHTNING_CLI"
+export BITCOINPIR_PAYMENT_CLN_REGTEST_WEB_PORT="$REGTEST_WEB_PORT"
+export BITCOINPIR_PAYMENT_CLN_JOINED_WEB_PORT="$JOINED_WEB_PORT"
 export CARGO_NET_OFFLINE=true
 export NO_PROXY=127.0.0.1,localhost
 export no_proxy=127.0.0.1,localhost

--- a/web/e2e/payment-real-issuer.spec.ts
+++ b/web/e2e/payment-real-issuer.spec.ts
@@ -198,7 +198,10 @@ for (const authorization of ['cashu-bat', 'arc-experimental'] as const) {
     expect(restored.count).toBeGreaterThan(0);
     const inventory = await call(page, 'capabilityInventory');
     const currentBinding = await call(page, 'capabilityBinding');
-    expect(inventory).toContainEqual({ ...currentBinding, count: restored.count });
+    expect(inventory).toContainEqual(expect.objectContaining({
+      ...currentBinding,
+      count: restored.count,
+    }));
     await expect(call(page, 'capabilityCount')).resolves.toBe(restored.count);
     const verifiedLength = await call(page, 'takeAndVerifyCapability');
     expect(verifiedLength).not.toBeNull();

--- a/web/playwright.payment-cln-joined.config.ts
+++ b/web/playwright.payment-cln-joined.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from '@playwright/test';
 
-const port = 4185;
+const configuredPort = process.env.BITCOINPIR_PAYMENT_CLN_JOINED_WEB_PORT;
+const port = configuredPort === undefined ? 4185 : Number(configuredPort);
+if (!Number.isInteger(port) || port < 20_000 || port > 65_535) {
+  throw new Error('BITCOINPIR_PAYMENT_CLN_JOINED_WEB_PORT must be a high TCP port');
+}
 process.env.BITCOINPIR_PAYMENT_TWO_PROVIDER_WEB_ORIGIN = `http://127.0.0.1:${port}`;
 process.env.BITCOINPIR_PAYMENT_TWO_PROVIDER_BACKEND = 'cln-regtest';
 

--- a/web/playwright.payment-cln-regtest.config.ts
+++ b/web/playwright.payment-cln-regtest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from '@playwright/test';
 
-const port = 4183;
+const configuredPort = process.env.BITCOINPIR_PAYMENT_CLN_REGTEST_WEB_PORT;
+const port = configuredPort === undefined ? 4183 : Number(configuredPort);
+if (!Number.isInteger(port) || port < 20_000 || port > 65_535) {
+  throw new Error('BITCOINPIR_PAYMENT_CLN_REGTEST_WEB_PORT must be a high TCP port');
+}
 process.env.BITCOINPIR_PAYMENT_REAL_WEB_ORIGIN = `http://127.0.0.1:${port}`;
 process.env.BITCOINPIR_PAYMENT_REAL_BACKEND = 'cln-regtest';
 


### PR DESCRIPTION
Fixes the three reproducible blockers found while running the real isolated CLN Regtest payment E2E: macOS rustix socket flag compatibility, fixed web-port collisions, and an inventory assertion that rejected the additive acquisitionContext field.

The repaired single end-to-end run passed real BOLT11 payment, claim recovery, BAT, experimental ARC, two-provider admission, encrypted DPF query and Merkle verification. No remote service or real funds were used.