### PR TITLE
Simplify CI and default to browserless checks

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,8 +1,9 @@
 name: Deploy Web Client to GitHub Pages
 
 on:
-  push:
-    branches: [ main ]
+  # A main push cannot publish: the deploy job requires the explicit confirmed
+  # dispatch below. Keep validation in its dedicated CI workflows and avoid a
+  # second full build/Playwright run that would always end with deploy skipped.
   workflow_dispatch:
     inputs:
       confirm_production_deploy:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,29 @@
+# Testing entry points
+
+Use the repository-owned payment check as the default local and agent entry:
+
+```sh
+scripts/payment-v1-local-check.sh
+```
+
+It is the `--quick` profile: locked/offline, no browser, no external network,
+and no privileged environment. It is the only profile agents should run by
+default.
+
+```text
+--quick    Default focused deterministic checks; no browser.
+--pr       Quick plus deterministic offline Rust, process, WASM, Web typecheck,
+           Web unit tests, and production bundle; no Playwright/Chromium.
+--browser  Explicit opt-in: --pr plus local headless Chromium payment checks.
+--full     Explicit compatibility alias for --browser.
+```
+
+Run `--browser` or `--full` only when browser coverage is explicitly requested.
+AI manual browser inspection also requires an explicit user request. Automatic
+headless browser checks belong only to an explicit browser profile, nightly, or
+release validation.
+
+Historical acceptance records in `docs/payment/LOCAL_ACCEPTANCE.md` and related
+rollout documents record prior evidence; they are not current operating entry
+points. Production deployment, public-server canaries, and real-fund flows are
+separate approved operations.

--- a/docs/payment/LOCAL_ACCEPTANCE.md
+++ b/docs/payment/LOCAL_ACCEPTANCE.md
@@ -40,18 +40,20 @@ local acceptance into deployment approval.
 
 - run from the repository root;
 - use the repository-pinned Rust toolchain and lockfile;
-- have the `wasm32-unknown-unknown` target installed for full mode;
+- have the `wasm32-unknown-unknown` target installed for `--pr` and browser
+  profiles;
 - have `wasm-pack 0.14.0` (the CI-pinned version) and its compatible
-  `wasm-bindgen` tools preinstalled; full mode regenerates the ignored WASM
+  `wasm-bindgen` tools preinstalled; `--pr` and browser profiles regenerate the
+  ignored WASM
   package with Cargo locked and offline before TypeScript. The local script
   checks `wasm-pack` directly and fails closed if `wasm-bindgen` is absent or
   incompatible; it does not install or silently replace either tool;
 - have `web/node_modules` populated by `npm ci` from the pinned lockfile before
-  full mode; the static Pages guard loads its exact YAML parser from that
+  `--pr` or a browser profile; the static Pages guard loads its exact YAML parser from that
   dependency boundary, while the same install supplies the remaining Web and
   Playwright dependencies. Quick mode exits before this guard and does not need
   `node_modules`;
-- have the Playwright-pinned Chromium runtime installed before full mode
+- have the Playwright-pinned Chromium runtime installed before a browser profile
   (`cd web && npx playwright install chromium` installs it separately; the
   acceptance script never downloads a browser);
 - do not set production Lightning, mint, relay or server credentials in the
@@ -59,24 +61,30 @@ local acceptance into deployment approval.
 
 The acceptance script forces Cargo offline and does not edit source. Quick mode
 starts no persistent service process, although focused unit tests briefly bind
-loopback TCP or Unix-domain listeners. Full mode starts temporary
+loopback TCP or Unix-domain listeners. The `--pr` profile starts temporary
 `unified_server` children, a fake `payment-issuer` and Vite test servers whose
-listeners are explicitly bound to `127.0.0.1`; the process and Playwright
-runners kill and wait for every child before returning.
+listeners are explicitly bound to `127.0.0.1`; only browser profiles start
+Playwright/Chromium. The runners kill and wait for every child before returning.
 
 ## One-command checks
 
-Focused check:
+Default focused check (the agent default; no browser):
 
 ```sh
-scripts/payment-v1-local-check.sh --quick
+scripts/payment-v1-local-check.sh
 ```
 
