### PR TITLE
Pin attested EasyCrypt verifier

### DIFF
--- a/.github/workflows/formal-proof.yml
+++ b/.github/workflows/formal-proof.yml
@@ -55,9 +55,8 @@ jobs:
           python3 verification/scripts/verify_formal_lock.py
           --proof-dir .formal-proof
 
-      # Phase A deliberately keeps this cold build: the lock has no real
-      # published OCI digest yet.  The validator is the only authority allowed
-      # to switch this condition to the attested, immutable Phase B image.
+      # Bootstrap is a reviewed rollback mode. The validator is the only
+      # authority allowed to select it instead of the attested Phase B image.
       - name: Build product-owned trusted EasyCrypt verifier (Phase A bootstrap)
         if: steps.lock.outputs.verifier_mode == 'bootstrap'
         run: |

--- a/.github/workflows/publish-easycrypt-verifier.yml
+++ b/.github/workflows/publish-easycrypt-verifier.yml
@@ -1,16 +1,14 @@
 name: Publish attested EasyCrypt verifier
 
 # This workflow is intentionally not a pull_request workflow: PR code must
-# never receive a package-write token.  Phase A formal CI continues to build
-# locally until a digest produced here is reviewed into formal-proofs.json.
+# never receive a package-write token. The formal lock consumes only a reviewed,
+# attested digest produced here; the bootstrap mode remains a deliberate rollback.
 on:
   push:
     branches: [main]
     paths:
       - '.github/workflows/publish-easycrypt-verifier.yml'
       - 'verification/toolchains/easycrypt.Dockerfile'
-      - 'verification/locks/formal-proofs.json'
-      - 'verification/scripts/verify_formal_lock.py'
   schedule:
     - cron: '17 4 * * 1'
   workflow_dispatch:

--- a/docs/REPOSITORY_BOUNDARIES.md
+++ b/docs/REPOSITORY_BOUNDARIES.md
@@ -104,26 +104,27 @@ The durable statement is that a specific proof tree and its deterministically
 generated contract binding passed a specific verifier. This remains narrower
 than a full refinement proof from Rust or TypeScript into EasyCrypt.
 
-### Product-owned EasyCrypt verifier bootstrap and rollback
+### Product-owned EasyCrypt verifier distribution and rollback
 
-The verifier lock has two fail-closed distribution modes. **Phase A** is
-`bootstrap`: there is deliberately no OCI image digest, so the formal job builds
-`verification/toolchains/easycrypt.Dockerfile` locally and still recompiles the
-proof. This is the only safe state before the first real package exists; a
-placeholder digest is invalid.
+The verifier lock has two fail-closed distribution modes. **Phase B is active**:
+the lock names a real, immutable, attested OCI digest, and the formal job pulls
+that digest before recompiling the proof. A digest placeholder is invalid. The
+alternate `bootstrap` mode deliberately has no OCI image digest and rebuilds
+`verification/toolchains/easycrypt.Dockerfile` locally; it is retained only as
+an explicit reviewed rollback path.
 
 The `Publish attested EasyCrypt verifier` workflow is not callable from a PR. It
-can publish only from `main` after a controlled toolchain change, an explicit
-`main` dispatch, or the weekly clean rebuild. It publishes a temporary discovery
-tag only to obtain an OCI digest; that tag is never a trust input. The workflow
-attests and verifies the final `ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:...`
-digest before reporting it.
+can publish only from `main` after its own workflow or the EasyCrypt Dockerfile
+changes, an explicit `main` dispatch, or the weekly clean rebuild. A lock or
+validator-only change therefore cannot cause an unnecessary cold rebuild. It
+publishes a temporary discovery tag only to obtain an OCI digest; that tag is
+never a trust input. The workflow attests and verifies the final
+`ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:...` digest before
+reporting it.
 
-To enter **Phase B**, a reviewed follow-up changes the lock to `pinned` with the
-reported immutable digest and its `main` publisher provenance. The ordinary
-formal job then pulls that exact digest, checks its RepoDigest and OCI source /
-revision labels, authenticates to GHCR with its read-only GitHub token, verifies
-the GitHub provenance attestation for the protected
+The ordinary formal job now pulls the exact lock digest, checks its RepoDigest
+and OCI source / revision labels, authenticates to GHCR with its read-only
+GitHub token, verifies the GitHub provenance attestation for the protected
 publisher workflow, and still runs `easycrypt compile -I . Theorem.ec`. It never
 uses a tag or a fallback image. Rollback is another reviewed lock change to an
 earlier attested digest; returning to `bootstrap` intentionally restores the

