### PR TITLE
Deduplicate Payment feature linting

### DIFF
--- a/.github/workflows/payment-platform.yml
+++ b/.github/workflows/payment-platform.yml
@@ -276,7 +276,6 @@ jobs:
         run: |
           cargo test --locked --offline --manifest-path vendor/bitcoinpir-oram/Cargo.toml
           cargo test --locked --offline -p runtime --features cuckoo-oram --test payment_v1_tee_oram_process_e2e
-          cargo clippy --locked --offline -p runtime --features cuckoo-oram --bin unified_server --test payment_v1_tee_oram_process_e2e --no-deps -- -D warnings
       - name: Exercise two independent directory-relay process stores and views
         run: |
           cargo test --locked --offline -p bitcoinpir-directory-relay --test payment_v1_two_relay_process_e2e two_relay_real_process_catalog_e2e -- --exact --ignored
@@ -296,8 +295,6 @@ jobs:
           cargo test --locked --offline -p runtime --features standard-cashu-process-e2e --test payment_v1_harmony_pool_process_e2e all_non_receipt_methods_restore_pre_dispatch_and_burn_on_real_hint_dispatch -- --exact
           cargo test --locked --offline -p runtime --features standard-cashu-process-e2e --test payment_v1_onion_process_e2e all_non_receipt_methods_commit_before_real_onion_job_and_replay_after_restart -- --exact
           cargo test --locked --offline -p runtime --features cuckoo-oram,standard-cashu-process-e2e --test payment_v1_tee_oram_process_e2e all_non_receipt_methods_commit_before_real_tee_oram_and_replay_after_restart -- --exact
-          cargo clippy --locked --offline -p runtime --features standard-cashu-process-e2e --bin unified_server --test payment_v1_standard_cashu_process_e2e --test payment_v1_process_e2e --test payment_v1_harmony_pool_process_e2e --test payment_v1_onion_process_e2e --no-deps -- -D warnings
-          cargo clippy --locked --offline -p runtime --features cuckoo-oram,standard-cashu-process-e2e --bin unified_server --test payment_v1_tee_oram_process_e2e --no-deps -- -D warnings
           log_file="$(mktemp "${RUNNER_TEMP}/bpir-cashu-test-root-cli.XXXXXX")"
           trap 'rm -f -- "$log_file"' EXIT
           if cargo run --locked --offline -p runtime --bin unified_server -- --test-only-service-https-root-pem /does/not/exist >"$log_file" 2>&1; then
@@ -323,10 +320,17 @@ jobs:
               -p runtime \
               --features shared-issuer-process-e2e \
               --test payment_v1_shared_issuer_process_e2e
+      - name: Lint runtime ORAM, Standard Cashu, and shared-issuer feature superset
+        run: |
           cargo clippy --locked --offline \
             -p runtime \
-            --features shared-issuer-process-e2e \
+            --features cuckoo-oram,shared-issuer-process-e2e \
             --bin unified_server \
+            --test payment_v1_tee_oram_process_e2e \
+            --test payment_v1_standard_cashu_process_e2e \
+            --test payment_v1_process_e2e \
+            --test payment_v1_harmony_pool_process_e2e \
+            --test payment_v1_onion_process_e2e \
             --test payment_v1_shared_issuer_process_e2e \
             --no-deps -- -D warnings
       - name: Prove test-only WebPKI roots cannot enter release artifacts

--- a/scripts/github-workflow-supply-chain-gate.mjs
+++ b/scripts/github-workflow-supply-chain-gate.mjs
@@ -218,6 +218,10 @@ function requireWorkflowStep(steps, predicate, label) {
   return step;
 }
 