-Full local check:
+Deterministic PR-equivalent check (Rust/process/WASM plus Web typecheck, unit
+tests and bundle; still no Playwright/Chromium):
 
 ```sh
-scripts/payment-v1-local-check.sh --full
+scripts/payment-v1-local-check.sh --pr
 ```
+
+The explicit browser profile remains `scripts/payment-v1-local-check.sh --browser`;
+`--full` is its compatibility alias. Use either only when browser coverage is
+explicitly required. Historical `--full` commands later in this document record
+past acceptance evidence, not the current default operating command.
 
 Optional real-CDK browser import, real-provider query, and native custody
 interoperability (outside the default offline suite) requires exact

--- a/scripts/payment-v1-local-check.sh
+++ b/scripts/payment-v1-local-check.sh
@@ -4,40 +4,53 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/payment-v1-local-check.sh [--quick|--full]
+Usage: scripts/payment-v1-local-check.sh [--quick|--pr|--browser|--full]
 
 Runs BitcoinPIR payment-v1 checks without contacting payment infrastructure or
-using real funds. Cargo is forced offline; full mode requires a preinstalled
-`wasm-pack`/`wasm-bindgen` toolchain and refuses to bootstrap it from the
-network.
+using real funds. Cargo is forced offline; `--pr` and browser profiles require
+a preinstalled `wasm-pack`/`wasm-bindgen` toolchain and refuse to bootstrap it
+from the network.
 
-  --quick  Five-method × five-workload matrix plus focused persistence,
+  --quick  Default. Five-method × five-workload matrix plus focused persistence,
            directory-relay, deployment-template and fake-Lightning checks.
            It starts no service process; unit tests may briefly bind loopback
            TCP or Unix-domain listeners.
-  --full   The default offline payment-platform Rust suite, operator tooling,
-           loopback-only unified-server process E2E (including strict-TLS
-           Standard Cashu and authenticated direct TEE-ORAM), WASM checks,
-           web typecheck/tests/bundle, a local
-           Chromium multi-tab vault test, a real-WASM/loopback no-funds issuer
-           acquisition test, and a browser -> two independent issuers -> two
-           real provider-gate test. This is the default.
+  --pr     Quick checks plus the deterministic offline payment-platform Rust
+           suite, operator tooling, loopback-only process E2E, WASM validation,
+           generated binding boundary, Web typecheck, Web unit tests, and Web
+           bundle. It does not install or run Playwright/Chromium.
+  --browser
+           Explicit opt-in: run the --pr profile, then local Chromium payment
+           boundaries. Requires preinstalled web dependencies and Chromium.
+  --full   Compatibility alias for --browser. It is explicit opt-in and never
+           the default.
 
-Full mode starts only temporary directory-relay, unified-server,
-rollback-authority, test-only TLS/NUT-03 mint, Vite and fake issuer listeners
-explicitly bound to 127.0.0.1; the tests kill and wait for every child. Neither
-mode contacts an external Lightning node or Cashu mint, publishes to a public
-Nostr relay, deploys a server, uses real funds, or modifies source files. Quick
-mode starts no persistent service process. Cargo, the JavaScript package
-manager, and tests may update their normal local build caches (for example
-target/ and web/node_modules cache metadata).
+The browser profiles add only local Chromium multi-tab vault, real-WASM loopback
+no-funds issuer, and two-provider payment E2E tests on top of `--pr`.
+
+The `--pr` profile is the normal deterministic CI-equivalent local entry. It
+includes the offline payment-platform Rust suite, operator tooling, loopback-only
+unified-server process E2E (including strict-TLS Standard Cashu and authenticated
+direct TEE-ORAM), WASM checks, and Web typecheck/tests/bundle; it contains no
+browser E2E.
+
+The `--pr` profile starts only temporary directory-relay, unified-server,
+rollback-authority, test-only TLS/NUT-03 mint and fake issuer listeners explicitly
+bound to 127.0.0.1. Browser profiles additionally start Vite and Playwright;
+the tests kill and wait for every child. No profile contacts an external Lightning
+node or Cashu mint, publishes to a public Nostr relay, deploys a server, uses real
+funds, or modifies source files. Quick mode starts no persistent service process.
+Cargo, the JavaScript package manager, and tests may update their normal local
+build caches (for example target/ and web/node_modules cache metadata).
 EOF
 }
 
