### PR TITLE
fix: boot VPSBG DPF beta without Direct ORAM

### DIFF
--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -54,6 +54,16 @@ UNIFIED_SERVER=/usr/local/bin/unified_server
 if [ ! -x "$UNIFIED_SERVER" ] && [ -x /home/pir/BitcoinPIR/target/release/unified_server ]; then
     UNIFIED_SERVER=/home/pir/BitcoinPIR/target/release/unified_server
 fi
+
+# The functional-beta policy embedded below advertises only db0 DPF-PIR.
+# Do not hold that usable path behind the separate Direct-ORAM ceremony: the
+# currently mounted db0 proof is V1 and deliberately lacks the typed
+# `direct_oram` data required by the newer Direct-ORAM bootstrap.  Direct ORAM
+# remains below as an explicit future path once a new attested full-build has
+# supplied that evidence; changing this constant requires a new measured UKI
+# review and release.
+VPSBG_DPF_ONLY_FUNCTIONAL_BETA=1
+
 ORAM_BOOT_ROOT=/home/pir/data/.oram-boot
 ORAM_BUILD_LOG_DIR=/home/pir/data/oram-boot-logs
 ORAM_STAGING_DIR="$ORAM_BOOT_ROOT/staging.$$"
@@ -320,8 +330,41 @@ verify_direct_oram_publish() {
     echo "[unified-server-run] verified published $db_label direct ORAM paths" >&2
 }
 
-[ -x "$ORAMCTL" ] || fatal "$ORAMCTL missing from UKI"
 [ -x "$UNIFIED_SERVER" ] || fatal "$UNIFIED_SERVER missing from UKI"
+if [ "$VPSBG_DPF_ONLY_FUNCTIONAL_BETA" = 1 ]; then
+    echo "[unified-server-run] starting VPSBG db0 DPF-only functional beta; Direct ORAM is not advertised" >&2
+    exec "$UNIFIED_SERVER" \
+        --port 8091 \
+        --role secondary \
+        --serve-queries \
+        --config /home/pir/data/databases.toml \
+        --admin-pubkey-hex 87d454db85266e10e55ed8b68417de9d79ceb1d5d944bae831a7877627efdad3 \
+        --vcek-dir /home/pir/data/vcek \
+        --identity-key-path /home/pir/data/pir2-identity.key \
+        --identity-cert-path /home/pir/data/pir2.cert \
+        --identity-server-id pir2 \
+        --require-service-auth-v1 \
+        --service-policy /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/service-policy.bin \
+        --service-provider-id-hex 85bfdd55b1408402bcad886568b732818a32472747226aa009839d45e0b96cac \
+        --service-policy-key-hex 73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5 \
+        --service-store /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/provider.sqlite3 \
+        --service-rollback-authority /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/rollback.sqlite3 \
+        --allow-local-service-rollback-authority-dev \
+        --service-shared-authorization /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-authorization.bin \
+        --service-shared-issuer-approval /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-clearing-approval.bin \
+        --service-shared-operator-key-hex 7ecb7900928f30efbf548a13c8d0b4fff5a580c7a145b003866580e42d9dc9cb \
+        --service-shared-issuer-settlement-key-hex 248df8866b89b05dbb5d1a2ebec398e4281d9f0e152073570965cd2fbdc422b7 \
+        --service-shared-clearing-key /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/provider-clearing-signing.key \
+        --service-shared-idempotency-key /home/pir/data/payment-v1/vpsbg-premium-free-pow-beta/shared-redeem-idempotency.key \
+        --service-shared-minimum-authorization-epoch 1 \
+        --allow-experimental-arc \
+        --service-max-concurrent-auth 4 \
+        --service-max-concurrent-online-v2full-auth 0 \
+        --service-pre-auth-timeout-ms 60000 \
+        2>&1
+fi
+
+[ -x "$ORAMCTL" ] || fatal "$ORAMCTL missing from UKI"
 require_file "$DELTA_BHTM_FROM_LEAF_PROOF"
 mkdir -p "$ORAM_BOOT_ROOT" "$ORAM_BUILD_LOG_DIR" || fatal "failed to create ORAM boot directories"
 for stale_staging in "$ORAM_BOOT_ROOT"/staging.*; do

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,7 +26,7 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "acef5f68c44147b2acd4616fc8c9403d32aa9652f827844bf369129816cee743",
+    "db54be40180c511459f2b2f58658669abcc5d0fc4d731d0394ca9ef907e0942d",
 });
 
 const VPSBG_MEASURED_RUN_PATH =
