### PR TITLE
Accelerate Payment CI compilation

### DIFF
--- a/.github/workflows/payment-platform.yml
+++ b/.github/workflows/payment-platform.yml
@@ -125,6 +125,13 @@ jobs:
     timeout-minutes: 120
     env:
       CARGO_TERM_COLOR: always
+      # CI-only compile override: keep optimized test code, but make independent
+      # cargo invocations reusable through sccache. Incremental object paths are
+      # intentionally disabled for this job; Cargo's release profile is unchanged.
+      CARGO_PROFILE_TEST_LTO: "off"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -132,9 +139,13 @@ jobs:
           persist-credentials: false
       - name: Install pinned Rust toolchain
         run: rustup toolchain install --profile minimal
+      # Official action v0.0.11. Its post step persists the compiler cache via
+      # the GitHub Actions cache backend; do not cache the workspace target dir.
+      - name: Install sccache compiler cache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Test payment platform offline
         run: >-
-          cargo test --locked --offline
+          cargo test --timings --locked --offline
           -p pir-channel
           -p pir-strict-https
           -p pir-private-files
@@ -192,7 +203,7 @@ jobs:
           --features provider-store
       - name: Deny warnings across dedicated Payment V1 crates and issuer
         run: >-
-          cargo clippy --locked --offline --all-targets --no-deps
+          cargo clippy --timings --locked --offline --all-targets --no-deps
           -p pir-strict-https
           -p pir-private-files
           -p pir-rollback-authority-protocol
@@ -297,12 +308,12 @@ jobs:
       - name: Exercise real provider to shared issuer clearing over pinned WebPKI TLS
         run: |
           issuer_e2e_target_dir="$PWD/target/payment-issuer-shared-e2e"
-          cargo build --locked --offline \
+          cargo build --timings --locked --offline \
             -p payment-issuer \
             --features test-only-fake-lightning \
             --bin payment-issuer \
             --target-dir "$issuer_e2e_target_dir"
-          cargo build --locked --offline \
+          cargo build --timings --locked --offline \
             -p bpir-admin \
             --bin bpir-admin \
             --target-dir "$issuer_e2e_target_dir"
@@ -414,6 +425,25 @@ jobs:
           grep -F 'playwright.payment-cln-joined.config.ts' web/package.json >/dev/null
           grep -F "BITCOINPIR_PAYMENT_TWO_PROVIDER_BACKEND = 'fake'" web/playwright.payment-two-provider.config.ts >/dev/null
           grep -F "BITCOINPIR_PAYMENT_TWO_PROVIDER_BACKEND = 'cln-regtest'" web/playwright.payment-cln-joined.config.ts >/dev/null
+      - name: Report sccache compiler-cache statistics
+        if: always()
+        shell: bash
+        run: |
+          if [[ -n "${SCCACHE_PATH:-}" ]]; then
+            "$SCCACHE_PATH" --show-stats
+          else
+            echo "sccache was unavailable before stats collection" >&2
+          fi
+      - name: Upload Cargo compile timing reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: protocol-and-persistence-cargo-timings-${{ github.run_id }}
+          path: |
+            target/cargo-timings
+            target/payment-issuer-shared-e2e/cargo-timings
+          if-no-files-found: ignore
+          retention-days: 7
 
   wasm-boundary:
     name: Browser payment and directory boundary

