### PR TITLE
Fix stale DPF production canary log check

### DIFF
--- a/web/e2e/strict-production.spec.ts
+++ b/web/e2e/strict-production.spec.ts
@@ -78,7 +78,6 @@ test('DPF-PIR verifies both servers, the result, and tears down transport', asyn
   await expectVerifiedResult(results);
   await expectLogContains(
     page,
-    'Upgraded to encrypted channel',
     'operator-endorsed identity verified (pir1)',
     'operator-endorsed identity verified (pir2)',
     'Bitcoin/MuHash anchor verified',


### PR DESCRIPTION
## Summary

- remove one stale DPF production-canary expectation for the legacy global `Upgraded to encrypted channel` log line
- retain both provider verification checks, verified result, operator identities, Bitcoin/MuHash anchor, batch completion, transport teardown, disconnect, and fatal-log rejection

## Root cause

The live DPF query completed successfully on the newly deployed bundle, but the staged per-provider connection path upgrades each leg through `upgradeServerToSecureChannel` without emitting the older global log message. The canary waited ten minutes for that presentation text after the query had already completed and disconnected.

## Validation

- `npx --no-install tsc --noEmit`
- `npm run build`
- `npx --no-install playwright test --config playwright.production.config.ts --list` (4 tests discovered)
- `git diff --check`

No production browser query was run locally. After merge, the GitHub production canary will be rerun against the already deployed WASM-fixed bundle.
