### PR TITLE
fix(web): bundle functional beta admission trust

### DIFF
--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -13,6 +13,12 @@ activated the path with real money.
   directory-selected Free query across two independently selected providers
   while retaining the normal strict identity, binary, database, preflight, and
   result-verification path.
+- The functional-beta web bundle carries the reviewed two-provider trusted
+  bootstrap needed to begin strict admission. It is parsed only into page
+  memory, remains independently authoritative over directory discovery, and
+  can be explicitly replaced for an intentional trust change. The bundled
+  directory defaults visibly identify the current single-relay mode as
+  degraded.
 - The browser and server now support bounded chunking/reassembly of a large
   strict Merkle tree-top preflight response. The server performs the payment
   admission check before the expensive query work, and the browser keeps the

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-AESrzJ6GX5DheGIv/LUDtWeGqgxbeewHdZua9hKsM2U=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-f6AcJoMBgTGpz3gm0fT5LYpEtwzwc1TlzRE8XvGHyHg=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
     <title>Bitcoin PIR</title>
     <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>
@@ -901,21 +901,21 @@
                 <details class="admission-config" id="admissionConfig">
                     <summary>Commercial admission trust configuration</summary>
                     <div class="admission-config-grid">
-                        <label for="admissionBootstrapJson">Trusted bootstrap JSON (endpoint, provider/policy/operator keys, server/binary/measurement/database pins, exact issuer/network/Lightning-payee trust)</label>
-                        <textarea id="admissionBootstrapJson" class="input" autocomplete="off" spellcheck="false" placeholder="No production trust bootstrap is bundled. Paste a complete V1 bootstrap for this page load only."></textarea>
+                        <label for="admissionBootstrapJson">Trusted bootstrap JSON (advanced replacement: endpoint, provider/policy/operator keys, server/binary/measurement/database pins, exact issuer/network/Lightning-payee trust)</label>
+                        <textarea id="admissionBootstrapJson" class="input" autocomplete="off" spellcheck="false" placeholder="A functional-beta trusted bootstrap is bundled for this page load. Paste a complete replacement only when intentionally changing trust."></textarea>
                         <div class="admission-config-actions">
-                            <button type="button" id="admissionApplyBootstrap" class="btn">Apply in memory</button>
-                            <span id="admissionConfigStatus" class="admission-config-status" role="status" aria-live="polite">Commercial admission unconfigured; all queries fail closed.</span>
+                            <button type="button" id="admissionApplyBootstrap" class="btn">Apply replacement in memory</button>
+                            <span id="admissionConfigStatus" class="admission-config-status" role="status" aria-live="polite">Bundled functional-beta bootstrap is loading; queries fail closed until it completes.</span>
                         </div>
                         <label for="admissionDirectoryMode">Assurance mode for the next directory refresh (changing it clears current directory trust)</label>
                         <select id="admissionDirectoryMode" class="input">
-                            <option value="strict-multi-relay" selected>Strict multi-relay (2–8 distinct WSS origins)</option>
-                            <option value="centralized-single-relay">Centralized single relay — degraded, no relay cross-check</option>
+                            <option value="strict-multi-relay">Strict multi-relay (2–8 distinct WSS origins)</option>
+                            <option value="centralized-single-relay" selected>Centralized single relay — degraded, no relay cross-check</option>
                         </select>
