### PR TITLE
Fix simple admission routing and unsupported workload choices

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-b8TG95QxjM4somz6wyvUYDWyB/lSvJGD5R+mrKDaIt8=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-a55CCVP4KsKQ2sVjnZ1OFNER96NPzLtsBqUvyjNNrMo=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
     <title>Bitcoin PIR</title>
     <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>
@@ -835,8 +835,14 @@
         .admission-notice {
             margin: 0; padding: 8px 10px; border-left: 3px solid var(--warn);
             background: var(--sunken); color: var(--ink-mute); font-size: 11.5px;
+            display: flex; align-items: center; justify-content: space-between; gap: 10px;
         }
         .admission-notice.error { border-left-color: var(--err); color: var(--err); }
+        .admission-notice > button { flex: 0 0 auto; white-space: nowrap; }
+        .product-admission-panel[data-admission-mode="simple"] .admission-provider-row,
+        .product-admission-panel[data-admission-mode="simple"] .admission-shared-infrastructure {
+            display: none;
+        }
         .admission-transport-boundary {
             margin: 6px 0 10px;
             color: var(--ink-mute);
@@ -915,12 +921,12 @@
                 </div>
                 <label class="admission-simple-mode" for="simpleAdmissionMode">
                     <input type="checkbox" id="simpleAdmissionMode" checked>
-                    <span><strong>Simple mode.</strong> Strictly verify the trusted servers, choose signed Free access, authorize each required role, and run one query automatically. Paid, ambiguous, or unavailable paths stop for review.</span>
+                    <span><strong>Simple mode (recommended).</strong> Click Query and the trusted server roles, signed Free access, and strict verification run automatically. You will only be asked to review a problem.</span>
                 </label>
                 <details class="admission-config" id="admissionConfig">
                     <summary>Provider verification trust configuration</summary>
                     <div class="admission-config-grid">
-                        <label for="admissionBootstrapJson">Trusted bootstrap JSON (advanced replacement: endpoint, provider/policy/operator keys, server/binary/measurement/database pins, exact issuer/network/Lightning-payee trust)</label>
+                        <label for="admissionBootstrapJson">Trusted bootstrap JSON (advanced replacement: endpoint, provider/policy/operator keys, server/binary/measurement/database pins, explicit product-role workloads, exact issuer/network/Lightning-payee trust)</label>
                         <textarea id="admissionBootstrapJson" class="input" autocomplete="off" spellcheck="false" placeholder="A functional-beta trusted bootstrap is bundled for this page load. Paste a complete replacement only when intentionally changing trust."></textarea>
                         <div class="admission-config-actions">
                             <button type="button" id="admissionApplyBootstrap" class="btn">Apply replacement in memory</button>
@@ -1663,7 +1669,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
     </section>
 
     <script type="module">
-        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, PRODUCTION_ONION_DB_PROOF_V2_PINS, DELTA_940611_948454_DB_PROOF_PIN, MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN, databaseProofAnchorLabel, databaseProofAnchorPoints, mempoolSpaceBlockUrl, verifyProductionTrustChain, verifyOramSourceProof, AdmissionCredentialVaultV1, DirectoryRollbackVaultV1, DirectoryRefreshIntentGuardV1, ProviderAdmissionSessionV1, ProductAdmissionControllerV1, ProductAdmissionPanelV1, assertIndependentProviderDialPairV1, assertSelectableDirectoryCatalogFreshV1, parseProductTrustedBootstrapV1, manualProviderAdmissionTrustAnchorV1, directoryBoundProviderTrustAnchorV1, providerArkFingerprintV1, providerLightningPayeeTrustV1, providerOperatorKeyV1, refreshNostrDirectoryV1, directoryRefreshFailureStateV1, publicAdmissionError, renderSecurityBadgeTextRowsV1, prepareQueryInspectorRenderDataV1, requireVerifiedQueryResultsV1, resourceBindingToHarmonyHintCacheBindingV1 } from './src/index.ts';
+        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, PRODUCTION_ONION_DB_PROOF_V2_PINS, DELTA_940611_948454_DB_PROOF_PIN, MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN, databaseProofAnchorLabel, databaseProofAnchorPoints, mempoolSpaceBlockUrl, verifyProductionTrustChain, verifyOramSourceProof, AdmissionCredentialVaultV1, DirectoryRollbackVaultV1, DirectoryRefreshIntentGuardV1, ProviderAdmissionSessionV1, ProductAdmissionControllerV1, ProductAdmissionPanelV1, assertIndependentProviderDialPairV1, assertSelectableDirectoryCatalogFreshV1, parseProductTrustedBootstrapV1, manualProviderAdmissionTrustAnchorV1, directoryBoundProviderTrustAnchorV1, providerArkFingerprintV1, providerLightningPayeeTrustV1, providerOperatorKeyV1, defaultProviderIdsForAdmissionRoutesV1, refreshNostrDirectoryV1, directoryRefreshFailureStateV1, publicAdmissionError, renderSecurityBadgeTextRowsV1, prepareQueryInspectorRenderDataV1, requireVerifiedQueryResultsV1, resourceBindingToHarmonyHintCacheBindingV1 } from './src/index.ts';
         import FUNCTIONAL_BETA_TRUSTED_BOOTSTRAP from './src/functional-beta-trusted-bootstrap.json';
         window.__bitcoinPirPrepareQueryInspectorRenderDataV1 = prepareQueryInspectorRenderDataV1;
         // Initialize SDK WASM (optional - falls back to TS if unavailable)
