### PR TITLE
Fix DPF WASM initialization race

### DIFF
--- a/web/e2e/strict-production.spec.ts
+++ b/web/e2e/strict-production.spec.ts
@@ -35,10 +35,7 @@ async function queryOnce(
   await button.click();
   await expect(button).toHaveText('Querying…');
   await expect(button).toBeEnabled({ timeout: QUERY_TIMEOUT });
-  await expect(button).toHaveText('Query UTXOs');
-  await expect(page.locator('#log')).not.toContainText(
-    /(?:connection failed:|query error:|batch error:)/i,
-  );
+  await expectNoFatalLog(page);
   await expect(results).toContainText(CANARY_ADDRESS);
   return results;
 }
@@ -67,7 +64,7 @@ async function expectLogContains(page: Page, ...messages: string[]): Promise<voi
 
 async function expectNoFatalLog(page: Page): Promise<void> {
   const fatal = page.locator('#log').getByText(
-    /(?:UNVERIFIED|chain validation failed|DB proof .* unavailable|ORAM source-binding proof check failed|query error:|batch error:|connection failed:)/i,
+    /(?:UNVERIFIED|chain validation failed|DB proof .* unavailable|ORAM source-binding proof check failed|WASM module required|query error:|batch error:|(?:connection|connect) failed:)/i,
   );
   await expect(fatal).toHaveCount(0);
 }
@@ -79,8 +76,6 @@ test('DPF-PIR verifies both servers, the result, and tears down transport', asyn
   await expect(page.locator('#dpfVerification0')).toHaveText('YES');
   await expect(page.locator('#dpfVerification1')).toHaveText('YES');
   await expectVerifiedResult(results);
-  await expectTornDown(page, '#connectBtn', '#disconnectBtn');
-  await expectNoFatalLog(page);
   await expectLogContains(
     page,
     'Upgraded to encrypted channel',
@@ -88,6 +83,11 @@ test('DPF-PIR verifies both servers, the result, and tears down transport', asyn
     'operator-endorsed identity verified (pir2)',
     'Bitcoin/MuHash anchor verified',
     'Batch complete: 1/1 found',
+  );
+  await expectTornDown(page, '#connectBtn', '#disconnectBtn');
+  await expectNoFatalLog(page);
+  await expectLogContains(
+    page,
     'Disconnected',
   );
 });
