### PR TITLE
feat(web): clarify free and premium access

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-wo7QXNt1ZMCqPCBnOpvh/faVj1GF+RJ1/yQDn5lXBOA=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-7/ijyE29NEP9JpRaQ4D3Fh9yYlMoeOmX07SJH9Pobjs=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
     <title>Bitcoin PIR</title>
     <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>
@@ -1797,7 +1797,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     }
                     if (!legs.every(isAdmissionAuthorized)) {
                         button.disabled = true;
-                        button.textContent = 'Complete capability acquisition and authorize both providers in the panels';
+                        button.textContent = 'Request Free access or authorize Premium access in both panels';
                         return;
                     }
                     button.disabled = false;

--- a/web/src/__tests__/product-admission-ui.test.ts
+++ b/web/src/__tests__/product-admission-ui.test.ts
@@ -3,12 +3,17 @@ import { describe, expect, it } from 'vitest';
 import {
   canBootstrapNextProviderV1,
   credentialActionsReadyV1,
+  offerChoiceLabelForOfferV1,
   pairAuthorizationReadyV1,
+  partitionOfferOptionsForDisplayV1,
   privacyLabelForOfferV1,
   retainedCapabilityLabelV1,
   retainedRecoveryLabelV1,
 } from '../product-admission-ui.js';