--- a/scripts/github-workflow-supply-chain-gate.mjs
+++ b/scripts/github-workflow-supply-chain-gate.mjs
@@ -32,8 +32,6 @@ export const EASYCRYPT_PUBLISH_WORKFLOW = ".github/workflows/publish-easycrypt-v
 export const EASYCRYPT_PUBLISH_PATHS = Object.freeze([
   ".github/workflows/publish-easycrypt-verifier.yml",
   "verification/toolchains/easycrypt.Dockerfile",
-  "verification/locks/formal-proofs.json",
-  "verification/scripts/verify_formal_lock.py",
 ]);
 
 export const SUPPLY_CHAIN_GATE_PUSH_PATHS = Object.freeze([

--- a/scripts/github-workflow-supply-chain-gate.test.mjs
+++ b/scripts/github-workflow-supply-chain-gate.test.mjs
@@ -94,6 +94,18 @@ const formalProofLock = readFileSync(
   "utf8",
 );
 
+function mutateFormalProofLock(mutate) {
+  const lock = JSON.parse(formalProofLock);
+  mutate(lock);
+  return `${JSON.stringify(lock, null, 2)}\n`;
+}
+
+function bootstrapFormalProofLock() {
+  return mutateFormalProofLock((lock) => {
+    lock.trustedVerifier.distribution = { mode: "bootstrap", image: null, provenance: null };
+  });
+}
+
 test("accepts the reviewed payment-platform compile acceleration boundary", () => {
   assert.doesNotThrow(() => validatePaymentPlatformCompileAcceleration(paymentPlatformWorkflow));
 });
@@ -102,9 +114,19 @@ test("accepts the reviewed payment CI lane inventory", () => {
   assert.doesNotThrow(() => validatePaymentV1CiLaneInventory(paymentLaneScript));
 });
 
-test("accepts the reviewed Phase A EasyCrypt verifier bootstrap", () => {
+test("accepts the reviewed Phase B pinned EasyCrypt verifier", () => {
   assert.deepEqual(
     validateEasyCryptVerifierPolicy(formalProofWorkflow, easyCryptPublisherWorkflow, formalProofLock),
+    {
+      mode: "pinned",
+      image: "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:bc174b56c1e59cfa3e8e0385fcf2dbc3332a1e433d99a59992562e56284b2d48",
+    },
+  );
+});
+
+test("accepts explicit Phase A bootstrap rollback without an OCI reference", () => {
+  assert.deepEqual(
+    validateEasyCryptVerifierPolicy(formalProofWorkflow, easyCryptPublisherWorkflow, bootstrapFormalProofLock()),
     { mode: "bootstrap", image: null },
   );
 });
@@ -209,24 +231,38 @@ for (const [label, formal, publisher, lock, pattern] of [
     "bootstrap fabricates an image digest",
     formalProofWorkflow,
     easyCryptPublisherWorkflow,
-    formalProofLock.replace('"image": null', `"image": "${EASYCRYPT_VERIFIER_IMAGE}@sha256:${"a".repeat(64)}"`),
+    mutateFormalProofLock((lock) => {
+      lock.trustedVerifier.distribution = {
+        mode: "bootstrap",
+        image: `${EASYCRYPT_VERIFIER_IMAGE}@sha256:${"a".repeat(64)}`,
+        provenance: null,
+      };
+    }),
     /must not trust an unpublished image/u,
   ],
   [
     "pinned phase uses a mutable image reference",
     formalProofWorkflow,
     easyCryptPublisherWorkflow,
-    formalProofLock
-      .replace('"mode": "bootstrap"', '"mode": "pinned"')
-      .replace('"image": null', `"image": "${EASYCRYPT_VERIFIER_IMAGE}:latest"`)
-      .replace('"provenance": null', '"provenance": {}'),
+    mutateFormalProofLock((lock) => {
+      lock.trustedVerifier.distribution.image = `${EASYCRYPT_VERIFIER_IMAGE}:latest`;
+    }),
     /immutable reviewed GHCR digest/u,
+  ],
+  [
+    "pinned phase uses provenance from an unprotected publisher",
+    formalProofWorkflow,
+    easyCryptPublisherWorkflow,
+    mutateFormalProofLock((lock) => {
+      lock.trustedVerifier.distribution.provenance.ref = "refs/pull/1/merge";
+    }),
+    /reviewed main publisher/u,
   ],
   [
     "publisher path scope expands beyond the reviewed toolchain inputs",
     formalProofWorkflow,
     easyCryptPublisherWorkflow.replace(
-      "verification/scripts/verify_formal_lock.py",
+      "verification/toolchains/easycrypt.Dockerfile",
       "verification/**",
     ),
     formalProofLock,
@@ -242,8 +278,6 @@ test("keeps the exact reviewed EasyCrypt publisher path inventory", () => {
   assert.deepEqual(EASYCRYPT_PUBLISH_PATHS, [
     ".github/workflows/publish-easycrypt-verifier.yml",
     "verification/toolchains/easycrypt.Dockerfile",
-    "verification/locks/formal-proofs.json",
-    "verification/scripts/verify_formal_lock.py",
   ]);
 });
 

--- a/verification/locks/formal-proofs.json
+++ b/verification/locks/formal-proofs.json
@@ -32,9 +32,15 @@
       "Theorem.ec"
     ],
     "distribution": {
-      "mode": "bootstrap",
-      "image": null,
-      "provenance": null
+      "mode": "pinned",
+      "image": "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:bc174b56c1e59cfa3e8e0385fcf2dbc3332a1e433d99a59992562e56284b2d48",
+      "provenance": {
+        "repository": "Bitcoin-PIR/Bitcoin-PIR",
+        "workflow": ".github/workflows/publish-easycrypt-verifier.yml",
+        "ref": "refs/heads/main",
+        "commit": "aab4e4ccf65a94969be34b65ab0f23c2623ee5a6",
+        "dockerfileSha256": "84b3d2e19b0d7b82b208000e4c9620178f0bd6aaf134d0e14d5a531dbeae58f9"
+      }
     }
   },
   "verification": {

--- a/verification/scripts/test_verify_formal_lock.py
+++ b/verification/scripts/test_verify_formal_lock.py
@@ -26,28 +26,27 @@ class TrustedVerifierDistributionTests(unittest.TestCase):
         self.verifier = lock["trustedVerifier"]
         self.dockerfile = (ROOT / "verification/toolchains/easycrypt.Dockerfile").read_bytes()
 
-    def test_bootstrap_keeps_the_local_build_until_a_real_digest_exists(self) -> None:
+    def test_current_pinned_distribution_uses_the_published_attested_verifier(self) -> None:
         self.assertEqual(
             VERIFY.validate_trusted_verifier(self.verifier, self.dockerfile),
-            ("bootstrap", "", ""),
+            (
+                "pinned",
+                "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:"
+                "bc174b56c1e59cfa3e8e0385fcf2dbc3332a1e433d99a59992562e56284b2d48",
+                "aab4e4ccf65a94969be34b65ab0f23c2623ee5a6",
+            ),
         )
 
-    def test_pinned_distribution_requires_an_immutable_ghcr_digest_and_main_provenance(self) -> None:
+    def test_bootstrap_remains_an_explicit_local_build_rollback(self) -> None:
         verifier = copy.deepcopy(self.verifier)
         verifier["distribution"] = {
-            "mode": "pinned",
-            "image": "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:" + "a" * 64,
-            "provenance": {
-                "repository": "Bitcoin-PIR/Bitcoin-PIR",
-                "workflow": ".github/workflows/publish-easycrypt-verifier.yml",
-                "ref": "refs/heads/main",
-                "commit": "b" * 40,
-                "dockerfileSha256": verifier["dockerfileSha256"],
-            },
+            "mode": "bootstrap",
+            "image": None,
+            "provenance": None,
         }
         self.assertEqual(
             VERIFY.validate_trusted_verifier(verifier, self.dockerfile),
-            ("pinned", verifier["distribution"]["image"], "b" * 40),
+            ("bootstrap", "", ""),
         )
 
     def test_rejects_mutable_image_tag_in_pinned_distribution(self) -> None:
@@ -68,9 +67,11 @@ class TrustedVerifierDistributionTests(unittest.TestCase):
 
     def test_rejects_bootstrap_placeholder_digest(self) -> None:
         verifier = copy.deepcopy(self.verifier)
-        verifier["distribution"]["image"] = (
-            "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:" + "a" * 64
-        )
+        verifier["distribution"] = {
+            "mode": "bootstrap",
+            "image": "ghcr.io/bitcoin-pir/bitcoinpir-easycrypt-verifier@sha256:" + "a" * 64,
+            "provenance": None,
+        }
         with self.assertRaises(SystemExit):
             VERIFY.validate_trusted_verifier(verifier, self.dockerfile)
 


### PR DESCRIPTION
## What changed

- pin the product-owned EasyCrypt verifier to the immutable GHCR digest published from `main`
- retain the cold Docker build only as an explicit reviewed bootstrap rollback
- stop lock-only or validator-only changes from triggering another verifier image build
- update policy mutation tests and repository boundary documentation for active Phase B

## Why

The formal-proof job previously spent about 14 minutes rebuilding the same locked verifier toolchain, while the actual EasyCrypt proof compile took about 2 seconds. This keeps the proof and provenance checks but replaces the repeated cold build with an authenticated digest pull and attestation verification.

## Validation

- `python3 -m unittest verification/scripts/test_verify_formal_lock.py` (5/5)
- `node --test scripts/github-workflow-supply-chain-gate.test.mjs` (69/69)
- `node scripts/github-workflow-supply-chain-gate.mjs`
- Python and Node syntax checks
- `git diff --check`

The PR CI is expected to provide the first end-to-end evidence that the pinned Phase B path can pull, verify provenance, and recompile the real proof without rebuilding the verifier.
