### PR TITLE
fix(web): clarify provider verification

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-Uyhpfvv5Fv64fQ0Zuw0AtenA264gybeTSNeNAGwvoho=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-wo7QXNt1ZMCqPCBnOpvh/faVj1GF+RJ1/yQDn5lXBOA=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
     <title>Bitcoin PIR</title>
     <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>
@@ -802,7 +802,7 @@
         .verification-dialog-close:hover { color: var(--ink); background: var(--sunken); }
         .verification-dialog-body { padding: 18px; overflow-y: auto; max-height: calc(100vh - 96px); }
 
-        /* Commercial admission is a compact, query-local gate. It follows the
+        /* Provider verification is a compact, query-local gate. It follows the
            existing dense form language instead of becoming a second dashboard. */
         .admission-config {
             margin-top: 12px;
@@ -899,7 +899,7 @@
                     </button>
                 </div>
                 <details class="admission-config" id="admissionConfig">
-                    <summary>Commercial admission trust configuration</summary>
+                    <summary>Provider verification trust configuration</summary>
                     <div class="admission-config-grid">
                         <label for="admissionBootstrapJson">Trusted bootstrap JSON (advanced replacement: endpoint, provider/policy/operator keys, server/binary/measurement/database pins, exact issuer/network/Lightning-payee trust)</label>
                         <textarea id="admissionBootstrapJson" class="input" autocomplete="off" spellcheck="false" placeholder="A functional-beta trusted bootstrap is bundled for this page load. Paste a complete replacement only when intentionally changing trust."></textarea>
@@ -1021,9 +1021,9 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                                     <button id="syncCancelBtn" class="btn ghost sm">Cancel</button>
                                 </div>
                             </div>
-                            <div id="dpfAdmissionPanel" class="product-admission-panel" aria-label="DPF provider admission"></div>
+                            <div id="dpfAdmissionPanel" class="product-admission-panel" aria-label="DPF provider verification"></div>
                             <div style="margin-top: 10px;">
-                                <button id="queryBtn" class="btn accent" style="width: 100%;">Select Server 0, then begin strict admission</button>
+                                <button id="queryBtn" class="btn accent" style="width: 100%;">Select Server 0, then verify it</button>
                             </div>
                         </div>
 
@@ -1208,7 +1208,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                                     <button id="op-syncCancelBtn" class="btn ghost sm">Cancel</button>
                                 </div>
                             </div>
-                            <div id="opAdmissionPanel" class="product-admission-panel" aria-label="OnionPIR provider admission"></div>
+                            <div id="opAdmissionPanel" class="product-admission-panel" aria-label="OnionPIR provider verification"></div>
                             <div style="margin-top: 10px;">
                                 <button id="op-queryBtn" class="btn accent" style="width: 100%;">Query UTXOs</button>
                             </div>
@@ -1380,7 +1380,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                                     <button id="hp-syncCancelBtn" class="btn ghost sm">Cancel</button>
                                 </div>
                             </div>
-                            <div id="hpAdmissionPanel" class="product-admission-panel" aria-label="HarmonyPIR provider admission"></div>
+                            <div id="hpAdmissionPanel" class="product-admission-panel" aria-label="HarmonyPIR provider verification"></div>
                             <div style="margin-top: 10px;">
                                 <button id="hp-queryBtn" class="btn accent" style="width: 100%;">Query UTXOs</button>
                             </div>
@@ -1540,7 +1540,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                                 <button id="oram-connectBtn" class="btn">Connect</button>
                                 <button id="oram-disconnectBtn" class="btn ghost" disabled>Disconnect</button>
                             </div>
-                            <div id="oramAdmissionPanel" class="product-admission-panel" aria-label="ORAM provider admission"></div>
+                            <div id="oramAdmissionPanel" class="product-admission-panel" aria-label="ORAM provider verification"></div>
                             <div style="margin-top: 10px;">
                                 <button id="oram-queryBtn" class="btn accent" style="width: 100%;">Query UTXOs</button>
                             </div>
@@ -1771,7 +1771,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 const legs = snapshot?.legs ?? [];
                 if (!snapshot) {
                     button.disabled = false;
-                    button.textContent = 'Select Server 0, then begin strict admission';
+                    button.textContent = 'Select Server 0, then verify it';
                     return;
                 }
                 if (snapshot.phase === 'querying') {
@@ -1805,7 +1805,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     return;
                 }
                 button.disabled = false;
-                button.textContent = 'Select Server 0, then begin strict admission';
+                button.textContent = 'Select Server 0, then verify it';
                 return;
             }
             if (button.disabled) return;
