### PR TITLE
fix: pin live DPF provider pair

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1924,10 +1924,15 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         }
 
         function sharedArkFingerprint(first, second) {
-            const left = first.expectedArkFingerprintHex ?? '';
-            const right = second.expectedArkFingerprintHex ?? '';
-            if (left !== right) throw new Error('the selected pair requires different ARK roots unsupported by one adapter session');
-            return providerArkFingerprintV1(first);
+            const left = first.expectedArkFingerprintHex ?? null;
+            const right = second.expectedArkFingerprintHex ?? null;
+            if (left !== null && right !== null && left !== right) {
+                throw new Error('the selected pair requires different ARK roots unsupported by one adapter session');
+            }
+            // A non-SEV provider has no ARK to pin. Passing the other leg's
+            // pinned root is safe: the adapter only invokes AMD chain
+            // validation for a leg that actually supplies a VCEK chain.
+            return providerArkFingerprintV1(left !== null ? first : second);
         }
 
         async function admissionVault() {

--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -7,13 +7,21 @@ import {
 } from '../product-provider-bootstrap.js';
 
 describe('bundled functional-beta trusted bootstrap', () => {
-  it('is a parseable Signet bootstrap for two independent providers', () => {
+  it('pins the live Hetzner and VPSBG providers as an independent Signet pair', () => {
     const parsed = parseProductTrustedBootstrapV1(
       JSON.stringify(bundledFunctionalBetaBootstrap),
     );
 
     expect(parsed.network).toBe('signet');
     expect(parsed.providers).toHaveLength(2);
+    expect(parsed.providers.map((provider) => provider.endpoint)).toEqual([
+      'wss://weikeng1.bitcoinpir.org',
+      'wss://weikeng2.bitcoinpir.org',
+    ]);
+    expect(parsed.providers[1].hardwareAttestation).toBe('required');
+    expect(parsed.providers[1].serverPin.measurementHex).toBe(
+      '3564465a167bcc8d406041f296ecce12749a151bebc996371ebbea35b3947ad85011d99777562ff8b53bfd314846de21',
+    );
     expect(() => assertIndependentProviderDialPairV1(
       parsed.providers[0],
       parsed.providers[1],

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -126,32 +126,24 @@ export interface ServerAttestPin {
 }
 
 /**
- * weikeng2.bitcoinpir.org — VPSBG Tier 3 ORAM UKI, pinned 2026-07-24.
- * Built by `scripts/build_uki_tier3.sh` on VPSBG and archived on Hetzner:
- * VPSBG kernel 7.0.0-28 + the ORAM-enabled `unified_server`
- * binary baked into the initramfs.
+ * weikeng2.bitcoinpir.org — VPSBG Tier 3 DPF-only Payment V1 beta UKI,
+ * pinned 2026-08-02. Built from BitcoinPIR commit 7f1db108 and archived on
+ * Hetzner before the measured-boot API rollout. This endpoint deliberately
+ * serves the verified DPF path only; it does not advertise direct ORAM.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // Tier 3 ORAM + database-proof-v2 UKI — 2026-07-24. The measured startup
-  // script and unified_server binary are both built from BitcoinPIR commit
-  // 81dd96d442d39200fee7e6c97f5c308f38126756. unified_server dual-serves
-  // v1/v2 DB proofs and direct ORAM lookup
-  // for db_id 0/1 as pir2 query-only (`--serve-queries`, no hint pool,
-  // no OnionPIR) plus `--identity-*` (operator-signed identity,
-  // server_id=pir2). MEASUREMENT captured from the live Tier 3 deploy via
-  // `bpir-admin attest wss://weikeng2.bitcoinpir.org` after uploading
-  // UKI sha256 `34b04d1bfc0501c0cc222aff446a55de0a74d4e5218a21a05bf8756f8293b681`
-  // (SEV-SNP REPORT_DATA binding verified on
-  // real hardware).
+  // MEASUREMENT captured from the live Tier 3 deploy after uploading the
+  // archived DPF-only UKI and validating REPORT_DATA plus the AMD chain.
   measurementHex:
-    'd7ae6fb895380b1408b5ba7640a2eaa091754fc6279b62eb96f4bd1eee5532e95bc1df3b1485a06b3f43d648d05d3245',
+    '3564465a167bcc8d406041f296ecce12749a151bebc996371ebbea35b3947ad85011d99777562ff8b53bfd314846de21',
   binarySha256Hex:
-    'cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e',
-  description: 'weikeng2.bitcoinpir.org (VPSBG, SEV-SNP, Tier 3 ORAM UKI)',
+    'ca5b5ec2b2c1eebcd02624d4a93d3bbcfe8a96afa718391d75b71777fc8ea9a4',
+  description: 'weikeng2.bitcoinpir.org (VPSBG, SEV-SNP, Tier 3 DPF-only Payment V1 beta)',
 };
 
 /**
- * weikeng1.bitcoinpir.org — Hetzner i7-8700, Intel chip, NO SEV-SNP.
+ * weikeng1.bitcoinpir.org — Hetzner Payment V1 provider, Intel host, NO
+ * SEV-SNP. The public endpoint is independently keyed and pinned below.
  * No MEASUREMENT to pin (no SEV report). binary_sha256 IS pinnable —
  * the value isn't hardware-backed without SEV, but pinning still
  * detects accidental drift between what the operator claims is
@@ -159,15 +151,11 @@ export const PIR2_TIER3_PIN: ServerAttestPin = {
  */
 export const PIR1_PIN: ServerAttestPin = {
   // No measurementHex — Hetzner has no SEV.
-  // Bumped 2026-07-24: pir1 redeployed from BitcoinPIR commit
-  // 81dd96d442d39200fee7e6c97f5c308f38126756. Both runtime services
-  // dual-serve database proofs v1/v2 while retaining the durable,
-  // non-blocking HarmonyPIR V2 hint pool.
-  // Both Hetzner systemd services use this binary. This remains independent
-  // from the pir2 Tier 3 UKI measurement pin.
+  // The public Payment V1 provider uses the independently deployed
+  // d23b5841 build. This remains independent from the VPSBG Tier 3 pin.
   binarySha256Hex:
-    'cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e',
-  description: 'weikeng1.bitcoinpir.org (Hetzner i7-8700, no SEV)',
+    'd23b58410f52fede21d013fbcec279c42d02b69d4b32791265cfb38e331770d8',
+  description: 'weikeng1.bitcoinpir.org (Hetzner Payment V1 provider, no SEV)',
 };
 
 /**

--- a/web/src/functional-beta-trusted-bootstrap.json
+++ b/web/src/functional-beta-trusted-bootstrap.json
@@ -3,8 +3,8 @@
   "network": "signet",
   "providers": [
     {
-      "label": "Provider 1 functional beta",
-      "endpoint": "wss://provider-beta.65-21-91-217.sslip.io",
+      "label": "Hetzner Payment V1 provider",
+      "endpoint": "wss://weikeng1.bitcoinpir.org",
       "providerIdHex": "9110aee8843ff4eaa60eb5e2f36345cef03c779c08becbfe76f4cc0400fc0eb0",
       "policySigningKeyHex": "6528d01b64275834460fd2c6f1d8b2df1374ea62ed0204ea2429adcc70246a93",
       "operatorSigningKeyHex": "d506c8630f13f31f0648228857c268d17996d600ed7169e091c88aadb5ecb2d4",
@@ -56,17 +56,26 @@
       ]
     },
     {
-      "label": "Provider 2 functional beta",
-      "endpoint": "wss://provider2-beta.65-21-91-217.sslip.io",
-      "providerIdHex": "83076521322104abbceca115f119c953c84561a29922e7ce444b7097ffc5f5d7",
-      "policySigningKeyHex": "c2e0598b34804d1b3c60b4b636bccd861b93cfa55671e27787f0eab50d9dbf8e",
-      "operatorSigningKeyHex": "5590cce35dc49fcde96b724899aef54487d9a43ec234815503723a5179e56d07",
-      "stableServerId": "pir2-payment-beta",
+      "label": "VPSBG DPF Payment V1 provider",
+      "endpoint": "wss://weikeng2.bitcoinpir.org",
+      "providerIdHex": "85bfdd55b1408402bcad886568b732818a32472747226aa009839d45e0b96cac",
+      "policySigningKeyHex": "73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5",
+      "operatorSigningKeyHex": "7ecb7900928f30efbf548a13c8d0b4fff5a580c7a145b003866580e42d9dc9cb",
+      "stableServerId": "pir2-vpsbg-dpf-v1",
       "serverPin": {
-        "binarySha256Hex": "d23b58410f52fede21d013fbcec279c42d02b69d4b32791265cfb38e331770d8"
+        "binarySha256Hex": "ca5b5ec2b2c1eebcd02624d4a93d3bbcfe8a96afa718391d75b71777fc8ea9a4",
+        "measurementHex": "3564465a167bcc8d406041f296ecce12749a151bebc996371ebbea35b3947ad85011d99777562ff8b53bfd314846de21"
       },
-      "hardwareAttestation": "unavailable-accepted",
-      "lightningPayeeTrust": [],
+      "hardwareAttestation": "required",
+      "expectedArkFingerprintHex": "1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a",
+      "lightningPayeeTrust": [
+        {
+          "issuerIdHex": "8799b9b02964688f7f5d35b1c502f1bfb4a344c8ca6bd3f7902814c558e1de86",
+          "issuerOrigin": "https://issuer-beta.65-21-91-217.sslip.io",
+          "network": "signet",
+          "expectedPayeePubkeyHex": "03d56b422257245d2c170393fe0242f8fd5668b12034fe9d059579951e19162232"
+        }
+      ],
       "databaseProofPins": [
         {
           "dbId": 0,


### PR DESCRIPTION
## What changed

- Pin the bundled Signet bootstrap to the live Hetzner Payment V1 provider and the VPSBG DPF-only measured provider.
- Update browser binary and SEV-SNP measurement pins.
- Allow a mixed non-SEV/SEV provider pair to share the SEV leg’s ARK pin, while VCEK validation remains conditional on a supplied chain.

## Why

The previous beta endpoints and old VPSBG UKI pin did not describe the production DPF pair, so the browser could not establish the intended Free admission path.

## Validation

- npm run build -- --pretty false
- npx vitest run src/__tests__/functional-beta-trusted-bootstrap.test.ts
- Live Hetzner: binary pin, encrypted channel, DPF Free admission, and DB proof.
- Live VPSBG: SEV-SNP report, AMD chain, binary/measurement pins, and DB proof.