### PR TITLE
payment: activate VPSBG free PoW premium beta

### DIFF
--- a/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
+++ b/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
@@ -103,19 +103,21 @@ add client certificate/key custody and real-handshake tests atomically.
 
 ## Frozen active-service boundary
 
-This preparation does not modify or replace:
+The preparation leaves the following active definitions unchanged:
 
 - `deploy/systemd/pir-primary.service`;
 - `deploy/systemd/pir-secondary.service`;
 - `deploy/systemd/pir-vpsbg.service`;
 - `deploy/systemd/dev-issuer.service`;
 - `deploy/systemd/cloudflared.service`; or
-- `scripts/dracut/97bpir-tier3-init/unified-server-run.sh`.
+- `scripts/dracut/97bpir-tier3-init/unified-server-run.sh`, except for the
+  separately reviewed VPSBG Premium + Free-PoW measured suffix described below.
 
-The deployment-template gate pins the SHA-256 of each file. It also verifies
-that none of those active definitions contains Payment V1 enforcement flags.
-This makes the preparation PR unable to activate charging by changing an old
-unit in place.
+The deployment-template gate pins the SHA-256 of each file. It rejects Payment
+V1 enforcement flags in every other active definition and, for the measured
+VPSBG run script, validates the complete fixed payment suffix after checking
+the file hash. This makes the activation an explicit UKI-bound change rather
+than an accidental old-unit mutation.
 
 All files below `deploy/payment-v1/` are inputs. Systemd templates use the
 `.service.in` suffix, omit `[Install]`, and require both the global activation
@@ -718,16 +720,18 @@ store, issuer redeem, policy verification, strict channel or query verification
 fails. There is no automatic retry of a capability after an ambiguous redeem
 or query outcome.
 
-Before a UKI build, render and sign the policy, initialize the two local SQLite
-files under `/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/`, generate
-all VPSBG-specific issuer-clearing artifacts, and add their matching policy,
-BAT/ARC keys and clearing records to the Hetzner issuer. The measured final
-run script receives the rendered argument list verbatim. Changing any of those
-arguments requires another UKI and the normal portal upload/reboot plus client
-measurement-pin update. The initial scope deliberately excludes db1, Standard
-Cashu eCash, direct BOLT11 receipt, Harmony hint/query, Onion and TEE-ORAM;
-each needs its own later workload policy and, where applicable, its own price
-and capability binding.
+The initial VPSBG ceremony fixes one public provider ID and policy key in the
+measured suffix; all mutable artifacts live below
+`/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/`. This directory must
+contain the signed policy, both clearing artifacts, provider store and rollback
+SQLite files, provider clearing key and redeem-idempotency key before the UKI
+boots. It must not contain issuer settlement material, BAT/ARC private keys,
+Lightning state, invoices or payment hashes. Changing a policy argument or
+public binding requires another UKI and the normal portal upload/reboot plus
+client measurement-pin update. The initial scope deliberately excludes db1,
+Standard Cashu eCash, direct BOLT11 receipt, Harmony hint/query, Onion and
+TEE-ORAM; each needs its own later workload policy and, where applicable, its
+own price and capability binding.
 
 ## Rendering and preflight
 

--- a/scripts/dracut/97bpir-tier3-init/module-setup.sh
+++ b/scripts/dracut/97bpir-tier3-init/module-setup.sh
@@ -103,7 +103,9 @@ install() {
     # /usr/local/bin/unified_server which the 96bpir-unified-server
     # module bakes in. The run script gates on /home/pir/data/
     # databases.toml (bind-mounted by bpir-tier3-init) and exec's
-    # the same flag set as deploy/systemd/pir-vpsbg.service.
+    # the same base topology flags as deploy/systemd/pir-vpsbg.service plus
+    # the explicitly reviewed VPSBG Payment V1 suffix baked into its measured
+    # run script.
     inst_dir /etc/sv/unified_server
     inst_simple "$moddir/unified-server-run.sh" /etc/sv/unified_server/run
 }

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -4,7 +4,9 @@
 # Lives at /etc/sv/unified_server/run inside the initramfs. runsvdir
 # starts this; runit restarts on exit (1s default backoff).
 #
-# Flags mirror deploy/systemd/pir-vpsbg.service:
+# Base topology flags mirror deploy/systemd/pir-vpsbg.service. The measured
+# Payment V1 suffix below is intentionally VPSBG-specific: it enables the
+# db0-only Free-PoW + Hetzner shared-issuer BAT/ARC functional beta.
 #   --port 8091
 #   --role secondary   (DPF queries + HarmonyPIR query phase, no OnionPIR)
 #   --serve-queries    (pir2 is queries-only per the production topology