-mode="full"
+mode="quick"
 case "${1:-}" in
   "") ;;
   --quick) mode="quick" ;;
+  --pr) mode="pr" ;;
+  --browser) mode="browser" ;;
   --full) mode="full" ;;
   -h|--help) usage; exit 0 ;;
   *) usage >&2; exit 2 ;;
@@ -51,10 +64,11 @@ if [[ ! -f Cargo.toml || ! -f docs/payment/IMPLEMENTATION_STATUS.md ]]; then
   exit 1
 fi
 
-echo "[1/5] canonical five-method x five-workload admission matrix"
+run_quick_checks() {
+echo "[quick] canonical five-method x five-workload admission matrix"
 cargo test --locked --offline -p pir-runtime-core --test service_admission_matrix
 
-echo "[2/5] real provider-store receipt/BAT adapters and durable replay boundary"
+echo "[quick] real provider-store receipt/BAT adapters and durable replay boundary"
 cargo test --locked --offline -p pir-strict-https
 cargo test --locked --offline -p pir-private-files
 cargo test --locked --offline -p pir-rollback-authority-protocol
@@ -66,13 +80,13 @@ cargo test --locked --offline -p pir-payment-crypto --features provider-store \
 cargo test --locked --offline -p pir-runtime-core --test service_admission_matrix \
   direct_receipt_production_committer_spend_survives_store_restart
 
-echo "[3/5] Free, standard Cashu, and experimental ARC persistence/concurrency"
+echo "[quick] Free, standard Cashu, and experimental ARC persistence/concurrency"
 cargo test --locked --offline -p pir-service-store free_ip_rate_limit
 cargo test --locked --offline -p pir-cashu-client
 cargo test --locked --offline -p pir-cashu-custody
 cargo test --locked --offline -p pir-arc-adapter --features provider-store
 
-echo "[4/5] fake-Lightning, quote/claim lifecycle, and native/WASM client boundaries"
+echo "[quick] fake-Lightning, quote/claim lifecycle, and native/WASM client boundaries"
 cargo test --locked --offline -p bitcoinpir-directory-relay
 cargo test --locked --offline -p bitcoinpir-cln-rpc-guard
 cargo test --locked --offline -p pir-lightning-backend
@@ -128,13 +142,10 @@ node --test --test-concurrency=1 \
   scripts/payment-v1-rendered-artifact-gate.test.mjs
 node --test --test-concurrency=1 \
   scripts/payment-v1-linux-runtime-evidence.test.mjs
+}
 
-if [[ "$mode" == "quick" ]]; then
-  echo "[5/5] quick mode complete (no external network, no funds)"
-  exit 0
-fi
-
-echo "[5/9] full offline platform, operator tooling, and server wiring"
+run_pr_checks() {
+echo "[pr] deterministic offline platform, operator tooling, and server wiring"
 cargo test --locked --offline \
   -p pir-channel \
   -p pir-strict-https \
@@ -291,7 +302,7 @@ cargo clippy --locked --offline -p payment-issuer \
   -- -D warnings
 cargo check --locked --offline -p runtime --bin unified_server
 
-echo "[6/9] Standard Cashu, complete method/backend matrix, and shared-issuer TLS boundaries"
+echo "[pr] Standard Cashu, complete method/backend matrix, and shared-issuer TLS boundaries"
 cargo test --locked --offline -p runtime \
   --features standard-cashu-process-e2e \
   --test payment_v1_standard_cashu_process_e2e \
@@ -444,7 +455,7 @@ node --test --test-concurrency=1 \
 node --test --test-concurrency=1 \
   scripts/payment-v1-linux-runtime-evidence.test.mjs
 
-echo "[7/9] warnings denied in dedicated Payment V1 crates and tools"
+echo "[pr] warnings denied in dedicated Payment V1 crates and tools"
 cargo clippy --locked --offline --all-targets --no-deps \
   -p pir-strict-https \
   -p pir-private-files \
@@ -491,23 +502,48 @@ cargo clippy --locked --offline -p runtime \
   --no-deps \
   -- -D warnings
 
-echo "[8/9] WASM target and generated binding boundary"
+echo "[pr] WASM target and generated binding boundary"
 cargo check --locked --offline --target wasm32-unknown-unknown -p pir-sdk-wasm
 if ! command -v wasm-pack >/dev/null 2>&1; then
-  echo "payment-v1-local-check: wasm-pack is required in full mode" >&2
+  echo "payment-v1-local-check: wasm-pack is required in the --pr and browser profiles" >&2
   exit 1
 fi
 CARGO_NET_OFFLINE=true wasm-pack build crates/sdk/wasm \
   --target web --out-dir pkg --mode no-install --no-opt \
   -- --locked --offline
+}
 