@@ -99,9 +99,6 @@ test('HarmonyPIR verifies both roles, the result, and preserves no socket', asyn
   await expect(page.locator('#hpVerificationHint')).toHaveText('YES');
   await expect(page.locator('#hpVerificationQuery')).toHaveText('YES');
   await expectVerifiedResult(results);
-  await expectTornDown(page, '#hp-connectBtn', '#hp-disconnectBtn');
-  await expect(page.locator('#hp-status')).toContainText('Status: Disconnected');
-  await expectNoFatalLog(page);
   await expectLogContains(
     page,
     'HarmonyPIR: upgraded to encrypted channel',
@@ -109,6 +106,9 @@ test('HarmonyPIR verifies both roles, the result, and preserves no socket', asyn
     'HarmonyPIR query: operator-endorsed identity verified (pir2)',
     'HarmonyPIR batch complete: 1/1 found',
   );
+  await expectTornDown(page, '#hp-connectBtn', '#hp-disconnectBtn');
+  await expect(page.locator('#hp-status')).toContainText('Status: Disconnected');
+  await expectNoFatalLog(page);
 });
 
 test('OnionPIR passes strict layout/tree-top preflight and verifies the result', async ({ page }) => {
@@ -117,9 +117,9 @@ test('OnionPIR passes strict layout/tree-top preflight and verifies the result',
 
   await expect(page.locator('#onionVerification')).toHaveText('YES');
   await expectVerifiedResult(results);
+  await expectLogContains(page, 'OnionPIR batch complete: 1/1 found');
   await expectTornDown(page, '#op-connectBtn', '#op-disconnectBtn');
   await expectNoFatalLog(page);
-  await expectLogContains(page, 'OnionPIR batch complete: 1/1 found');
 });
 
 test('ORAM TEE verifies the runtime, completes a lookup, and disconnects', async ({ page }) => {
@@ -127,14 +127,17 @@ test('ORAM TEE verifies the runtime, completes a lookup, and disconnects', async
   await queryOnce(page, '#oram-scriptPubkeys', '#oram-queryBtn', '#oram-resultsContainer');
 
   await expect(page.locator('#oramVerification')).toHaveText('YES');
-  await expectTornDown(page, '#oram-connectBtn', '#oram-disconnectBtn');
-  await expect(page.locator('#oram-status')).toContainText('Status: Disconnected');
-  await expectNoFatalLog(page);
   await expectLogContains(
     page,
     'ORAM upgraded to encrypted channel',
     'ORAM: operator-endorsed identity verified (pir2)',
     'ORAM batch complete: 1/1 found',
+  );
+  await expectTornDown(page, '#oram-connectBtn', '#oram-disconnectBtn');
+  await expect(page.locator('#oram-status')).toContainText('Status: Disconnected');
+  await expectNoFatalLog(page);
+  await expectLogContains(
+    page,
     'ORAM: Disconnected',
   );
 });

--- a/web/src/__tests__/adapter-lifecycle.test.ts
+++ b/web/src/__tests__/adapter-lifecycle.test.ts
@@ -1,15 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { policyFree } = vi.hoisted(() => ({ policyFree: vi.fn() }));
+const { policyFree, initSdkWasm, isSdkWasmReady, requireSdkWasm, defaultSdk } = vi.hoisted(() => {
+  const policyFree = vi.fn();
+  return {
+    policyFree,
+    initSdkWasm: vi.fn<() => Promise<boolean>>(),
+    isSdkWasmReady: vi.fn<() => boolean>(),
+    requireSdkWasm: vi.fn(),
+    defaultSdk: {
+      WasmPolicyRequirements: class {
+        free(): void {
+          policyFree();
+        }
+      },
+    },
+  };
+});
 
 vi.mock('../sdk-bridge.js', () => ({
-  requireSdkWasm: () => ({
-    WasmPolicyRequirements: class {
-      free(): void {
-        policyFree();
-      }
-    },
-  }),
+  initSdkWasm,
+  isSdkWasmReady,
+  requireSdkWasm: () => requireSdkWasm(),
 }));
 
 import { BatchPirClientAdapter } from '../dpf-adapter.js';
@@ -198,6 +209,12 @@ function strictHarmonyPair(client: any): HarmonyPirClientAdapter {
 describe('adapter WASM lifecycle', () => {
   beforeEach(() => {
     policyFree.mockClear();
+    initSdkWasm.mockReset();
+    initSdkWasm.mockResolvedValue(true);
+    isSdkWasmReady.mockReset();
+    isSdkWasmReady.mockReturnValue(true);
+    requireSdkWasm.mockReset();
+    requireSdkWasm.mockReturnValue(defaultSdk);
   });
 
   it('installs the selected peer ARK before its staged attestation', () => {
@@ -238,6 +255,94 @@ describe('adapter WASM lifecycle', () => {
     expect(() => adapter.setExpectedArkFingerprint(new Uint8Array(31))).toThrow(
       'exactly 32 bytes',
     );
+  });
+
+  it('waits for SDK initialization before constructing or dialing a staged DPF leg', async () => {
+    let resolveInit!: (ready: boolean) => void;
+    initSdkWasm.mockImplementationOnce(() => new Promise<boolean>((resolve) => {
+      resolveInit = resolve;
+    }));
+    isSdkWasmReady.mockReturnValue(false);
+    const diagnosticConnect = vi.fn(async () => {});
+    const nativeClient = {
+      setRequireVerifiedDatabaseRoots: vi.fn(),
+      onStateChange: vi.fn(),
+      connectServer: vi.fn(async () => { throw new Error('stop after native dial'); }),
+      disconnectServer: vi.fn(async () => {}),
+      isServerConnected: vi.fn(() => false),
+      free: vi.fn(),
+    };
+    const WasmDpfClient = vi.fn(() => nativeClient);
+    requireSdkWasm.mockReturnValue({ WasmDpfClient });
+    const adapter = new BatchPirClientAdapter({
+      server0Url: 'wss://pir1.invalid',
+      server1Url: '',
+      strictVerification: true,
+      pinnedOperatorPubkey0: OPERATOR_PIN_0,
+    });
+    (adapter as any).ws0 = {
+      connect: diagnosticConnect,
+      disconnect: vi.fn(),
+    };
+
+    const connecting = adapter.connectLeg(0);
+    await Promise.resolve();
+
+    expect(initSdkWasm).toHaveBeenCalledOnce();
+    expect(WasmDpfClient).not.toHaveBeenCalled();
+    expect(diagnosticConnect).not.toHaveBeenCalled();
+
+    resolveInit(true);
+    await expect(connecting).rejects.toThrow('stop after native dial');
+
+    expect(WasmDpfClient).toHaveBeenCalledOnce();
+    expect(diagnosticConnect).toHaveBeenCalledOnce();
+    expect(nativeClient.connectServer).toHaveBeenCalledWith(0);
+  });
+
+  it('rejects a failed SDK initialization without constructing or dialing a staged DPF leg', async () => {
+    initSdkWasm.mockResolvedValueOnce(false);
+    isSdkWasmReady.mockReturnValue(false);
+    const diagnosticConnect = vi.fn(async () => {});
+    const adapter = new BatchPirClientAdapter({
+      server0Url: 'wss://pir1.invalid',
+      server1Url: '',
+      strictVerification: true,
+      pinnedOperatorPubkey0: OPERATOR_PIN_0,
+    });
+    (adapter as any).ws0 = {
+      connect: diagnosticConnect,
+      disconnect: vi.fn(),
+    };
+
+    await expect(adapter.connectLeg(0)).rejects.toThrow(
+      'PIR SDK WASM initialization failed; cannot establish DPF transport',
+    );
+
+    expect(requireSdkWasm).not.toHaveBeenCalled();
+    expect(diagnosticConnect).not.toHaveBeenCalled();
+  });
+
+  it('rejects a failed SDK initialization before the public DPF connect path dials either socket', async () => {
+    initSdkWasm.mockRejectedValueOnce(new Error('WASM fetch failed'));
+    isSdkWasmReady.mockReturnValue(false);
+    const connect0 = vi.fn(async () => {});
+    const connect1 = vi.fn(async () => {});
+    const adapter = new BatchPirClientAdapter({
+      server0Url: 'wss://pir1.invalid',
+      server1Url: 'wss://pir2.invalid',
+      strictVerification: true,
+    });
+    (adapter as any).ws0 = { connect: connect0, disconnect: vi.fn() };
+    (adapter as any).ws1 = { connect: connect1, disconnect: vi.fn() };
+
+    await expect(adapter.connect()).rejects.toThrow(
+      'PIR SDK WASM initialization failed; cannot establish DPF transport',
+    );
+
+    expect(requireSdkWasm).not.toHaveBeenCalled();
+    expect(connect0).not.toHaveBeenCalled();
+    expect(connect1).not.toHaveBeenCalled();
   });
 
   it('publishes a verified first-leg DPF root before pair preflight without authorizing use', async () => {

--- a/web/src/dpf-adapter.ts
+++ b/web/src/dpf-adapter.ts
@@ -42,6 +42,8 @@ import {
   type ServerInfoJson,
 } from './server-info.js';
 import {
+  initSdkWasm,
+  isSdkWasmReady,
   requireSdkWasm,
   type WasmAnnounceVerification,
   type WasmAttestVerification,
@@ -557,6 +559,7 @@ export class BatchPirClientAdapter {
       if (this.strictLegReady[peerIndex] || this.wasmClient?.isServerConnected(peerIndex)) {
         this.assertIndependentOperatorPins();
       }
+      await this.ensureSdkWasmInitialized();
       const diagnostic = this.diagnosticSocket(serverIndex);
       const client = this.ensureStagedWasmClient();
       owner = {
@@ -813,6 +816,22 @@ export class BatchPirClientAdapter {
     return client;
   }
 
+  /**
+   * Native DPF transport has no TypeScript fallback.  Wait for the shared SDK
+   * initializer here, rather than relying on a page-level best-effort startup
+   * call, so neither public connection entry can race WASM module setup.
+   */
+  private async ensureSdkWasmInitialized(): Promise<void> {
+    if (isSdkWasmReady()) return;
+    try {
+      if (await initSdkWasm()) return;
+    } catch {
+      // Normalize loader failures with the unavailable case. The native SDK
+      // must not be touched until it has completed initialization.
+    }
+    throw new Error('PIR SDK WASM initialization failed; cannot establish DPF transport');
+  }
+
   private operatorPinForLeg(serverIndex: 0 | 1): Uint8Array {
     const configured = serverIndex === 0
       ? this.config.pinnedOperatorPubkey0
@@ -938,6 +957,8 @@ export class BatchPirClientAdapter {
       if (this.isStrictVerification() && this.config.useSecureChannel === false) {
         throw new Error('strict verification requires the secure channel');
       }
+
+      await this.ensureSdkWasmInitialized();
 
       // Side-channels first — these carry small diagnostic frames, so
       // they're useful even before the PIR client comes up.


### PR DESCRIPTION
## What changed

- make the DPF adapter await shared SDK WASM initialization before creating any diagnostic socket or native client
- normalize unavailable/rejected initialization into a stable no-transport failure
- add deferred and failed initialization lifecycle regressions for staged and public DPF connection paths
- remove the production canary's stale post-query button-label assertion and strengthen fatal-log detection

## Root cause

The page started `initSdkWasm()` without awaiting it. A fast DPF query could enter the adapter before the shared SDK singleton was ready, causing `requireSdkWasm()` to fail. The production trace showed the query failing and the button resetting before the WASM-loaded log appeared.

## Impact

DPF connection paths now own their initialization prerequisite and cannot dial, purchase credentials, or query before WASM is ready. The canary checks semantic completion, verification, fatal logs, and teardown instead of presentation text.

## Validation

- `npm exec vitest run src/__tests__/adapter-lifecycle.test.ts`: 49/49 passed
- `npm test`: 516 passed, 2 existing skips
- `npm run build`
- `npm run build-web` including CSP verification
- `npm run test:production-canary-readiness`
- `git diff --check`

No Playwright/Chromium production test and no deployment were run locally.