@@ -1745,31 +1751,35 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             dpf: new ProductAdmissionPanelV1({
                 root: document.getElementById('dpfAdmissionPanel'),
                 roles: [
-                    { role: 'server0', label: 'Server 0 · DPF query' },
-                    { role: 'server1', label: 'Server 1 · DPF query' },
+                    { role: 'server0', label: 'Server 0 · DPF query', workload: 'dpf-query' },
+                    { role: 'server1', label: 'Server 1 · DPF query', workload: 'dpf-query' },
                 ],
                 beforeSecurityTransition: requireFreshDirectoryTrustForSecurityTransition,
+                onRequestAdvancedMode: requestAdvancedAdmissionMode,
                 onStateChange: snapshot => updateAdmissionQueryButton('queryBtn', snapshot),
             }),
             onion: new ProductAdmissionPanelV1({
                 root: document.getElementById('opAdmissionPanel'),
-                roles: [{ role: 'onion', label: 'Onion provider' }],
+                roles: [{ role: 'onion', label: 'Onion provider', workload: 'onion-session' }],
                 beforeSecurityTransition: requireFreshDirectoryTrustForSecurityTransition,
+                onRequestAdvancedMode: requestAdvancedAdmissionMode,
                 onStateChange: snapshot => updateAdmissionQueryButton('op-queryBtn', snapshot),
             }),
             harmony: new ProductAdmissionPanelV1({
                 root: document.getElementById('hpAdmissionPanel'),
                 roles: [
-                    { role: 'hint', label: 'Hint provider · large one-time hint workload' },
-                    { role: 'query', label: 'Query provider · per-query workload' },
+                    { role: 'hint', label: 'Hint provider · large one-time hint workload', workload: 'harmony-hint' },
+                    { role: 'query', label: 'Query provider · per-query workload', workload: 'harmony-query' },
                 ],
                 beforeSecurityTransition: requireFreshDirectoryTrustForSecurityTransition,
+                onRequestAdvancedMode: requestAdvancedAdmissionMode,
                 onStateChange: snapshot => updateAdmissionQueryButton('hp-queryBtn', snapshot),
             }),
             oram: new ProductAdmissionPanelV1({
                 root: document.getElementById('oramAdmissionPanel'),
-                roles: [{ role: 'oram', label: 'ORAM provider' }],
+                roles: [{ role: 'oram', label: 'ORAM provider', workload: 'tee-oram-query' }],
                 beforeSecurityTransition: requireFreshDirectoryTrustForSecurityTransition,
+                onRequestAdvancedMode: requestAdvancedAdmissionMode,
                 onStateChange: snapshot => updateAdmissionQueryButton('oram-queryBtn', snapshot),
             }),
         };
@@ -1779,19 +1789,28 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             return checkbox instanceof HTMLInputElement && checkbox.checked;
         }
 
