### PR TITLE
Bootstrap attested EasyCrypt verifier images

### DIFF
--- a/.github/workflows/formal-proof.yml
+++ b/.github/workflows/formal-proof.yml
@@ -12,6 +12,8 @@ on:
 
 permissions:
   contents: read
+  packages: read
+  attestations: read
 
 concurrency:
   group: formal-proof-${{ github.workflow }}-${{ github.ref }}
@@ -53,7 +55,11 @@ jobs:
           python3 verification/scripts/verify_formal_lock.py
           --proof-dir .formal-proof
 
-      - name: Build product-owned trusted EasyCrypt verifier
+      # Phase A deliberately keeps this cold build: the lock has no real
+      # published OCI digest yet.  The validator is the only authority allowed
+      # to switch this condition to the attested, immutable Phase B image.
+      - name: Build product-owned trusted EasyCrypt verifier (Phase A bootstrap)
+        if: steps.lock.outputs.verifier_mode == 'bootstrap'
         run: |
           docker build \
             --platform linux/amd64 \
@@ -61,13 +67,56 @@ jobs:
             --file verification/toolchains/easycrypt.Dockerfile \
             verification/toolchains
 
+      - name: Log in to GitHub Container Registry (Phase B)
+        if: steps.lock.outputs.verifier_mode == 'pinned'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Pull product-owned trusted EasyCrypt verifier (Phase B)
+        if: steps.lock.outputs.verifier_mode == 'pinned'
+        run: |
+          set -euo pipefail
+          docker pull "${{ steps.lock.outputs.verifier_image }}"
+
+      - name: Verify prebuilt verifier identity and provenance (Phase B)
+        if: steps.lock.outputs.verifier_mode == 'pinned'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          image_ref="${{ steps.lock.outputs.verifier_image }}"
+          observed_ref="$(docker image inspect --format '{{index .RepoDigests 0}}' "$image_ref")"
+          test "$observed_ref" = "$image_ref"
+          source_label="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.source"}}' "$image_ref")"
+          revision_label="$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "$image_ref")"
+          test "$source_label" = "https://github.com/Bitcoin-PIR/Bitcoin-PIR"
+          test "$revision_label" = "${{ steps.lock.outputs.verifier_source_commit }}"
+          gh attestation verify "oci://${image_ref}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/publish-easycrypt-verifier.yml" \
+            --source-ref refs/heads/main \
+            --source-digest "${{ steps.lock.outputs.verifier_source_commit }}"
+
+      - name: Select trusted verifier image
+        id: verifier
+        run: |
+          set -euo pipefail
+          case "${{ steps.lock.outputs.verifier_mode }}" in
+            bootstrap) echo 'image=bitcoinpir/protocol-proofs-toolchain:locked' >> "$GITHUB_OUTPUT" ;;
+            pinned) echo "image=${{ steps.lock.outputs.verifier_image }}" >> "$GITHUB_OUTPUT" ;;
+            *) echo 'formal lock selected an unsupported verifier mode' >&2; exit 1 ;;
+          esac
+
       - name: Re-run locked proof with trusted command
         run: |
           docker run --rm \
             --platform linux/amd64 \
             --volume "$GITHUB_WORKSPACE/.formal-proof:/proofs" \
             --workdir /proofs \
-            bitcoinpir/protocol-proofs-toolchain:locked \
+            "${{ steps.verifier.outputs.image }}" \
             easycrypt compile -I . Theorem.ec
 
   gate:

--- a/.github/workflows/publish-easycrypt-verifier.yml
+++ b/.github/workflows/publish-easycrypt-verifier.yml
@@ -1,0 +1,96 @@
+name: Publish attested EasyCrypt verifier
+
+# This workflow is intentionally not a pull_request workflow: PR code must
+# never receive a package-write token.  Phase A formal CI continues to build
+# locally until a digest produced here is reviewed into formal-proofs.json.
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/publish-easycrypt-verifier.yml'
+      - 'verification/toolchains/easycrypt.Dockerfile'
+      - 'verification/locks/formal-proofs.json'
+      - 'verification/scripts/verify_formal_lock.py'
+  schedule:
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-easycrypt-verifier-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    # A manual dispatch from another ref and any future non-main event fail
+    # closed before credentials capable of publishing a package are granted.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    env:
+      IMAGE: ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier
+    steps:
+      - name: Check out BitcoinPIR
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish a bootstrap image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: verification/toolchains
+          file: verification/toolchains/easycrypt.Dockerfile
+          platforms: linux/amd64
+          push: true
+          # This unique discovery tag is never a consumer input.  Consumers
+          # accept only the immutable digest emitted by this build.
+          tags: ${{ env.IMAGE }}:bootstrap-${{ github.run_id }}-${{ github.run_attempt }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/Bitcoin-PIR/Bitcoin-PIR
+            org.opencontainers.image.revision=${{ github.sha }}
+          provenance: false
+
+      - name: Attest the immutable verifier digest
+        id: attest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: false
+
+      - name: Verify published provenance before reporting the digest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          image_ref="${IMAGE}@${IMAGE_DIGEST}"
+          gh attestation verify "oci://${image_ref}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/publish-easycrypt-verifier.yml" \
+            --source-ref refs/heads/main \
+            --source-digest "$GITHUB_SHA"
+          {
+            echo "Published, attested verifier digest: ${image_ref}"
+            echo "Phase B: copy this exact digest and the current source commit into"
+            echo "verification/locks/formal-proofs.json, then require a fresh PR CI run."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/workflow-supply-chain.yml
+++ b/.github/workflows/workflow-supply-chain.yml
@@ -10,6 +10,10 @@ on:
       - 'web/package.json'
       - 'web/package-lock.json'
       - 'web/npm-shrinkwrap.json'
+      - 'verification/locks/formal-proofs.json'
+      - 'verification/scripts/verify_formal_lock.py'
+      - 'verification/scripts/test_verify_formal_lock.py'
+      - 'verification/toolchains/easycrypt.Dockerfile'
   # Keep the PR event unfiltered so this job can become a required check
   # without unrelated PRs remaining permanently Pending.
   pull_request:
@@ -58,3 +62,5 @@ jobs:
           node --check scripts/github-workflow-supply-chain-gate.test.mjs
           node --test scripts/github-workflow-supply-chain-gate.test.mjs
           node scripts/github-workflow-supply-chain-gate.mjs
+          python3 -m py_compile verification/scripts/verify_formal_lock.py verification/scripts/test_verify_formal_lock.py
+          python3 -m unittest verification/scripts/test_verify_formal_lock.py

--- a/docs/REPOSITORY_BOUNDARIES.md
+++ b/docs/REPOSITORY_BOUNDARIES.md
@@ -104,6 +104,31 @@ The durable statement is that a specific proof tree and its deterministically
 generated contract binding passed a specific verifier. This remains narrower
 than a full refinement proof from Rust or TypeScript into EasyCrypt.
 
+### Product-owned EasyCrypt verifier bootstrap and rollback
+
+The verifier lock has two fail-closed distribution modes. **Phase A** is
+`bootstrap`: there is deliberately no OCI image digest, so the formal job builds
+`verification/toolchains/easycrypt.Dockerfile` locally and still recompiles the
+proof. This is the only safe state before the first real package exists; a
+placeholder digest is invalid.
+
+The `Publish attested EasyCrypt verifier` workflow is not callable from a PR. It
+can publish only from `main` after a controlled toolchain change, an explicit
+`main` dispatch, or the weekly clean rebuild. It publishes a temporary discovery
+tag only to obtain an OCI digest; that tag is never a trust input. The workflow
+attests and verifies the final `ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:...`
+digest before reporting it.
+
+To enter **Phase B**, a reviewed follow-up changes the lock to `pinned` with the
+reported immutable digest and its `main` publisher provenance. The ordinary
+formal job then pulls that exact digest, checks its RepoDigest and OCI source /
+revision labels, authenticates to GHCR with its read-only GitHub token, verifies
+the GitHub provenance attestation for the protected
+publisher workflow, and still runs `easycrypt compile -I . Theorem.ec`. It never
+uses a tag or a fallback image. Rollback is another reviewed lock change to an
+earlier attested digest; returning to `bootstrap` intentionally restores the
+local build rather than trusting a mutable reference.
+
 Changes to protocol framing, backend round shape, database selection, padding,
 or query-dependent branching must update the contract and proof lock. Pure
 documentation and path-only changes do not require a new proof when the

--- a/scripts/github-workflow-supply-chain-gate.mjs
+++ b/scripts/github-workflow-supply-chain-gate.mjs
@@ -17,11 +17,24 @@ export const APPROVED_ACTION_COMMITS = Object.freeze({
   "actions/checkout": "3d3c42e5aac5ba805825da76410c181273ba90b1",
   "actions/configure-pages": "45bfe0192ca1faeb007ade9deae92b16b8254a0d",
   "actions/deploy-pages": "cd2ce8fcbc39b97be8ca5fce6e763baed58fa128",
+  "actions/attest": "1e69f48acb82d1966a394da916b4c1698aa569d6",
   "actions/setup-node": "820762786026740c76f36085b0efc47a31fe5020",
   "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
   "actions/upload-pages-artifact": "fc324d3547104276b827a68afc52ff2a11cc49c9",
   "mozilla-actions/sccache-action": "fc920bf0ec8de6ee65d409111f7ec508035751ba",
+  "docker/build-push-action": "53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
+  "docker/login-action": "dbcb813823bdd20940b903addbd779551569679f",
+  "docker/setup-buildx-action": "bb05f3f5519dd87d3ba754cc423b652a5edd6d2c",
 });
+
+export const EASYCRYPT_VERIFIER_IMAGE = "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier";
+export const EASYCRYPT_PUBLISH_WORKFLOW = ".github/workflows/publish-easycrypt-verifier.yml";
+export const EASYCRYPT_PUBLISH_PATHS = Object.freeze([
+  ".github/workflows/publish-easycrypt-verifier.yml",
+  "verification/toolchains/easycrypt.Dockerfile",
+  "verification/locks/formal-proofs.json",
+  "verification/scripts/verify_formal_lock.py",
+]);
 
 export const SUPPLY_CHAIN_GATE_PUSH_PATHS = Object.freeze([
   ".github/workflows/**",
@@ -30,6 +43,10 @@ export const SUPPLY_CHAIN_GATE_PUSH_PATHS = Object.freeze([
   "web/package.json",
   "web/package-lock.json",
   "web/npm-shrinkwrap.json",
+  "verification/locks/formal-proofs.json",
+  "verification/scripts/verify_formal_lock.py",
+  "verification/scripts/test_verify_formal_lock.py",
+  "verification/toolchains/easycrypt.Dockerfile",
 ]);
 
 function fail(message) {
@@ -170,6 +187,30 @@ export function validateSupplyChainGateTriggers(source, label = "workflow supply
   return { events: 4, pushPaths: SUPPLY_CHAIN_GATE_PUSH_PATHS.length };
 }
 
+export function validateSupplyChainGateValidatorCoverage(
+  source,
+  label = "workflow supply-chain gate",
+) {
+  const workflow = parseWorkflowSource(source, label);
+  const steps = workflow.jobs?.["workflow-supply-chain"]?.steps;
+  if (!Array.isArray(steps)) fail(`${label} must retain its validation steps`);
+  const policyStep = requireWorkflowStep(
+    steps,
+    (step) => step.name === "Validate workflow supply-chain policy" && typeof step.run === "string",
+    `${label} must retain workflow policy validation`,
+  );
+  for (const command of [
+    "node --test scripts/github-workflow-supply-chain-gate.test.mjs",
+    "node scripts/github-workflow-supply-chain-gate.mjs",
+    "python3 -m py_compile verification/scripts/verify_formal_lock.py verification/scripts/test_verify_formal_lock.py",
+    "python3 -m unittest verification/scripts/test_verify_formal_lock.py",
+  ]) {
+    if (!policyStep.run.includes(command)) {
+      fail(`${label} must execute ${command}`);
+    }
+  }
+}
+
 function validateActionUse(actionUse, step, label) {
   if (typeof actionUse !== "string") fail(`${label}.uses must be a string`);
   const match = /^([0-9A-Za-z_.-]+\/[0-9A-Za-z_.-]+(?:\/[0-9A-Za-z_./-]+)?)@([0-9a-f]{40})$/u.exec(actionUse);
@@ -220,6 +261,241 @@ function requireWorkflowStep(steps, predicate, label) {
 
 function normalizeWorkflowCommand(command) {
   return command.replaceAll(/\\\s*/gu, " ").replaceAll(/\s+/gu, " ").trim();
+}
+
+function requireExactPermissionMapping(value, expected, label) {
+  requireExactMappingKeys(value, Object.keys(expected), label);
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    if (value[key] !== expectedValue) fail(`${label}.${key} must equal ${expectedValue}`);
+  }
+}
+
+function requireRunStep(steps, name, label) {
+  return requireWorkflowStep(
+    steps,
+    (step) => step.name === name && typeof step.run === "string",
+    label,
+  );
+}
+
+function parseFormalVerifierLock(lockSource, label) {
+  let lock;
+  try {
+    lock = JSON.parse(lockSource);
+  } catch {
+    fail(`${label} must be strict JSON`);
+  }
+  if (!isRecord(lock) || !isRecord(lock.trustedVerifier)) {
+    fail(`${label} must contain trustedVerifier`);
+  }
+  const verifier = lock.trustedVerifier;
+  requireExactMappingKeys(
+    verifier,
+    [
+      "altErgoVersion",
+      "baseImage",
+      "command",
+      "distribution",
+      "dockerfilePath",
+      "dockerfileSha256",
+      "easycryptCommit",
+      "easycryptRepository",
+      "ocamlVersion",
+      "platform",
+      "schema",
+      "why3Version",
+    ],
+    `${label}.trustedVerifier`,
+  );
+  if (verifier.schema !== "BitcoinPIR/product-owned-easycrypt-verifier/v2") {
+    fail(`${label}.trustedVerifier must use the reviewed v2 schema`);
+  }
+  if (!isRecord(verifier.distribution)) fail(`${label}.trustedVerifier.distribution must be a mapping`);
+  requireExactMappingKeys(
+    verifier.distribution,
+    ["image", "mode", "provenance"],
+    `${label}.trustedVerifier.distribution`,
+  );
+  const distribution = verifier.distribution;
+  if (distribution.mode === "bootstrap") {
+    if (distribution.image !== null || distribution.provenance !== null) {
+      fail(`${label} bootstrap distribution must not trust an unpublished image`);
+    }
+    return { mode: "bootstrap", image: null };
+  }
+  if (distribution.mode !== "pinned") fail(`${label} verifier distribution mode is unsupported`);
+  if (
+    typeof distribution.image !== "string" ||
+    !new RegExp(`^${EASYCRYPT_VERIFIER_IMAGE.replaceAll("/", "\\/")}@sha256:[0-9a-f]{64}$`, "u").test(distribution.image)
+  ) {
+    fail(`${label} pinned verifier image must be the immutable reviewed GHCR digest`);
+  }
+  if (!isRecord(distribution.provenance)) fail(`${label} pinned verifier provenance must be a mapping`);
+  requireExactMappingKeys(
+    distribution.provenance,
+    ["commit", "dockerfileSha256", "ref", "repository", "workflow"],
+    `${label}.trustedVerifier.distribution.provenance`,
+  );
+  if (
+    distribution.provenance.repository !== "Bitcoin-PIR/Bitcoin-PIR" ||
+    distribution.provenance.workflow !== EASYCRYPT_PUBLISH_WORKFLOW ||
+    distribution.provenance.ref !== "refs/heads/main" ||
+    !/^[0-9a-f]{40}$/u.test(distribution.provenance.commit) ||
+    distribution.provenance.dockerfileSha256 !== verifier.dockerfileSha256
+  ) {
+    fail(`${label} pinned verifier provenance must bind the reviewed main publisher and Dockerfile`);
+  }
+  return { mode: "pinned", image: distribution.image };
+}
+
+export function validateEasyCryptVerifierPolicy(
+  formalSource,
+  publishSource,
+  lockSource,
+  label = "EasyCrypt verifier policy",
+) {
+  const distribution = parseFormalVerifierLock(lockSource, `${label} lock`);
+  const formal = parseWorkflowSource(formalSource, `${label} formal workflow`);
+  requireExactPermissionMapping(
+    formal.permissions,
+    { attestations: "read", contents: "read", packages: "read" },
+    `${label} formal workflow.permissions`,
+  );
+  const formalSteps = formal.jobs?.verify?.steps;
+  if (!Array.isArray(formalSteps)) fail(`${label} formal workflow must retain verify steps`);
+  const bootstrap = requireRunStep(
+    formalSteps,
+    "Build product-owned trusted EasyCrypt verifier (Phase A bootstrap)",
+    `${label} must retain an explicit Phase A build`,
+  );
+  if (
+    bootstrap.if !== "steps.lock.outputs.verifier_mode == 'bootstrap'" ||
+    !bootstrap.run.includes("docker build") ||
+    !bootstrap.run.includes("verification/toolchains/easycrypt.Dockerfile")
+  ) {
+    fail(`${label} Phase A build must be only validator-selected bootstrap`);
+  }
+  const consumerLogin = requireWorkflowStep(
+    formalSteps,
+    (step) => step.name === "Log in to GitHub Container Registry (Phase B)" && typeof step.uses === "string",
+    `${label} must log in before pulling a Phase B package`,
+  );
+  if (
+    consumerLogin.if !== "steps.lock.outputs.verifier_mode == 'pinned'" ||
+    consumerLogin.uses !== `docker/login-action@${APPROVED_ACTION_COMMITS["docker/login-action"]}` ||
+    consumerLogin.with?.registry !== "ghcr.io" ||
+    consumerLogin.with?.username !== "${{ github.actor }}" ||
+    consumerLogin.with?.password !== "${{ github.token }}"
+  ) {
+    fail(`${label} Phase B GHCR login must use the reviewed action and ephemeral GitHub token`);
+  }
+  const pull = requireRunStep(
+    formalSteps,
+    "Pull product-owned trusted EasyCrypt verifier (Phase B)",
+    `${label} must retain Phase B immutable pull`,
+  );
+  if (
+    pull.if !== "steps.lock.outputs.verifier_mode == 'pinned'" ||
+    !pull.run.includes('docker pull "${{ steps.lock.outputs.verifier_image }}"')
+  ) {
+    fail(`${label} Phase B must pull only the lock-selected digest`);
+  }
+  const verify = requireRunStep(
+    formalSteps,
+    "Verify prebuilt verifier identity and provenance (Phase B)",
+    `${label} must verify the Phase B image`,
+  );
+  for (const required of [
+    "docker image inspect",
+    "RepoDigests",
+    "org.opencontainers.image.source",
+    "org.opencontainers.image.revision",
+    "gh attestation verify",
+    "--signer-workflow",
+    "--source-ref refs/heads/main",
+    "--source-digest",
+  ]) {
+    if (
+      verify.if !== "steps.lock.outputs.verifier_mode == 'pinned'" ||
+      verify.env?.GH_TOKEN !== "${{ github.token }}" ||
+      !verify.run.includes(required)
+    ) {
+      fail(`${label} Phase B verifier check must retain ${required}`);
+    }
+  }
+  const compile = requireRunStep(
+    formalSteps,
+    "Re-run locked proof with trusted command",
+    `${label} must retain real EasyCrypt compile`,
+  );
+  if (!compile.run.includes("easycrypt compile -I . Theorem.ec") || !compile.run.includes("${{ steps.verifier.outputs.image }}")) {
+    fail(`${label} must re-run the real proof through the selected verifier image`);
+  }
+
+  const publish = parseWorkflowSource(publishSource, `${label} publisher workflow`);
+  requireExactMappingKeys(publish.on, ["push", "schedule", "workflow_dispatch"], `${label} publisher.on`);
+  requireExactMappingKeys(publish.on.push, ["branches", "paths"], `${label} publisher.on.push`);
+  requireExactStringList(publish.on.push.branches, ["main"], `${label} publisher.on.push.branches`);
+  requireExactStringList(publish.on.push.paths, EASYCRYPT_PUBLISH_PATHS, `${label} publisher.on.push.paths`);
+  if (!Array.isArray(publish.on.schedule) || publish.on.schedule.length !== 1 || publish.on.schedule[0]?.cron !== "17 4 * * 1") {
+    fail(`${label} publisher must retain its weekly clean rebuild`);
+  }
+  if (publish.on.workflow_dispatch !== null) fail(`${label} publisher dispatch must remain input-free`);
+  requireExactPermissionMapping(publish.permissions, { contents: "read" }, `${label} publisher.permissions`);
+  const publishJob = publish.jobs?.publish;
+  if (!isRecord(publishJob) || publishJob.if !== "github.ref == 'refs/heads/main'") {
+    fail(`${label} publisher must fail closed outside main`);
+  }
+  requireExactPermissionMapping(
+    publishJob.permissions,
+    { attestations: "write", contents: "read", "id-token": "write", packages: "write" },
+    `${label} publisher job.permissions`,
+  );
+  const publishSteps = publishJob.steps;
+  if (!Array.isArray(publishSteps)) fail(`${label} publisher must contain steps`);
+  const build = requireWorkflowStep(
+    publishSteps,
+    (step) => step.id === "build" && typeof step.uses === "string",
+    `${label} publisher must build the image`,
+  );
+  if (
+    build.uses !== `docker/build-push-action@${APPROVED_ACTION_COMMITS["docker/build-push-action"]}` ||
+    build.with?.platforms !== "linux/amd64" ||
+    build.with?.push !== true ||
+    build.with?.provenance !== false ||
+    build.with?.tags !== "${{ env.IMAGE }}:bootstrap-${{ github.run_id }}-${{ github.run_attempt }}" ||
+    typeof build.with?.tags !== "string" || build.with.tags.includes("latest")
+  ) {
+    fail(`${label} publisher must emit only a unique bootstrap discovery tag and immutable digest`);
+  }
+  const attest = requireWorkflowStep(
+    publishSteps,
+    (step) => step.id === "attest" && typeof step.uses === "string",
+    `${label} publisher must attest the image digest`,
+  );
+  if (
+    attest.uses !== `actions/attest@${APPROVED_ACTION_COMMITS["actions/attest"]}` ||
+    attest.with?.["subject-name"] !== "${{ env.IMAGE }}" ||
+    attest.with?.["subject-digest"] !== "${{ steps.build.outputs.digest }}" ||
+    attest.with?.["push-to-registry"] !== true ||
+    attest.with?.["create-storage-record"] !== false
+  ) {
+    fail(`${label} publisher must attest its exact pushed digest without extra metadata permission`);
+  }
+  const publishVerify = requireRunStep(
+    publishSteps,
+    "Verify published provenance before reporting the digest",
+    `${label} publisher must verify its attestation`,
+  );
+  for (const required of ["gh attestation verify", "--signer-workflow", "--source-ref refs/heads/main", "--source-digest \"$GITHUB_SHA\""]) {
+    if (
+      publishVerify.env?.GH_TOKEN !== "${{ github.token }}" ||
+      !publishVerify.run.includes(required)
+    ) {
+      fail(`${label} publisher verification must retain ${required}`);
+    }
+  }
+  return { mode: distribution.mode, image: distribution.image };
 }
 
 export function validatePaymentPlatformCompileAcceleration(
@@ -379,6 +655,7 @@ export function validateWorkflowDirectory(directoryInput) {
   if (entries.length < 1) fail("workflow directory is empty");
   let actionUses = 0;
   let checkouts = 0;
+  const workflowSources = new Map();
   for (const entry of entries) {
     if (entry.isSymbolicLink() || !entry.isFile() || !/\.ya?ml$/u.test(entry.name)) {
       fail(`workflow directory contains an unreviewed entry: ${entry.name}`);
@@ -402,14 +679,31 @@ export function validateWorkflowDirectory(directoryInput) {
       fail(`workflow is not canonical UTF-8: ${entry.name}`);
     }
     const result = validateWorkflowSource(source, `workflow ${entry.name}`);
+    workflowSources.set(entry.name, source);
     if (entry.name === "workflow-supply-chain.yml") {
       validateSupplyChainGateTriggers(source, `workflow ${entry.name}`);
+      validateSupplyChainGateValidatorCoverage(source, `workflow ${entry.name}`);
     }
     if (entry.name === "payment-platform.yml") {
       validatePaymentPlatformCompileAcceleration(source, `workflow ${entry.name}`);
     }
     actionUses += result.actionUses;
     checkouts += result.checkouts;
+  }
+  const formalSource = workflowSources.get("formal-proof.yml");
+  const publishSource = workflowSources.get("publish-easycrypt-verifier.yml");
+  if (formalSource !== undefined || publishSource !== undefined) {
+    if (formalSource === undefined || publishSource === undefined) {
+      fail("formal proof and EasyCrypt publisher workflows must be reviewed together");
+    }
+    const lockPath = resolve(REPOSITORY_ROOT, "verification/locks/formal-proofs.json");
+    let lockSource;
+    try {
+      lockSource = new TextDecoder("utf-8", { fatal: true }).decode(readFileSync(lockPath));
+    } catch {
+      fail("formal proof lock must be canonical UTF-8");
+    }
+    validateEasyCryptVerifierPolicy(formalSource, publishSource, lockSource);
   }
   return { actionUses, checkouts, workflows: entries.length };
 }

--- a/scripts/github-workflow-supply-chain-gate.test.mjs
+++ b/scripts/github-workflow-supply-chain-gate.test.mjs
@@ -15,10 +15,14 @@ import test from "node:test";
 
 import {
   APPROVED_ACTION_COMMITS,
+  EASYCRYPT_PUBLISH_PATHS,
+  EASYCRYPT_VERIFIER_IMAGE,
   SUPPLY_CHAIN_GATE_PUSH_PATHS,
+  validateEasyCryptVerifierPolicy,
   validateNpmParserLockBoundary,
   validatePaymentPlatformCompileAcceleration,
   validatePaymentV1CiLaneInventory,
+  validateSupplyChainGateValidatorCoverage,
   validateSupplyChainGateTriggers,
   validateWorkflowDirectory,
   validateWorkflowSource,
@@ -77,6 +81,18 @@ const paymentLaneScript = readFileSync(
   new URL("./payment-v1-ci-lane.sh", import.meta.url),
   "utf8",
 );
+const formalProofWorkflow = readFileSync(
+  new URL("../.github/workflows/formal-proof.yml", import.meta.url),
+  "utf8",
+);
+const easyCryptPublisherWorkflow = readFileSync(
+  new URL("../.github/workflows/publish-easycrypt-verifier.yml", import.meta.url),
+  "utf8",
+);
+const formalProofLock = readFileSync(
+  new URL("../verification/locks/formal-proofs.json", import.meta.url),
+  "utf8",
+);
 
 test("accepts the reviewed payment-platform compile acceleration boundary", () => {
   assert.doesNotThrow(() => validatePaymentPlatformCompileAcceleration(paymentPlatformWorkflow));
@@ -84,6 +100,151 @@ test("accepts the reviewed payment-platform compile acceleration boundary", () =
 
 test("accepts the reviewed payment CI lane inventory", () => {
   assert.doesNotThrow(() => validatePaymentV1CiLaneInventory(paymentLaneScript));
+});
+
+test("accepts the reviewed Phase A EasyCrypt verifier bootstrap", () => {
+  assert.deepEqual(
+    validateEasyCryptVerifierPolicy(formalProofWorkflow, easyCryptPublisherWorkflow, formalProofLock),
+    { mode: "bootstrap", image: null },
+  );
+});
+
+for (const [label, formal, publisher, lock, pattern] of [
+  [
+    "unconditional cold build",
+    formalProofWorkflow.replace(
+      "if: steps.lock.outputs.verifier_mode == 'bootstrap'\n        run: |\n          docker build",
+      "run: |\n          docker build",
+    ),
+    easyCryptPublisherWorkflow,
+    formalProofLock,
+    /Phase A build/u,
+  ],
+  [
+    "missing real proof compile",
+    formalProofWorkflow.replace("easycrypt compile -I . Theorem.ec", "easycrypt --version"),
+    easyCryptPublisherWorkflow,
+    formalProofLock,
+    /real proof/u,
+  ],
+  [
+    "mutable Phase B pull",
+    formalProofWorkflow.replace("${{ steps.lock.outputs.verifier_image }}", "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier:latest"),
+    easyCryptPublisherWorkflow,
+    formalProofLock,
+    /Phase B must pull/u,
+  ],
+  [
+    "Phase B pull lacks GHCR login",
+    formalProofWorkflow.replace(
+      "Log in to GitHub Container Registry (Phase B)",
+      "Removed GHCR login",
+    ),
+    easyCryptPublisherWorkflow,
+    formalProofLock,
+    /log in before pulling/u,
+  ],
+  [
+    "Phase B login drops the ephemeral token",
+    formalProofWorkflow.replace(
+      "password: ${{ github.token }}",
+      "password: ${{ secrets.UNRELATED_TOKEN }}",
+    ),
+    easyCryptPublisherWorkflow,
+    formalProofLock,
+    /GHCR login/u,
+  ],
+  [
+    "Phase B provenance check lacks authenticated gh CLI",
+    formalProofWorkflow.replace(
+      "GH_TOKEN: ${{ github.token }}",
+      "GH_TOKEN: missing",
+    ),
+    easyCryptPublisherWorkflow,
+    formalProofLock,
+    /Phase B verifier check/u,
+  ],
+  [
+    "publisher provenance self-check lacks authenticated gh CLI",
+    formalProofWorkflow,
+    easyCryptPublisherWorkflow.replace(
+      "GH_TOKEN: ${{ github.token }}",
+      "GH_TOKEN: missing",
+    ),
+    formalProofLock,
+    /publisher verification/u,
+  ],
+  [
+    "publisher accepts pull requests",
+    formalProofWorkflow,
+    easyCryptPublisherWorkflow.replace("on:\n  push:", "on:\n  pull_request:\n  push:"),
+    formalProofLock,
+    /publisher\.on must contain exactly/u,
+  ],
+  [
+    "publisher uses mutable latest tag",
+    formalProofWorkflow,
+    easyCryptPublisherWorkflow.replace(
+      "bootstrap-${{ github.run_id }}-${{ github.run_attempt }}",
+      "latest",
+    ),
+    formalProofLock,
+    /unique bootstrap discovery tag/u,
+  ],
+  [
+    "publisher can publish from a non-main ref",
+    formalProofWorkflow,
+    easyCryptPublisherWorkflow.replace("github.ref == 'refs/heads/main'", "always()"),
+    formalProofLock,
+    /fail closed outside main/u,
+  ],
+  [
+    "publisher drops attestation",
+    formalProofWorkflow,
+    easyCryptPublisherWorkflow.replace("uses: actions/attest@", "uses: actions/upload-artifact@"),
+    formalProofLock,
+    /attest its exact pushed digest/u,
+  ],
+  [
+    "bootstrap fabricates an image digest",
+    formalProofWorkflow,
+    easyCryptPublisherWorkflow,
+    formalProofLock.replace('"image": null', `"image": "${EASYCRYPT_VERIFIER_IMAGE}@sha256:${"a".repeat(64)}"`),
+    /must not trust an unpublished image/u,
+  ],
+  [
+    "pinned phase uses a mutable image reference",
+    formalProofWorkflow,
+    easyCryptPublisherWorkflow,
+    formalProofLock
+      .replace('"mode": "bootstrap"', '"mode": "pinned"')
+      .replace('"image": null', `"image": "${EASYCRYPT_VERIFIER_IMAGE}:latest"`)
+      .replace('"provenance": null', '"provenance": {}'),
+    /immutable reviewed GHCR digest/u,
+  ],
+  [
+    "publisher path scope expands beyond the reviewed toolchain inputs",
+    formalProofWorkflow,
+    easyCryptPublisherWorkflow.replace(
+      "verification/scripts/verify_formal_lock.py",
+      "verification/**",
+    ),
+    formalProofLock,
+    /publisher\.on\.push\.paths/u,
+  ],
+]) {
+  test(`rejects EasyCrypt verifier regression: ${label}`, () => {
+    assert.throws(() => validateEasyCryptVerifierPolicy(formal, publisher, lock), pattern);
+  });
+}
+
+test("keeps the exact reviewed EasyCrypt publisher path inventory", () => {
+  assert.deepEqual(EASYCRYPT_PUBLISH_PATHS, [
+    ".github/workflows/publish-easycrypt-verifier.yml",
+    "verification/toolchains/easycrypt.Dockerfile",
+    "verification/locks/formal-proofs.json",
+    "verification/scripts/verify_formal_lock.py",
+  ]);
 });
 
 for (const [label, source, pattern] of [
@@ -332,6 +493,24 @@ test("accepts always-reporting PR and merge-queue gate triggers", () => {
     events: 4,
     pushPaths: SUPPLY_CHAIN_GATE_PUSH_PATHS.length,
   });
+});
+
+const supplyChainGateWorkflow = readFileSync(
+  new URL("../.github/workflows/workflow-supply-chain.yml", import.meta.url),
+  "utf8",
+);
+
+test("requires the formal verifier validator mutation suite in the supply-chain gate", () => {
+  assert.doesNotThrow(() => validateSupplyChainGateValidatorCoverage(supplyChainGateWorkflow));
+  assert.throws(
+    () => validateSupplyChainGateValidatorCoverage(
+      supplyChainGateWorkflow.replace(
+        "python3 -m unittest verification/scripts/test_verify_formal_lock.py",
+        "true",
+      ),
+    ),
+    /test_verify_formal_lock/u,
+  );
 });
 
 test("rejects a PR path filter that can strand a required check", () => {

--- a/verification/locks/formal-proofs.json
+++ b/verification/locks/formal-proofs.json
@@ -14,8 +14,15 @@
     "sha256": "648227ffba4946b5adc55291bdb77eb452d93a5c03c553a17dc6f5d053b97bf7"
   },
   "trustedVerifier": {
+    "schema": "BitcoinPIR/product-owned-easycrypt-verifier/v2",
     "dockerfilePath": "verification/toolchains/easycrypt.Dockerfile",
     "dockerfileSha256": "84b3d2e19b0d7b82b208000e4c9620178f0bd6aaf134d0e14d5a531dbeae58f9",
+    "baseImage": "ghcr.io/easycrypt/ec-build-box@sha256:5a46a4d816e763ad5de9ee9502d52158c742b9b98cc1f60c443d135a270fdb6a",
+    "easycryptRepository": "https://github.com/EasyCrypt/easycrypt",
+    "easycryptCommit": "dd9bd930d45e81980e546fc835ed2022418644be",
+    "ocamlVersion": "4.14.1",
+    "why3Version": "1.8.2",
+    "altErgoVersion": "2.6.3",
     "platform": "linux/amd64",
     "command": [
       "easycrypt",
@@ -23,7 +30,12 @@
       "-I",
       ".",
       "Theorem.ec"
-    ]
+    ],
+    "distribution": {
+      "mode": "bootstrap",
+      "image": null,
+      "provenance": null
+    }
   },
   "verification": {
     "command": "make check"

--- a/verification/scripts/test_verify_formal_lock.py
+++ b/verification/scripts/test_verify_formal_lock.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Focused mutation tests for the formal verifier-distribution lock policy."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "verification/scripts/verify_formal_lock.py"
+SPEC = importlib.util.spec_from_file_location("verify_formal_lock", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+VERIFY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VERIFY)
+
+
+class TrustedVerifierDistributionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        lock = json.loads(
+            (ROOT / "verification/locks/formal-proofs.json").read_text(encoding="utf-8")
+        )
+        self.verifier = lock["trustedVerifier"]
+        self.dockerfile = (ROOT / "verification/toolchains/easycrypt.Dockerfile").read_bytes()
+
+    def test_bootstrap_keeps_the_local_build_until_a_real_digest_exists(self) -> None:
+        self.assertEqual(
+            VERIFY.validate_trusted_verifier(self.verifier, self.dockerfile),
+            ("bootstrap", "", ""),
+        )
+
+    def test_pinned_distribution_requires_an_immutable_ghcr_digest_and_main_provenance(self) -> None:
+        verifier = copy.deepcopy(self.verifier)
+        verifier["distribution"] = {
+            "mode": "pinned",
+            "image": "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:" + "a" * 64,
+            "provenance": {
+                "repository": "Bitcoin-PIR/Bitcoin-PIR",
+                "workflow": ".github/workflows/publish-easycrypt-verifier.yml",
+                "ref": "refs/heads/main",
+                "commit": "b" * 40,
+                "dockerfileSha256": verifier["dockerfileSha256"],
+            },
+        }
+        self.assertEqual(
+            VERIFY.validate_trusted_verifier(verifier, self.dockerfile),
+            ("pinned", verifier["distribution"]["image"], "b" * 40),
+        )
+
+    def test_rejects_mutable_image_tag_in_pinned_distribution(self) -> None:
+        verifier = copy.deepcopy(self.verifier)
+        verifier["distribution"] = {
+            "mode": "pinned",
+            "image": "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier:latest",
+            "provenance": {
+                "repository": "Bitcoin-PIR/Bitcoin-PIR",
+                "workflow": ".github/workflows/publish-easycrypt-verifier.yml",
+                "ref": "refs/heads/main",
+                "commit": "b" * 40,
+                "dockerfileSha256": verifier["dockerfileSha256"],
+            },
+        }
+        with self.assertRaises(SystemExit):
+            VERIFY.validate_trusted_verifier(verifier, self.dockerfile)
+
+    def test_rejects_bootstrap_placeholder_digest(self) -> None:
+        verifier = copy.deepcopy(self.verifier)
+        verifier["distribution"]["image"] = (
+            "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:" + "a" * 64
+        )
+        with self.assertRaises(SystemExit):
+            VERIFY.validate_trusted_verifier(verifier, self.dockerfile)
+
+    def test_rejects_provenance_that_is_not_the_protected_main_publisher(self) -> None:
+        verifier = copy.deepcopy(self.verifier)
+        verifier["distribution"] = {
+            "mode": "pinned",
+            "image": "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:" + "a" * 64,
+            "provenance": {
+                "repository": "Bitcoin-PIR/Bitcoin-PIR",
+                "workflow": ".github/workflows/other.yml",
+                "ref": "refs/pull/1/merge",
+                "commit": "b" * 40,
+                "dockerfileSha256": verifier["dockerfileSha256"],
+            },
+        }
+        with self.assertRaises(SystemExit):
+            VERIFY.validate_trusted_verifier(verifier, self.dockerfile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/verification/scripts/verify_formal_lock.py
+++ b/verification/scripts/verify_formal_lock.py
@@ -21,6 +21,16 @@ PROOF_MANIFEST_PATH = Path("proof-manifest.json")
 IMPLEMENTATION_CONTRACT_PATH = Path("verification/contracts/wire-shape-v1.json")
 TRUSTED_VERIFIER_COMMAND = ["easycrypt", "compile", "-I", ".", "Theorem.ec"]
 TRUSTED_VERIFIER_DOCKERFILE = Path("verification/toolchains/easycrypt.Dockerfile")
+TRUSTED_VERIFIER_SCHEMA = "BitcoinPIR/product-owned-easycrypt-verifier/v2"
+TRUSTED_VERIFIER_IMAGE = "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier"
+TRUSTED_VERIFIER_SOURCE_REPOSITORY = "Bitcoin-PIR/Bitcoin-PIR"
+TRUSTED_VERIFIER_PUBLISH_WORKFLOW = (
+    ".github/workflows/publish-easycrypt-verifier.yml"
+)
+TRUSTED_VERIFIER_SOURCE_REF = "refs/heads/main"
+OCI_IMAGE_DIGEST = re.compile(
+    r"ghcr\.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:[0-9a-f]{64}"
+)
 COMPILED_PROOF_SUFFIXES = {".eco", ".ecpc", ".ecaut"}
 FORBIDDEN_PROOF_FILENAMES = {"easycrypt.project"}
 FORBIDDEN_PROOF_SUFFIXES = {".eca"}
@@ -50,6 +60,15 @@ def load_json(path: Path, label: str) -> tuple[dict[str, object], bytes]:
     if not isinstance(value, dict):
         fail(f"{label} must be a JSON object")
     return value, raw
+
+
+def require_exact_keys(value: dict[str, object], expected: set[str], label: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        fail(
+            f"{label} keys must be exactly {sorted(expected)}; "
+            f"got {sorted(actual)}"
+        )
 
 
 def sha256(raw: bytes) -> str:
@@ -689,15 +708,123 @@ def git_tracked_files(repository: Path) -> set[str]:
 
 
 def write_github_output(
-    path: Path, repository: str, commit: str, run_id: str
+    path: Path,
+    repository: str,
+    commit: str,
+    run_id: str,
+    verifier_mode: str,
+    verifier_image: str,
+    verifier_source_commit: str,
 ) -> None:
     try:
         with path.open("a", encoding="utf-8") as output:
             output.write(f"repository={repository}\n")
             output.write(f"commit={commit}\n")
             output.write(f"run_id={run_id}\n")
+            output.write(f"verifier_mode={verifier_mode}\n")
+            output.write(f"verifier_image={verifier_image}\n")
+            output.write(f"verifier_source_commit={verifier_source_commit}\n")
     except OSError as error:
         fail(f"cannot write GitHub output {path}: {error}")
+
+
+def validate_trusted_verifier(
+    trusted_verifier: dict[str, object], verifier_raw: bytes
+) -> tuple[str, str, str]:
+    """Validate the product-owned verifier and select its safe distribution mode.
+
+    Bootstrap deliberately has no OCI reference: a PR keeps the old local build
+    until a separately published, attested image digest has been reviewed into
+    this lock.  A pinned distribution is always an immutable GHCR digest.
+    """
+    require_exact_keys(
+        trusted_verifier,
+        {
+            "schema",
+            "dockerfilePath",
+            "dockerfileSha256",
+            "baseImage",
+            "easycryptRepository",
+            "easycryptCommit",
+            "ocamlVersion",
+            "why3Version",
+            "altErgoVersion",
+            "platform",
+            "command",
+            "distribution",
+        },
+        "trustedVerifier",
+    )
+    if string_field(trusted_verifier, "schema") != TRUSTED_VERIFIER_SCHEMA:
+        fail("trusted verifier schema is unsupported")
+    verifier_dockerfile = safe_relative_path(trusted_verifier, "dockerfilePath")
+    if verifier_dockerfile != TRUSTED_VERIFIER_DOCKERFILE:
+        fail(f"trusted verifier Dockerfile must remain {TRUSTED_VERIFIER_DOCKERFILE}")
+    expected_verifier_digest = digest_field(trusted_verifier, "dockerfileSha256")
+    actual_verifier_digest = sha256(verifier_raw)
+    if actual_verifier_digest != expected_verifier_digest:
+        fail(
+            "trusted verifier Dockerfile digest drifted: "
+            f"expected {expected_verifier_digest}, got {actual_verifier_digest}"
+        )
+
+    expected_fields = {
+        "baseImage": TRUSTED_PROOF_TOOLCHAIN["base_image"],
+        "easycryptRepository": TRUSTED_PROOF_TOOLCHAIN["easycrypt_repository"],
+        "easycryptCommit": TRUSTED_PROOF_TOOLCHAIN["easycrypt_commit"],
+        "ocamlVersion": TRUSTED_PROOF_TOOLCHAIN["ocaml_version"],
+        "why3Version": TRUSTED_PROOF_TOOLCHAIN["why3_version"],
+        "altErgoVersion": TRUSTED_PROOF_TOOLCHAIN["solvers"][0]["version"],
+        "platform": TRUSTED_PROOF_TOOLCHAIN["platform"],
+    }
+    for field, expected in expected_fields.items():
+        if string_field(trusted_verifier, field) != expected:
+            fail(f"trusted verifier {field} drifted from the reviewed toolchain")
+    if string_list_field(trusted_verifier, "command") != TRUSTED_VERIFIER_COMMAND:
+        fail("trusted verifier command drifted from the reviewed EasyCrypt invocation")
+
+    dockerfile = verifier_raw.decode("utf-8", errors="strict")
+    for required in [
+        f"FROM {expected_fields['baseImage']}",
+        f"ARG EASYCRYPT_COMMIT={expected_fields['easycryptCommit']}",
+        f"ARG OCAML_VERSION={expected_fields['ocamlVersion']}",
+        f"ARG WHY3_VERSION={expected_fields['why3Version']}",
+        f"ARG ALT_ERGO_VERSION={expected_fields['altErgoVersion']}",
+    ]:
+        if required not in dockerfile:
+            fail(f"trusted verifier Dockerfile no longer binds {required}")
+
+    distribution = object_field(trusted_verifier, "distribution")
+    require_exact_keys(distribution, {"mode", "image", "provenance"}, "trustedVerifier.distribution")
+    mode = string_field(distribution, "mode")
+    image = distribution.get("image")
+    provenance = distribution.get("provenance")
+    if mode == "bootstrap":
+        if image is not None or provenance is not None:
+            fail("bootstrap verifier distribution must not name an unpublished image")
+        return mode, "", ""
+    if mode != "pinned":
+        fail("trusted verifier distribution mode must be bootstrap or pinned")
+    if not isinstance(image, str) or not OCI_IMAGE_DIGEST.fullmatch(image):
+        fail("pinned verifier image must be the reviewed GHCR immutable sha256 reference")
+    provenance_object = object_field(distribution, "provenance")
+    require_exact_keys(
+        provenance_object,
+        {"repository", "workflow", "ref", "commit", "dockerfileSha256"},
+        "trustedVerifier.distribution.provenance",
+    )
+    if string_field(provenance_object, "repository") != TRUSTED_VERIFIER_SOURCE_REPOSITORY:
+        fail("pinned verifier provenance repository drifted")
+    if string_field(provenance_object, "workflow") != TRUSTED_VERIFIER_PUBLISH_WORKFLOW:
+        fail("pinned verifier provenance workflow drifted")
+    if string_field(provenance_object, "ref") != TRUSTED_VERIFIER_SOURCE_REF:
+        fail("pinned verifier provenance ref must be main")
+    source_commit = string_field(provenance_object, "commit")
+    if not GIT_COMMIT.fullmatch(source_commit):
+        fail("pinned verifier provenance commit must be a full lowercase Git commit")
+    if digest_field(provenance_object, "dockerfileSha256") != expected_verifier_digest:
+        fail("pinned verifier provenance Dockerfile digest drifted")
+    return mode, image, source_commit
 
 
 def main() -> None:
@@ -762,23 +889,13 @@ def main() -> None:
 
     trusted_verifier = object_field(lock, "trustedVerifier")
     verifier_dockerfile = safe_relative_path(trusted_verifier, "dockerfilePath")
-    if verifier_dockerfile != TRUSTED_VERIFIER_DOCKERFILE:
-        fail(f"trusted verifier Dockerfile must remain {TRUSTED_VERIFIER_DOCKERFILE}")
-    expected_verifier_digest = digest_field(trusted_verifier, "dockerfileSha256")
-    if string_field(trusted_verifier, "platform") != "linux/amd64":
-        fail("trusted verifier platform must remain linux/amd64")
-    if string_list_field(trusted_verifier, "command") != TRUSTED_VERIFIER_COMMAND:
-        fail("trusted verifier command drifted from the reviewed EasyCrypt invocation")
     try:
         verifier_raw = (ROOT / verifier_dockerfile).read_bytes()
     except OSError as error:
         fail(f"cannot read trusted verifier Dockerfile: {error}")
-    actual_verifier_digest = sha256(verifier_raw)
-    if actual_verifier_digest != expected_verifier_digest:
-        fail(
-            "trusted verifier Dockerfile digest drifted: "
-            f"expected {expected_verifier_digest}, got {actual_verifier_digest}"
-        )
+    verifier_mode, verifier_image, verifier_source_commit = validate_trusted_verifier(
+        trusted_verifier, verifier_raw
+    )
 
     record, record_raw = load_json(
         ROOT / verification_record_path, "formal proof verification record"
@@ -821,7 +938,15 @@ def main() -> None:
         fail("verification record toolchain does not match the trusted toolchain")
 
     if arguments.github_output:
-        write_github_output(arguments.github_output, repository, commit, run_id)
+        write_github_output(
+            arguments.github_output,
+            repository,
+            commit,
+            run_id,
+            verifier_mode,
+            verifier_image,
+            verifier_source_commit,
+        )
 
     if arguments.proof_dir:
         proof_dir = arguments.proof_dir.resolve()


### PR DESCRIPTION
## Summary

- add a main-only workflow that builds and publishes the product-owned EasyCrypt verifier to GHCR, signs its immutable digest with GitHub artifact attestation, and verifies the attestation before reporting the digest
- extend the formal lock with explicit `bootstrap` and `pinned` distribution modes
- prepare formal CI to authenticate, pull, and verify a digest-pinned verifier image while always retaining the real `easycrypt compile -I . Theorem.ec` proof check
- add fail-closed workflow and lock mutation tests for permissions, action pins, publisher triggers, mutable tags, provenance, registry authentication, and real proof execution

## Safety boundary

This PR is Phase A only. The lock remains in `bootstrap` mode with no image or provenance value, so formal CI still performs its existing cold verifier build. This PR does not publish a package and does not reduce CI time yet.

After this PR is reviewed and merged, the separate bootstrap sequence is:

1. explicitly run the publisher on `main` to produce an attested immutable GHCR digest
2. review the reported digest and source commit
3. open a separate Phase B lock PR that selects the digest-pinned image

There is no mutable tag consumer and no fallback from a failed pinned image to an unverified verifier.

## Validation

- `node --test scripts/github-workflow-supply-chain-gate.test.mjs` (67/67)
- `node scripts/github-workflow-supply-chain-gate.mjs`
- `python3 -m unittest verification/scripts/test_verify_formal_lock.py` (5/5)
- Python syntax compilation for the lock validator and tests
- `git diff --check`

No Docker build, package publication, browser check, or deployment was performed locally.