--- a/scripts/github-workflow-supply-chain-gate.mjs
+++ b/scripts/github-workflow-supply-chain-gate.mjs
@@ -20,6 +20,7 @@ export const APPROVED_ACTION_COMMITS = Object.freeze({
   "actions/setup-node": "820762786026740c76f36085b0efc47a31fe5020",
   "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
   "actions/upload-pages-artifact": "fc324d3547104276b827a68afc52ff2a11cc49c9",
+  "mozilla-actions/sccache-action": "fc920bf0ec8de6ee65d409111f7ec508035751ba",
 });
 
 export const SUPPLY_CHAIN_GATE_PUSH_PATHS = Object.freeze([
@@ -211,6 +212,77 @@ export function validateWorkflowSource(source, label = "workflow") {
   return counters;
 }
 
+function requireWorkflowStep(steps, predicate, label) {
+  const step = steps.find((candidate) => isRecord(candidate) && predicate(candidate));
+  if (step === undefined) fail(label);
+  return step;
+}
+
+export function validatePaymentPlatformCompileAcceleration(
+  source,
+  label = "payment platform workflow",
+) {
+  const workflow = parseWorkflowSource(source, label);
+  if (!isRecord(workflow.jobs) || !isRecord(workflow.jobs["protocol-and-persistence"])) {
+    fail(`${label} must define the protocol-and-persistence job`);
+  }
+  const job = workflow.jobs["protocol-and-persistence"];
+  if (!isRecord(job.env)) fail(`${label} protocol job must define compiler-cache env`);
+  const expectedEnv = {
+    CARGO_PROFILE_TEST_LTO: "off",
+    CARGO_INCREMENTAL: "0",
+    SCCACHE_GHA_ENABLED: "true",
+    RUSTC_WRAPPER: "sccache",
+  };
+  for (const [key, value] of Object.entries(expectedEnv)) {
+    if (job.env[key] !== value) fail(`${label} protocol job must set ${key}=${value}`);
+  }
+  if (!Array.isArray(job.steps)) fail(`${label} protocol job steps must be a list`);
+
+  const steps = job.steps;
+  const sccacheAction = `mozilla-actions/sccache-action@${APPROVED_ACTION_COMMITS["mozilla-actions/sccache-action"]}`;
+  requireWorkflowStep(
+    steps,
+    (step) => step.uses === sccacheAction,
+    `${label} protocol job must install the reviewed sccache action`,
+  );
+  if (steps.some((step) => typeof step.uses === "string" && step.uses.startsWith("actions/cache@"))) {
+    fail(`${label} protocol job must not cache the workspace target directory`);
+  }
+
+  const cargoRuns = steps
+    .filter((step) => typeof step.run === "string")
+    .map((step) => step.run)
+    .join("\n");
+  for (const command of ["cargo test --timings", "cargo clippy --timings", "cargo build --timings"]) {
+    if (!cargoRuns.includes(command)) {
+      fail(`${label} protocol job must collect timings from a representative ${command}`);
+    }
+  }
+  const stats = requireWorkflowStep(
+    steps,
+    (step) => step.if === "always()" && typeof step.run === "string" &&
+      step.run.includes("SCCACHE_PATH") && step.run.includes("--show-stats"),
+    `${label} protocol job must report sccache stats in an always step`,
+  );
+  if (stats.shell !== "bash") fail(`${label} sccache stats step must use bash`);
+  const timingArtifact = requireWorkflowStep(
+    steps,
+    (step) => step.if === "always()" &&
+      step.uses === `actions/upload-artifact@${APPROVED_ACTION_COMMITS["actions/upload-artifact"]}` &&
+      isRecord(step.with) && typeof step.with.path === "string",
+    `${label} protocol job must upload only Cargo timing reports`,
+  );
+  requireExactStringList(
+    timingArtifact.with.path.trimEnd().split("\n").map((path) => path.trim()),
+    ["target/cargo-timings", "target/payment-issuer-shared-e2e/cargo-timings"],
+    `${label} Cargo timing artifact paths`,
+  );
+  if (timingArtifact.with["if-no-files-found"] !== "ignore" || timingArtifact.with["retention-days"] !== 7) {
+    fail(`${label} Cargo timing artifact must be optional with seven-day retention`);
+  }
+}
+
 export function validateWorkflowDirectory(directoryInput) {
   const directory = requireCanonicalDirectory(directoryInput, "workflow directory");
   const entries = readdirSync(directory, { withFileTypes: true })
@@ -243,6 +315,9 @@ export function validateWorkflowDirectory(directoryInput) {
     const result = validateWorkflowSource(source, `workflow ${entry.name}`);
     if (entry.name === "workflow-supply-chain.yml") {
       validateSupplyChainGateTriggers(source, `workflow ${entry.name}`);
+    }
+    if (entry.name === "payment-platform.yml") {
+      validatePaymentPlatformCompileAcceleration(source, `workflow ${entry.name}`);
     }
     actionUses += result.actionUses;
     checkouts += result.checkouts;

--- a/scripts/github-workflow-supply-chain-gate.test.mjs
+++ b/scripts/github-workflow-supply-chain-gate.test.mjs
@@ -3,6 +3,7 @@ import {
   linkSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -16,6 +17,7 @@ import {
   APPROVED_ACTION_COMMITS,
   SUPPLY_CHAIN_GATE_PUSH_PATHS,
   validateNpmParserLockBoundary,
+  validatePaymentPlatformCompileAcceleration,
   validateSupplyChainGateTriggers,
   validateWorkflowDirectory,
   validateWorkflowSource,
@@ -23,6 +25,7 @@ import {
 
 const checkout = APPROVED_ACTION_COMMITS["actions/checkout"];
 const setupNode = APPROVED_ACTION_COMMITS["actions/setup-node"];
+const sccacheAction = APPROVED_ACTION_COMMITS["mozilla-actions/sccache-action"];
 
 function workflow(stepSource = `
       - name: Checkout
@@ -55,12 +58,99 @@ test("accepts exact allowlisted commits and non-persisting checkout credentials"
   assert.deepEqual(result, { actionUses: 2, checkouts: 1 });
 });
 
+test("accepts the reviewed exact sccache action pin", () => {
+  const result = validateWorkflowSource(workflow(`
+      - uses: actions/checkout@${checkout}
+        with:
+          persist-credentials: false
+      - uses: mozilla-actions/sccache-action@${sccacheAction}
+`));
+  assert.deepEqual(result, { actionUses: 2, checkouts: 1 });
+});
+
+const paymentPlatformWorkflow = readFileSync(
+  new URL("../.github/workflows/payment-platform.yml", import.meta.url),
+  "utf8",
+);
+
+test("accepts the reviewed payment-platform compile acceleration boundary", () => {
+  assert.doesNotThrow(() => validatePaymentPlatformCompileAcceleration(paymentPlatformWorkflow));
+});
+
+for (const [label, source, pattern] of [
+  [
+    "payment platform test LTO regression",
+    paymentPlatformWorkflow.replace('CARGO_PROFILE_TEST_LTO: "off"', 'CARGO_PROFILE_TEST_LTO: "thin"'),
+    /CARGO_PROFILE_TEST_LTO=off/u,
+  ],
+  [
+    "payment platform incremental regression",
+    paymentPlatformWorkflow.replace('CARGO_INCREMENTAL: "0"', 'CARGO_INCREMENTAL: "1"'),
+    /CARGO_INCREMENTAL=0/u,
+  ],
+  [
+    "payment platform sccache env regression",
+    paymentPlatformWorkflow.replace('SCCACHE_GHA_ENABLED: "true"', 'SCCACHE_GHA_ENABLED: "false"'),
+    /SCCACHE_GHA_ENABLED=true/u,
+  ],
+  [
+    "payment platform mutable sccache action",
+    paymentPlatformWorkflow.replace(
+      `mozilla-actions/sccache-action@${sccacheAction}`,
+      "mozilla-actions/sccache-action@v0.0.11",
+    ),
+    /reviewed sccache action/u,
+  ],
+  [
+    "payment platform target cache regression",
+    paymentPlatformWorkflow.replace(
+      "- name: Test payment platform offline",
+      `- name: Forbidden target cache\n        uses: actions/cache@${APPROVED_ACTION_COMMITS["actions/cache"]}\n      - name: Test payment platform offline`,
+    ),
+    /must not cache the workspace target directory/u,
+  ],
+  [
+    "payment platform timings artifact retention regression",
+    paymentPlatformWorkflow.replace("retention-days: 7", "retention-days: 14"),
+    /seven-day retention/u,
+  ],
+  [
+    "payment platform custom timing path missing",
+    paymentPlatformWorkflow.replace("\n            target/payment-issuer-shared-e2e/cargo-timings", ""),
+    /Cargo timing artifact paths/u,
+  ],
+  [
+    "payment platform broad timing path",
+    paymentPlatformWorkflow.replace(
+      "target/payment-issuer-shared-e2e/cargo-timings",
+      "target/**/cargo-timings",
+    ),
+    /Cargo timing artifact paths/u,
+  ],
+]) {
+  test(`rejects ${label}`, () => {
+    assert.throws(() => validatePaymentPlatformCompileAcceleration(source), pattern);
+  });
+}
+
 for (const [label, source, pattern] of [
   ["mutable tag", workflow(`
       - uses: actions/checkout@v7.0.1
         with:
           persist-credentials: false
 `), /lowercase 40-hex/u],
+  ["mutable sccache tag", workflow(`
+      - uses: actions/checkout@${checkout}
+        with:
+          persist-credentials: false
+      - uses: mozilla-actions/sccache-action@v0.0.11
+`), /lowercase 40-hex/u],
+  ["wrong sccache commit", workflow(`
+      - uses: actions/checkout@${checkout}
+        with:
+          persist-credentials: false
+      - uses: mozilla-actions/sccache-action@${"1".repeat(40)}
+`), /allowlist/u],
   ["unknown exact action", workflow(`
       - uses: example/unknown@${"1".repeat(40)}
 `), /allowlist/u],


### PR DESCRIPTION
## Summary

- enable the official, commit-pinned sccache action for the long Payment protocol job
- disable test-profile LTO and Cargo incremental compilation only inside that CI job
- collect representative Cargo build timing reports and sccache statistics
- upload only bounded timing HTML artifacts with seven-day retention
- extend the workflow supply-chain gate with exact action-pin and compile-acceleration policy checks

## Why

The Payment protocol job performs dozens of Cargo test, clippy, check, build, and run invocations across several feature combinations. Its optimized test profile uses thin LTO, while the job previously had no compiler cache. This made repeated crate compilation and test-binary linking dominate CI latency.

This phase establishes measurable compiler caching without caching or uploading the workspace target directory. It does not yet deduplicate feature combinations or split the long job; those changes will follow only after cold and warm CI data are available.

## Safety boundaries

- release and UKI reproducibility profiles are unchanged
- root UID/GID temporary target isolation is unchanged
- release compile-fail gates, directory artifact reproduction, browser jobs, and deployment are unchanged
- the new sccache action is pinned to official v0.0.11 commit `fc920bf0ec8de6ee65d409111f7ec508035751ba`

## Validation

- `cargo test/build/clippy --timings --help` argument parsing checked
- `node --check scripts/github-workflow-supply-chain-gate.mjs`
- `node --check scripts/github-workflow-supply-chain-gate.test.mjs`
- `node --test scripts/github-workflow-supply-chain-gate.test.mjs` — 40/40 passed
- `node scripts/github-workflow-supply-chain-gate.mjs`
- `git diff --check`

No long Cargo, browser, public-network, production, or deployment test was run locally. The first CI run is expected to be a cold sccache population run.