@@ -1818,7 +1818,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     ? 'Verify independent second provider'
                 : snapshot?.phase === 'selecting'
                     ? 'Query blocked · authorize current provider'
-                    : 'Start strict admission';
+                    : 'Verify provider';
         }
 
         function allDirectoryEntries() {
@@ -1854,7 +1854,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             } catch {
                 productTrustedBootstrap = null;
                 renderTrustedProviderOptions();
-                status.textContent = 'Bundled functional-beta trusted bootstrap is invalid; commercial admission remains fail closed.';
+                status.textContent = 'Bundled functional-beta trusted bootstrap is invalid; query access remains blocked.';
                 return;
             }
             renderTrustedProviderOptions();
@@ -1893,7 +1893,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         }
 
         function selectedAdmissionProviders(kind) {
-            if (!productTrustedBootstrap) throw new Error('commercial admission is unconfigured');
+            if (!productTrustedBootstrap) throw new Error('query access is unconfigured');
             const ids = admissionPanels[kind].selectedProviderIds();
             const selected = Object.fromEntries(Object.entries(ids).map(([role, id]) => [role, providerById(id)]));
             const values = Object.values(selected);
@@ -1904,7 +1904,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         }
 
         function selectedAdmissionProvider(kind, role) {
-            if (!productTrustedBootstrap) throw new Error('commercial admission is unconfigured');
+            if (!productTrustedBootstrap) throw new Error('query access is unconfigured');
             return providerById(admissionPanels[kind].freezeProviderSelection(role));
         }
 
@@ -1948,7 +1948,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             }
         }
 
-        async function closeAdmissionAttempt(kind, message = 'Start a new strict admission attempt.') {
+        async function closeAdmissionAttempt(kind, message = 'Start a new provider verification setup.') {
             const controller = admissionControllers[kind];
             admissionControllers[kind] = null;
             if (controller) await controller.close().catch(() => {});
@@ -2041,14 +2041,14 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 ? 'Applying replacement trusted bootstrap; admission is temporarily fail closed.'
                 : 'Rejecting invalid trusted bootstrap; admission is temporarily fail closed.';
             await closeAllAdmissionAttempts(parsed
-                ? 'Trusted bootstrap changed; start a new strict admission attempt.'
-                : 'Invalid trusted bootstrap; strict admission attempts were closed.');
+                ? 'Trusted bootstrap changed; start a new provider verification setup.'
+                : 'Invalid trusted bootstrap; provider verification attempts were closed.');
             if (!directoryRefreshIntentGuard.isCurrent(
                 applyIntent,
                 currentDirectoryRefreshInput(),
             )) return;
             if (!parsed) {
-                status.textContent = 'Rejected invalid trusted bootstrap; commercial admission remains fail closed.';
+                status.textContent = 'Rejected invalid trusted bootstrap; query access remains blocked.';
                 return;
             }
             productTrustedBootstrap = parsed;
@@ -2355,7 +2355,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             const staged = await prepareIndependentProductLeg(kind, role, vault);
             if (admissionControllers[kind] !== controller) {
                 await staged.close();
-                throw new Error('strict admission was invalidated while provider bootstrap was in flight');
+                throw new Error('provider verification was invalidated while bootstrap was in flight');
             }
             return staged;
         }
@@ -2464,10 +2464,10 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 try {
                     controller = await prepareProductAdmission(kind);
                 } catch (error) {
-                    await closeAdmissionAttempt(kind, 'Strict admission failed; inputs are editable again.');
+                    await closeAdmissionAttempt(kind, 'Provider verification failed; inputs are editable again.');
                     throw error;
                 }
-                log(`${kind}: strict verification and signed policy complete; select and authorize each exact offer.`, 'success');
+                log(`${kind}: provider verification and signed policy complete; select and authorize each exact offer.`, 'success');
                 return;
             }
             const snapshot = controller.snapshot();
@@ -2483,7 +2483,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 await requireFreshDirectoryTrustForSecurityTransition();
                 installPreparedProductQueryShapes(kind, controller);
                 admissionPanels[kind].render(controller.snapshot());
