### PR TITLE
Update production canary identity assertions

### DIFF
--- a/web/e2e/strict-production.spec.ts
+++ b/web/e2e/strict-production.spec.ts
@@ -78,8 +78,8 @@ test('DPF-PIR verifies both servers, the result, and tears down transport', asyn
   await expectVerifiedResult(results);
   await expectLogContains(
     page,
-    'operator-endorsed identity verified (pir1)',
-    'operator-endorsed identity verified (pir2)',
+    'operator-endorsed identity verified (pir1-payment-beta)',
+    'operator-endorsed identity verified (pir2-vpsbg-dpf-v1)',
     'Bitcoin/MuHash anchor verified',
     'Batch complete: 1/1 found',
   );


### PR DESCRIPTION
## Summary
- keep the strict DPF operator identity checks
- update the expected IDs to the production bootstrap stable IDs
- leave all result, anchor, teardown, no-fatal, and other backend checks unchanged

## Evidence
- production canary run 31320527152 completed DPF verification and Batch complete, but timed out expecting the retired pir1 alias
- current production logs and functional-beta-trusted-bootstrap.json use pir1-payment-beta and pir2-vpsbg-dpf-v1

## Validation
- npx --no-install tsc --noEmit
- npm run build
- npx --no-install playwright test e2e/strict-production.spec.ts --list
- git diff --check

No browser or production query was run locally.