### PR TITLE
Use locked Onion V2 database proof pins

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-sRlmD0eadjZswbJv08HtozMwakJ76W0psVu62XSltEo=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-StWEzAkK23p4PC8zbLk2BK+3QTSr7otx6F3/VSyT93M=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
     <title>Bitcoin PIR</title>
     <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>
@@ -4564,7 +4564,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     expectedServerPin: provider.serverPin,
                     expectedServerId: provider.stableServerId,
                     pinnedOperatorPubkey: providerOperatorKeyV1(provider),
-                    databaseProofPins: provider.databaseProofPins,
+                    databaseProofPins: PRODUCTION_ONION_DB_PROOF_V2_PINS,
                     onConnectionStateChange: (state, message) => {
                         log(`OnionPIR: ${state}${message ? ' - ' + message : ''}`,
                             state === 'connected' ? 'success' : state === 'disconnected' ? 'error' : 'info');

--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 import bundledFunctionalBetaBootstrap from '../functional-beta-trusted-bootstrap.json';
@@ -46,5 +47,17 @@ describe('bundled functional-beta trusted bootstrap', () => {
     expect(() => parseProductTrustedBootstrapV1(JSON.stringify(replacement))).toThrow(
       /must declare supported workloads/,
     );
+  });
+
+  it('routes strict OnionPIR through the reviewed v2 proof pins', () => {
+    const html = readFileSync(new URL('../../index.html', import.meta.url), 'utf8');
+    const start = html.indexOf('async function opConnect(provider)');
+    const end = html.indexOf('function opDisconnect', start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const onionConnect = html.slice(start, end);
+    expect(onionConnect).toContain('databaseProofPins: PRODUCTION_ONION_DB_PROOF_V2_PINS');
+    expect(onionConnect).not.toContain('databaseProofPins: provider.databaseProofPins');
   });
 });


### PR DESCRIPTION
## Summary
- route strict OnionPIR through the reviewed V2 proof registry pins
- keep DPF/Harmony provider V1 pins unchanged
- add a focused glue regression test for the production Onion client config

## Production evidence
Canary run 31323446443 passed DPF and Harmony, then Onion failed closed before admission because the Web client expected the V1 db0 params hash ac364e... while the V2 server and proof registry returned a600f3....

## Validation
- focused functional-beta bootstrap test
- proof-registry-lock test
- npx --no-install tsc --noEmit
- npm run build
- node scripts/verify-csp.mjs
- Playwright production test --list
- git diff --check

No local browser or production query was run.