+        function requestAdvancedAdmissionMode() {
+            const checkbox = document.getElementById('simpleAdmissionMode');
+            if (!(checkbox instanceof HTMLInputElement) || !checkbox.checked) return;
+            checkbox.checked = false;
+            checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+
         function defaultProviderIdsForKind(kind) {
             const providers = productTrustedBootstrap?.providers ?? [];
-            const roles = {
-                dpf: ['server0', 'server1'],
-                harmony: ['hint', 'query'],
-                onion: ['onion'],
-                oram: ['oram'],
+            const routes = {
+                dpf: [
+                    ['server0', 'dpf-query'],
+                    ['server1', 'dpf-query'],
+                ],
+                harmony: [
+                    ['hint', 'harmony-hint'],
+                    ['query', 'harmony-query'],
+                ],
+                onion: [['onion', 'onion-session']],
+                oram: [['oram', 'tee-oram-query']],
             }[kind] ?? [];
-            if (providers.length < roles.length) return {};
-            return Object.fromEntries(roles.map((role, index) => [
-                role,
-                providers[index].providerIdHex,
-            ]));
+            return defaultProviderIdsForAdmissionRoutesV1(providers, routes);
         }
 
         function hasExactAdmissionSelection(leg) {
@@ -1903,8 +1922,10 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 providerIdHex: provider.providerIdHex,
                 label: provider.label,
                 source: matchingDirectoryEntry(provider) ? 'directory' : 'manual',
+                supportedWorkloads: provider.supportedWorkloads,
             }));
             Object.entries(admissionPanels).forEach(([kind, panel]) => {
+                panel.setSimpleMode(simpleAdmissionEnabled());
                 panel.setProviderOptions(choices);
                 if (simpleAdmissionEnabled()) {
                     panel.setDefaultProviderIds(defaultProviderIdsForKind(kind));
@@ -2581,6 +2602,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     controller = await prepareProductAdmission(kind);
                 } catch (error) {
                     await closeAdmissionAttempt(kind, 'Provider verification failed; inputs are editable again.');
+                    admissionPanels[kind].setPublicError(publicAdmissionError(error));
                     throw error;
                 }
                 if (simpleAdmissionEnabled()) {

--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -25,10 +25,26 @@ describe('bundled functional-beta trusted bootstrap', () => {
     expect(parsed.providers[1].serverPin.measurementHex).toBe(
       'cfae85d99232010a028b4dd820b0da67069c0685a1b8cb72520b0d884f678f3def19febe5cc18b0af3c976821791b897',
     );
+    expect(parsed.providers[0].supportedWorkloads).toEqual([
+      'dpf-query', 'harmony-hint', 'onion-session',
+    ]);
+    expect(parsed.providers[1].supportedWorkloads).toEqual([
+      'dpf-query', 'harmony-query', 'tee-oram-query',
+    ]);
     expect(() => assertIndependentProviderDialPairV1(
       parsed.providers[0],
       parsed.providers[1],
     )).not.toThrow();
     expect(parsed.providers.flatMap((provider) => provider.databaseProofPins)).not.toHaveLength(0);
+  });
+
+  it('rejects a provider without an explicit pre-connection workload allowlist', () => {
+    const replacement = structuredClone(bundledFunctionalBetaBootstrap) as {
+      providers: Array<Record<string, unknown>>;
+    };
+    delete replacement.providers[0].supportedWorkloads;
+    expect(() => parseProductTrustedBootstrapV1(JSON.stringify(replacement))).toThrow(
+      /must declare supported workloads/,
+    );
   });
 });

--- a/web/src/__tests__/product-provider-bootstrap.test.ts
+++ b/web/src/__tests__/product-provider-bootstrap.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   assertIndependentProviderDialPairV1,
+  defaultProviderIdsForAdmissionRoutesV1,
   expectedLightningPayeeForOfferV1,
   parseProductTrustedBootstrapV1,
   providerLightningPayeeTrustV1,
@@ -48,6 +49,7 @@ function bootstrapProvider() {
     stableServerId: 'pir0',
     serverPin: { binarySha256Hex: '24'.repeat(32) },
     hardwareAttestation: 'unavailable-accepted',
+    supportedWorkloads: ['dpf-query', 'harmony-hint'],
     databaseProofPins: [databaseProofPin],
     lightningPayeeTrust: [{
       issuerIdHex: ISSUER_ID,
@@ -126,6 +128,31 @@ describe('pre-dial provider independence', () => {
     const second = provider('02', 'wss://pir1.example');
     second[field] = first[field];
     expect(() => assertIndependentProviderDialPairV1(first, second)).toThrow(reason);
+  });
+});
+
+describe('explicit product role routing', () => {
+  it('routes Harmony hint/query and ORAM to their declared providers', () => {
+    const providers = [
+      { providerIdHex: '01', supportedWorkloads: ['dpf-query', 'harmony-hint', 'onion-session'] as const },
+      { providerIdHex: '02', supportedWorkloads: ['dpf-query', 'harmony-query', 'tee-oram-query'] as const },
+    ];
+    expect(defaultProviderIdsForAdmissionRoutesV1(providers, [
+      ['hint', 'harmony-hint'],
+      ['query', 'harmony-query'],
+    ])).toEqual({ hint: '01', query: '02' });
+    expect(defaultProviderIdsForAdmissionRoutesV1(providers, [
+      ['onion', 'onion-session'],
+    ])).toEqual({ onion: '01' });
+    expect(defaultProviderIdsForAdmissionRoutesV1(providers, [
+      ['oram', 'tee-oram-query'],
+    ])).toEqual({ oram: '02' });
+  });
+
+  it('fails closed when a fixed role has no declared provider', () => {
+    expect(defaultProviderIdsForAdmissionRoutesV1([
+      { providerIdHex: '01', supportedWorkloads: ['dpf-query'] },
+    ], [['query', 'harmony-query']])).toEqual({});
   });
 });
 

--- a/web/src/functional-beta-trusted-bootstrap.json
+++ b/web/src/functional-beta-trusted-bootstrap.json
@@ -13,6 +13,11 @@
         "binarySha256Hex": "d23b58410f52fede21d013fbcec279c42d02b69d4b32791265cfb38e331770d8"
       },
       "hardwareAttestation": "unavailable-accepted",
+      "supportedWorkloads": [
+        "dpf-query",
+        "harmony-hint",
+        "onion-session"
+      ],
       "lightningPayeeTrust": [
         {
           "issuerIdHex": "8799b9b02964688f7f5d35b1c502f1bfb4a344c8ca6bd3f7902814c558e1de86",
@@ -68,6 +73,11 @@
       },
       "hardwareAttestation": "required",
       "expectedArkFingerprintHex": "1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a",
+      "supportedWorkloads": [
+        "dpf-query",
+        "harmony-query",
+        "tee-oram-query"
+      ],
       "lightningPayeeTrust": [
         {
           "issuerIdHex": "8799b9b02964688f7f5d35b1c502f1bfb4a344c8ca6bd3f7902814c558e1de86",

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -395,6 +395,7 @@ export { renderSecurityBadgeTextRowsV1 } from './security-badge.js';
 export type { SecurityBadgeTextRowV1 } from './security-badge.js';
 export {
   assertIndependentProviderDialPairV1,
+  defaultProviderIdsForAdmissionRoutesV1,
   directoryBoundProviderTrustAnchorV1,
   manualProviderAdmissionTrustAnchorV1,
   parseProductTrustedBootstrapV1,
@@ -402,9 +403,12 @@ export {
   providerArkFingerprintV1,
   providerLightningPayeeTrustV1,
   providerOperatorKeyV1,
+  providerSupportsWorkloadV1,
 } from './product-provider-bootstrap.js';
 export type {
   ProductLightningPayeeTrustV1,
+  ProductAdmissionWorkloadV1,
+  ProductAdmissionRouteV1,
   ProductTrustedBootstrapV1,
   ProductTrustedProviderV1,
 } from './product-provider-bootstrap.js';

--- a/web/src/product-admission-ui.ts
+++ b/web/src/product-admission-ui.ts
@@ -11,17 +11,20 @@ import {
   type ProductRetainedCapabilitySelectorV1,
   type ProductRetainedRecoveryOptionV1,
 } from './product-admission-controller.js';
+import type { ProductAdmissionWorkloadV1 } from './product-provider-bootstrap.js';
 import type { RetainedServiceRedemptionViewV1 } from './sdk-bridge.js';
 
 export interface ProductProviderChoiceV1 {
   providerIdHex: string;
   label: string;
   source: 'directory' | 'manual';
+  supportedWorkloads: readonly ProductAdmissionWorkloadV1[];
 }
 
 export interface ProductAdmissionPanelRoleV1 {
   role: string;
   label: string;
+  workload: ProductAdmissionWorkloadV1;
 }
 
 export interface ProductAdmissionPanelOptionsV1 {
@@ -31,6 +34,8 @@ export interface ProductAdmissionPanelOptionsV1 {
   transportCompatibilityNotice?: string;
   /** Fresh fail-closed trust check before offer/payment/token/auth transitions. */
   beforeSecurityTransition?: () => void | Promise<void>;
+  /** Offer an explicit escape hatch only when simple mode needs review. */
+  onRequestAdvancedMode?: () => void;
   onStateChange?: (snapshot: ProductAdmissionSnapshotV1 | null) => void;
 }
 
@@ -91,9 +96,11 @@ export class ProductAdmissionPanelV1 {
   private automationNotice: string | null = null;
   private unavailableNotice = 'Query access is not configured; queries are blocked.';
   private busy = false;
+  private simpleMode = false;
 
   constructor(private readonly options: ProductAdmissionPanelOptionsV1) {
     options.root.replaceChildren();
+    options.root.dataset.admissionMode = 'advanced';
     const notice = document.createElement('p');
     notice.className = 'admission-notice';
     notice.dataset.admissionNotice = 'true';
@@ -158,16 +165,24 @@ export class ProductAdmissionPanelV1 {
   }
 
   setProviderOptions(options: ProductProviderChoiceV1[]): void {
-    for (const row of this.rows.values()) {
+    for (const role of this.options.roles) {
+      const row = this.rows.get(role.role);
+      if (!row) continue;
+      const matchingOptions = options.filter((provider) =>
+        provider.supportedWorkloads.includes(role.workload));
       const previous = row.provider.value;
       row.provider.replaceChildren(optionElement('', 'Select trusted provider…'));
-      for (const provider of options) {
+      for (const provider of matchingOptions) {
         const suffix = provider.source === 'directory' ? ' · verified directory' : ' · manual';
         row.provider.appendChild(optionElement(provider.providerIdHex, provider.label + suffix));
       }
-      if (options.some((candidate) => candidate.providerIdHex === previous)) {
+      if (matchingOptions.some((candidate) => candidate.providerIdHex === previous)) {
         row.provider.value = previous;
       }
+    }
+    if (this.simpleMode) {
+      this.renderSimpleAvailability(options.length > 0);
+      return;
     }
     this.renderUnavailable(
       options.length === 0
@@ -180,7 +195,10 @@ export class ProductAdmissionPanelV1 {
 
   /** Apply simple-mode defaults without overwriting an explicit selection. */
   setDefaultProviderIds(defaults: Record<string, string>): void {
-    if (Object.keys(defaults).length === 0) return;
+    if (Object.keys(defaults).length === 0) {
+      if (this.simpleMode) this.renderSimpleAvailability(false);
+      return;
+    }
     for (const [role, providerIdHex] of Object.entries(defaults)) {
       const row = this.rows.get(role);
       if (!row || row.provider.value || !providerIdHex) continue;
@@ -188,9 +206,26 @@ export class ProductAdmissionPanelV1 {
         row.provider.value = providerIdHex;
       }
     }
-    this.renderUnavailable(
-      'Simple mode will use the selected trusted provider defaults and signed Free access when available.',
-    );
+    if (this.simpleMode) {
+      this.renderSimpleAvailability(true);
+    } else {
+      this.renderUnavailable(
+        'Simple mode defaults are available only while Simple mode is enabled.',
+      );
+    }
+  }
+
+  setSimpleMode(enabled: boolean): void {
+    if (this.simpleMode === enabled) return;
+    this.simpleMode = enabled;
+    this.options.root.dataset.admissionMode = enabled ? 'simple' : 'advanced';
+    if (enabled && !this.publicError && !this.controller) {
+      this.automationNotice = 'Simple mode is ready. Click the query button; trusted roles, Free access, and strict verification run automatically.';
+    } else if (!enabled && this.automationNotice?.startsWith('Simple mode')) {
+      this.automationNotice = null;
+    }
+    this.render();
+    this.options.onStateChange?.(this.snapshot);
   }
 
   selectedProviderIds(): Record<string, string> {
@@ -250,9 +285,11 @@ export class ProductAdmissionPanelV1 {
     this.snapshot = snapshot;
     const notice = this.options.root.querySelector<HTMLElement>('[data-admission-notice]');
     if (notice) {
-      notice.textContent = this.publicError
+      const message = this.publicError
         ?? this.automationNotice
-        ?? (snapshot?.phase === 'ready-to-query'
+        ?? (this.simpleMode
+          ? 'Simple mode is ready. Click the query button; trusted roles, Free access, and strict verification run automatically.'
+          : snapshot?.phase === 'ready-to-query'
           ? 'All exact provider roles are authorized. The next action sends one query to every required provider role.'
           : snapshot?.phase === 'querying'
             ? 'One authorized PIR query is in flight; it will not be retried automatically.'
@@ -268,6 +305,12 @@ export class ProductAdmissionPanelV1 {
                 : this.options.roles.length > 1
                   ? 'Verify and authorize the first independent provider.'
                   : 'Verify and authorize the provider.');
+      notice.replaceChildren(document.createTextNode(message));
+      if (this.simpleMode && this.publicError && this.options.onRequestAdvancedMode) {
+        notice.appendChild(actionButton('Open advanced setup', () => {
+          this.options.onRequestAdvancedMode?.();
+        }));
+      }
       notice.classList.toggle('error', this.publicError !== null || snapshot?.phase === 'failed');
     }
     if (!snapshot) return;
@@ -520,6 +563,10 @@ export class ProductAdmissionPanelV1 {
 
   private renderUnavailable(message: string): void {
     this.unavailableNotice = message;
+    if (this.simpleMode) {
+      this.renderSimpleAvailability(this.hasCompleteSimpleRouting());
+      return;
+    }
     const notice = this.options.root.querySelector<HTMLElement>('[data-admission-notice]');
     if (notice) {
       notice.textContent = message;
@@ -539,6 +586,19 @@ export class ProductAdmissionPanelV1 {
       row.status.textContent = 'Query access: blocked';
       row.actions.replaceChildren();
     }
+  }
+
+  private renderSimpleAvailability(hasTrustedBootstrap: boolean): void {
+    if (!hasTrustedBootstrap) {
+      this.automationNotice = 'Simple mode is waiting for the trusted server routing table; no provider role is shown until it is complete.';
+    } else if (!this.publicError && !this.controller) {
+      this.automationNotice = 'Simple mode is ready. Click the query button; trusted roles, Free access, and strict verification run automatically.';
+    }
+    this.render();
+  }
+
+  private hasCompleteSimpleRouting(): boolean {
+    return Array.from(this.rows.values()).every((row) => row.provider.options.length > 1);
   }
 }
 

--- a/web/src/product-provider-bootstrap.ts
+++ b/web/src/product-provider-bootstrap.ts
@@ -11,6 +11,20 @@ import type { ServiceOfferViewV1 } from './sdk-bridge.js';
 
 const MAX_LIGHTNING_PAYEE_TRUST_ENTRIES_V1 = 64;
 
+/**
+ * Workloads that can be routed to one provider role before a connection is
+ * opened. This is an operator-published routing allowlist, not a capability
+ * grant: the live signed service policy remains the final authority.
+ */
+export type ProductAdmissionWorkloadV1 =
+  | 'dpf-query'
+  | 'harmony-hint'
+  | 'harmony-query'
+  | 'onion-session'
+  | 'tee-oram-query';
+
+export type ProductAdmissionRouteV1 = readonly [role: string, workload: ProductAdmissionWorkloadV1];
+
 export interface ProductLightningPayeeTrustV1 {
   /** Exact issuer identity committed by the signed service offer. */
   issuerIdHex: string;
@@ -33,6 +47,8 @@ export interface ProductTrustedProviderV1 {
   /** Explicitly records why a missing hardware measurement is accepted. */
   hardwareAttestation: 'required' | 'unavailable-accepted';
   expectedArkFingerprintHex?: string;
+  /** Explicit pre-connection workload routing; absence is rejected. */
+  supportedWorkloads: readonly ProductAdmissionWorkloadV1[];
   databaseProofPins: DatabaseProofPin[];
   /** Independent exact-offer payment trust; the Nostr directory does not supply this. */
   lightningPayeeTrust: ProductLightningPayeeTrustV1[];
@@ -173,6 +189,34 @@ export function providerArkFingerprintV1(
     : null;
 }
 
+export function providerSupportsWorkloadV1(
+  provider: Pick<ProductTrustedProviderV1, 'supportedWorkloads'>,
+  workload: ProductAdmissionWorkloadV1,
+): boolean {
+  return provider.supportedWorkloads.includes(workload);
+}
+
+/**
+ * Pick deterministic defaults only from the explicitly declared workload
+ * routes. A provider cannot fill two independent roles in one pair.
+ */
+export function defaultProviderIdsForAdmissionRoutesV1(
+  providers: readonly Pick<ProductTrustedProviderV1, 'providerIdHex' | 'supportedWorkloads'>[],
+  routes: readonly ProductAdmissionRouteV1[],
+): Record<string, string> {
+  const selected = new Set<string>();
+  const defaults: Record<string, string> = {};
+  for (const [role, workload] of routes) {
+    const provider = providers.find((candidate) =>
+      !selected.has(candidate.providerIdHex)
+      && providerSupportsWorkloadV1(candidate, workload));
+    if (!provider) return {};
+    selected.add(provider.providerIdHex);
+    defaults[role] = provider.providerIdHex;
+  }
+  return defaults;
+}
+
 function parseProvider(value: unknown, index: number): ProductTrustedProviderV1 {
   if (!isRecord(value)) throw new Error(`provider ${index} must be an object`);
   const label = boundedText(`provider ${index} label`, value.label, 1, 80);
@@ -213,6 +257,18 @@ function parseProvider(value: unknown, index: number): ProductTrustedProviderV1 
   if (value.hardwareAttestation === 'required' && !expectedArkFingerprintHex) {
     throw new Error(`provider ${index} requires an independently pinned ARK fingerprint`);
   }
+  if (!Array.isArray(value.supportedWorkloads)
+      || value.supportedWorkloads.length === 0
+      || value.supportedWorkloads.length > 8) {
+    throw new Error(`provider ${index} must declare supported workloads`);
+  }
+  const supportedWorkloads = value.supportedWorkloads.map((workload, workloadIndex) => {
+    if (!isProductAdmissionWorkload(workload)) {
+      throw new Error(`provider ${index} workload ${workloadIndex} is invalid`);
+    }
+    return workload;
+  });
+  requireUnique(supportedWorkloads, `provider ${index} supported workload`);
   if (!Array.isArray(value.databaseProofPins) || value.databaseProofPins.length === 0) {
     throw new Error(`provider ${index} requires database proof pins`);
   }
@@ -248,6 +304,7 @@ function parseProvider(value: unknown, index: number): ProductTrustedProviderV1 
     serverPin: { binarySha256Hex, measurementHex, description: label },
     hardwareAttestation: value.hardwareAttestation,
     expectedArkFingerprintHex,
+    supportedWorkloads,
     databaseProofPins,
     lightningPayeeTrust,
   };
@@ -377,6 +434,14 @@ function requireUnique(values: string[], label: string): void {
 
 function isNetwork(value: unknown): value is LightningNetworkNameV1 {
   return value === 'bitcoin' || value === 'testnet' || value === 'signet' || value === 'regtest';
+}
+
+function isProductAdmissionWorkload(value: unknown): value is ProductAdmissionWorkloadV1 {
+  return value === 'dpf-query'
+    || value === 'harmony-hint'
+    || value === 'harmony-query'
+    || value === 'onion-session'
+    || value === 'tee-oram-query';
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

- Make Simple mode a one-click path: trusted provider roles, signed Free access, strict verification, and authorization run automatically after Query.
- Hide provider, offer, payment, and shared-issuer controls in Simple mode; expose an Advanced setup action only when an error needs review.
- Add explicit workload routing to the trusted bootstrap so the UI cannot offer unsupported product roles.

## Fixed deployment routing

- DPF: both trusted servers may serve the DPF query workload, while the independent pair still requires distinct providers.
- HarmonyPIR: Hetzner is Hint provider; VPSBG is Query provider. The roles are no longer interchangeable in the UI.
- OnionPIR: Hetzner only.
- TEE-ORAM: VPSBG only; the non-TEE Hetzner path is not offered.

The live signed service policy and the server's local workload validation remain the final authority after connection. The existing `REQ_ANNOUNCE` identity bundle does not currently carry product-role declarations, so this change does not pretend that it does: the pre-connection route map is explicit and fail-closed, while exact signed backend/workload scopes still gate use.

## Validation

- `npm test -- --run` — 513 passed, 2 existing skipped
- `npm run build`
- `npm run build-web` — production CSP verification passed
- Local browser check confirmed Simple mode hides manual admission controls and Advanced Harmony shows only the fixed Hint/Query providers.