@@ -386,6 +388,8 @@ verify_direct_oram_publish "$ORAM_DELTA_DIR" "$ORAM_DELTA_TRUSTED_STATE_DIR" del
 safe_remove_runtime_path "$TRUSTED_INPUT_ROOT"
 trap - EXIT
 
+# VPSBG is query-only and has no Harmony V2 hint pool, so the measured
+# invocation keeps online V2Full authorization disabled (limit 0).
 exec "$UNIFIED_SERVER" \
     --port 8091 \
     --role secondary \
@@ -406,6 +410,24 @@ exec "$UNIFIED_SERVER" \
     --identity-key-path /home/pir/data/pir2-identity.key \
     --identity-cert-path /home/pir/data/pir2.cert \
     --identity-server-id pir2 \
+    --require-service-auth-v1 \
+    --service-policy /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/service-policy.bin \
+    --service-provider-id-hex 85bfdd55b1408402bcad886568b732818a32472747226aa009839d45e0b96cac \
+    --service-policy-key-hex 73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5 \
+    --service-store /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/provider.sqlite3 \
+    --service-rollback-authority /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/rollback.sqlite3 \
+    --allow-local-service-rollback-authority-dev \
+    --service-shared-authorization /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-authorization.bin \
+    --service-shared-issuer-approval /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-approval.bin \
+    --service-shared-operator-key-hex 7ecb7900928f30efbf548a13c8d0b4fff5a580c7a145b003866580e42d9dc9cb \
+    --service-shared-issuer-settlement-key-hex 248df8866b89b05dbb5d1a2ebec398e4281d9f0e152073570965cd2fbdc422b7 \
+    --service-shared-clearing-key /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/provider-clearing-signing.key \
+    --service-shared-idempotency-key /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-redeem-idempotency.key \
+    --service-shared-minimum-authorization-epoch 1 \
+    --allow-experimental-arc \
+    --service-max-concurrent-auth 4 \
+    --service-max-concurrent-online-v2full-auth 0 \
+    --service-pre-auth-timeout-ms 60000 \
     2>&1
 # --identity-* (operator-signed identity / REQ_ANNOUNCE): key + cert live
 # in the bind-mounted rootfs /home/pir/data — NOT baked into the measured

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,8 +26,13 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "4f23190c44b03b326403cb5b68633e462024018e5404a2ed91c7e408072b6799",
+    "acef5f68c44147b2acd4616fc8c9403d32aa9652f827844bf369129816cee743",
 });
