### PR TITLE
Fix ORAM WASM initialization race

### DIFF
--- a/web/src/__tests__/adapter-lifecycle.test.ts
+++ b/web/src/__tests__/adapter-lifecycle.test.ts
@@ -25,6 +25,7 @@ vi.mock('../sdk-bridge.js', () => ({
 
 import { BatchPirClientAdapter } from '../dpf-adapter.js';
 import { HarmonyPirClientAdapter } from '../harmonypir-adapter.js';
+import { OramPirClientAdapter } from '../oram-adapter.js';
 import type { WasmAnnounceVerification, WasmAttestVerification } from '../sdk-bridge.js';
 
 function fakeAttestation(free: () => void): WasmAttestVerification {
@@ -418,6 +419,67 @@ describe('adapter WASM lifecycle', () => {
 
     expect(requireSdkWasm).not.toHaveBeenCalled();
     expect(WasmHarmonyClient).not.toHaveBeenCalled();
+  });
+
+  it('waits for SDK initialization before constructing or dialing an ORAM client', async () => {
+    let resolveInit!: (ready: boolean) => void;
+    initSdkWasm.mockImplementationOnce(() => new Promise<boolean>((resolve) => {
+      resolveInit = resolve;
+    }));
+    isSdkWasmReady.mockReturnValue(false);
+    const nativeClient = {
+      connect: vi.fn(async () => { throw new Error('stop after ORAM native dial'); }),
+      disconnect: vi.fn(async () => {}),
+      free: vi.fn(),
+    };
+    const WasmOramClient = vi.fn(() => nativeClient);
+    requireSdkWasm.mockReturnValue({ WasmOramClient });
+    const adapter = new OramPirClientAdapter({ serverUrl: 'wss://oram.invalid' });
+
+    const connecting = adapter.connect();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(initSdkWasm).toHaveBeenCalledOnce();
+    expect(requireSdkWasm).not.toHaveBeenCalled();
+    expect(WasmOramClient).not.toHaveBeenCalled();
+    expect(nativeClient.connect).not.toHaveBeenCalled();
+
+    resolveInit(true);
+    await expect(connecting).rejects.toThrow('stop after ORAM native dial');
+
+    expect(WasmOramClient).toHaveBeenCalledOnce();
+    expect(nativeClient.connect).toHaveBeenCalledOnce();
+  });
+
+  it('rejects unavailable ORAM SDK initialization without constructing or dialing a client', async () => {
+    initSdkWasm.mockResolvedValueOnce(false);
+    isSdkWasmReady.mockReturnValue(false);
+    const WasmOramClient = vi.fn();
+    requireSdkWasm.mockReturnValue({ WasmOramClient });
+    const adapter = new OramPirClientAdapter({ serverUrl: 'wss://oram.invalid' });
+
+    await expect(adapter.connect()).rejects.toThrow(
+      'PIR SDK WASM initialization failed; cannot establish ORAM transport',
+    );
+
+    expect(requireSdkWasm).not.toHaveBeenCalled();
+    expect(WasmOramClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects failed ORAM SDK initialization without constructing or dialing a client', async () => {
+    initSdkWasm.mockRejectedValueOnce(new Error('WASM fetch failed'));
+    isSdkWasmReady.mockReturnValue(false);
+    const WasmOramClient = vi.fn();
+    requireSdkWasm.mockReturnValue({ WasmOramClient });
+    const adapter = new OramPirClientAdapter({ serverUrl: 'wss://oram.invalid' });
+
+    await expect(adapter.connect()).rejects.toThrow(
+      'PIR SDK WASM initialization failed; cannot establish ORAM transport',
+    );
+
+    expect(requireSdkWasm).not.toHaveBeenCalled();
+    expect(WasmOramClient).not.toHaveBeenCalled();
   });
 
   it('publishes a verified first-leg DPF root before pair preflight without authorizing use', async () => {

--- a/web/src/oram-adapter.ts
+++ b/web/src/oram-adapter.ts
@@ -30,6 +30,8 @@ import {
   type DatabaseCatalogEntry,
 } from './server-info.js';
 import {
+  initSdkWasm,
+  isSdkWasmReady,
   requireSdkWasm,
   type WasmAnnounceVerification,
   type WasmAtomicMetrics,
@@ -184,6 +186,7 @@ export class OramPirClientAdapter {
         throw new Error('strict ORAM requires the secure channel');
       }
 
+      await this.ensureSdkWasmInitialized();
       const sdk = requireSdkWasm();
       client = new sdk.WasmOramClient(this.config.serverUrl);
       this.wasmClient = client;
@@ -515,6 +518,22 @@ export class OramPirClientAdapter {
       }
       client.free();
     }
+  }
+
+  /**
+   * The page boot path starts the shared SDK loader, but a direct adapter
+   * connection can otherwise race it. Keep the transport boundary fail-closed:
+   * no native client is constructed or dialed until the module is ready.
+   */
+  private async ensureSdkWasmInitialized(): Promise<void> {
+    if (isSdkWasmReady()) return;
+    try {
+      if (await initSdkWasm()) return;
+    } catch {
+      // Normalize loader failures with the unavailable case. The native SDK
+      // must not be touched until it has completed initialization.
+    }
+    throw new Error('PIR SDK WASM initialization failed; cannot establish ORAM transport');
   }
 
   private async verifyConfiguredDatabaseProofs(


### PR DESCRIPTION
## What changed

- make `OramPirClientAdapter.connect()` await the shared SDK WASM initializer before constructing or dialing the native client
- fail closed without touching the native SDK when initialization is unavailable or rejects
- add deferred, false, and rejected initialization lifecycle regressions

## Root cause

Production canary run 31326594652 showed DPF, Harmony, and Onion passing, then ORAM constructing its native client while page-level WASM initialization was still in flight. ORAM therefore failed before runtime verification or query execution with `WASM module required`.

## Impact

ORAM connection no longer depends on page evaluation timing. Its adapter now enforces the same internal initialization boundary as the DPF and Harmony adapters.

## Validation

- `npm exec -- vitest run src/__tests__/adapter-lifecycle.test.ts` (55/55)
- `npx --no-install tsc --noEmit`
- `npm run build`
- `git diff --check`

No production E2E assertion was changed, and no browser or production request was run locally. After merge and deployment, the four-backend production canary will supply live acceptance evidence.