-import type { ProductAdmissionSnapshotV1 } from '../product-admission-controller.js';
+import type {
+  ProductAdmissionSnapshotV1,
+  ProductOfferOptionV1,
+} from '../product-admission-controller.js';
 import type { ServiceOfferViewV1 } from '../sdk-bridge.js';
 
 function offer(overrides: Partial<ServiceOfferViewV1>): ServiceOfferViewV1 {
@@ -34,6 +39,48 @@ function offer(overrides: Partial<ServiceOfferViewV1>): ServiceOfferViewV1 {
 }
 
 describe('signed offer privacy wording', () => {
+  it('labels free capacity and premium authorization methods distinctly', () => {
+    const free = offerChoiceLabelForOfferV1({ offer: offer({}) } as ProductOfferOptionV1);
+    const bolt11 = offerChoiceLabelForOfferV1({ offer: offer({
+      acquisition: 'bolt11',
+      authorization: 'bolt11-direct-receipt',
+      freeMode: 'not-free',
+      price: { kind: 'msat', amount: '1000' },
+    }) } as ProductOfferOptionV1);
+    const bat = offerChoiceLabelForOfferV1({ offer: offer({
+      acquisition: 'bolt11',
+      authorization: 'cashu-bat',
+      freeMode: 'not-free',
+      price: { kind: 'msat', amount: '1000' },
+    }) } as ProductOfferOptionV1);
+    const arc = offerChoiceLabelForOfferV1({ offer: offer({
+      acquisition: 'bolt11',
+      authorization: 'arc-experimental',
+      freeMode: 'not-free',
+      price: { kind: 'msat', amount: '1000' },
+    }) } as ProductOfferOptionV1);
+
+    expect(free).toMatch(/Free access.*best effort, may queue.*no charge/i);
+    expect(bolt11).toMatch(/Premium access.*BOLT11 direct receipt.*1000 msat/i);
+    expect(bat).toMatch(/Premium access.*Cashu BAT.*acquire with BOLT11/i);
+    expect(arc).toMatch(/Premium access.*ARC.*EXPERIMENTAL.*acquire with BOLT11/i);
+  });
+
+  it('puts Free offers before Premium offers without dropping either exact offer', () => {
+    const free = { offer: offer({ offerId: 11 }) } as ProductOfferOptionV1;
+    const premium = { offer: offer({
+      offerId: 12,
+      acquisition: 'bolt11',
+      authorization: 'cashu-bat',
+      freeMode: 'not-free',
+      price: { kind: 'msat', amount: '1000' },
+    }) } as ProductOfferOptionV1;
+
+    const grouped = partitionOfferOptionsForDisplayV1([premium, free]);
+    expect(grouped.free).toEqual([free]);
+    expect(grouped.premium).toEqual([premium]);
+  });
+
   it('warns that a direct BOLT11 receipt is payment-to-spend linkable', () => {
     expect(privacyLabelForOfferV1(offer({
       acquisition: 'bolt11',
@@ -250,6 +297,47 @@ describe('staged provider UI ordering', () => {
     }];
     expect(pairAuthorizationReadyV1(snapshot)).toBe(false);
     snapshot.legs[1].inventory = 1;
+    expect(pairAuthorizationReadyV1(snapshot)).toBe(true);
+  });
+
+  it('allows a Free access choice on both providers without Premium inventory', () => {
+    const snapshot = stagedSnapshot(['ready', 'ready'], [true, true]);
+    snapshot.legs[0].offers = [{
+      scopeIdHex: snapshot.legs[0].selected!.scopeIdHex,
+      offerId: snapshot.legs[0].selected!.offerId,
+      scope: {
+        scopeIdHex: snapshot.legs[0].selected!.scopeIdHex,
+        backend: 'dpf-pir',
+        workload: 'dpf-query',
+        protocolVersion: 1,
+        operationProfile: 1,
+        entitlementProfile: 1,
+        dataset: { kind: 'manifest-root', rootHex: '5a'.repeat(32) },
+        limits: {
+          maxLogicalInputs: 1,
+          maxFrames: 64,
+          maxRequestBytes: '1048576',
+          maxResponseBytes: '2097152',
+          maxWallTimeMs: 30_000,
+          maxConcurrentSockets: 1,
+          maxHintGroups: 0,
+          maxWorkUnits: '10000',
+        },
+        offers: [],
+      },
+      offer: offer({}),
+    }];
+    snapshot.legs[1].offers = [{
+      ...snapshot.legs[0].offers[0],
+      scopeIdHex: snapshot.legs[1].selected!.scopeIdHex,
+      offerId: snapshot.legs[1].selected!.offerId,
+      scope: {
+        ...snapshot.legs[0].offers[0].scope,
+        scopeIdHex: snapshot.legs[1].selected!.scopeIdHex,
+      },
+      offer: offer({ offerId: snapshot.legs[1].selected!.offerId }),
+    }];
+
     expect(pairAuthorizationReadyV1(snapshot)).toBe(true);
   });
 });

--- a/web/src/functional-beta-trusted-bootstrap.json
+++ b/web/src/functional-beta-trusted-bootstrap.json
@@ -56,7 +56,7 @@
       ]
     },
     {
-      "label": "Provider 2 functional beta Free DPF",
+      "label": "Provider 2 functional beta",
       "endpoint": "wss://provider2-beta.65-21-91-217.sslip.io",
       "providerIdHex": "83076521322104abbceca115f119c953c84561a29922e7ce444b7097ffc5f5d7",
       "policySigningKeyHex": "c2e0598b34804d1b3c60b4b636bccd861b93cfa55671e27787f0eab50d9dbf8e",

--- a/web/src/product-admission-ui.ts
+++ b/web/src/product-admission-ui.ts
@@ -126,12 +126,12 @@ export class ProductAdmissionPanelV1 {
       const identity = textLine('admission-provider-identity', 'Provider identity: not selected');
       const offer = document.createElement('select');
       offer.className = 'select admission-offer-select';
-      offer.setAttribute('aria-label', `${role.label} exact signed service offer`);
+      offer.setAttribute('aria-label', `${role.label} Free or Premium exact signed service offer`);
       offer.disabled = true;
       offer.addEventListener('change', () => void this.handleOfferSelection(role.role, offer.value));
       const terms = textLine('admission-provider-terms', 'Scope/offer: unavailable');
-      const warning = textLine('admission-provider-warning', 'Privacy: no payment method selected');
-      const status = textLine('admission-provider-status', 'Admission: blocked');
+      const warning = textLine('admission-provider-warning', 'Access: select Free or Premium');
+      const status = textLine('admission-provider-status', 'Query access: blocked');
       status.setAttribute('role', 'status');
       status.setAttribute('aria-live', 'polite');
       const actions = document.createElement('div');
@@ -171,8 +171,8 @@ export class ProductAdmissionPanelV1 {
       options.length === 0
         ? 'Query access is not configured. Load a complete trusted bootstrap before querying.'
         : this.options.roles.length > 1
-          ? 'Verify the first provider’s identity, software, and database, then select its exact offer. The second role will then be enabled; payment remains disabled.'
-          : 'Verify the provider’s identity, software, and database, then select its exact offer.',
+          ? 'Verify the first provider’s identity, software, and database, then select Free or Premium access. The second role will then be enabled; Premium authorization remains disabled.'
+          : 'Verify the provider’s identity, software, and database, then select Free or Premium access.',
     );
   }
 
@@ -225,14 +225,14 @@ export class ProductAdmissionPanelV1 {
           : snapshot?.phase === 'querying'
             ? 'One authorized PIR query is in flight; it will not be retried automatically.'
             : snapshot?.legs.length === 1 && canBootstrapNextProviderV1(snapshot)
-              ? 'First exact offer is locked. Verify the independent second provider before any capability acquisition or payment.'
+              ? 'First exact offer is locked. Verify the independent second provider before any Premium acquisition or payment.'
               : snapshot?.legs.length === 2 && !credentialActionsReadyV1(snapshot)
-                ? 'Both providers are verified. Select the remaining exact signed offer before acquiring a capability or authorizing either provider.'
+                ? 'Both providers are verified. Choose Free access on each provider for best-effort capacity, or select a Premium method before authorization.'
                 : snapshot?.legs.length === 2 && !snapshot.legs.every((leg) => leg.status === 'authorized'
                   || leg.status === 'cached-resource-ready')
-                  ? 'Both exact offers are selected. Complete any capability acquisition and authorize each provider independently.'
-              : snapshot?.legs.length === 1
-                ? 'Select the first provider exact signed offer before connecting the second.'
+                  ? 'Both access methods are selected. Request Free access directly, or complete the selected Premium authorization for each provider independently.'
+                : snapshot?.legs.length === 1
+                ? 'Select the first provider Free or Premium method before connecting the second.'
                 : this.options.roles.length > 1
                   ? 'Verify and authorize the first independent provider.'
                   : 'Verify and authorize the provider.');
@@ -272,13 +272,18 @@ export class ProductAdmissionPanelV1 {
           acquisitionContext: leg.retainedSelected.acquisitionContext,
         }))
       : leg.selected ? choiceValue(leg.selected.scopeIdHex, leg.selected.offerId) : '';
-    row.offer.replaceChildren(optionElement('', 'Select exact signed offer…'));
-    for (const option of leg.offers) {
-      row.offer.appendChild(optionElement(
-        choiceValue(option.scopeIdHex, option.offerId),
-        offerLabel(option),
-      ));
-    }
+    row.offer.replaceChildren(optionElement('', 'Select Free or Premium access…'));
+    const groupedOffers = partitionOfferOptionsForDisplayV1(leg.offers);
+    appendOfferGroup(
+      row.offer,
+      'Free access · best effort, may queue or rate-limit',
+      groupedOffers.free,
+    );
+    appendOfferGroup(
+      row.offer,
+      'Premium access · authorization required',
+      groupedOffers.premium,
+    );
     for (const capability of leg.retainedCapabilities) {
       row.offer.appendChild(optionElement(
         retainedChoiceValue(capability),
@@ -301,11 +306,11 @@ export class ProductAdmissionPanelV1 {
       (option) => choiceValue(option.scopeIdHex, option.offerId) === selectedValue,
       );
     row.terms.textContent = selected
-      ? `${leg.retainedSelected ? 'Retained signed terms' : 'Scope'} ${abbreviate(selected.scopeIdHex)} · ${selected.scope.workload} · ${priceLabel(selected)} · ${limitsLabel(selected)}`
-      : 'Scope/offer: selection required';
+      ? `${leg.retainedSelected ? 'Retained signed terms' : 'Scope'} ${abbreviate(selected.scopeIdHex)} · ${selected.scope.workload} · ${accessTermsLabel(selected.offer)} · ${limitsLabel(selected)}`
+      : 'Scope/offer: choose Free or Premium access';
     row.warning.textContent = selected
       ? privacyLabelForOfferV1(selected.offer)
-      : 'Privacy: no payment method selected';
+      : 'Access: no Free or Premium method selected';
     row.warning.classList.toggle(
       'experimental',
       selected?.offer.authorization === 'arc-experimental',
@@ -341,12 +346,12 @@ export class ProductAdmissionPanelV1 {
       invoice.value = leg.invoice;
       invoice.setAttribute('aria-label', `${leg.label} BOLT11 invoice`);
       container.appendChild(invoice);
-      container.appendChild(actionButton('Copy invoice', () => void copyText(invoice.value)));
-      container.appendChild(actionButton('Check payment', () => this.runAction(
+      container.appendChild(actionButton('Copy BOLT11 invoice', () => void copyText(invoice.value)));
+      container.appendChild(actionButton('Check Premium payment', () => this.runAction(
         () => this.controller!.pollBolt11(leg.role),
       )));
       if (leg.status === 'payment-settled') {
-        container.appendChild(actionButton('Claim capability', () => this.runAction(
+        container.appendChild(actionButton('Claim Premium capability', () => this.runAction(
           () => this.controller!.claimBolt11(leg.role),
         )));
       }
@@ -354,13 +359,13 @@ export class ProductAdmissionPanelV1 {
     }
 
     if (leg.recoveryIds.length > 0) {
-      container.appendChild(actionButton('Resume encrypted invoice recovery', () => this.runAction(
+      container.appendChild(actionButton('Resume encrypted Premium invoice recovery', () => this.runAction(
         () => this.controller!.resumeBolt11(leg.role, leg.recoveryIds[0]),
       )));
     }
 
     if (!retained && selected.offer.acquisition === 'bolt11') {
-      container.appendChild(actionButton('Create BOLT11 invoice', () => this.runAction(
+      container.appendChild(actionButton('Create Premium BOLT11 invoice', () => this.runAction(
         () => this.controller!.startBolt11(leg.role),
       )));
     }
@@ -374,7 +379,7 @@ export class ProductAdmissionPanelV1 {
       token.spellcheck = false;
       token.setAttribute('aria-label', `${leg.label} standard Cashu token`);
       container.appendChild(token);
-      container.appendChild(actionButton('Import Cashu token', async () => {
+      container.appendChild(actionButton('Import Premium Cashu token', async () => {
         const value = token.value;
         token.value = '';
         await this.runAction(() => this.controller!.importStandardCashu(leg.role, value));
@@ -386,7 +391,9 @@ export class ProductAdmissionPanelV1 {
         && (!retained || (leg.inventory ?? 0) > 0)
         && (authorizationReady || selected.scope.workload === 'harmony-hint')) {
       container.appendChild(actionButton(
-        selected.scope.workload === 'harmony-hint' ? 'Use cache or authorize hint' : 'Authorize once',
+        selected.scope.workload === 'harmony-hint'
+          ? `Use cache or ${selected.offer.authorization === 'free' ? 'request Free access' : 'authorize Premium access'}`
+          : selected.offer.authorization === 'free' ? 'Request Free access' : 'Authorize Premium access',
         () => this.runAction(() => this.controller!.authorize(leg.role)),
       ));
     }
@@ -445,7 +452,7 @@ export class ProductAdmissionPanelV1 {
 
   private invalidatePreparedAttempt(): void {
     if (!this.controller) return;
-    this.publicError = 'Provider selection changed. Cancel this connection and start a new strict attempt.';
+    this.publicError = 'Provider selection changed. Cancel this connection and start provider verification again.';
     this.render();
   }
 
@@ -470,11 +477,11 @@ export class ProductAdmissionPanelV1 {
       : 'Complete previous provider first'));
     row.offer.disabled = true;
     row.terms.textContent = available
-      ? 'Scope/offer: connect this provider next'
-      : 'Scope/offer: waiting for previous provider';
-    row.warning.textContent = 'Privacy: this provider has not been contacted';
+      ? 'Scope/offer: connect this provider to load Free and Premium methods'
+      : 'Scope/offer: waiting for the previous provider';
+    row.warning.textContent = 'Access: this provider has not been contacted';
     row.warning.classList.remove('experimental');
-    row.status.textContent = available ? 'Admission: ready for strict bootstrap' : 'Admission: waiting';
+    row.status.textContent = available ? 'Query access: ready for provider verification' : 'Query access: waiting';
     row.status.className = 'admission-provider-status status-strict-bootstrap-pending';
     row.actions.replaceChildren();
   }
@@ -495,7 +502,7 @@ export class ProductAdmissionPanelV1 {
       row.offer.replaceChildren(optionElement('', 'Signed policy required'));
       row.offer.disabled = true;
       row.terms.textContent = 'Scope/offer: unavailable';
-      row.warning.textContent = 'Privacy: no payment method selected';
+      row.warning.textContent = 'Access: no Free or Premium method selected';
       row.status.textContent = 'Query access: blocked';
       row.actions.replaceChildren();
     }
@@ -525,18 +532,71 @@ function publicErrorForCode(code: ProductAdmissionErrorCodeV1): string {
   }
 }
 
-function offerLabel(option: ProductOfferOptionV1): string {
+function appendOfferGroup(
+  select: HTMLSelectElement,
+  label: string,
+  offers: ProductOfferOptionV1[],
+): void {
+  if (offers.length === 0) return;
+  const group = document.createElement('optgroup');
+  group.label = label;
+  for (const option of offers) {
+    group.appendChild(optionElement(
+      choiceValue(option.scopeIdHex, option.offerId),
+      offerChoiceLabelForOfferV1(option),
+    ));
+  }
+  select.appendChild(group);
+}
+
+export function partitionOfferOptionsForDisplayV1(options: ProductOfferOptionV1[]): {
+  free: ProductOfferOptionV1[];
+  premium: ProductOfferOptionV1[];
+} {
+  return {
+    free: options.filter((option) => option.offer.authorization === 'free'),
+    premium: options.filter((option) => option.offer.authorization !== 'free'),
+  };
+}
+
+export function offerChoiceLabelForOfferV1(option: ProductOfferOptionV1): string {
   const offer = option.offer;
-  const method = offer.authorization === 'free'
-    ? `Free/${offer.freeMode}`
-    : offer.authorization === 'arc-experimental'
-      ? 'ARC EXPERIMENTAL'
-      : offer.authorization;
-  return `#${offer.offerId} · ${method} · ${priceLabel(option)}`;
+  if (offer.authorization === 'free') {
+    return `#${offer.offerId} · Free access · ${freeAccessModeLabel(offer.freeMode)} · no charge`;
+  }
+  return `#${offer.offerId} · Premium access · ${premiumMethodLabel(offer)} · ${priceLabel(option)}`;
+}
+
+function accessTermsLabel(offer: ProductOfferOptionV1['offer']): string {
+  return offer.authorization === 'free'
+    ? `Free access · ${freeAccessModeLabel(offer.freeMode)} · no payment required`
+    : `Premium access · ${premiumMethodLabel(offer)} · authorization required · ${priceLabelForOffer(offer)}`;
+}
+
+function freeAccessModeLabel(offerFreeMode: ProductOfferOptionV1['offer']['freeMode']): string {
+  switch (offerFreeMode) {
+    case 'open-best-effort': return 'best effort, may queue';
+    case 'ip-rate-limited': return 'rate limited, may queue';
+    case 'proof-of-work': return 'one-shot proof of work, may queue';
+    case 'anonymous-ticket': return 'anonymous ticket, may queue';
+    default: return 'provider-defined free policy';
+  }
+}
+
+function premiumMethodLabel(offer: ProductOfferOptionV1['offer']): string {
+  if (offer.authorization === 'bolt11-direct-receipt') return 'BOLT11 direct receipt';
+  if (offer.authorization === 'cashu-bat') return 'Cashu BAT · acquire with BOLT11';
+  if (offer.authorization === 'cashu-ecash') return 'Cashu eCash';
+  if (offer.authorization === 'arc-experimental') return 'ARC · EXPERIMENTAL · acquire with BOLT11';
+  return offer.authorization;
 }
 
 function priceLabel(option: ProductOfferOptionV1): string {
-  const price = option.offer.price;
+  return priceLabelForOffer(option.offer);
+}
+
+function priceLabelForOffer(offer: ProductOfferOptionV1['offer']): string {
+  const price = offer.price;
   if (price.kind === 'free') return 'free';
   return price.kind === 'msat'
     ? `${price.amount} msat`
@@ -601,18 +661,24 @@ function statusLabel(
   leg: ProductAdmissionLegSnapshotV1,
   selected: ProductOfferOptionV1 | undefined,
 ): string {
-  if (leg.status === 'ambiguous-spend') return 'Admission: ambiguous spend — no retry';
-  if (leg.status === 'authorized') return 'Admission: authorized for one query';
-  if (leg.status === 'cached-resource-ready') return 'Admission: exact verified hint cache hit — no hint purchase';
+  const access = selected?.offer.authorization === 'free' ? 'Free access' : 'Premium access';
+  if (leg.status === 'ambiguous-spend') return 'Query access: ambiguous spend — no retry';
+  if (leg.status === 'authorized') return selected?.offer.authorization === 'free'
+    ? 'Free access: ready for one query'
+    : `${access}: authorized for one query`;
+  if (leg.status === 'cached-resource-ready') return `${access}: exact verified hint cache hit — no hint purchase`;
   if (leg.status === 'invoice-open') return `Invoice: open${leg.invoiceExpiresAtUnix ? ` · expires ${leg.invoiceExpiresAtUnix}` : ''}`;
   if (leg.status === 'payment-settled') return 'Invoice: payment settled · claim required';
-  if (leg.status === 'failed') return 'Admission: failed closed';
+  if (leg.status === 'failed') return 'Query access: failed closed';
   if (selected && (selected.offer.authorization === 'cashu-bat'
       || selected.offer.authorization === 'arc-experimental') && leg.inventory === 0) {
     return `Inventory: 0 · import or acquire a capability first${selected.offer.authorization === 'arc-experimental' ? ' · EXPERIMENTAL' : ''}`;
   }
+  if (selected?.offer.authorization === 'free') {
+    return `Free access: selected · ${freeAccessModeLabel(selected.offer.freeMode)}`;
+  }
   if (leg.inventory !== null) return `Inventory: ${leg.inventory} exact capability record(s)`;
-  return `Admission: ${leg.status}`;
+  return `Query access: ${leg.status}`;
 }
 
 function actionButton(label: string, action: () => void | Promise<void>): HTMLButtonElement {


### PR DESCRIPTION
## What changed

- Group every verified exact offer into **Free access** or **Premium access**.
- Describe Free access as best effort and potentially queued or rate-limited.
- Keep BOLT11, Cashu eCash, Cashu BAT, and experimental ARC under Premium access with their existing authorization flows.
- Make the two-provider DPF button and per-provider actions explain the Free/Premium split.

## Behavior

This is a presentation-only change. It does not change signed policy validation, two-provider gating, credential consumption, payment, or server scheduling semantics. Premium access is not advertised as a priority queue.

## Validation

- `npm test -- src/__tests__/product-admission-ui.test.ts src/__tests__/functional-beta-trusted-bootstrap.test.ts`
- `npm run build`
- `npm run build-web`
- Local browser verification against Provider 1 live signed policy; no PIR query, payment, invoice, or authorization request was sent.