+
+const VPSBG_MEASURED_RUN_PATH =
+  "scripts/dracut/97bpir-tier3-init/unified-server-run.sh";
+const VPSBG_PREMIUM_FREE_POW_STATE_ROOT =
+  "/home/pir/data/payment-v1/vpsbg-premium-free-pow-beta";
 
 export const REVIEWED_PREPARATION_HASHES = Object.freeze({
   "deploy/payment-v1/edge/directory-public-haproxy.cfg.in":
@@ -2275,6 +2280,127 @@ function activeArgumentText(text) {
     .join(" ");
 }
 
+function measuredShellLogicalLines(text, label) {
+  const lines = [];
+  let pending = "";
+  for (const original of text.split(/\r?\n/u)) {
+    const trimmed = original.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    const continued = original.trimEnd().endsWith("\\");
+    const fragment = continued
+      ? original.trimEnd().slice(0, -1).trim()
+      : original.trim();
+    pending = pending === "" ? fragment : `${pending} ${fragment}`;
+    if (!continued) {
+      lines.push(pending);
+      pending = "";
+    }
+  }
+  if (pending !== "") fail(`${label} ends with an unterminated continuation`);
+  return lines;
+}
+
+function requireMeasuredPublicHex(value, flag, label) {
+  if (!/^[0-9a-f]{64}$/u.test(value) || /^0{64}$/u.test(value)) {
+    fail(`${label} ${flag} must contain a non-placeholder 64-hex public value`);
+  }
+}
+
+/**
+ * Validate the measured final `unified_server` argv once the VPSBG Premium +
+ * Free-PoW profile replaces the inert runit baseline.  The caller first pins
+ * the whole script hash, so this intentionally focuses on the payment suffix:
+ * the fixed state paths and argument order must not drift while the four
+ * public identifiers are rendered during the deployment ceremony.
+ */
+export function validateVpsbgPremiumFreePowMeasuredFinalExec(text) {
+  const label = "VPSBG Premium + Free-PoW measured final exec";
+  const execLines = measuredShellLogicalLines(text, label).filter((line) =>
+    /^exec\s+"\$UNIFIED_SERVER"(?:\s|$)/u.test(line),
+  );
+  if (execLines.length !== 1) {
+    fail(`${label} must contain exactly one final exec for $UNIFIED_SERVER`);
+  }
+  const tokens = execLines[0].split(/\s+/u);
+  if (
+    tokens[0] !== "exec" ||
+    tokens[1] !== '"$UNIFIED_SERVER"' ||
+    tokens.at(-1) !== "2>&1"
+  ) {
+    fail(`${label} must use the reviewed exec prefix and final 2>&1`);
+  }
+  const argv = tokens.slice(2, -1);
+  const paymentStart = argv.indexOf("--require-service-auth-v1");
+  if (
+    paymentStart < 2 ||
+    argv.lastIndexOf("--require-service-auth-v1") !== paymentStart ||
+    argv[paymentStart - 2] !== "--identity-server-id" ||
+    argv[paymentStart - 1] !== "pir2"
+  ) {
+    fail(`${label} must begin immediately after --identity-server-id pir2`);
+  }
+  for (const value of argv.slice(0, paymentStart)) {
+    if (
+      value.startsWith("--service-") ||
+      value === "--allow-experimental-arc"
+    ) {
+      fail(`${label} must keep all payment options in the final payment suffix`);
+    }
+  }
+
+  const command = execLines[0];
+  rejectPattern(command, /@[A-Z][A-Z0-9_]*@/u, label, "placeholder value");
+  for (const [pattern, description] of [
+    [/(?:^|\s)--service-storeless-free-pow-policy-digest-hex(?:\s|=)/u, "storeless policy digest"],
+    [/(?:^|\s)--service-remote-rollback-authority-config(?:\s|=)/u, "remote rollback authority"],
+    [/(?:^|\s)--service-bat-key(?:\s|=)/u, "provider-local BAT key"],
+    [/(?:^|\s)--service-arc-key(?:\s|=)/u, "provider-local ARC key"],
+    [/(?:^|\s)--service-cashu-(?:recovery|custody|exposure-limit)(?:\s|=)/u, "provider-local Cashu material"],
+    [/(?:^|\s)--(?:arc-key|cashu-keyset)(?:\s|=)/u, "issuer key material"],
+  ]) {
+    rejectPattern(command, pattern, label, description);
+  }
+
+  const expected = [
+    ["--require-service-auth-v1", null],
+    ["--service-policy", `${VPSBG_PREMIUM_FREE_POW_STATE_ROOT}/service-policy.bin`],
+    ["--service-provider-id-hex", "public-hex"],
+    ["--service-policy-key-hex", "public-hex"],
+    ["--service-store", `${VPSBG_PREMIUM_FREE_POW_STATE_ROOT}/provider.sqlite3`],
+    ["--service-rollback-authority", `${VPSBG_PREMIUM_FREE_POW_STATE_ROOT}/rollback.sqlite3`],
+    ["--allow-local-service-rollback-authority-dev", null],
+    ["--service-shared-authorization", `${VPSBG_PREMIUM_FREE_POW_STATE_ROOT}/shared-clearing-authorization.bin`],
+    ["--service-shared-issuer-approval", `${VPSBG_PREMIUM_FREE_POW_STATE_ROOT}/shared-clearing-approval.bin`],
+    ["--service-shared-operator-key-hex", "public-hex"],
+    ["--service-shared-issuer-settlement-key-hex", "public-hex"],
+    ["--service-shared-clearing-key", `${VPSBG_PREMIUM_FREE_POW_STATE_ROOT}/provider-clearing-signing.key`],
+    ["--service-shared-idempotency-key", `${VPSBG_PREMIUM_FREE_POW_STATE_ROOT}/shared-redeem-idempotency.key`],
+    ["--service-shared-minimum-authorization-epoch", "1"],
+    ["--allow-experimental-arc", null],
+    ["--service-max-concurrent-auth", "4"],
+    ["--service-max-concurrent-online-v2full-auth", "0"],
+    ["--service-pre-auth-timeout-ms", "60000"],
+  ];
+  let cursor = paymentStart;
+  for (const [flag, expectedValue] of expected) {
+    if (argv[cursor] !== flag) {
+      fail(`${label} must contain ${flag} exactly once and in canonical order`);
+    }
+    cursor += 1;
+    if (expectedValue === null) continue;
+    const actual = argv[cursor];
+    if (expectedValue === "public-hex") {
+      requireMeasuredPublicHex(actual, flag, label);
+    } else if (actual !== expectedValue) {
+      fail(`${label} ${flag} must equal ${expectedValue}`);
+    }
+    cursor += 1;
+  }
+  if (cursor !== argv.length) {
+    fail(`${label} contains an unreviewed, duplicate, or positional argv value`);
+  }
+}
+
 function validateVpsbgPremiumFreePowBeta(text, mode) {
   const label = "VPSBG Premium + Free-PoW beta argument fragment";
   requireText(text, "not a run script", label);
@@ -2647,6 +2773,13 @@ function validateActiveBaselines(root) {
     const actual = sha256File(absolute);
     if (actual !== expected) {
       fail(`active deployment file changed outside this slice: ${relativePath}`);
+    }
+    if (
+      relativePath === VPSBG_MEASURED_RUN_PATH &&
+      /^\s*--require-service-auth-v1(?:\s|$)/mu.test(text)
+    ) {
+      validateVpsbgPremiumFreePowMeasuredFinalExec(text);
+      continue;
     }
     rejectPattern(
       text,

--- a/scripts/payment-v1-deployment-template-gate.test.mjs
+++ b/scripts/payment-v1-deployment-template-gate.test.mjs
@@ -18,6 +18,7 @@ import {
   REQUIRED_PREPARATION_FILES,
   validateDeploymentTree,
   validateRelaySelection,
+  validateVpsbgPremiumFreePowMeasuredFinalExec,
 } from "./payment-v1-deployment-template-gate.mjs";
 
 const REPOSITORY = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -590,6 +591,77 @@ test("VPSBG premium beta remains a separate stateful shared-issuer profile", () 
       /must contain kind = "manifest-root"/,
     );
   });
+});
+
+test("VPSBG measured final exec fixes the premium suffix while accepting rendered public keys", () => {
+  const measuredRunPath =
+    "scripts/dracut/97bpir-tier3-init/unified-server-run.sh";
+  const measuredRun = readFileSync(join(REPOSITORY, measuredRunPath), "utf8");
+  assert.doesNotThrow(() =>
+    validateVpsbgPremiumFreePowMeasuredFinalExec(measuredRun),
+  );
+
+  const alternatePublicValue = "a".repeat(64);
+  const alternateRun = measuredRun.replace(
+    "85bfdd55b1408402bcad886568b732818a32472747226aa009839d45e0b96cac",
+    alternatePublicValue,
+  );
+  assert.notEqual(alternateRun, measuredRun);
+  assert.doesNotThrow(() =>
+    validateVpsbgPremiumFreePowMeasuredFinalExec(alternateRun),
+  );
+});
+
+test("VPSBG measured final exec rejects placeholders and forbidden payment material", () => {
+  const measuredRunPath =
+    "scripts/dracut/97bpir-tier3-init/unified-server-run.sh";
+  const measuredRun = readFileSync(join(REPOSITORY, measuredRunPath), "utf8");
+
+  const placeholder = measuredRun.replace(
+    "85bfdd55b1408402bcad886568b732818a32472747226aa009839d45e0b96cac",
+    "@VPSBG_PREMIUM_PROVIDER_ID_HEX@",
+  );
+  assert.throws(
+    () => validateVpsbgPremiumFreePowMeasuredFinalExec(placeholder),
+    /placeholder value/,
+  );
+
+  const suffixEnd = [
+    "    --service-pre-auth-timeout-ms 60000 \\",
+    "    2>&1",
+  ].join("\n");
+  for (const [line, expected] of [
+    [
+      "--service-storeless-free-pow-policy-digest-hex deadbeef",
+      /storeless policy digest/,
+    ],
+    [
+      "--service-remote-rollback-authority-config /home/pir/data/payment-v1/remote.toml",
+      /remote rollback authority/,
+    ],
+    [
+      "--service-bat-key /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/bat.key",
+      /provider-local BAT key/,
+    ],
+    [
+      "--service-arc-key /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/arc.key",
+      /provider-local ARC key/,
+    ],
+  ]) {
+    const mutated = measuredRun.replace(
+      suffixEnd,
+      [
+        "    --service-pre-auth-timeout-ms 60000 \\",
+        "    " + line + " \\",
+        "    2>&1",
+      ].join("\n"),
+    );
+    assert.notEqual(mutated, measuredRun);
+    assert.throws(
+      () => validateVpsbgPremiumFreePowMeasuredFinalExec(mutated),
+      expected,
+    );
+  }
 });
 
 test("systemd resets, duplicate CLI overrides, and secret argv fail closed", () => {


### PR DESCRIPTION
## Summary
- add the reviewed measured VPSBG admission suffix for db0 DPF Free-PoW and Hetzner shared-issuer BAT/experimental ARC
- pin and validate the exact measured suffix, including query-only online-V2Full limit 0
- document the rootfs-only provider state boundary

## Validation
- `sh -n scripts/dracut/97bpir-tier3-init/unified-server-run.sh`
- `node scripts/payment-v1-deployment-template-gate.mjs`
- `node --test scripts/payment-v1-deployment-template-gate.test.mjs` (29 passing)
- `git diff --check`

No real Lightning payment or VPSBG reboot is included. The next deployment step is to build the UKI, then stage its rootfs payload before the user uploads/reboots it.