-                        <label for="admissionDirectoryRelays">Optional Nostr directory relays (one wss:// URL per line; explicit refresh only)</label>
-                        <textarea id="admissionDirectoryRelays" class="input" rows="2" autocomplete="off" spellcheck="false"></textarea>
+                        <label for="admissionDirectoryRelays">Nostr directory relays (one wss:// URL per line; explicit refresh only)</label>
+                        <textarea id="admissionDirectoryRelays" class="input" rows="2" autocomplete="off" spellcheck="false">wss://directory.65-21-91-217.sslip.io</textarea>
                         <label for="admissionDirectoryKey">Pinned directory Nostr x-only secp256k1 public key (64 lowercase hex; independent bootstrap)</label>
-                        <input id="admissionDirectoryKey" class="input" autocomplete="off" spellcheck="false">
+                        <input id="admissionDirectoryKey" class="input" autocomplete="off" spellcheck="false" value="0d399dc19efb5632e4a1d26ad5fec578fb401c6b3af80e234cea7339a8c7ad0c">
                         <div class="admission-config-actions">
                             <button type="button" id="admissionRefreshDirectory" class="btn ghost">Refresh directory now</button>
                             <span>Centralized mode requires exactly one relay and is visibly degraded. Relay data remains signed discovery metadata; live identity, binary, attestation, database and result verification still fail closed.</span>
@@ -1645,6 +1645,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
 
     <script type="module">
         import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, PRODUCTION_ONION_DB_PROOF_V2_PINS, DELTA_940611_948454_DB_PROOF_PIN, MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN, databaseProofAnchorLabel, databaseProofAnchorPoints, mempoolSpaceBlockUrl, verifyProductionTrustChain, verifyOramSourceProof, AdmissionCredentialVaultV1, DirectoryRollbackVaultV1, DirectoryRefreshIntentGuardV1, ProviderAdmissionSessionV1, ProductAdmissionControllerV1, ProductAdmissionPanelV1, assertIndependentProviderDialPairV1, assertSelectableDirectoryCatalogFreshV1, parseProductTrustedBootstrapV1, manualProviderAdmissionTrustAnchorV1, directoryBoundProviderTrustAnchorV1, providerArkFingerprintV1, providerLightningPayeeTrustV1, providerOperatorKeyV1, refreshNostrDirectoryV1, directoryRefreshFailureStateV1, publicAdmissionError, renderSecurityBadgeTextRowsV1, prepareQueryInspectorRenderDataV1, requireVerifiedQueryResultsV1 } from './src/index.ts';
+        import FUNCTIONAL_BETA_TRUSTED_BOOTSTRAP from './src/functional-beta-trusted-bootstrap.json';
         window.__bitcoinPirPrepareQueryInspectorRenderDataV1 = prepareQueryInspectorRenderDataV1;
         // Initialize SDK WASM (optional - falls back to TS if unavailable)
         initSdkWasm().then(ok => {
@@ -1791,6 +1792,22 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 source: matchingDirectoryEntry(provider) ? 'directory' : 'manual',
             }));
             Object.values(admissionPanels).forEach(panel => panel.setProviderOptions(choices));
+        }
+
+        function loadBundledFunctionalBetaTrustedBootstrap() {
+            const status = document.getElementById('admissionConfigStatus');
+            try {
+                productTrustedBootstrap = parseProductTrustedBootstrapV1(
+                    JSON.stringify(FUNCTIONAL_BETA_TRUSTED_BOOTSTRAP),
+                );
+            } catch {
+                productTrustedBootstrap = null;
+                renderTrustedProviderOptions();
+                status.textContent = 'Bundled functional-beta trusted bootstrap is invalid; commercial admission remains fail closed.';
+                return;
+            }
+            renderTrustedProviderOptions();
+            status.textContent = `${productTrustedBootstrap.providers.length} bundled functional-beta trusted provider(s) loaded in memory; no connection was made.`;
         }
 
         function providerById(providerIdHex) {
@@ -2073,7 +2090,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             }
         });
 