@@ -2318,47 +2318,33 @@ export function validateVpsbgPremiumFreePowMeasuredFinalExec(text) {
   const execLines = measuredShellLogicalLines(text, label).filter((line) =>
     /^exec\s+"\$UNIFIED_SERVER"(?:\s|$)/u.test(line),
   );
-  if (execLines.length !== 1) {
-    fail(`${label} must contain exactly one final exec for $UNIFIED_SERVER`);
-  }
-  const tokens = execLines[0].split(/\s+/u);
+  const dpfOnlyExecLines = execLines.filter(
+    (line) => !line.includes("--direct-oram-db"),
+  );
+  const directOramExecLines = execLines.filter((line) =>
+    line.includes("--direct-oram-db"),
+  );
   if (
-    tokens[0] !== "exec" ||
-    tokens[1] !== '"$UNIFIED_SERVER"' ||
-    tokens.at(-1) !== "2>&1"
+    execLines.length !== 2 ||
+    dpfOnlyExecLines.length !== 1 ||
+    directOramExecLines.length !== 1
   ) {
-    fail(`${label} must use the reviewed exec prefix and final 2>&1`);
+    fail(`${label} must contain exactly one db0 DPF-only and one Direct ORAM fallback exec`);
   }
-  const argv = tokens.slice(2, -1);
-  const paymentStart = argv.indexOf("--require-service-auth-v1");
+  if (!/^VPSBG_DPF_ONLY_FUNCTIONAL_BETA=1$/mu.test(text)) {
+    fail(`${label} must keep the reviewed DPF-only functional-beta switch enabled`);
+  }
+  const dpfOnlyExec = dpfOnlyExecLines[0];
+  const dpfOnlyBranchOffset = text.indexOf(
+    'if [ "$VPSBG_DPF_ONLY_FUNCTIONAL_BETA" = 1 ]; then',
+  );
+  const directOramBootstrapOffset = text.indexOf('[ -x "$ORAMCTL" ] || fatal');
   if (
-    paymentStart < 2 ||
-    argv.lastIndexOf("--require-service-auth-v1") !== paymentStart ||
-    argv[paymentStart - 2] !== "--identity-server-id" ||
-    argv[paymentStart - 1] !== "pir2"
+    dpfOnlyBranchOffset < 0 ||
+    directOramBootstrapOffset < 0 ||
+    directOramBootstrapOffset < dpfOnlyBranchOffset
   ) {
-    fail(`${label} must begin immediately after --identity-server-id pir2`);
-  }
-  for (const value of argv.slice(0, paymentStart)) {
-    if (
-      value.startsWith("--service-") ||
-      value === "--allow-experimental-arc"
-    ) {
-      fail(`${label} must keep all payment options in the final payment suffix`);
-    }
-  }
-
-  const command = execLines[0];
-  rejectPattern(command, /@[A-Z][A-Z0-9_]*@/u, label, "placeholder value");
-  for (const [pattern, description] of [
-    [/(?:^|\s)--service-storeless-free-pow-policy-digest-hex(?:\s|=)/u, "storeless policy digest"],
-    [/(?:^|\s)--service-remote-rollback-authority-config(?:\s|=)/u, "remote rollback authority"],
-    [/(?:^|\s)--service-bat-key(?:\s|=)/u, "provider-local BAT key"],
-    [/(?:^|\s)--service-arc-key(?:\s|=)/u, "provider-local ARC key"],
-    [/(?:^|\s)--service-cashu-(?:recovery|custody|exposure-limit)(?:\s|=)/u, "provider-local Cashu material"],
-    [/(?:^|\s)--(?:arc-key|cashu-keyset)(?:\s|=)/u, "issuer key material"],
-  ]) {
-    rejectPattern(command, pattern, label, description);
+    fail(`${label} must start the DPF-only path before Direct ORAM bootstrap`);
   }
 
   const expected = [
@@ -2381,23 +2367,66 @@ export function validateVpsbgPremiumFreePowMeasuredFinalExec(text) {
     ["--service-max-concurrent-online-v2full-auth", "0"],
     ["--service-pre-auth-timeout-ms", "60000"],
   ];
-  let cursor = paymentStart;
-  for (const [flag, expectedValue] of expected) {
-    if (argv[cursor] !== flag) {
-      fail(`${label} must contain ${flag} exactly once and in canonical order`);
+  for (const [profile, command] of [
+    ["db0 DPF-only", dpfOnlyExec],
+    ["Direct ORAM fallback", directOramExecLines[0]],
+  ]) {
+    const profileLabel = `${label} ${profile}`;
+    const tokens = command.split(/\s+/u);
+    if (
+      tokens[0] !== "exec" ||
+      tokens[1] !== '"$UNIFIED_SERVER"' ||
+      tokens.at(-1) !== "2>&1"
+    ) {
+      fail(`${profileLabel} must use the reviewed exec prefix and final 2>&1`);
     }
-    cursor += 1;
-    if (expectedValue === null) continue;
-    const actual = argv[cursor];
-    if (expectedValue === "public-hex") {
-      requireMeasuredPublicHex(actual, flag, label);
-    } else if (actual !== expectedValue) {
-      fail(`${label} ${flag} must equal ${expectedValue}`);
+    const argv = tokens.slice(2, -1);
+    const paymentStart = argv.indexOf("--require-service-auth-v1");
+    if (
+      paymentStart < 2 ||
+      argv.lastIndexOf("--require-service-auth-v1") !== paymentStart ||
+      argv[paymentStart - 2] !== "--identity-server-id" ||
+      argv[paymentStart - 1] !== "pir2"
+    ) {
+      fail(`${profileLabel} must begin immediately after --identity-server-id pir2`);
     }
-    cursor += 1;
-  }
-  if (cursor !== argv.length) {
-    fail(`${label} contains an unreviewed, duplicate, or positional argv value`);
+    for (const value of argv.slice(0, paymentStart)) {
+      if (
+        value.startsWith("--service-") ||
+        value === "--allow-experimental-arc"
+      ) {
+        fail(`${profileLabel} must keep all payment options in the final payment suffix`);
+      }
+    }
+    rejectPattern(command, /@[A-Z][A-Z0-9_]*@/u, profileLabel, "placeholder value");
+    for (const [pattern, description] of [
+      [/(?:^|\s)--service-storeless-free-pow-policy-digest-hex(?:\s|=)/u, "storeless policy digest"],
+      [/(?:^|\s)--service-remote-rollback-authority-config(?:\s|=)/u, "remote rollback authority"],
+      [/(?:^|\s)--service-bat-key(?:\s|=)/u, "provider-local BAT key"],
+      [/(?:^|\s)--service-arc-key(?:\s|=)/u, "provider-local ARC key"],
+      [/(?:^|\s)--service-cashu-(?:recovery|custody|exposure-limit)(?:\s|=)/u, "provider-local Cashu material"],
+      [/(?:^|\s)--(?:arc-key|cashu-keyset)(?:\s|=)/u, "issuer key material"],
+    ]) {
+      rejectPattern(command, pattern, profileLabel, description);
+    }
+    let cursor = paymentStart;
+    for (const [flag, expectedValue] of expected) {
+      if (argv[cursor] !== flag) {
+        fail(`${profileLabel} must contain ${flag} exactly once and in canonical order`);
+      }
+      cursor += 1;
+      if (expectedValue === null) continue;
+      const actual = argv[cursor];
+      if (expectedValue === "public-hex") {
+        requireMeasuredPublicHex(actual, flag, profileLabel);
+      } else if (actual !== expectedValue) {
+        fail(`${profileLabel} ${flag} must equal ${expectedValue}`);
+      }
+      cursor += 1;
+    }
+    if (cursor !== argv.length) {
+      fail(`${profileLabel} contains an unreviewed, duplicate, or positional argv value`);
+    }
   }
 }
 


### PR DESCRIPTION
## What changed

Starts the VPSBG functional-beta UKI in its published db0 DPF-PIR profile before the optional Direct ORAM bootstrap.

## Why

The mounted db0 evidence is the existing V1 form and intentionally has no typed Direct ORAM evidence. The newer Direct ORAM bootstrap therefore fails before the DPF service can start, even though this payment policy advertises only DPF.

## Impact

The Free-PoW, Cashu BAT, and experimental ARC admission suffix is unchanged. Direct ORAM remains an explicit fallback path for a future UKI built with the required V2 full-build evidence; it is not advertised by this beta policy.

## Validation

- `sh -n scripts/dracut/97bpir-tier3-init/unified-server-run.sh`
- `node scripts/payment-v1-deployment-template-gate.mjs`
- `node --test scripts/payment-v1-deployment-template-gate.test.mjs` (29 passing)
- `git diff --check`