### PR TITLE
payment: prepare VPSBG Free-PoW premium beta

### DIFF
--- a/.github/workflows/payment-platform.yml
+++ b/.github/workflows/payment-platform.yml
@@ -311,8 +311,7 @@ jobs:
             cargo test --locked --offline \
               -p runtime \
               --features shared-issuer-process-e2e \
-              --test payment_v1_shared_issuer_process_e2e \
-              shared_issuer_real_process_tls_e2e -- --exact
+              --test payment_v1_shared_issuer_process_e2e
           cargo clippy --locked --offline \
             -p runtime \
             --features shared-issuer-process-e2e \

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ deploy/payment-v1/edge/*
 !deploy/payment-v1/edge/directory-public-haproxy.cfg.in
 !deploy/payment-v1/edge/directory-public-haproxy-build-manifest.json.in
 !deploy/payment-v1/edge/integrated-existing-bhtm-caddy-directory-public.managed.Caddyfile.in
+!deploy/payment-v1/vpsbg/
+!deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in
+!deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-service-auth.args.in
+!deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in
 !deploy/payment-v1/systemd/
 deploy/payment-v1/systemd/*
 !deploy/payment-v1/systemd/bhtm-caddy.directory-public-edge.conf.in

--- a/apps/server/tests/payment_v1_shared_issuer_process_e2e.rs
+++ b/apps/server/tests/payment_v1_shared_issuer_process_e2e.rs
@@ -38,18 +38,21 @@ use pir_runtime_core::protocol::{BatchQuery, Request, Response};
 use pir_sdk_client::attest::{attest_with_eph_binding, SevStatus};
 use pir_sdk_client::channel::{establish, SecureChannelTransport};
 use pir_sdk_client::{
-    dangerous_unpaired_authorize_service_operation_v1, fetch_verified_service_policy_v1,
-    AcceptedServicePolicyV1, PirTransport, ServicePolicyCheckpointV1, WsConnection,
+    dangerous_unpaired_authorize_service_operation_v1,
+    dangerous_unpaired_build_authorization_proof_v1, fetch_verified_service_policy_v1,
+    request_pow_challenge_v1, AcceptedServicePolicyV1, PirTransport, ServicePolicyCheckpointV1,
+    WsConnection,
 };
 use pir_service_protocol::{
-    derive_bat_key_id_v1, derive_issuer_id, derive_provider_id, AcquisitionMethod,
-    AuthPaddingClassV1, AuthScheme, AuthorizationProofV1, BackendId, BitcoinPirCashuBatProofV1,
-    Bolt11QuoteKeyDelegationV1, CredentialKeyBindingClaimsV1, CredentialKeyBindingV1,
-    CredentialUnitV1, DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1,
-    FreeAuthorizationProofV1, FreeModeV1, IssuerClearingApprovalV1, LightningNetworkV1,
-    OperationStartV1, PriceV1, PrivacyLeakageV1, ProviderClearingAuthorizationV1,
-    ProviderRedeemEnvelopeV1, ProviderRedeemResponseV1, ServiceOfferV1, ServicePolicyV1,
-    ServiceScopePolicyV1, ServiceScopeV1, SettlementUnitV1, VerificationMode, WorkloadId,
+    derive_bat_key_id_v1, derive_issuer_id, derive_provider_id, pow_solution_meets_difficulty_v1,
+    AcquisitionMethod, AuthPaddingClassV1, AuthScheme, AuthorizationProofV1, BackendId,
+    BitcoinPirCashuBatProofV1, Bolt11QuoteKeyDelegationV1, CredentialKeyBindingClaimsV1,
+    CredentialKeyBindingV1, CredentialUnitV1, DatasetBindingV1, DeploymentStatus,
+    EntitlementLimitsV1, FreeAuthorizationProofV1, FreeModeV1, FreePowProofV1,
+    IssuerClearingApprovalV1, LightningNetworkV1, OperationStartV1, PowChallengeResponseV1,
+    PriceV1, PrivacyLeakageV1, ProviderClearingAuthorizationV1, ProviderRedeemEnvelopeV1,
+    ProviderRedeemResponseV1, ServiceOfferV1, ServicePolicyV1, ServiceScopePolicyV1,
+    ServiceScopeV1, SettlementUnitV1, VerificationMode, WorkloadId,
 };
 use pir_service_store::{
     ProviderStore, SqliteRollbackFloorAuthorityV1, StoreOptions as ProviderStoreOptions,
@@ -73,6 +76,8 @@ use zeroize::Zeroizing;
 
 const SHARED_OFFER_ID: u32 = 61;
 const FREE_OFFER_ID: u32 = 62;
+const FREE_POW_OFFER_ID: u32 = 63;
+const FREE_POW_DIFFICULTY_BITS: u8 = 4;
 const OPERATION_PROFILE: u16 = 41;
 const ENTITLEMENT_PROFILE: u16 = 401;
 const TINY_BINS_PER_TABLE: usize = 128;
@@ -92,6 +97,7 @@ static SESSION_COUNTER: AtomicU64 = AtomicU64::new(1);
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ProviderMethod {
     SharedIssuerBat,
+    SharedIssuerBatWithFreePow,
     FreeOpen,
 }
 
@@ -125,13 +131,15 @@ struct ProviderFixture {
 impl ProviderFixture {
     fn proof(&self) -> AuthorizationProofV1 {
         match self.method {
-            ProviderMethod::SharedIssuerBat => AuthorizationProofV1::BitcoinPirCashuBat(
-                self.shared
-                    .as_ref()
-                    .expect("shared provider config")
-                    .proof
-                    .clone(),
-            ),
+            ProviderMethod::SharedIssuerBat | ProviderMethod::SharedIssuerBatWithFreePow => {
+                AuthorizationProofV1::BitcoinPirCashuBat(
+                    self.shared
+                        .as_ref()
+                        .expect("shared provider config")
+                        .proof
+                        .clone(),
+                )
+            }
             ProviderMethod::FreeOpen => {
                 AuthorizationProofV1::Free(FreeAuthorizationProofV1::OpenBestEffort)
             }
@@ -140,7 +148,9 @@ impl ProviderFixture {
 
     fn offer_id(&self) -> u32 {
         match self.method {
-            ProviderMethod::SharedIssuerBat => SHARED_OFFER_ID,
+            ProviderMethod::SharedIssuerBat | ProviderMethod::SharedIssuerBatWithFreePow => {
+                SHARED_OFFER_ID
+            }
             ProviderMethod::FreeOpen => FREE_OFFER_ID,
         }
     }
@@ -253,7 +263,7 @@ impl RedeemTranscriptDigests {
 }
 
 #[test]
-#[ignore = "spawned only by shared_issuer_real_process_tls_e2e"]
+#[ignore = "spawned only by shared-issuer process E2E tests"]
 fn shared_issuer_tls_edge_subprocess() {
     if env::var_os(TLS_EDGE_HELPER_MARKER).is_none() {
         return;
@@ -552,6 +562,111 @@ async fn shared_issuer_real_process_tls_e2e() {
     assert_issuer_ledger(&issuer, &paid, &[&wrong_ca, &wrong_pin, &offline]);
 }
 
+/// A provider may publish a local Free-PoW offer alongside a shared-issuer
+/// Cashu BAT offer for the exact same DPF scope.  The former must never call
+/// the issuer; the latter must still redeem through the issuer even though the
+/// provider has no provider-local BAT or ARC key material.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn shared_issuer_free_pow_and_bat_share_one_strict_policy_scope_e2e() {
+    let root = tempfile::tempdir().expect("shared-issuer plus Free-PoW process test root");
+    chmod(root.path(), 0o700);
+    let (db_path, manifest_root) = write_tiny_manifest_database(root.path());
+    let tls = install_tls_material(root.path());
+
+    let issuer_port = unused_loopback_port();
+    let edge_port = distinct_unused_port(&[issuer_port]);
+    let redeem_endpoint = format!("https://localhost:{edge_port}");
+    let issuer = build_issuer_material(root.path(), unix_now());
+    let provider = build_provider(
+        root.path(),
+        20,
+        ProviderMethod::SharedIssuerBatWithFreePow,
+        manifest_root,
+        &issuer,
+        &redeem_endpoint,
+        vec![test_leaf_spki_sha256()],
+        unix_now(),
+    );
+
+    let policy_bytes = fs::read(&provider.policy_path).expect("read combined provider policy");
+    let policy = ServicePolicyV1::decode(&policy_bytes).expect("decode combined provider policy");
+    assert_eq!(
+        policy.scopes.len(),
+        1,
+        "combined policy must have one scope"
+    );
+    assert_eq!(policy.scopes[0].scope.scope_id(), provider.scope_id);
+    assert_eq!(
+        policy.scopes[0]
+            .offers
+            .iter()
+            .map(|offer| offer.offer_id)
+            .collect::<Vec<_>>(),
+        vec![SHARED_OFFER_ID, FREE_POW_OFFER_ID],
+        "the same signed scope must offer both premium BAT and Free-PoW"
+    );
+
+    init_issuer_store(&issuer);
+    let payment_issuer = spawn_payment_issuer(root.path(), issuer_port, &issuer, &[&provider]);
+    let forward_counter = root.path().join("combined-tls-edge-forwarded.log");
+    let transcript_path = root.path().join("combined-tls-edge-transcript-digests.bin");
+    write_private_file(&forward_counter, b"");
+    write_private_file(&transcript_path, b"");
+    let tls_edge = spawn_tls_edge(
+        root.path(),
+        edge_port,
+        issuer_port,
+        &tls,
+        &forward_counter,
+        &transcript_path,
+        None,
+    );
+    let provider_port = distinct_unused_port(&[issuer_port, edge_port]);
+    let provider_server = spawn_provider(
+        root.path(),
+        &db_path,
+        &provider,
+        provider_port,
+        0,
+        Some(&tls.root),
+    );
+
+    exercise_free_pow_grant_and_dpf(provider_port, &provider, manifest_root)
+        .await
+        .expect("Free-PoW offer in the combined policy must authorize one real DPF query");
+    assert_eq!(
+        forwarded_request_count(&forward_counter),
+        0,
+        "Free-PoW must not contact the shared issuer"
+    );
+
+    // Stop only the issuer to inspect its durable inventory, then restart it
+    // against the same store before presenting the premium BAT on the already
+    // running strict provider.
+    let (free_issuer_stdout, free_issuer_stderr) = payment_issuer.stop();
+    assert_issuer_log(&free_issuer_stdout, &free_issuer_stderr, &provider);
+    assert_issuer_redemption_inventory(&issuer, 0);
+    let payment_issuer = spawn_payment_issuer(root.path(), issuer_port, &issuer, &[&provider]);
+
+    exercise_grant_and_dpf(provider_port, &provider, manifest_root)
+        .await
+        .expect("shared-issuer BAT in the combined policy must authorize one real DPF query");
+    assert_eq!(
+        forwarded_request_count(&forward_counter),
+        1,
+        "only the premium BAT must reach the issuer redeem endpoint"
+    );
+
+    let (provider_stdout, provider_stderr) = provider_server.stop();
+    assert_server_log(&provider_stdout, &provider_stderr, provider_port, &provider);
+    assert_provider_spend_inventory(&provider, 1);
+    let (edge_stdout, edge_stderr) = tls_edge.stop();
+    let (issuer_stdout, issuer_stderr) = payment_issuer.stop();
+    assert_payment_material_absent(&edge_stdout, &edge_stderr, &[&provider]);
+    assert_issuer_log(&issuer_stdout, &issuer_stderr, &provider);
+    assert_issuer_ledger(&issuer, &provider, &[]);
+}
+
 fn build_issuer_material(root: &Path, now: u64) -> IssuerMaterial {
     let binary = required_payment_issuer_binary();
     let admin_binary = required_bpir_admin_binary();
@@ -689,8 +804,8 @@ fn build_provider(
     };
     let scope_id = scope.scope_id();
 
-    let (offer, shared) = match method {
-        ProviderMethod::SharedIssuerBat => {
+    let (mut offers, shared) = match method {
+        ProviderMethod::SharedIssuerBat | ProviderMethod::SharedIssuerBatWithFreePow => {
             assert!(redeem_endpoint.starts_with("https://localhost:"));
             assert!(!redeem_pins.is_empty());
             let denomination_public_key = issuer.bat_keyring.denomination_public_keys()[0];
@@ -885,7 +1000,7 @@ fn build_provider(
             )
             .expect("self-verified CLI clearing approval");
             (
-                offer,
+                vec![offer],
                 Some(SharedProviderConfig {
                     authorization_epoch: 1,
                     authorization_path,
@@ -905,7 +1020,7 @@ fn build_provider(
             assert!(redeem_endpoint.is_empty());
             assert!(redeem_pins.is_empty());
             (
-                ServiceOfferV1 {
+                vec![ServiceOfferV1 {
                     offer_id: FREE_OFFER_ID,
                     acquisition: AcquisitionMethod::FreeV1,
                     free_mode: FreeModeV1::OpenBestEffort,
@@ -930,11 +1045,39 @@ fn build_provider(
                     credential_presentation_limit: 1,
                     privacy_leakage: PrivacyLeakageV1::from_bits(PrivacyLeakageV1::KNOWN_MASK)
                         .expect("known Free privacy flags"),
-                },
+                }],
                 None,
             )
         }
     };
+
+    if method == ProviderMethod::SharedIssuerBatWithFreePow {
+        offers.push(ServiceOfferV1 {
+            offer_id: FREE_POW_OFFER_ID,
+            acquisition: AcquisitionMethod::FreeV1,
+            free_mode: FreeModeV1::ProofOfWork,
+            free_quota: 0,
+            free_window_seconds: 0,
+            free_pow_difficulty_bits: FREE_POW_DIFFICULTY_BITS,
+            priority_class: 1,
+            authorization: AuthScheme::FreeV1,
+            verification: VerificationMode::ProviderLocal,
+            deployment_status: DeploymentStatus::Stable,
+            price: PriceV1::Free,
+            issuer_id: [0; 32],
+            key_id: Vec::new(),
+            credential_binding: None,
+            cashu_mint_manifest: None,
+            endpoint: String::new(),
+            invoice_expiry_seconds: 0,
+            claim_window_seconds: 0,
+            minimum_credential_validity_seconds: 60,
+            retired_policy_grace_seconds: 0,
+            credential_count: 1,
+            credential_presentation_limit: 1,
+            privacy_leakage: PrivacyLeakageV1::NONE,
+        });
+    }
 
     let policy = ServicePolicyV1::sign(
         provider_id,
@@ -954,7 +1097,7 @@ fn build_provider(
                 max_hint_groups: 0,
                 max_work_units: 2,
             },
-            offers: vec![offer],
+            offers,
         }],
         &policy_signing_key,
     )
@@ -1341,6 +1484,14 @@ fn spawn_provider(
     } else {
         assert!(test_root.is_none());
     }
+    if fixture.method == ProviderMethod::SharedIssuerBatWithFreePow {
+        assert!(
+            !args.iter().any(|arg| {
+                arg == "--service-bat-key" || arg == "--service-arc-key"
+            }),
+            "combined shared-issuer/Free-PoW process test must not pass provider-local BAT or ARC keys"
+        );
+    }
 
     let child = Command::new(env!("CARGO_BIN_EXE_unified_server"))
         .args(args)
@@ -1450,6 +1601,71 @@ async fn exercise_grant_and_dpf(
         other => {
             return Err(format!(
                 "authorized DPF frame did not reach handler: {other:?}"
+            ))
+        }
+    }
+    secure.close().await.map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+async fn exercise_free_pow_grant_and_dpf(
+    port: u16,
+    fixture: &ProviderFixture,
+    manifest_root: [u8; 32],
+) -> Result<(), String> {
+    let request = valid_tiny_dpf_request();
+    let (mut secure, accepted) =
+        open_verified_session(port, fixture, manifest_root, &request).await;
+    let operation = OperationStartV1::DpfQuery { db_id: 0 };
+    let challenge = request_pow_challenge_v1(
+        &mut secure,
+        &accepted,
+        fixture.scope_id,
+        FREE_POW_OFFER_ID,
+        operation.clone(),
+        unix_now(),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    if challenge.difficulty_bits != FREE_POW_DIFFICULTY_BITS {
+        return Err(format!(
+            "combined Free-PoW challenge used {} bits instead of {FREE_POW_DIFFICULTY_BITS}",
+            challenge.difficulty_bits
+        ));
+    }
+    let solution = solve_pow(&challenge);
+    let proof = dangerous_unpaired_build_authorization_proof_v1(
+        &accepted,
+        &fixture.scope_id,
+        FREE_POW_OFFER_ID,
+        &solution.encode().map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())?;
+    let grant = dangerous_unpaired_authorize_service_operation_v1(
+        &mut secure,
+        &accepted,
+        fixture.scope_id,
+        FREE_POW_OFFER_ID,
+        operation,
+        proof,
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    if grant.scope_id != fixture.scope_id || grant.enforced_profile != ENTITLEMENT_PROFILE {
+        return Err("Free-PoW AUTH grant did not bind the selected scope/profile".to_owned());
+    }
+    let response = secure
+        .roundtrip(&request)
+        .await
+        .map_err(|error| error.to_string())?;
+    match Response::decode(&response).map_err(|error| error.to_string())? {
+        Response::IndexBatch(result)
+            if result.results.len() == 1
+                && result.results[0].len() == 2
+                && result.results[0].iter().all(|item| item.len() == 52) => {}
+        other => {
+            return Err(format!(
+                "Free-PoW authorized DPF frame did not reach handler: {other:?}"
             ))
         }
     }
@@ -1569,6 +1785,21 @@ fn valid_tiny_dpf_request() -> Vec<u8> {
     .encode()
 }
 
+fn solve_pow(challenge: &PowChallengeResponseV1) -> FreePowProofV1 {
+    for nonce in 0..=u64::MAX {
+        let solution = FreePowProofV1 {
+            challenge_id: challenge.challenge_id,
+            nonce,
+        };
+        if pow_solution_meets_difficulty_v1(challenge, &solution)
+            .expect("test Free-PoW challenge must be valid")
+        {
+            return solution;
+        }
+    }
+    unreachable!("bounded test Free-PoW difficulty has a solution")
+}
+
 fn expect_error_response(response: &[u8], needle: &str) {
     match Response::decode(response).expect("decode runtime response") {
         Response::Error(message) => assert!(
@@ -1627,6 +1858,29 @@ fn assert_provider_spend_inventory(fixture: &ProviderFixture, expected: u64) {
         .expect("provider operational inventory");
     assert_eq!(inventory.spent_capability_rows, expected);
     assert_eq!(inventory.observed_spend_commit_seq, expected);
+}
+
+fn assert_issuer_redemption_inventory(issuer: &IssuerMaterial, expected: u64) {
+    let rollback = SqliteIssuerRollbackFloorAuthorityV1::open_existing(
+        &issuer.rollback_path,
+        IssuerStoreOptions::default().busy_timeout,
+    )
+    .expect("open issuer rollback floor for redemption inventory");
+    let store = IssuerStore::open_existing(
+        &issuer.store_path,
+        issuer.issuer_id,
+        LightningNetworkV1::Regtest,
+        IssuerStoreOptions::default(),
+        Arc::new(rollback),
+    )
+    .expect("open issuer store for redemption inventory");
+    assert_eq!(
+        store
+            .operational_inventory()
+            .expect("issuer operational inventory")
+            .redemption_rows,
+        expected
+    );
 }
 
 fn assert_issuer_ledger(

--- a/deploy/payment-v1/README.md
+++ b/deploy/payment-v1/README.md
@@ -222,13 +222,21 @@ The templates divide responsibilities as follows:
   Nostr signature and pinned directory key remain the publication authority.
   Both units require a separate publisher-private-ingress sentinel. Rollback
   authorities do not use this public HAProxy.
-- `vpsbg/vpsbg-free-pow-service-auth.args.in` is the only VPSBG change described
-  by this directory. It lists the enforced Payment V1 arguments that a reviewed
-  UKI rebuild would append to the existing query-only provider's final exec. It
-  deliberately omits that measured script's ORAM build/verification, identity,
-  database, attestation and cloudflared logic so it cannot be mistaken for a
-  standalone replacement. It does not add an issuer, relay, mint, Lightning
-  node, Cashu/ARC key, or rollback-authority process to VPSBG.
+- `vpsbg/vpsbg-free-pow-service-auth.args.in` is the immutable storeless
+  Free-PoW-only VPSBG profile. It lists the enforced Payment V1 arguments that
+  a reviewed UKI rebuild would append to the existing query-only provider's
+  final exec. It deliberately omits that measured script's ORAM
+  build/verification, identity, database, attestation and cloudflared logic so
+  it cannot be mistaken for a standalone replacement. It does not add an
+  issuer, relay, mint, Lightning node, Cashu/ARC key, or rollback-authority
+  process to VPSBG.
+- `vpsbg/vpsbg-premium-free-pow-beta-service-auth.args.in` and its policy TOML
+  are a separate stateful functional-beta profile. They offer local Free-PoW,
+  online shared-issuer Cashu BAT, and explicitly experimental shared-issuer
+  ARC. The Hetzner issuer remains the BAT/ARC validator and Lightning boundary;
+  VPSBG holds neither Lightning nor issuer private keys. This profile must
+  never be appended to the storeless fragment or described as a production
+  rollback boundary.
 
 Production templates use only remote rollback authorities. Issuer and rollback
 authority application listeners remain on loopback behind separately reviewed,

--- a/deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in
+++ b/deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in
@@ -21,8 +21,11 @@ operation_profile = @VPSBG_DPF_OPERATION_PROFILE@
 entitlement_profile = @VPSBG_DPF_ENTITLEMENT_PROFILE@
 
 [scopes.dataset]
-kind = "class"
-class_id = @VPSBG_DATASET_CLASS_ID@
+# Tier 3 strict admission resolves each database by its exact MANIFEST.toml
+# hash. This initial offer is deliberately db0-only; add a separately priced
+# scope and fresh BAT/ARC bindings before ever admitting db1.
+kind = "manifest-root"
+root_hex = "@VPSBG_DPF_DB0_MANIFEST_ROOT_HEX@"
 
 [scopes.limits]
 max_logical_inputs = 1

--- a/deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in
+++ b/deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in
@@ -1,0 +1,110 @@
+# VPSBG Free-PoW + Hetzner shared-issuer premium functional-beta policy.
+#
+# Replace every @...@ value, generate the two credential bindings and sign the
+# complete TOML before copying service-policy.bin into the Tier 3 data root.
+# This DPF-only profile keeps Harmony hint/query, Onion and TEE-ORAM pricing in
+# separate future scopes; their workload costs must never be inferred from this
+# one query scope.
+
+operator_pubkey_hex = "@VPSBG_OPERATOR_PUBKEY_HEX@"
+stable_server_id = "@VPSBG_PREMIUM_SERVER_ID@"
+policy_epoch = 1
+issued_at = @POLICY_ISSUED_AT_UNIX@
+expires_at = @POLICY_EXPIRES_AT_UNIX@
+auth_padding_class = "16-kib"
+
+[[scopes]]
+backend = "dpf-pir-v1"
+workload = "dpf-evaluate-job-v1"
+protocol_version = 1
+operation_profile = @VPSBG_DPF_OPERATION_PROFILE@
+entitlement_profile = @VPSBG_DPF_ENTITLEMENT_PROFILE@
+
+[scopes.dataset]
+kind = "class"
+class_id = @VPSBG_DATASET_CLASS_ID@
+
+[scopes.limits]
+max_logical_inputs = 1
+max_frames = @VPSBG_DPF_MAX_FRAMES@
+max_request_bytes = @VPSBG_DPF_MAX_REQUEST_BYTES@
+max_response_bytes = @VPSBG_DPF_MAX_RESPONSE_BYTES@
+max_wall_time_ms = @VPSBG_DPF_MAX_WALL_TIME_MS@
+max_concurrent_sockets = 1
+max_hint_groups = 0
+max_work_units = @VPSBG_DPF_MAX_WORK_UNITS@
+
+# Free is a one-shot, secure-channel-bound proof of work. It is independent of
+# Hetzner and cannot be reused as a premium capability.
+[[scopes.offers]]
+offer_id = 101
+acquisition = "free"
+free_mode = "proof-of-work"
+free_pow_difficulty_bits = @VPSBG_FREE_POW_DIFFICULTY_BITS@
+priority_class = 1
+authorization = "free"
+verification = "provider-local"
+deployment_status = "stable"
+minimum_credential_validity_seconds = 1
+retired_policy_grace_seconds = 0
+credential_count = 1
+credential_presentation_limit = 1
+privacy_leakage_bits = 0
+
+[scopes.offers.price]
+kind = "free"
+
+# Stable premium path. The browser purchases blinded single-use BATs from the
+# Hetzner issuer; VPSBG sends their opaque presentation to that issuer only for
+# authoritative redeem and provider bookkeeping. VPSBG never sees the invoice
+# or payment hash.
+[[scopes.offers]]
+offer_id = 102
+acquisition = "bolt11"
+free_mode = "not-free"
+priority_class = 1
+authorization = "cashu-bat"
+verification = "shared-issuer-online"
+deployment_status = "stable"
+issuer_id_hex = "@HETZNER_ISSUER_ID_HEX@"
+key_id_hex = "@VPSBG_BAT_KEY_ID_HEX@"
+credential_binding_path = "bindings/dpf-evaluate-job-v1/cashu-bat.bin"
+endpoint = "@HETZNER_ISSUER_ORIGIN@"
+invoice_expiry_seconds = 600
+claim_window_seconds = 86400
+minimum_credential_validity_seconds = 604800
+retired_policy_grace_seconds = 700000
+credential_count = @VPSBG_BAT_CREDENTIAL_COUNT@
+credential_presentation_limit = 1
+privacy_leakage_bits = 28
+
+[scopes.offers.price]
+kind = "msat"
+amount = @VPSBG_BAT_PRICE_MSAT@
+
+# ARC deliberately remains experimental. It uses the same online issuer path,
+# never puts the ARC private verification key on VPSBG, and needs a fresh UKI
+# only because the measured server must explicitly acknowledge the method.
+[[scopes.offers]]
+offer_id = 103
+acquisition = "bolt11"
+free_mode = "not-free"
+priority_class = 1
+authorization = "arc-experimental"
+verification = "shared-issuer-online"
+deployment_status = "experimental"
+issuer_id_hex = "@HETZNER_ISSUER_ID_HEX@"
+key_id_hex = "@VPSBG_ARC_KEY_ID_HEX@"
+credential_binding_path = "bindings/dpf-evaluate-job-v1/arc-experimental.bin"
+endpoint = "@HETZNER_ISSUER_ORIGIN@"
+invoice_expiry_seconds = 600
+claim_window_seconds = 86400
+minimum_credential_validity_seconds = 604800
+retired_policy_grace_seconds = 700000
+credential_count = 1
+credential_presentation_limit = 4
+privacy_leakage_bits = 28
+
+[scopes.offers.price]
+kind = "msat"
+amount = @VPSBG_ARC_PRICE_MSAT@

--- a/deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-service-auth.args.in
+++ b/deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-service-auth.args.in
@@ -1,0 +1,29 @@
+# BitcoinPIR VPSBG Payment V1 functional-beta argument fragment; not a run script.
+# Render and merge these arguments into the final unified_server exec in a
+# separately approved measured Tier 3 UKI rebuild. Never execute, source, or
+# install this file by itself.
+#
+# This is an alternative to vpsbg-free-pow-service-auth.args.in, not an
+# extension of it. It deliberately leaves the storeless Free-PoW profile so
+# that the same provider can offer local Free-PoW and Hetzner shared-issuer
+# Premium capabilities. Hetzner keeps Lightning, Cashu BAT and ARC private
+# material; VPSBG keeps only its provider state and clearing credentials.
+
+--require-service-auth-v1
+--service-policy /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/service-policy.bin
+--service-provider-id-hex @VPSBG_PREMIUM_PROVIDER_ID_HEX@
+--service-policy-key-hex @VPSBG_PREMIUM_POLICY_PUBKEY_HEX@
+--service-store /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/provider.sqlite3
+--service-rollback-authority /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/rollback.sqlite3
+--allow-local-service-rollback-authority-dev
+--service-shared-authorization /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-authorization.bin
+--service-shared-issuer-approval /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-approval.bin
+--service-shared-operator-key-hex @HETZNER_ISSUER_OPERATOR_PUBKEY_HEX@
+--service-shared-issuer-settlement-key-hex @HETZNER_ISSUER_SETTLEMENT_PUBKEY_HEX@
+--service-shared-clearing-key /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/provider-clearing-signing.key
+--service-shared-idempotency-key /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-redeem-idempotency.key
+--service-shared-minimum-authorization-epoch 1
+--allow-experimental-arc
+--service-max-concurrent-auth 4
+--service-max-concurrent-online-v2full-auth 2
+--service-pre-auth-timeout-ms 60000

--- a/deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-service-auth.args.in
+++ b/deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-service-auth.args.in
@@ -18,7 +18,9 @@
 --allow-local-service-rollback-authority-dev
 --service-shared-authorization /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-authorization.bin
 --service-shared-issuer-approval /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-approval.bin
---service-shared-operator-key-hex @HETZNER_ISSUER_OPERATOR_PUBKEY_HEX@
+# This is the VPSBG provider operator key bound into the clearing authorization,
+# not an issuer operator key.
+--service-shared-operator-key-hex @VPSBG_OPERATOR_PUBKEY_HEX@
 --service-shared-issuer-settlement-key-hex @HETZNER_ISSUER_SETTLEMENT_PUBKEY_HEX@
 --service-shared-clearing-key /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/provider-clearing-signing.key
 --service-shared-idempotency-key /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-redeem-idempotency.key

--- a/docs/payment/DEPLOYMENT_INPUT_MATRIX.md
+++ b/docs/payment/DEPLOYMENT_INPUT_MATRIX.md
@@ -98,8 +98,9 @@ valid in this profile.
 
 `vpsbg-premium-free-pow-beta` is a separate functional-beta UKI preparation,
 not an exception to that storeless rule. It uses a fresh VPSBG provider
-identity, local ProviderStore and local beta rollback floor, then redeems
-VPSBG-specific Cashu BAT and experimental ARC capabilities online at the
+identity, exact db0 manifest-root scope, local ProviderStore and local beta
+rollback floor, then redeems VPSBG-specific Cashu BAT and experimental ARC
+capabilities online at the
 Hetzner issuer. Its required inputs include the provider clearing key,
 idempotency key, issuer approval/authorization and a signed DPF-only policy;
 it deliberately excludes Lightning, issuer private keys, BAT mint scalars,

--- a/docs/payment/DEPLOYMENT_INPUT_MATRIX.md
+++ b/docs/payment/DEPLOYMENT_INPUT_MATRIX.md
@@ -96,6 +96,16 @@ fresh attestation measurement and client pin migration. No ProviderStore,
 rollback client, retained policy, Free-IP state or payment/credential input is
 valid in this profile.
 
+`vpsbg-premium-free-pow-beta` is a separate functional-beta UKI preparation,
+not an exception to that storeless rule. It uses a fresh VPSBG provider
+identity, local ProviderStore and local beta rollback floor, then redeems
+VPSBG-specific Cashu BAT and experimental ARC capabilities online at the
+Hetzner issuer. Its required inputs include the provider clearing key,
+idempotency key, issuer approval/authorization and a signed DPF-only policy;
+it deliberately excludes Lightning, issuer private keys, BAT mint scalars,
+ARC private keys and Standard Cashu custody material from VPSBG. The profile
+requires a new UKI/upload/reboot and is not a mainnet production profile.
+
 ## 4. Non-secret input register
 
 The following values are safe to review as public or operational metadata, but

--- a/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
+++ b/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
@@ -679,11 +679,19 @@ activation actions and require separate approval.
 `deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-service-auth.args.in`
 and its matching policy TOML prepare a different measured image. They must
 never be merged with the storeless fragment above. The beta has exactly one
-initial DPF query scope with three independently selected offers:
+initial DPF db0 scope, bound to the exact db0 `MANIFEST.toml` root, with three
+independently selected offers:
 
 - local `FreeV1` proof of work;
 - stable `cashu-bat` with `shared-issuer-online`; and
 - explicitly experimental `arc-experimental` with `shared-issuer-online`.
+
+The value for that root must be recomputed from the actual strict DPF database
+proof sidecar immediately before rendering the policy; it is not the separate
+attestation `manifest_roots` value. The read-only db0 value observed on
+2026-08-02 was
+`0f5d943de226fc1b47ba22bc6dd99065e7435c76c9c0dd9564aa98e3280492ec`, but
+that observation is a deployment input, not a timeless pin.
 
 The browser buys BAT or ARC capabilities from the Hetzner issuer after it has
 verified the VPSBG provider. It sends only the opaque capability to VPSBG. For
@@ -716,9 +724,10 @@ all VPSBG-specific issuer-clearing artifacts, and add their matching policy,
 BAT/ARC keys and clearing records to the Hetzner issuer. The measured final
 run script receives the rendered argument list verbatim. Changing any of those
 arguments requires another UKI and the normal portal upload/reboot plus client
-measurement-pin update. The initial scope deliberately excludes Standard Cashu
-eCash, direct BOLT11 receipt, Harmony hint/query, Onion and TEE-ORAM; each needs
-its own later workload policy and, where applicable, its own price.
+measurement-pin update. The initial scope deliberately excludes db1, Standard
+Cashu eCash, direct BOLT11 receipt, Harmony hint/query, Onion and TEE-ORAM;
+each needs its own later workload policy and, where applicable, its own price
+and capability binding.
 
 ## Rendering and preflight
 

--- a/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
+++ b/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
@@ -674,6 +674,52 @@ previous known-good UKI, portal upload, reboot, fresh SEV-SNP measurement,
 binary hash, attestation verification and client pin update. Those are remote
 activation actions and require separate approval.
 
+## VPSBG Premium + Free-PoW functional beta
+
+`deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-service-auth.args.in`
+and its matching policy TOML prepare a different measured image. They must
+never be merged with the storeless fragment above. The beta has exactly one
+initial DPF query scope with three independently selected offers:
+
+- local `FreeV1` proof of work;
+- stable `cashu-bat` with `shared-issuer-online`; and
+- explicitly experimental `arc-experimental` with `shared-issuer-online`.
+
+The browser buys BAT or ARC capabilities from the Hetzner issuer after it has
+verified the VPSBG provider. It sends only the opaque capability to VPSBG. For
+Premium authorization, VPSBG performs an authenticated redeem against the
+Hetzner issuer; the issuer verifies/consumes the capability and credits the
+VPSBG provider ledger before VPSBG grants the costly query. VPSBG never
+receives a BOLT11 invoice, payment hash, Lightning wallet key, BAT mint scalar,
+or ARC secret verification key. The issuer does observe the VPSBG provider,
+scope, capability and redemption time; this beta does not claim to remove that
+timing correlation.
+
+The profile intentionally has state, so it needs a fresh VPSBG provider ID,
+policy key, `ProviderStore`, local functional-beta rollback floor, clearing
+signing key, redeem-idempotency key, clearing authorization and issuer
+approval. It must not reuse any P1/P2 provider state, BAT/ARC lineage,
+clearing credential, provider ID or policy binding. The corresponding Hetzner
+issuer update adds those VPSBG-specific artifacts alongside its existing
+providers; it does not move issuer or Lightning state into VPSBG.
+
+This is a functional-beta route, not a production rollback profile: it uses
+the explicit local rollback-development flag to avoid introducing another
+authority host into the first VPSBG premium test. It still fails closed if the
+store, issuer redeem, policy verification, strict channel or query verification
+fails. There is no automatic retry of a capability after an ambiguous redeem
+or query outcome.
+
+Before a UKI build, render and sign the policy, initialize the two local SQLite
+files under `/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/`, generate
+all VPSBG-specific issuer-clearing artifacts, and add their matching policy,
+BAT/ARC keys and clearing records to the Hetzner issuer. The measured final
+run script receives the rendered argument list verbatim. Changing any of those
+arguments requires another UKI and the normal portal upload/reboot plus client
+measurement-pin update. The initial scope deliberately excludes Standard Cashu
+eCash, direct BOLT11 receipt, Harmony hint/query, Onion and TEE-ORAM; each needs
+its own later workload policy and, where applicable, its own price.
+
 ## Rendering and preflight
 
 ### P1 activation blocker: live source-fair evidence

--- a/docs/payment/LOCAL_ACCEPTANCE.md
+++ b/docs/payment/LOCAL_ACCEPTANCE.md
@@ -894,9 +894,14 @@ BITCOINPIR_BPIR_ADMIN_BIN="$issuer_e2e_target_dir/debug/bpir-admin" \
   cargo test --locked --offline \
     -p runtime \
     --features shared-issuer-process-e2e \
-    --test payment_v1_shared_issuer_process_e2e \
-    shared_issuer_real_process_tls_e2e -- --exact
+    --test payment_v1_shared_issuer_process_e2e
 ```
+
+The target includes a minimal mixed-offer provider: a single strict DPF scope
+serves 4-bit Free-PoW and shared-issuer BAT. Free-PoW leaves the issuer's
+durable redemption count at zero; after issuer restart BAT redeems exactly
+once, while `unified_server` receives neither `--service-bat-key` nor
+`--service-arc-key`.
 
 This is the executable provider-to-shared-clearing seam: a real issuer behind
 a private signed-pin TLS edge, a real paid provider and an independent Free

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -386,9 +386,14 @@ BITCOINPIR_BPIR_ADMIN_BIN="$issuer_e2e_target_dir/debug/bpir-admin" \
   cargo test --locked --offline \
     -p runtime \
     --features shared-issuer-process-e2e \
-    --test payment_v1_shared_issuer_process_e2e \
-    shared_issuer_real_process_tls_e2e -- --exact
+    --test payment_v1_shared_issuer_process_e2e
 ```
+
+The same process-test target also covers one strict provider whose single DPF
+scope offers both 4-bit Free-PoW and shared-issuer BAT. Free-PoW must complete
+a real DPF request with zero issuer redemption rows; after issuer restart the
+BAT must redeem exactly once, without passing provider-local `--service-bat-key`
+or `--service-arc-key` material to `unified_server`.
 
 It launches a real `payment-issuer`, a redeem/balance-only private WebPKI TLS edge, one
 real shared-BAT `unified_server`, and an independently selected Free/Open peer.

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -2342,6 +2342,8 @@ function validateVpsbgPremiumFreePowBetaPolicy(text, mode) {
   for (const expected of [
     'backend = "dpf-pir-v1"',
     'workload = "dpf-evaluate-job-v1"',
+    'kind = "manifest-root"',
+    'root_hex = "@VPSBG_DPF_DB0_MANIFEST_ROOT_HEX@"',
     'free_mode = "proof-of-work"',
     'free_pow_difficulty_bits = @VPSBG_FREE_POW_DIFFICULTY_BITS@',
     'authorization = "cashu-bat"',
@@ -2367,6 +2369,8 @@ function validateVpsbgPremiumFreePowBetaPolicy(text, mode) {
     'authorization = "bolt11-direct-receipt"',
     'authorization = "cashu-ecash"',
     'verification = "standard-cashu-mint-online"',
+    'kind = "class"',
+    'kind = "catalog-epoch"',
   ]) {
     if (active.includes(forbidden)) fail(`${label} contains unsupported ${forbidden}`);
   }

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -2310,7 +2310,7 @@ function validateVpsbgPremiumFreePowBeta(text, mode) {
       ["--allow-local-service-rollback-authority-dev", null],
       ["--service-shared-authorization", "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-authorization.bin"],
       ["--service-shared-issuer-approval", "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-approval.bin"],
-      ["--service-shared-operator-key-hex", "@HETZNER_ISSUER_OPERATOR_PUBKEY_HEX@"],
+      ["--service-shared-operator-key-hex", "@VPSBG_OPERATOR_PUBKEY_HEX@"],
       ["--service-shared-issuer-settlement-key-hex", "@HETZNER_ISSUER_SETTLEMENT_PUBKEY_HEX@"],
       ["--service-shared-clearing-key", "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/provider-clearing-signing.key"],
       ["--service-shared-idempotency-key", "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-redeem-idempotency.key"],

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -79,6 +79,9 @@ export const REVIEWED_PREPARATION_HASHES = Object.freeze({
 export const REQUIRED_PREPARATION_FILES = Object.freeze([
   "deploy/payment-v1/README.md",
   "deploy/payment-v1/functional-beta/README.md",
+  "deploy/payment-v1/functional-beta/bitcoinpir-payment-issuer-functional-beta.service.in",
+  "deploy/payment-v1/functional-beta/bitcoinpir-provider-functional-beta.service.in",
+  "deploy/payment-v1/functional-beta/hetzner-existing-caddy.fragment.in",
   "deploy/payment-v1/functional-beta/issuer-all-methods.args.in",
   "deploy/payment-v1/functional-beta/provider-all-methods.args.in",
   "deploy/payment-v1/functional-beta/service-policy.toml.in",
@@ -121,6 +124,8 @@ export const REQUIRED_PREPARATION_FILES = Object.freeze([
   "deploy/payment-v1/network/directory-publisher-resolv.conf.in",
   "deploy/payment-v1/network/directory-publisher-nsswitch.conf.in",
   "deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in",
+  "deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-service-auth.args.in",
+  "deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in",
   "docs/payment/HETZNER_VPSBG_DEPLOYMENT.md",
   "scripts/payment-v1-publisher-netns.c",
   "scripts/payment-v1-directory-public-haproxy-artifact-gate.mjs",
@@ -2262,6 +2267,111 @@ function validateVpsbgFreePow(text, mode) {
   }
 }
 
+function activeArgumentText(text) {
+  return text
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line !== "" && !line.startsWith("#"))
+    .join(" ");
+}
+
+function validateVpsbgPremiumFreePowBeta(text, mode) {
+  const label = "VPSBG Premium + Free-PoW beta argument fragment";
+  requireText(text, "not a run script", label);
+  requireText(text, "alternative to vpsbg-free-pow-service-auth.args.in", label);
+  requireText(text, "Hetzner keeps Lightning, Cashu BAT and ARC private", label);
+  rejectPattern(text, /^\s*#!+/m, label, "shebang");
+  rejectPattern(text, /^\s*exec(?:\s|$)/m, label, "exec command");
+  const active = activeArgumentText(text);
+  for (const [pattern, description] of [
+    [/(?:^|\s)--service-storeless-free-pow-policy-digest-hex(?:\s|=)/u, "storeless policy pin"],
+    [/(?:^|\s)--service-retained-policy(?:\s|=)/u, "retained policy"],
+    [/(?:^|\s)--service-remote-rollback-authority-config(?:\s|=)/u, "remote rollback authority"],
+    [/(?:^|\s)--service-bat-key(?:\s|=)/u, "provider-local BAT key"],
+    [/(?:^|\s)--service-arc-key(?:\s|=)/u, "provider-local ARC key"],
+    [/(?:^|\s)--service-cashu-(?:recovery|custody|exposure-limit)(?:\s|=)/u, "standard Cashu material"],
+    [/(?:^|\s)--service-free-ip-key(?:\s|=)/u, "Free IP key"],
+    [/(?:^|\s)--service-trust-direct-peer-ip(?:\s|$)/u, "direct peer IP trust"],
+    [/(?:^|\s)--require-(?:arc|cashu)(?:\s|$)/u, "legacy admission gate"],
+    [/(?:^|\s)--(?:arc-key|cashu-keyset)(?:\s|=)/u, "legacy issuer/keyset material"],
+  ]) {
+    rejectPattern(active, pattern, label, description);
+  }
+  validateExactCommand(
+    active,
+    [],
+    [
+      ["--require-service-auth-v1", null],
+      ["--service-policy", "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/service-policy.bin"],
+      ["--service-provider-id-hex", "@VPSBG_PREMIUM_PROVIDER_ID_HEX@"],
+      ["--service-policy-key-hex", "@VPSBG_PREMIUM_POLICY_PUBKEY_HEX@"],
+      ["--service-store", "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/provider.sqlite3"],
+      ["--service-rollback-authority", "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/rollback.sqlite3"],
+      ["--allow-local-service-rollback-authority-dev", null],
+      ["--service-shared-authorization", "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-authorization.bin"],
+      ["--service-shared-issuer-approval", "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-approval.bin"],
+      ["--service-shared-operator-key-hex", "@HETZNER_ISSUER_OPERATOR_PUBKEY_HEX@"],
+      ["--service-shared-issuer-settlement-key-hex", "@HETZNER_ISSUER_SETTLEMENT_PUBKEY_HEX@"],
+      ["--service-shared-clearing-key", "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/provider-clearing-signing.key"],
+      ["--service-shared-idempotency-key", "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-redeem-idempotency.key"],
+      ["--service-shared-minimum-authorization-epoch", "1"],
+      ["--allow-experimental-arc", null],
+      ["--service-max-concurrent-auth", "4"],
+      ["--service-max-concurrent-online-v2full-auth", "2"],
+      ["--service-pre-auth-timeout-ms", "60000"],
+    ],
+    label,
+  );
+  if ((mode & 0o111) !== 0) {
+    fail(`${label} must remain non-executable`);
+  }
+}
+
+function validateVpsbgPremiumFreePowBetaPolicy(text, mode) {
+  const label = "VPSBG Premium + Free-PoW beta policy template";
+  const active = activeTemplateLines(text, label);
+  if ((mode & 0o111) !== 0) {
+    fail(`${label} must remain non-executable`);
+  }
+  if (active.filter((line) => line === "[[scopes]]").length !== 1) {
+    fail(`${label} must declare exactly one initial scope`);
+  }
+  if (active.filter((line) => line === "[[scopes.offers]]").length !== 3) {
+    fail(`${label} must declare exactly Free-PoW, BAT and ARC offers`);
+  }
+  for (const expected of [
+    'backend = "dpf-pir-v1"',
+    'workload = "dpf-evaluate-job-v1"',
+    'free_mode = "proof-of-work"',
+    'free_pow_difficulty_bits = @VPSBG_FREE_POW_DIFFICULTY_BITS@',
+    'authorization = "cashu-bat"',
+    'authorization = "arc-experimental"',
+    'deployment_status = "experimental"',
+    'issuer_id_hex = "@HETZNER_ISSUER_ID_HEX@"',
+    'endpoint = "@HETZNER_ISSUER_ORIGIN@"',
+    'credential_binding_path = "bindings/dpf-evaluate-job-v1/cashu-bat.bin"',
+    'credential_binding_path = "bindings/dpf-evaluate-job-v1/arc-experimental.bin"',
+  ]) {
+    if (!active.includes(expected)) fail(`${label} must contain ${expected}`);
+  }
+  if (active.filter((line) => line === 'verification = "shared-issuer-online"').length !== 2) {
+    fail(`${label} must make BAT and ARC shared-issuer-online only`);
+  }
+  if (active.filter((line) => line === "priority_class = 1").length !== 3) {
+    fail(`${label} must make no QoS/priority claim`);
+  }
+  if (active.filter((line) => line === "privacy_leakage_bits = 28").length !== 2) {
+    fail(`${label} must disclose issuer issuance/redemption/provider leakage`);
+  }
+  for (const forbidden of [
+    'authorization = "bolt11-direct-receipt"',
+    'authorization = "cashu-ecash"',
+    'verification = "standard-cashu-mint-online"',
+  ]) {
+    if (active.includes(forbidden)) fail(`${label} contains unsupported ${forbidden}`);
+  }
+}
+
 function parseScalar(raw, lineNumber) {
   if (/^"[^"\r\n]*"$/.test(raw)) {
     return raw.slice(1, -1);
@@ -2510,6 +2620,7 @@ function validateTemplateTreeShape(root) {
       !rel.endsWith(".service.in") &&
       !rel.endsWith(".args.in") &&
       !rel.endsWith(".Caddyfile.in") &&
+      !rel.endsWith(".fragment.in") &&
       !rel.endsWith(".cfg.in") &&
       !rel.endsWith(".conf.in") &&
       !rel.endsWith(".json.in") &&
@@ -2843,6 +2954,16 @@ export function validateDeploymentTree(rootInput) {
     "deploy/payment-v1/vpsbg/vpsbg-free-pow-service-auth.args.in",
   );
   validateVpsbgFreePow(vpsbg.text, vpsbg.stat.mode);
+  const vpsbgPremium = readRequired(
+    root,
+    "deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-service-auth.args.in",
+  );
+  validateVpsbgPremiumFreePowBeta(vpsbgPremium.text, vpsbgPremium.stat.mode);
+  const vpsbgPremiumPolicy = readRequired(
+    root,
+    "deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in",
+  );
+  validateVpsbgPremiumFreePowBetaPolicy(vpsbgPremiumPolicy.text, vpsbgPremiumPolicy.stat.mode);
   const deploymentDoc = readRequired(
     root,
     "docs/payment/HETZNER_VPSBG_DEPLOYMENT.md",
@@ -2853,6 +2974,7 @@ export function validateDeploymentTree(rootInput) {
     "exact protocol digest argument and the script that supplies it MUST be",
     "requires a new measured UKI",
     "opens no ProviderStore or rollback authority",
+    "VPSBG Premium + Free-PoW functional beta",
   ]) {
     requireText(deploymentDoc.text, required, "Hetzner/VPSBG deployment document");
   }

--- a/scripts/payment-v1-deployment-template-gate.test.mjs
+++ b/scripts/payment-v1-deployment-template-gate.test.mjs
@@ -575,6 +575,21 @@ test("VPSBG premium beta remains a separate stateful shared-issuer profile", () 
       /must contain authorization = "arc-experimental"/,
     );
   });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in",
+      (text) => text.replace(
+        'kind = "manifest-root"\nroot_hex = "@VPSBG_DPF_DB0_MANIFEST_ROOT_HEX@"',
+        'kind = "class"\nclass_id = 1',
+      ),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /must contain kind = "manifest-root"/,
+    );
+  });
 });
 
 test("systemd resets, duplicate CLI overrides, and secret argv fail closed", () => {

--- a/scripts/payment-v1-deployment-template-gate.test.mjs
+++ b/scripts/payment-v1-deployment-template-gate.test.mjs
@@ -528,6 +528,55 @@ test("VPSBG fragment remains service-auth-only, exact-pinned and storeless Free-
   });
 });
 
+test("VPSBG premium beta remains a separate stateful shared-issuer profile", () => {
+  const argsPath = "deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-service-auth.args.in";
+  for (const [line, expected] of [
+    ["--service-storeless-free-pow-policy-digest-hex deadbeef", /storeless policy pin/],
+    ["--service-bat-key /home/pir/data/bat.key", /provider-local BAT key/],
+    ["--service-remote-rollback-authority-config /home/pir/data/authority.toml", /remote rollback authority/],
+  ]) {
+    withFixture((root) => {
+      mutate(root, argsPath, (text) => `${text}\n${line}\n`);
+      assert.throws(() => validateDeploymentTree(root), expected);
+    });
+  }
+
+  withFixture((root) => {
+    mutate(root, argsPath, (text) => text.replace("--allow-experimental-arc\n", ""));
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /must contain --allow-experimental-arc exactly once and in canonical order/,
+    );
+  });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in",
+      (text) => text.replace(
+        'verification = "shared-issuer-online"',
+        'verification = "provider-local"',
+      ),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /must make BAT and ARC shared-issuer-online only/,
+    );
+  });
+
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in",
+      (text) => text.replace('authorization = "arc-experimental"', 'authorization = "cashu-ecash"'),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /must contain authorization = "arc-experimental"/,
+    );
+  });
+});
+
 test("systemd resets, duplicate CLI overrides, and secret argv fail closed", () => {
   withFixture((root) => {
     mutate(

--- a/scripts/payment-v1-local-check.sh
+++ b/scripts/payment-v1-local-check.sh
@@ -377,8 +377,7 @@ BITCOINPIR_BPIR_ADMIN_BIN="$issuer_e2e_target_dir/debug/bpir-admin" \
   cargo test --locked --offline \
     -p runtime \
     --features shared-issuer-process-e2e \
-    --test payment_v1_shared_issuer_process_e2e \
-    shared_issuer_real_process_tls_e2e -- --exact
+    --test payment_v1_shared_issuer_process_e2e
 cargo clippy --locked --offline \
   -p runtime \
   --features shared-issuer-process-e2e \


### PR DESCRIPTION
## Summary

- Add a separate stateful `vpsbg-premium-free-pow-beta` profile: local Free-PoW plus Hetzner shared-issuer Cashu BAT and experimental ARC. The existing storeless Free-PoW profile remains unchanged.
- Bind the first premium scope to VPSBG's exact db0 DPF manifest root. db1, Harmony, Onion, TEE-ORAM, direct receipts, and Standard Cashu remain separate future scopes.
- Keep Lightning, invoices/payment hashes, BAT scalars, and ARC secret keys off VPSBG. Hetzner is the online issuer/validator and clearing boundary.
- Add template gates and a real same-policy process E2E: Free-PoW reaches no issuer redemption; shared BAT redeems exactly once and completes DPF without provider-local BAT/ARC keys.

## Validation

- `node --test scripts/payment-v1-deployment-template-gate.test.mjs` — 27 passed
- `node scripts/payment-v1-deployment-template-gate.mjs` — passed
- Shared-issuer process E2E and targeted `clippy -D warnings` passed in a clean isolated worktree; the current branch also reran the isolated process flow and cleaned its temporary Cargo target.

## Deployment boundary

This PR prepares artifacts and the measured-UKI input only. It does not change a live VPSBG process, create a Lightning payment, or install issuer/VPSBG secrets. A later frozen-artifact step will add a third provider to the Hetzner issuer and produce a new VPSBG UKI for the user's portal upload/reboot.
