### PR TITLE
fix: keep live bootstrap CSP and fixtures aligned

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-7/ijyE29NEP9JpRaQ4D3Fh9yYlMoeOmX07SJH9Pobjs=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-cXarfqKGbu9RX9FnlwKjP3RVaxZdvK1bSGoEyUxX9eA=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
     <title>Bitcoin PIR</title>
     <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>

--- a/web/src/__tests__/oram-source-proof.test.ts
+++ b/web/src/__tests__/oram-source-proof.test.ts
@@ -2,7 +2,6 @@ import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
 import {
   MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN,
-  PIR2_TIER3_PIN,
 } from '../attest-pin.js';
 import {
   DEFAULT_ORAM_SOURCE_PROOF_MANIFEST_PATH,
@@ -21,6 +20,12 @@ const legacyFixtureRoot = new URL(
   import.meta.url,
 );
 const LEGACY_V1_MANIFEST_PATH = '/proofs/oram-source/mainnet_948454.json';
+// This forensic fixture documents the superseded ORAM deployment. It must not
+// follow the current DPF-only VPSBG runtime pin.
+const LEGACY_V1_PIR2_BINARY_SHA256 =
+  'cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e';
+const LEGACY_V1_PIR2_MEASUREMENT_HEX =
+  'd7ae6fb895380b1408b5ba7640a2eaa091754fc6279b62eb96f4bd1eee5532e95bc1df3b1485a06b3f43d648d05d3245';
 
 async function publicArtifactLoader(path: string): Promise<Uint8Array> {
   const clean = path.startsWith('/') ? path.slice(1) : path;
@@ -65,10 +70,10 @@ describe('ORAM source-binding proof', () => {
       'strict-source-bound-boot-regeneration-live-on-pir2',
     );
     expect(status.manifest?.liveDeployment.pir2BinarySha256).toBe(
-      PIR2_TIER3_PIN.binarySha256Hex,
+      LEGACY_V1_PIR2_BINARY_SHA256,
     );
     expect(status.manifest?.liveDeployment.pir2MeasurementHex).toBe(
-      PIR2_TIER3_PIN.measurementHex,
+      LEGACY_V1_PIR2_MEASUREMENT_HEX,
     );
     expect(status.manifest?.liveDeployment.pir2UkiSha256).toBe(
       '34b04d1bfc0501c0cc222aff446a55de0a74d4e5218a21a05bf8756f8293b681',


### PR DESCRIPTION
## What changed

- Refresh the `web/index.html` CSP hash after updating the inline bootstrap script.
- Keep the superseded ORAM forensic fixture pinned to its documented historical VPSBG image instead of the current DPF-only runtime pin.

## Validation

- npm run build -- --pretty false
- npm test (43 files passed, 502 tests passed; 1 pre-existing skipped suite)