### PR TITLE
admin: fix Signet smoke Clippy type complexity

### DIFF
--- a/apps/admin/src/payment_v1_signet_smoke.rs
+++ b/apps/admin/src/payment_v1_signet_smoke.rs
@@ -422,6 +422,12 @@ struct BatSecretV1 {
     blinding_scalar: Zeroizing<[u8; 32]>,
 }
 
+type IssuanceItemsV1 = (
+    CredentialIssuanceRequestItemsV1,
+    Option<Vec<BatSecretV1>>,
+    Option<pir_arc_adapter::PendingArcCredentialRequestV1>,
+);
+
 fn build_issuance_items(
     method: PaidMethodV1,
     binding: &pir_service_protocol::CredentialKeyBindingV1,
@@ -429,14 +435,7 @@ fn build_issuance_items(
     scope_id: &[u8; 32],
     offer: &pir_service_protocol::ServiceOfferV1,
     now_unix: u64,
-) -> Result<
-    (
-        CredentialIssuanceRequestItemsV1,
-        Option<Vec<BatSecretV1>>,
-        Option<pir_arc_adapter::PendingArcCredentialRequestV1>,
-    ),
-    String,
-> {
+) -> Result<IssuanceItemsV1, String> {
     match method {
         PaidMethodV1::DirectReceipt => Ok((
             CredentialIssuanceRequestItemsV1::DirectPaidReceipt,


### PR DESCRIPTION
## Summary
- Factor the Signet smoke issuance tuple into a named type alias.
- Keep the existing issuance flow and security behavior unchanged.

## Validation
- Clean-worktree cargo clippy with all targets and deny-warnings for bpir-admin passes.
- git diff --check passes.
- The full package list is blocked locally by the pre-existing macOS cln-rpc-guard st_dev i32/u64 mismatch; the original GitHub failure was isolated to bpir-admin type-complexity.