### PR TITLE
Fix Harmony WASM initialization race

### DIFF
--- a/web/src/__tests__/adapter-lifecycle.test.ts
+++ b/web/src/__tests__/adapter-lifecycle.test.ts
@@ -345,6 +345,81 @@ describe('adapter WASM lifecycle', () => {
     expect(connect1).not.toHaveBeenCalled();
   });
 
+  it('waits for SDK initialization before constructing or dialing a staged Harmony leg', async () => {
+    let resolveInit!: (ready: boolean) => void;
+    initSdkWasm.mockImplementationOnce(() => new Promise<boolean>((resolve) => {
+      resolveInit = resolve;
+    }));
+    isSdkWasmReady.mockReturnValue(false);
+    const nativeClient = {
+      setRequireVerifiedDatabaseRoots: vi.fn(),
+      setPrpBackend: vi.fn(),
+      setMasterKey: vi.fn(),
+      connectProvider: vi.fn(async () => { throw new Error('stop after Harmony native dial'); }),
+      disconnectProvider: vi.fn(async () => {}),
+      isProviderConnected: vi.fn(() => false),
+      free: vi.fn(),
+    };
+    const WasmHarmonyClient = vi.fn(() => nativeClient);
+    requireSdkWasm.mockReturnValue({ WasmHarmonyClient });
+    const adapter = new HarmonyPirClientAdapter({
+      hintServerUrl: 'wss://hint.invalid',
+      queryServerUrl: '',
+      strictVerification: true,
+      pinnedHintOperatorPubkey: OPERATOR_PIN_0,
+    });
+
+    const connecting = adapter.connectLeg(0);
+    await Promise.resolve();
+
+    expect(initSdkWasm).toHaveBeenCalledOnce();
+    expect(requireSdkWasm).not.toHaveBeenCalled();
+    expect(WasmHarmonyClient).not.toHaveBeenCalled();
+    expect(nativeClient.connectProvider).not.toHaveBeenCalled();
+
+    resolveInit(true);
+    await expect(connecting).rejects.toThrow('stop after Harmony native dial');
+
+    expect(WasmHarmonyClient).toHaveBeenCalledOnce();
+    expect(nativeClient.connectProvider).toHaveBeenCalledWith(0);
+  });
+
+  it('rejects unavailable Harmony SDK initialization without constructing a client', async () => {
+    initSdkWasm.mockResolvedValueOnce(false);
+    isSdkWasmReady.mockReturnValue(false);
+    const WasmHarmonyClient = vi.fn();
+    requireSdkWasm.mockReturnValue({ WasmHarmonyClient });
+    const adapter = new HarmonyPirClientAdapter({
+      hintServerUrl: 'wss://hint.invalid',
+      queryServerUrl: '',
+    });
+
+    await expect(adapter.loadWasm()).rejects.toThrow(
+      'PIR SDK WASM initialization failed; cannot establish Harmony transport',
+    );
+
+    expect(requireSdkWasm).not.toHaveBeenCalled();
+    expect(WasmHarmonyClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects failed Harmony SDK initialization without constructing a client', async () => {
+    initSdkWasm.mockRejectedValueOnce(new Error('WASM fetch failed'));
+    isSdkWasmReady.mockReturnValue(false);
+    const WasmHarmonyClient = vi.fn();
+    requireSdkWasm.mockReturnValue({ WasmHarmonyClient });
+    const adapter = new HarmonyPirClientAdapter({
+      hintServerUrl: 'wss://hint.invalid',
+      queryServerUrl: '',
+    });
+
+    await expect(adapter.loadWasm()).rejects.toThrow(
+      'PIR SDK WASM initialization failed; cannot establish Harmony transport',
+    );
+
+    expect(requireSdkWasm).not.toHaveBeenCalled();
+    expect(WasmHarmonyClient).not.toHaveBeenCalled();
+  });
+
   it('publishes a verified first-leg DPF root before pair preflight without authorizing use', async () => {
     const dpf = new BatchPirClientAdapter({
       server0Url: 'wss://pir1.invalid',

--- a/web/src/harmonypir-adapter.ts
+++ b/web/src/harmonypir-adapter.ts
@@ -67,6 +67,8 @@ import {
   type ServerInfoJson,
 } from './server-info.js';
 import {
+  initSdkWasm,
+  isSdkWasmReady,
   requireSdkWasm,
   type WasmAnnounceVerification,
   type WasmAttestVerification,
@@ -1184,6 +1186,7 @@ export class HarmonyPirClientAdapter {
    */
   async loadWasm(): Promise<void> {
     if (this.wasmClient) return;
+    await this.ensureSdkWasmInitialized();
     const sdk = requireSdkWasm();
     this.wasmClient = new sdk.WasmHarmonyClient(
       this.config.hintServerUrl,
@@ -1203,6 +1206,22 @@ export class HarmonyPirClientAdapter {
     this.wasmClient.setMasterKey(masterKey);
     const backendName = ['HMR12', 'FastPRP'][backend] ?? 'HMR12';
     this.log(`WASM loaded: ${backendName}`);
+  }
+
+  /**
+   * Harmony has no TypeScript fallback for its native transport. Await the
+   * shared SDK initializer here so every public setup path, including staged
+   * provider legs, fails closed before constructing or dialing the client.
+   */
+  private async ensureSdkWasmInitialized(): Promise<void> {
+    if (isSdkWasmReady()) return;
+    try {
+      if (await initSdkWasm()) return;
+    } catch {
+      // Normalize loader failures with the unavailable case. Do not touch the
+      // native SDK until initialization has completed successfully.
+    }
+    throw new Error('PIR SDK WASM initialization failed; cannot establish Harmony transport');
   }
 
   /**


### PR DESCRIPTION
## What changed

- make `HarmonyPirClientAdapter.loadWasm()` await the shared SDK WASM initializer
- fail closed before requiring, constructing, or dialing the native Harmony client when initialization is unavailable
- add deferred, false, and rejected initialization lifecycle regressions

## Root cause

Production canary run 31325225847 showed the Harmony hint provider path constructing its native client while the page-level best-effort WASM initialization was still in flight. DPF already enforced this boundary inside its adapter; Harmony did not.

## Impact

Harmony setup no longer depends on page evaluation timing. Both staged provider admission and the public `loadWasm()` entry wait for SDK readiness before touching the native transport.

## Validation

- `npx --no-install vitest run src/__tests__/adapter-lifecycle.test.ts` (52/52)
- `npx --no-install tsc --noEmit`
- `npm run build`
- `git diff --check`

No manual browser check was run. After merge and production deployment, the four-backend production canary will provide the live acceptance evidence.