-                log(`${kind}: both providers and tree-tops strictly verified; capabilities may now be acquired or authorized independently.`, 'success');
+                log(`${kind}: both providers and tree-tops verified; capabilities may now be acquired or authorized independently.`, 'success');
                 return;
             }
             if (!controller.canQuery()) {
@@ -2498,7 +2498,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     query,
                 );
             } finally {
-                await closeAdmissionAttempt(kind, 'Previous one-query connection closed. Start a new strict admission attempt.');
+                await closeAdmissionAttempt(kind, 'Previous one-query connection closed. Start a new provider verification setup.');
             }
         }
 
@@ -3501,7 +3501,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
 
         async function connectDpfLeg(provider, serverIndex) {
             if (!provider?.endpoint || (serverIndex !== 0 && serverIndex !== 1)) {
-                throw new Error('DPF commercial admission requires one complete trusted provider bootstrap per leg');
+                throw new Error('DPF query access requires one complete trusted provider bootstrap per leg');
             }
             const previous = dpfAdmissionProviders[serverIndex];
             if (previous && previous.providerIdHex !== provider.providerIdHex) {
@@ -3928,7 +3928,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         }
 
         async function planSync() {
-            log('Sync is disabled in commercial admission V1 because it can issue multiple queries.', 'error');
+            log('Sync is disabled in query-access V1 because it can issue multiple queries.', 'error');
             return;
 
             const parsed = parseScriptInputs('scriptPubkeys');
@@ -3992,7 +3992,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         }
 
         async function executeSync() {
-            log('Sync execution is disabled in commercial admission V1.', 'error');
+            log('Sync execution is disabled in query-access V1.', 'error');
             return;
             if (!pendingSync || !client || !client.isConnected()) return;
             const { plan, lines, scriptHashes } = pendingSync;
@@ -4383,7 +4383,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
 
         async function opConnect(provider) {
             if (!provider?.endpoint) {
-                throw new Error('OnionPIR commercial admission requires a complete trusted provider bootstrap');
+                throw new Error('OnionPIR query access requires a complete trusted provider bootstrap');
             }
             const serverUrl = provider.endpoint;
             document.getElementById('op-serverUrl').value = serverUrl;
@@ -4455,7 +4455,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
 
         // ─── OnionPIR sync flow (mirrors DPF) ─────────────────────────────
         async function opPlanSync() {
-            log('OnionPIR sync is disabled in commercial admission V1 because it can issue multiple queries.', 'error');
+            log('OnionPIR sync is disabled in query-access V1 because it can issue multiple queries.', 'error');
             return;
 
             const parsed = parseOpScriptInputs();
@@ -4543,7 +4543,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         }
 
         async function opExecuteSync() {
-            log('OnionPIR sync execution is disabled in commercial admission V1.', 'error');
+            log('OnionPIR sync execution is disabled in query-access V1.', 'error');
             return;
             if (!opPendingSync || !opClient || !opClient.isConnected()) return;
             const { plan, lines, scriptHashes } = opPendingSync;
@@ -4811,7 +4811,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             if (admissionControllers.onion) {
                 await closeAdmissionAttempt(
                     'onion',
-                    'Database selection changed; start a new strict admission attempt.',
+                    'Database selection changed; start a new provider verification setup.',
                 );
                 log('OnionPIR: database change closed the exact admission before any query spend', 'info');
                 return;
@@ -4937,7 +4937,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             if (newDbId === hpClient.getDbId()) return;
             hpClient.setDbId(newDbId);
             hpHintsLoaded = false;
-            await closeAdmissionAttempt('harmony', 'Database changed; start a new strict admission attempt.');
+            await closeAdmissionAttempt('harmony', 'Database changed; start a new provider verification setup.');
             log(`HarmonyPIR: db_id=${newDbId} selected; old policy, grant, and hint binding invalidated.`, 'info');
         }
 
@@ -5257,12 +5257,12 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         }
 
         async function hpPlanSync() {
-            log('HarmonyPIR sync is disabled in commercial admission V1 because it can issue multiple queries.', 'error');
+            log('HarmonyPIR sync is disabled in query-access V1 because it can issue multiple queries.', 'error');
             return;
             if (hpSwitchingPrp) { log('HarmonyPIR: PRP switch in progress, please wait.', 'error'); return; }
             if (!hpClient || !hpHintsLoaded) {
                 log('HarmonyPIR: Auto-connecting...', 'info');
-                throw new Error('automatic Harmony reconnect is disabled for commercial admission');
+                throw new Error('automatic Harmony reconnect is disabled for query access');
                 if (!hpClient || !hpHintsLoaded) {
                     log('HarmonyPIR: Connection or hint download failed.', 'error');
                     return;
@@ -5327,7 +5327,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         }
 
         async function hpExecuteSync() {
-            log('HarmonyPIR sync execution is disabled in commercial admission V1.', 'error');
+            log('HarmonyPIR sync execution is disabled in query-access V1.', 'error');
             return;
             if (!hpPendingSync || !hpClient || !hpHintsLoaded) return;
             const { plan, lines, scriptHashes } = hpPendingSync;
@@ -5769,7 +5769,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             }
             hpCurrentPrp = newPrp;
             const names = ['HMR12', 'FastPRP'];
-            await closeAdmissionAttempt('harmony', 'PRP backend changed; start a new strict admission attempt.');
+            await closeAdmissionAttempt('harmony', 'PRP backend changed; start a new provider verification setup.');
             if (hpClient) hpDisconnect(true, true);
             log(`HarmonyPIR: PRP changed to ${names[newPrp] ?? 'HMR12'}; live policy/grants invalidated.`, 'info');
         });
@@ -5899,7 +5899,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
 
         async function oramConnect(provider) {
             if (!provider?.endpoint) {
-                throw new Error('ORAM commercial admission requires a complete trusted provider bootstrap');
+                throw new Error('ORAM query access requires a complete trusted provider bootstrap');
             }
             const serverUrl = provider.endpoint;
             document.getElementById('oram-serverUrl').value = serverUrl;
@@ -6179,7 +6179,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             if (admissionControllers.oram) {
                 await closeAdmissionAttempt(
                     'oram',
-                    'Database selection changed; start a new strict admission attempt.',
+                    'Database selection changed; start a new provider verification setup.',
                 );
                 log('ORAM: database change closed the exact admission before any query spend', 'info');
                 return;

--- a/web/src/product-admission-ui.ts
+++ b/web/src/product-admission-ui.ts
@@ -97,7 +97,7 @@ export class ProductAdmissionPanelV1 {
     notice.dataset.admissionNotice = 'true';
     notice.setAttribute('role', 'status');
     notice.setAttribute('aria-live', 'polite');
-    notice.textContent = 'Commercial admission is not configured; queries fail closed.';
+    notice.textContent = 'Query access is not configured; queries are blocked.';
     options.root.appendChild(notice);
 
     if (options.transportCompatibilityNotice) {
@@ -169,8 +169,10 @@ export class ProductAdmissionPanelV1 {
     }
     this.renderUnavailable(
       options.length === 0
-        ? 'Commercial admission is not configured. Load a complete trusted bootstrap before querying.'
-        : 'First strictly verify the first provider and select its exact offer. The second role will then be enabled; payment remains disabled.',
+        ? 'Query access is not configured. Load a complete trusted bootstrap before querying.'
+        : this.options.roles.length > 1
+          ? 'Verify the first provider’s identity, software, and database, then select its exact offer. The second role will then be enabled; payment remains disabled.'
+          : 'Verify the provider’s identity, software, and database, then select its exact offer.',
     );
   }
 
@@ -204,7 +206,7 @@ export class ProductAdmissionPanelV1 {
     this.render(controller.snapshot());
   }
 
-  detach(message = 'Commercial admission is not configured; queries fail closed.'): void {
+  detach(message = 'Query access is not configured; queries are blocked.'): void {
     this.controller = null;
     this.snapshot = null;
     this.busy = false;
@@ -223,15 +225,17 @@ export class ProductAdmissionPanelV1 {
           : snapshot?.phase === 'querying'
             ? 'One authorized PIR query is in flight; it will not be retried automatically.'
             : snapshot?.legs.length === 1 && canBootstrapNextProviderV1(snapshot)
-              ? 'First exact offer is locked. Strictly verify the independent second provider before any capability acquisition or payment.'
+              ? 'First exact offer is locked. Verify the independent second provider before any capability acquisition or payment.'
               : snapshot?.legs.length === 2 && !credentialActionsReadyV1(snapshot)
-                ? 'Both providers are strictly verified. Select the remaining exact signed offer before acquiring a capability or authorizing either provider.'
+                ? 'Both providers are verified. Select the remaining exact signed offer before acquiring a capability or authorizing either provider.'
                 : snapshot?.legs.length === 2 && !snapshot.legs.every((leg) => leg.status === 'authorized'
                   || leg.status === 'cached-resource-ready')
                   ? 'Both exact offers are selected. Complete any capability acquisition and authorize each provider independently.'
               : snapshot?.legs.length === 1
                 ? 'Select the first provider exact signed offer before connecting the second.'
-                : 'Strictly verify and authorize the first independent provider.');
+                : this.options.roles.length > 1
+                  ? 'Verify and authorize the first independent provider.'
+                  : 'Verify and authorize the provider.');
       notice.classList.toggle('error', this.publicError !== null || snapshot?.phase === 'failed');
     }
     if (!snapshot) return;
@@ -488,11 +492,11 @@ export class ProductAdmissionPanelV1 {
       row.identity.textContent = row.provider.value
         ? `Trusted bootstrap: ${abbreviate(row.provider.value)}`
         : 'Provider identity: not selected';
-      row.offer.replaceChildren(optionElement('', 'Strict policy required'));
+      row.offer.replaceChildren(optionElement('', 'Signed policy required'));
       row.offer.disabled = true;
       row.terms.textContent = 'Scope/offer: unavailable';
       row.warning.textContent = 'Privacy: no payment method selected';
-      row.status.textContent = 'Admission: blocked';
+      row.status.textContent = 'Query access: blocked';
       row.actions.replaceChildren();
     }
   }
@@ -505,19 +509,19 @@ export function publicAdmissionError(error: unknown): string {
 
 function publicErrorForCode(code: ProductAdmissionErrorCodeV1): string {
   switch (code) {
-    case 'commercial-admission-unconfigured': return 'Commercial admission is not configured.';
+    case 'commercial-admission-unconfigured': return 'Query access is not configured.';
     case 'strict-bootstrap-failed': return 'Strict server verification failed; no quote, capability, or query was sent.';
-    case 'policy-unavailable': return 'A live signed V1 policy/anchor is unavailable; legacy admission is disabled.';
+    case 'policy-unavailable': return 'A live signed V1 policy/anchor is unavailable; legacy query access is disabled.';
     case 'query-shape-unavailable': return 'The exact backend planner demand is unavailable; no offer or capability may be used.';
     case 'entitlement-limits-insufficient': return 'The signed entitlement is below the backend planner’s known demand; no payment or capability was used.';
-    case 'offer-selection-invalidated': return 'The exact offer selection changed or is incomplete; restart admission.';
+    case 'offer-selection-invalidated': return 'The exact offer selection changed or is incomplete; restart provider verification.';
     case 'pair-correlation-rejected': return 'The selected pair shares an issuer or trust key; choose independently, or use the one-attempt advanced confirmation.';
     case 'lightning-payee-untrusted': return 'BOLT11 is blocked because no independent expected-payee key is trusted.';
     case 'bolt11-recovery-required': return 'The invoice response may have been lost. Resume the encrypted recovery; do not create another invoice.';
     case 'capability-inventory-empty': return 'No exact capability is available. Import or purchase one before authorization.';
     case 'ambiguous-capability-spend': return 'Capability spend is ambiguous. It will not be retried automatically.';
     case 'resource-failed-after-authorization': return 'Authorization succeeded but the resource failed. It will not retry automatically.';
-    default: return 'Admission operation failed without exposing secret material.';
+    default: return 'Provider verification operation failed without exposing secret material.';
   }
 }
 


### PR DESCRIPTION
## What changed

Replaced public-facing "strict/commercial admission" wording with clear Provider verification and Query access language.

## Why

The prior internal protocol term was ambiguous in the browser UI. This is a copy-only clarification; strict identity, secure-channel, binary/attestation, database-root, signed-policy, and authorization checks are unchanged.

## Validation

- `npm test -- src/__tests__/product-admission-ui.test.ts src/__tests__/security-badge.test.ts src/__tests__/functional-beta-trusted-bootstrap.test.ts`
- `npm run build-web` (including CSP verification)