-        renderTrustedProviderOptions();
+        loadBundledFunctionalBetaTrustedBootstrap();
 
         function validateQueryInputBeforeAdmission(kind) {
             const textareaId = {

--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import bundledFunctionalBetaBootstrap from '../functional-beta-trusted-bootstrap.json';
+import {
+  assertIndependentProviderDialPairV1,
+  parseProductTrustedBootstrapV1,
+} from '../product-provider-bootstrap.js';
+
+describe('bundled functional-beta trusted bootstrap', () => {
+  it('is a parseable Signet bootstrap for two independent providers', () => {
+    const parsed = parseProductTrustedBootstrapV1(
+      JSON.stringify(bundledFunctionalBetaBootstrap),
+    );
+
+    expect(parsed.network).toBe('signet');
+    expect(parsed.providers).toHaveLength(2);
+    expect(() => assertIndependentProviderDialPairV1(
+      parsed.providers[0],
+      parsed.providers[1],
+    )).not.toThrow();
+    expect(parsed.providers.flatMap((provider) => provider.databaseProofPins)).not.toHaveLength(0);
+  });
+});

--- a/web/src/functional-beta-trusted-bootstrap.json
+++ b/web/src/functional-beta-trusted-bootstrap.json
@@ -1,0 +1,105 @@
+{
+  "version": 1,
+  "network": "signet",
+  "providers": [
+    {
+      "label": "Provider 1 functional beta",
+      "endpoint": "wss://provider-beta.65-21-91-217.sslip.io",
+      "providerIdHex": "9110aee8843ff4eaa60eb5e2f36345cef03c779c08becbfe76f4cc0400fc0eb0",
+      "policySigningKeyHex": "6528d01b64275834460fd2c6f1d8b2df1374ea62ed0204ea2429adcc70246a93",
+      "operatorSigningKeyHex": "d506c8630f13f31f0648228857c268d17996d600ed7169e091c88aadb5ecb2d4",
+      "stableServerId": "pir1-payment-beta",
+      "serverPin": {
+        "binarySha256Hex": "d23b58410f52fede21d013fbcec279c42d02b69d4b32791265cfb38e331770d8"
+      },
+      "hardwareAttestation": "unavailable-accepted",
+      "lightningPayeeTrust": [
+        {
+          "issuerIdHex": "8799b9b02964688f7f5d35b1c502f1bfb4a344c8ca6bd3f7902814c558e1de86",
+          "issuerOrigin": "https://issuer-beta.65-21-91-217.sslip.io",
+          "network": "signet",
+          "expectedPayeePubkeyHex": "03d56b422257245d2c170393fe0242f8fd5668b12034fe9d059579951e19162232"
+        }
+      ],
+      "databaseProofPins": [
+        {
+          "dbId": 0,
+          "buildKind": "snapshot",
+          "fromHeight": 0,
+          "height": 948454,
+          "fromBlockHashHex": "0000000000000000000000000000000000000000000000000000000000000000",
+          "blockHashHex": "00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4",
+          "muhashHex": "cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee",
+          "bucketSuperRootHex": "45def9b3c191cd28e630dae51f32d3e2f85f4d8ccf38c0712a23136967f2ec0b",
+          "onionSuperRootHex": "e83efa5730c47b94e8e6af09b1cb76a9e006634645fd39c939bd7b8ea554f8b4",
+          "paramsHashHex": "ac364eb24e24ba025e2dcfdd50b9ccf65ffd556488afc076b70b557084c5318e",
+          "networkMagicHex": "f9beb4d9",
+          "builderBinarySha256Hex": "d4da29807e806c8a16eec94b86119bd16df7805a66fa4ff1c187a26832a36427",
+          "builderGitCommit": "b692aec18b9c20ac92cb9fe22588e96ff96ad27d"
+        },
+        {
+          "dbId": 1,
+          "buildKind": "delta",
+          "fromHeight": 940611,
+          "height": 948454,
+          "fromBlockHashHex": "000000000000000000002c41243b3d74d135942031ef15f547bca1ce8f85eb99",
+          "fromMuhashHex": "aebb29df12e045ef5279036263aba3b8f8e9e816e05b04a58f57e63b3b25756b",
+          "blockHashHex": "00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4",
+          "muhashHex": "cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee",
+          "bucketSuperRootHex": "e2ba2eee6788424309a95f771893d5401cc8e3ceec6188dc2708900e211a910a",
+          "onionSuperRootHex": "f86baa3966a61cdcd70d8c0ad9bed233f591806eb351db2ae35ac0192a3fe997",
+          "paramsHashHex": "2b3e488c04433ed8bd293fd3adab72b49bf52346b81160365486d76f9b4d4e39",
+          "networkMagicHex": "f9beb4d9",
+          "builderBinarySha256Hex": "34a677847b9be6580385c73f163279c81561772f8d3ad782d0ca08f1c01fad4a",
+          "builderGitCommit": "01e8db91d76037cd5562fce85c40e832ad156431"
+        }
+      ]
+    },
+    {
+      "label": "Provider 2 functional beta Free DPF",
+      "endpoint": "wss://provider2-beta.65-21-91-217.sslip.io",
+      "providerIdHex": "83076521322104abbceca115f119c953c84561a29922e7ce444b7097ffc5f5d7",
+      "policySigningKeyHex": "c2e0598b34804d1b3c60b4b636bccd861b93cfa55671e27787f0eab50d9dbf8e",
+      "operatorSigningKeyHex": "5590cce35dc49fcde96b724899aef54487d9a43ec234815503723a5179e56d07",
+      "stableServerId": "pir2-payment-beta",
+      "serverPin": {
+        "binarySha256Hex": "d23b58410f52fede21d013fbcec279c42d02b69d4b32791265cfb38e331770d8"
+      },
+      "hardwareAttestation": "unavailable-accepted",
+      "lightningPayeeTrust": [],
+      "databaseProofPins": [
+        {
+          "dbId": 0,
+          "buildKind": "snapshot",
+          "fromHeight": 0,
+          "height": 948454,
+          "fromBlockHashHex": "0000000000000000000000000000000000000000000000000000000000000000",
+          "blockHashHex": "00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4",
+          "muhashHex": "cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee",
+          "bucketSuperRootHex": "45def9b3c191cd28e630dae51f32d3e2f85f4d8ccf38c0712a23136967f2ec0b",
+          "onionSuperRootHex": "e83efa5730c47b94e8e6af09b1cb76a9e006634645fd39c939bd7b8ea554f8b4",
+          "paramsHashHex": "ac364eb24e24ba025e2dcfdd50b9ccf65ffd556488afc076b70b557084c5318e",
+          "networkMagicHex": "f9beb4d9",
+          "builderBinarySha256Hex": "d4da29807e806c8a16eec94b86119bd16df7805a66fa4ff1c187a26832a36427",
+          "builderGitCommit": "b692aec18b9c20ac92cb9fe22588e96ff96ad27d"
+        },
+        {
+          "dbId": 1,
+          "buildKind": "delta",
+          "fromHeight": 940611,
+          "height": 948454,
+          "fromBlockHashHex": "000000000000000000002c41243b3d74d135942031ef15f547bca1ce8f85eb99",
+          "fromMuhashHex": "aebb29df12e045ef5279036263aba3b8f8e9e816e05b04a58f57e63b3b25756b",
+          "blockHashHex": "00000000000000000001ef683c02c383315db7e917c69d20f79e05985560a4e4",
+          "muhashHex": "cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee",
+          "bucketSuperRootHex": "e2ba2eee6788424309a95f771893d5401cc8e3ceec6188dc2708900e211a910a",
+          "onionSuperRootHex": "f86baa3966a61cdcd70d8c0ad9bed233f591806eb351db2ae35ac0192a3fe997",
+          "paramsHashHex": "2b3e488c04433ed8bd293fd3adab72b49bf52346b81160365486d76f9b4d4e39",
+          "networkMagicHex": "f9beb4d9",
+          "builderBinarySha256Hex": "34a677847b9be6580385c73f163279c81561772f8d3ad782d0ca08f1c01fad4a",
+          "builderGitCommit": "01e8db91d76037cd5562fce85c40e832ad156431"
+        }
+      ]
+    }
+  ]
+}

--- a/web/src/product-admission-ui.ts
+++ b/web/src/product-admission-ui.ts
@@ -97,7 +97,7 @@ export class ProductAdmissionPanelV1 {
     notice.dataset.admissionNotice = 'true';
     notice.setAttribute('role', 'status');
     notice.setAttribute('aria-live', 'polite');
-    notice.textContent = 'Commercial admission 未配置；查询会 fail closed。';
+    notice.textContent = 'Commercial admission is not configured; queries fail closed.';
     options.root.appendChild(notice);
 
     if (options.transportCompatibilityNotice) {
@@ -169,8 +169,8 @@ export class ProductAdmissionPanelV1 {
     }
     this.renderUnavailable(
       options.length === 0
-        ? 'Commercial admission 未配置；导入完整 trusted bootstrap 后才能查询。'
-        : '先严格验证第一个 provider 并选择其精确 offer；随后启用第二个角色，付款仍保持禁用。',
+        ? 'Commercial admission is not configured. Load a complete trusted bootstrap before querying.'
+        : 'First strictly verify the first provider and select its exact offer. The second role will then be enabled; payment remains disabled.',
     );
   }
 
@@ -204,7 +204,7 @@ export class ProductAdmissionPanelV1 {
     this.render(controller.snapshot());
   }
 
-  detach(message = 'Commercial admission 未配置；查询会 fail closed。'): void {
+  detach(message = 'Commercial admission is not configured; queries fail closed.'): void {
     this.controller = null;
     this.snapshot = null;
     this.busy = false;
@@ -600,7 +600,7 @@ function statusLabel(
   if (leg.status === 'failed') return 'Admission: failed closed';
   if (selected && (selected.offer.authorization === 'cashu-bat'
       || selected.offer.authorization === 'arc-experimental') && leg.inventory === 0) {
-    return `Inventory: 0 · 需先导入/购买 capability${selected.offer.authorization === 'arc-experimental' ? ' · EXPERIMENTAL' : ''}`;
+    return `Inventory: 0 · import or acquire a capability first${selected.offer.authorization === 'arc-experimental' ? ' · EXPERIMENTAL' : ''}`;
   }
   if (leg.inventory !== null) return `Inventory: ${leg.inventory} exact capability record(s)`;
   return `Admission: ${leg.status}`;


### PR DESCRIPTION
## What changed

- Bundle the reviewed two-provider functional-beta trusted bootstrap in the public web build.
- Load it only into page memory and retain explicit, visibly degraded central-directory refresh.
- Make all current admission UI copy English.

## Why

The public Pages bundle had no bootstrap, so its provider selectors were empty and strict admission failed closed before a query could begin.

## Validation

- Focused Vitest: 36 passing tests
- TypeScript build
- Production Vite build and CSP verification
- Bootstrap byte-for-byte comparison with the reviewed deployment artifact
- Frontend-source English-character scan