### PR TITLE
Update Harmony production canary contract

### DIFF
--- a/web/e2e/strict-production.spec.ts
+++ b/web/e2e/strict-production.spec.ts
@@ -100,9 +100,8 @@ test('HarmonyPIR verifies both roles, the result, and preserves no socket', asyn
   await expectVerifiedResult(results);
   await expectLogContains(
     page,
-    'HarmonyPIR: upgraded to encrypted channel',
-    'HarmonyPIR hint: operator-endorsed identity verified (pir1)',
-    'HarmonyPIR query: operator-endorsed identity verified (pir2)',
+    'HarmonyPIR hint: operator-endorsed identity verified (pir1-payment-beta)',
+    'HarmonyPIR query: operator-endorsed identity verified (pir2-vpsbg-dpf-v1)',
     'HarmonyPIR batch complete: 1/1 found',
   );
   await expectTornDown(page, '#hp-connectBtn', '#hp-disconnectBtn');


### PR DESCRIPTION
## Summary
- retain strict Harmony hint/query identity checks using current production stable IDs
- remove the retired global encrypted-channel log assertion
- preserve verification, result, teardown, disconnected, and no-fatal checks

## Evidence
Production canary run 31321768033 passed DPF, then Harmony verified both roles, downloaded 155/155 hints, and completed 1/1 found. It timed out only on the retired global log string.

## Validation
- npx --no-install tsc --noEmit
- npm run build
- npx --no-install playwright test e2e/strict-production.spec.ts --list
- git diff --check

No browser or production query was run locally.