+function normalizeWorkflowCommand(command) {
+  return command.replaceAll(/\\\s*/gu, " ").replaceAll(/\s+/gu, " ").trim();
+}
+
 export function validatePaymentPlatformCompileAcceleration(
   source,
   label = "payment platform workflow",
@@ -280,6 +284,41 @@ export function validatePaymentPlatformCompileAcceleration(
   );
   if (timingArtifact.with["if-no-files-found"] !== "ignore" || timingArtifact.with["retention-days"] !== 7) {
     fail(`${label} Cargo timing artifact must be optional with seven-day retention`);
+  }
+
+  const featureSupersetStep = requireWorkflowStep(
+    steps,
+    (step) => step.name === "Lint runtime ORAM, Standard Cashu, and shared-issuer feature superset" &&
+      typeof step.run === "string",
+    `${label} protocol job must lint the reviewed runtime feature superset`,
+  );
+  const featureSupersetCommand = normalizeWorkflowCommand(featureSupersetStep.run);
+  for (const requiredArgument of [
+    "cargo clippy --locked --offline -p runtime",
+    "--features cuckoo-oram,shared-issuer-process-e2e",
+    "--bin unified_server",
+    "--test payment_v1_tee_oram_process_e2e",
+    "--test payment_v1_standard_cashu_process_e2e",
+    "--test payment_v1_process_e2e",
+    "--test payment_v1_harmony_pool_process_e2e",
+    "--test payment_v1_onion_process_e2e",
+    "--test payment_v1_shared_issuer_process_e2e",
+    "--no-deps -- -D warnings",
+  ]) {
+    if (!featureSupersetCommand.includes(requiredArgument)) {
+      fail(`${label} runtime feature-superset Clippy must include ${requiredArgument}`);
+    }
+  }
+  const normalizedCargoRuns = normalizeWorkflowCommand(cargoRuns);
+  for (const obsoleteCommand of [
+    "cargo clippy --locked --offline -p runtime --features cuckoo-oram --bin unified_server",
+    "cargo clippy --locked --offline -p runtime --features standard-cashu-process-e2e --bin unified_server",
+    "cargo clippy --locked --offline -p runtime --features cuckoo-oram,standard-cashu-process-e2e --bin unified_server",
+    "cargo clippy --locked --offline -p runtime --features shared-issuer-process-e2e --bin unified_server",
+  ]) {
+    if (normalizedCargoRuns.includes(obsoleteCommand)) {
+      fail(`${label} must not retain obsolete feature-specific runtime Clippy commands`);
+    }
   }
 }
 

--- a/scripts/github-workflow-supply-chain-gate.test.mjs
+++ b/scripts/github-workflow-supply-chain-gate.test.mjs
@@ -127,6 +127,30 @@ for (const [label, source, pattern] of [
     ),
     /Cargo timing artifact paths/u,
   ],
+  [
+    "payment platform feature superset regression",
+    paymentPlatformWorkflow.replace(
+      "--features cuckoo-oram,shared-issuer-process-e2e",
+      "--features cuckoo-oram,standard-cashu-process-e2e",
+    ),
+    /runtime feature-superset Clippy/u,
+  ],
+  [
+    "payment platform feature-superset test target missing",
+    paymentPlatformWorkflow.replaceAll(
+      "--test payment_v1_shared_issuer_process_e2e",
+      "--test payment_v1_removed_process_e2e",
+    ),
+    /payment_v1_shared_issuer_process_e2e/u,
+  ],
+  [
+    "payment platform obsolete feature Clippy returns",
+    paymentPlatformWorkflow.replace(
+      "      - name: Prove test-only WebPKI roots cannot enter release artifacts",
+      "      - name: Forbidden duplicate runtime feature Clippy\n        run: cargo clippy --locked --offline -p runtime --features cuckoo-oram --bin unified_server --test payment_v1_tee_oram_process_e2e --no-deps -- -D warnings\n      - name: Prove test-only WebPKI roots cannot enter release artifacts",
+    ),
+    /must not retain obsolete feature-specific runtime Clippy commands/u,
+  ],
 ]) {
   test(`rejects ${label}`, () => {
     assert.throws(() => validatePaymentPlatformCompileAcceleration(source), pattern);


### PR DESCRIPTION
Summary
- replace four overlapping runtime feature Clippy invocations with one reviewed feature-superset invocation
- keep every Cargo test, process boundary, root UID check, and release security negative gate
- add semantic regression checks that reject missing targets or reintroduced duplicate lint commands

Validation
- Node syntax checks passed
- workflow supply-chain tests: 43/43 passed
- full workflow semantic gate passed
- git diff check passed

Stacking
- this PR is intentionally based on #149 so Phase 1 cache/profile changes remain independently reviewable
- no browser, deploy, or release-profile behavior is changed