-echo "[9/9] web typecheck, unit tests, bundle, and local Chromium payment boundaries"
+run_web_checks() {
+echo "[web] typecheck, unit tests, and production bundle"
 (cd web \
   && npm run build \
   && npm test \
-  && npm run build-web \
+  && npm run build-web)
+}
+
+run_browser_checks() {
+echo "[browser] local Chromium payment boundaries"
+(cd web \
   && npm run test:e2e:payment-vault \
   && npm run test:e2e:payment-real-issuer \
   && npm run test:e2e:payment-two-provider)
+}
 
-echo "payment-v1-local-check: full mode complete (no external network, no funds)"
+run_quick_checks
+
+case "$mode" in
+  quick)
+    echo "payment-v1-local-check: quick profile complete (no external network, no funds, no browser)"
+    ;;
+  pr)
+    run_pr_checks
+    run_web_checks
+    echo "payment-v1-local-check: pr profile complete (no external network, no funds, no browser)"
+    ;;
+  browser|full)
+    run_pr_checks
+    run_web_checks
+    run_browser_checks
+    echo "payment-v1-local-check: $mode profile complete (no external network, no funds)"
+    ;;
+esac

--- a/scripts/payment-v1-pages-deploy-gate.mjs
+++ b/scripts/payment-v1-pages-deploy-gate.mjs
@@ -296,21 +296,9 @@ function verifyDeployWorkflow(workflowPath) {
 
   const triggers = requireExactKeys(
     workflow.on,
-    ['push', 'workflow_dispatch'],
+    ['workflow_dispatch'],
     'workflow triggers',
   );
-  const pushTrigger = requireExactKeys(
-    triggers.push,
-    ['branches'],
-    'push trigger',
-  );
-  if (
-    !Array.isArray(pushTrigger.branches) ||
-    pushTrigger.branches.length !== 1 ||
-    pushTrigger.branches[0] !== 'main'
-  ) {
-    fail('push trigger must contain exactly the main branch');
-  }
   const workflowDispatch = requireExactKeys(
     triggers.workflow_dispatch,
     ['inputs'],


### PR DESCRIPTION
## Summary

- make the local Payment V1 check default to a focused browserless profile
- add explicit `--pr`, `--browser`, and compatibility `--full` profiles
- stop running the full Pages build on every `main` push when deployment is manual-only
- document the short, repository-owned testing entry points and explicit browser opt-in policy
- update the Pages workflow policy gate for the manual-only trigger

## Why

The previous no-argument local check launched the full Chromium boundary suite, which made routine agent verification expensive and context-heavy. The Pages workflow also rebuilt and reran Playwright on every `main` push even though its deploy job could only run from a confirmed manual dispatch.

This change makes deterministic browserless checks the normal path while retaining explicit browser coverage and the existing production confirmation gate. The Playwright checks inside the manual deployment workflow remain in place until required-check equivalence and external branch-protection settings are verified.

## Validation

- `bash -n scripts/payment-v1-local-check.sh`
- `scripts/payment-v1-local-check.sh --help`
- `node scripts/payment-v1-pages-deploy-gate.mjs`
- `node --test scripts/github-workflow-supply-chain-gate.test.mjs` — 28/28 passed
- `node scripts/github-workflow-supply-chain-gate.mjs`
- `git diff --check`

No browser, production, public-network, push-triggered deployment, or real-fund test was run locally.
