### PR TITLE
Stage consistent VPSBG Tier3 generations

### DIFF
--- a/apps/server/tests/payment_v1_tee_oram_process_e2e.rs
+++ b/apps/server/tests/payment_v1_tee_oram_process_e2e.rs
@@ -597,7 +597,13 @@ fn production_direct_oram_startup_rejects_unbound_or_unsafe_configurations() {
 #[test]
 fn measured_boot_copies_exact_manifest_and_sources_before_strict_build() {
     let script = include_str!("../../../scripts/dracut/97bpir-tier3-init/unified-server-run.sh");
-    assert!(script.contains("server-db/MANIFEST.toml missing"));
+    assert!(script.contains("load_active_database_generation 0 db0"));
+    assert!(script.contains("load_active_database_generation 1 db1"));
+    assert!(script.contains("runtime/proof MANIFEST bytes differ"));
+    assert!(!script.contains("first_existing_dir"));
+    assert!(!script.contains("first_existing_file"));
+    assert!(!script.contains("attested-builder-runs/mainnet_948454_oram_948454_sev_snp"));
+    assert!(!script.contains("attestations/delta_940611_948454_sev_snp"));
     assert!(script.contains("$trusted_input_dir/server-db-MANIFEST.toml"));
     assert_eq!(
         script
@@ -628,6 +634,9 @@ fn measured_boot_copies_exact_manifest_and_sources_before_strict_build() {
     let strict_build = script
         .find("--server-db-manifest \"$db_manifest\"")
         .unwrap();
+    let active_generation = script.find("load_active_database_generation 0 db0").unwrap();
+    let build_invocation = script.rfind("build_direct_oram mainnet-948454").unwrap();
+    assert!(active_generation < build_invocation);
     assert!(copy < trusted_rebind && trusted_rebind < strict_build);
 }
 

--- a/docs/DATABASE_ROOT_ROTATION_RUNBOOK.md
+++ b/docs/DATABASE_ROOT_ROTATION_RUNBOOK.md
@@ -123,6 +123,26 @@ Hetzner and VPSBG. Verify file hashes after transfer. Prepare a new
 `databases.toml` for each host and retain a timestamped copy of the active
 configuration.
 
+For VPSBG Tier 3 Direct ORAM, stage each complete attested-builder output as
+one generation; do not pair a serving database tree with a proof directory
+from another run. The helper below copies the complete db0/db1 outputs beneath
+`/home/pir/data/generations/<generation>/`, verifies the staged manifest bytes,
+and writes a candidate catalog. It never replaces the active
+`/home/pir/data/databases.toml`:
+
+```bash
+./scripts/stage_vpsbg_tier3_generation.sh \
+  --generation <reviewed-generation> \
+  --db0-output <complete-db0-build-output> \
+  --db0-name <name> --db0-type full --db0-base-height 0 --db0-height <height> \
+  --db1-output <complete-db1-build-output> \
+  --db1-name <name> --db1-type delta --db1-base-height <height> --db1-height <height>
+```
+
+The resulting candidate points `path` at that generation's `server-db` tree
+and `proof_dir` at the same generation root. Review it and use the maintenance
+window activation step below; never edit its generated path/proof pairing.
+
 Hetzner can be staged over its normal SSH/operator path. VPSBG Tier 3 has no
 SSH, so a complete proof/root rotation must use a planned portal maintenance
 boot: select `UKI: None`, reboot into the maintenance system, stage the

--- a/scripts/dracut/97bpir-tier3-init/module-setup.sh
+++ b/scripts/dracut/97bpir-tier3-init/module-setup.sh
@@ -68,9 +68,10 @@ install() {
     # explicitly is idempotent (inst_multiple no-ops if already there).
     # nc is needed by cloudflared-run.sh's port-wait gate (Phase 3.2);
     # blkid for the FATAL-path diagnostic when rootfs mount fails.
-    # awk/dd/od/tr/tail/rm/mv are used by unified-server-run.sh to derive fresh
-    # ORAM seeds, parse direct-input hash files, and publish boot images.
-    inst_multiple ip modprobe mount sleep ln mkdir cat sh nc blkid awk dd od tr tail rm mv
+    # awk/cmp/dd/od/tr/tail/rm/mv are used by unified-server-run.sh to derive
+    # fresh ORAM seeds, parse the active catalog, bind its runtime/proof
+    # manifests byte-for-byte, and publish boot images.
+    inst_multiple ip modprobe mount sleep ln mkdir cat sh nc blkid awk cmp dd od tr tail rm mv
 
     # udhcpc is a busybox applet, NOT a standalone binary on Ubuntu.
     # Bake busybox itself in (statically linked, ~1.5 MB) and create

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -52,6 +52,9 @@ ORAMCTL=/usr/local/bin/oramctl
 if [ ! -x "$ORAMCTL" ] && [ -x /home/pir/BitcoinPIR/vendor/bitcoinpir-oram/target/release/oramctl ]; then
     ORAMCTL=/home/pir/BitcoinPIR/vendor/bitcoinpir-oram/target/release/oramctl
 fi
+
+TIER3_DATA_ROOT=/home/pir/data
+TIER3_DATABASES_CONFIG="$TIER3_DATA_ROOT/databases.toml"
 UNIFIED_SERVER=/usr/local/bin/unified_server
 if [ ! -x "$UNIFIED_SERVER" ] && [ -x /home/pir/BitcoinPIR/target/release/unified_server ]; then
     UNIFIED_SERVER=/home/pir/BitcoinPIR/target/release/unified_server
@@ -129,32 +132,81 @@ require_file() {
     [ -r "$1" ] || fatal "required file missing or unreadable: $1"
 }
 
-first_existing_dir() {
-    for path in "$@"; do
-        if [ -d "$path" ]; then
-            echo "$path"
-            return 0
-        fi
-    done
-    return 1
-}
-
-first_existing_file() {
-    for path in "$@"; do
-        if [ -r "$path" ]; then
-            echo "$path"
-            return 0
-        fi
-    done
-    return 1
-}
-
 direct_input_hash() {
     awk -v name="$1" '$2 == name || $2 == "./" name { print $1; exit }' "$2"
 }
 
 sha256_path() {
     sha256sum "$1" | awk '{ print $1 }'
+}
+
+# Extract a quoted path from the selected [[database]] entry without evaluating
+# mutable-rootfs TOML as shell.  The generation helper emits this canonical
+# shape; rejecting exotic TOML is intentional because this measured boot path
+# must fail closed rather than guess a different database/proof pairing.
+toml_database_path() {
+    database_index="$1"
+    field_name="$2"
+    awk -v target="$database_index" -v field="$field_name" '
+        BEGIN { current = -1; seen = 0 }
+        /^[[:space:]]*\[\[database\]\][[:space:]]*(#.*)?$/ { current++; next }
+        current == target {
+            line = $0
+            sub(/^[[:space:]]*/, "", line)
+            if (line ~ ("^" field "[[:space:]]*=")) {
+                sub(("^" field "[[:space:]]*=[[:space:]]*"), "", line)
+                if (line !~ /^"[^"]*"[[:space:]]*(#.*)?$/ || seen) exit 2
+                sub(/^"/, "", line)
+                sub(/"[[:space:]]*(#.*)?$/, "", line)
+                value = line
+                seen = 1
+            }
+        }
+        END {
+            if (seen != 1) exit 1
+            print value
+        }
+    ' "$TIER3_DATABASES_CONFIG"
+}
+
+resolve_tier3_data_path() {
+    raw_path="$1"
+    case "$raw_path" in
+        ''|*[!A-Za-z0-9_./-]*) fatal "database catalog path contains unsupported characters" ;;
+    esac
+    case "/$raw_path/" in
+        */../*|*/./*) fatal "database catalog path must not contain dot segments: $raw_path" ;;
+    esac
+    case "$raw_path" in
+        /*) resolved_path="$raw_path" ;;
+        *) resolved_path="$TIER3_DATA_ROOT/$raw_path" ;;
+    esac
+    case "$resolved_path" in
+        "$TIER3_DATA_ROOT"/*) ;;
+        *) fatal "database catalog path escapes $TIER3_DATA_ROOT: $raw_path" ;;
+    esac
+    printf '%s\n' "$resolved_path"
+}
+
+load_active_database_generation() {
+    database_index="$1"
+    database_label="$2"
+    runtime_raw="$(toml_database_path "$database_index" path)" \
+        || fatal "$database_label path missing or non-canonical in $TIER3_DATABASES_CONFIG"
+    proof_raw="$(toml_database_path "$database_index" proof_dir)" \
+        || fatal "$database_label proof_dir missing or non-canonical in $TIER3_DATABASES_CONFIG"
+    ACTIVE_DB_RUNTIME_DIR="$(resolve_tier3_data_path "$runtime_raw")"
+    ACTIVE_DB_PROOF_DIR="$(resolve_tier3_data_path "$proof_raw")"
+    require_file "$ACTIVE_DB_RUNTIME_DIR/MANIFEST.toml"
+    require_file "$ACTIVE_DB_PROOF_DIR/server-db/MANIFEST.toml"
+    cmp -s "$ACTIVE_DB_RUNTIME_DIR/MANIFEST.toml" \
+        "$ACTIVE_DB_PROOF_DIR/server-db/MANIFEST.toml" \
+        || fatal "$database_label runtime/proof MANIFEST bytes differ"
+    require_file "$ACTIVE_DB_PROOF_DIR/build-evidence.bin"
+    require_file "$ACTIVE_DB_PROOF_DIR/root-bundle-payload.bin"
+    require_file "$ACTIVE_DB_PROOF_DIR/oram-direct-inputs/utxo_chunks_index_nodust.bin"
+    require_file "$ACTIVE_DB_PROOF_DIR/oram-direct-inputs/utxo_chunks_nodust.bin"
+    require_file "$ACTIVE_DB_PROOF_DIR/oram-direct-inputs/direct-inputs.sha256"
 }
 
 random_seed_hex() {
@@ -401,41 +453,17 @@ mkdir -p "$TRUSTED_INPUT_ROOT" "$TRUSTED_STATE_ROOT" \
 ORAM_PAGE_KEY_HEX="$(random_seed_hex)"
 trap cleanup_build_staging EXIT
 
-MAINNET_SOURCE_DIR="$(first_existing_dir \
-    /home/pir/data/oram-inputs/checkpoints/948454 \
-    /home/pir/data/attested-builder-runs/mainnet_948454_oram_948454_sev_snp/oram-direct-inputs \
-    /home/pir/data/attestations/mainnet_948454_oram_sev_snp/run/oram-direct-inputs)" \
-    || fatal "mainnet direct-input directory missing"
-MAINNET_DB_EVIDENCE="$(first_existing_file \
-    /home/pir/data/attestations/mainnet_948454_oram_sev_snp/run/build-evidence.bin \
-    /home/pir/data/attested-builder-runs/mainnet_948454_oram_948454_sev_snp/build-evidence.bin)" \
-    || fatal "mainnet build-evidence.bin missing"
-MAINNET_DB_MANIFEST="$(first_existing_file \
-    /home/pir/data/attestations/mainnet_948454_oram_sev_snp/run/server-db/MANIFEST.toml \
-    /home/pir/data/attested-builder-runs/mainnet_948454_oram_948454_sev_snp/server-db/MANIFEST.toml)" \
-    || fatal "mainnet exact server-db/MANIFEST.toml missing"
-MAINNET_ROOT_BUNDLE="$(first_existing_file \
-    /home/pir/data/attestations/mainnet_948454_oram_sev_snp/run/root-bundle-payload.bin \
-    /home/pir/data/attested-builder-runs/mainnet_948454_oram_948454_sev_snp/root-bundle-payload.bin)" \
-    || fatal "mainnet root-bundle-payload.bin missing"
+load_active_database_generation 0 db0
+MAINNET_SOURCE_DIR="$ACTIVE_DB_PROOF_DIR/oram-direct-inputs"
+MAINNET_DB_EVIDENCE="$ACTIVE_DB_PROOF_DIR/build-evidence.bin"
+MAINNET_DB_MANIFEST="$ACTIVE_DB_PROOF_DIR/server-db/MANIFEST.toml"
+MAINNET_ROOT_BUNDLE="$ACTIVE_DB_PROOF_DIR/root-bundle-payload.bin"
 
-DELTA_SOURCE_DIR="$(first_existing_dir \
-    /home/pir/data/oram-inputs/deltas/940611_948454_canonical_20260615 \
-    /home/pir/data/attested-builder-runs/delta_940611_948454_delta_940611_948454_sev_snp/oram-direct-inputs \
-    /home/pir/data/attestations/delta_940611_948454_sev_snp/oram-direct-inputs)" \
-    || fatal "delta direct-input directory missing"
-DELTA_DB_EVIDENCE="$(first_existing_file \
-    /home/pir/data/attestations/delta_940611_948454_sev_snp/build-evidence.bin \
-    /home/pir/data/attested-builder-runs/delta_940611_948454_delta_940611_948454_sev_snp/build-evidence.bin)" \
-    || fatal "delta build-evidence.bin missing"
-DELTA_DB_MANIFEST="$(first_existing_file \
-    /home/pir/data/attestations/delta_940611_948454_sev_snp/server-db/MANIFEST.toml \
-    /home/pir/data/attested-builder-runs/delta_940611_948454_delta_940611_948454_sev_snp/server-db/MANIFEST.toml)" \
-    || fatal "delta exact server-db/MANIFEST.toml missing"
-DELTA_ROOT_BUNDLE="$(first_existing_file \
-    /home/pir/data/attestations/delta_940611_948454_sev_snp/root-bundle-payload.bin \
-    /home/pir/data/attested-builder-runs/delta_940611_948454_delta_940611_948454_sev_snp/root-bundle-payload.bin)" \
-    || fatal "delta root-bundle-payload.bin missing"
+load_active_database_generation 1 db1
+DELTA_SOURCE_DIR="$ACTIVE_DB_PROOF_DIR/oram-direct-inputs"
+DELTA_DB_EVIDENCE="$ACTIVE_DB_PROOF_DIR/build-evidence.bin"
+DELTA_DB_MANIFEST="$ACTIVE_DB_PROOF_DIR/server-db/MANIFEST.toml"
+DELTA_ROOT_BUNDLE="$ACTIVE_DB_PROOF_DIR/root-bundle-payload.bin"
 
 build_direct_oram mainnet-948454 "$MAINNET_SOURCE_DIR" "$ORAM_STAGING_DIR/db0-mainnet-948454" \
     "$MAINNET_DB_EVIDENCE" "$MAINNET_DB_MANIFEST" "$MAINNET_ROOT_BUNDLE" "$MAINNET_EXPECTED_MUHASH" "" \

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,7 +26,7 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "87db8a202e5e5366aba5fdda28b13d07a177e5fa24f0eea6b3975517f62b4c7c",
+    "12dd0af352e7d6706f9249150c1c5d5f82995d1ac088ca30dd6277e0edcabca5",
 });
 
 const VPSBG_MEASURED_RUN_PATH =

--- a/scripts/stage_vpsbg_tier3_generation.sh
+++ b/scripts/stage_vpsbg_tier3_generation.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Stage complete, attested VPSBG Tier 3 database generations without changing
+# the active catalog.  The candidate catalog is directly activatable later by
+# atomically replacing /home/pir/data/databases.toml during a maintenance boot.
+
+set -euo pipefail
+umask 077
+
+usage() {
+    cat <<'USAGE'
+usage: stage_vpsbg_tier3_generation.sh \
+  --generation NAME --db0-output DIR --db1-output DIR \
+  --db0-name NAME --db0-type full|delta --db0-base-height N --db0-height N \
+  --db1-name NAME --db1-type full|delta --db1-base-height N --db1-height N \
+  [--data-root DIR] [--candidate-config PATH]
+
+Each --dbN-output must be one complete attested build output containing:
+  server-db/MANIFEST.toml, build-evidence.bin, root-bundle-payload.bin,
+  build-evidence.sev-snp-report.bin, database.manifest.sha256,
+  all-artifacts.manifest.sha256, and oram-direct-inputs/.
+
+The helper stages each output under DATA_ROOT/generations/NAME/dbN and writes
+a candidate catalog.  It never replaces DATA_ROOT/databases.toml.
+USAGE
+}
+
+fail() {
+    echo "[stage-vpsbg-tier3-generation] ERROR: $*" >&2
+    exit 1
+}
+
+require_value() {
+    [ "$#" -ge 2 ] || fail "missing value for $1"
+    printf '%s' "$2"
+}
+
+require_safe_name() {
+    case "$2" in
+        ''|*[!A-Za-z0-9._=-]*) fail "$1 contains unsupported characters" ;;
+    esac
+}
+
+require_type() {
+    case "$2" in
+        full|delta) ;;
+        *) fail "$1 must be full or delta" ;;
+    esac
+}
+
+require_unsigned_integer() {
+    case "$2" in
+        ''|*[!0-9]*) fail "$1 must be a non-negative integer" ;;
+    esac
+}
+
+require_file() {
+    [ -r "$1" ] || fail "required file missing or unreadable: $1"
+}
+
+require_directory() {
+    [ -d "$1" ] || fail "required directory missing: $1"
+}
+
+validate_output() {
+    output="$1"
+    label="$2"
+    require_directory "$output"
+    for rel in \
+        server-db/MANIFEST.toml \
+        build-evidence.bin \
+        root-bundle-payload.bin \
+        build-evidence.sev-snp-report.bin \
+        database.manifest.sha256 \
+        all-artifacts.manifest.sha256 \
+        oram-direct-inputs/utxo_chunks_index_nodust.bin \
+        oram-direct-inputs/utxo_chunks_nodust.bin \
+        oram-direct-inputs/direct-inputs.sha256; do
+        require_file "$output/$rel"
+    done
+}
+
+GENERATION=''
+DB0_OUTPUT=''
+DB1_OUTPUT=''
+DB0_NAME=''
+DB1_NAME=''
+DB0_TYPE=''
+DB1_TYPE=''
+DB0_BASE_HEIGHT=''
+DB1_BASE_HEIGHT=''
+DB0_HEIGHT=''
+DB1_HEIGHT=''
+DATA_ROOT=/home/pir/data
+CANDIDATE_CONFIG=''
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --generation) GENERATION="$(require_value "$@")"; shift 2 ;;
+        --db0-output) DB0_OUTPUT="$(require_value "$@")"; shift 2 ;;
+        --db1-output) DB1_OUTPUT="$(require_value "$@")"; shift 2 ;;
+        --db0-name) DB0_NAME="$(require_value "$@")"; shift 2 ;;
+        --db1-name) DB1_NAME="$(require_value "$@")"; shift 2 ;;
+        --db0-type) DB0_TYPE="$(require_value "$@")"; shift 2 ;;
+        --db1-type) DB1_TYPE="$(require_value "$@")"; shift 2 ;;
+        --db0-base-height) DB0_BASE_HEIGHT="$(require_value "$@")"; shift 2 ;;
+        --db1-base-height) DB1_BASE_HEIGHT="$(require_value "$@")"; shift 2 ;;
+        --db0-height) DB0_HEIGHT="$(require_value "$@")"; shift 2 ;;
+        --db1-height) DB1_HEIGHT="$(require_value "$@")"; shift 2 ;;
+        --data-root) DATA_ROOT="$(require_value "$@")"; shift 2 ;;
+        --candidate-config) CANDIDATE_CONFIG="$(require_value "$@")"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) fail "unknown argument: $1" ;;
+    esac
+done
+
+for spec in \
+    "generation:$GENERATION" \
+    "db0 name:$DB0_NAME" \
+    "db1 name:$DB1_NAME"; do
+    require_safe_name "${spec%%:*}" "${spec#*:}"
+done
+require_type "db0 type" "$DB0_TYPE"
+require_type "db1 type" "$DB1_TYPE"
+for spec in \
+    "db0 base height:$DB0_BASE_HEIGHT" \
+    "db0 height:$DB0_HEIGHT" \
+    "db1 base height:$DB1_BASE_HEIGHT" \
+    "db1 height:$DB1_HEIGHT"; do
+    require_unsigned_integer "${spec%%:*}" "${spec#*:}"
+done
+
+validate_output "$DB0_OUTPUT" db0
+validate_output "$DB1_OUTPUT" db1
+
+STAGE_ROOT="$DATA_ROOT/generations"
+FINAL_DIR="$STAGE_ROOT/$GENERATION"
+STAGING_DIR="$STAGE_ROOT/.${GENERATION}.staging.$$"
+if [ -z "$CANDIDATE_CONFIG" ]; then
+    CANDIDATE_CONFIG="$DATA_ROOT/databases.toml.candidate-$GENERATION"
+fi
+
+[ ! -e "$FINAL_DIR" ] || fail "refusing to overwrite existing generation: $FINAL_DIR"
+[ ! -e "$STAGING_DIR" ] || fail "staging path already exists: $STAGING_DIR"
+[ ! -e "$CANDIDATE_CONFIG" ] || fail "refusing to overwrite candidate config: $CANDIDATE_CONFIG"
+mkdir -p "$STAGE_ROOT"
+
+cleanup() {
+    if [ -n "${STAGING_DIR:-}" ] && [ -d "$STAGING_DIR" ]; then
+        rm -rf "$STAGING_DIR"
+    fi
+}
+trap cleanup EXIT
+
+mkdir "$STAGING_DIR"
+mkdir "$STAGING_DIR/db0" "$STAGING_DIR/db1"
+cp -a "$DB0_OUTPUT/." "$STAGING_DIR/db0/"
+cp -a "$DB1_OUTPUT/." "$STAGING_DIR/db1/"
+
+for db in db0 db1; do
+    source_output="$DB0_OUTPUT"
+    [ "$db" = db0 ] || source_output="$DB1_OUTPUT"
+    # The staged runtime path is deliberately the exact server-db tree inside
+    # the staged proof output.  Compare it to the source before publishing so
+    # the candidate catalog cannot pair a regenerated runtime manifest with
+    # attested proof sidecars from another build.
+    cmp -s "$source_output/server-db/MANIFEST.toml" \
+        "$STAGING_DIR/$db/server-db/MANIFEST.toml" \
+        || fail "$db runtime/proof MANIFEST bytes differ after staging"
+done
+
+candidate_tmp="$CANDIDATE_CONFIG.tmp.$$"
+trap 'rm -f "$candidate_tmp"; cleanup' EXIT
+cat >"$candidate_tmp" <<EOF
+# Candidate only; stage_vpsbg_tier3_generation.sh never activates this file.
+
+[[database]]
+name = "$DB0_NAME"
+type = "$DB0_TYPE"
+path = "$STAGE_ROOT/$GENERATION/db0/server-db"
+proof_dir = "$STAGE_ROOT/$GENERATION/db0"
+base_height = $DB0_BASE_HEIGHT
+height = $DB0_HEIGHT
+
+[[database]]
+name = "$DB1_NAME"
+type = "$DB1_TYPE"
+path = "$STAGE_ROOT/$GENERATION/db1/server-db"
+proof_dir = "$STAGE_ROOT/$GENERATION/db1"
+base_height = $DB1_BASE_HEIGHT
+height = $DB1_HEIGHT
+EOF
+
+mv "$STAGING_DIR" "$FINAL_DIR"
+STAGING_DIR=''
+mv "$candidate_tmp" "$CANDIDATE_CONFIG"
+
+echo "[stage-vpsbg-tier3-generation] staged generation: $FINAL_DIR"
+echo "[stage-vpsbg-tier3-generation] candidate catalog (not active): $CANDIDATE_CONFIG"

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const stageHelper = path.join(scriptsDir, "stage_vpsbg_tier3_generation.sh");
+const tier3RunScript = path.join(
+  scriptsDir,
+  "dracut/97bpir-tier3-init/unified-server-run.sh",
+);
+
+function write(pathname, contents = "fixture\n") {
+  mkdirSync(path.dirname(pathname), { recursive: true });
+  writeFileSync(pathname, contents);
+}
+
+function createCompleteOutput(root, name, manifest) {
+  const output = path.join(root, name);
+  for (const relative of [
+    "server-db/MANIFEST.toml",
+    "build-evidence.bin",
+    "root-bundle-payload.bin",
+    "build-evidence.sev-snp-report.bin",
+    "database.manifest.sha256",
+    "all-artifacts.manifest.sha256",
+    "oram-direct-inputs/utxo_chunks_index_nodust.bin",
+    "oram-direct-inputs/utxo_chunks_nodust.bin",
+    "oram-direct-inputs/direct-inputs.sha256",
+  ]) {
+    write(path.join(output, relative), relative.includes("MANIFEST") ? manifest : "fixture\n");
+  }
+  return output;
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { encoding: "utf8", ...options });
+  if (result.error) throw result.error;
+  return result;
+}
+
+const tempRoot = mkdtempSync(path.join(os.tmpdir(), "bpir-tier3-generation-"));
+try {
+  const dataRoot = path.join(tempRoot, "data");
+  mkdirSync(dataRoot, { recursive: true });
+  const activeCatalog = path.join(dataRoot, "databases.toml");
+  writeFileSync(activeCatalog, "# known-active catalog\n");
+
+  const db0 = createCompleteOutput(tempRoot, "db0-output", "db0 manifest\n");
+  const db1 = createCompleteOutput(tempRoot, "db1-output", "db1 manifest\n");
+  const stage = run("bash", [
+    stageHelper,
+    "--generation",
+    "fixture-1",
+    "--db0-output",
+    db0,
+    "--db1-output",
+    db1,
+    "--db0-name",
+    "main",
+    "--db0-type",
+    "full",
+    "--db0-base-height",
+    "0",
+    "--db0-height",
+    "948454",
+    "--db1-name",
+    "delta_940611_948454",
+    "--db1-type",
+    "delta",
+    "--db1-base-height",
+    "940611",
+    "--db1-height",
+    "948454",
+    "--data-root",
+    dataRoot,
+  ]);
+  assert.equal(stage.status, 0, stage.stdout + stage.stderr);
+  assert.equal(readFileSync(activeCatalog, "utf8"), "# known-active catalog\n");
+  const candidate = path.join(dataRoot, "databases.toml.candidate-fixture-1");
+  assert.ok(existsSync(candidate));
+  const candidateText = readFileSync(candidate, "utf8");
+  assert.ok(candidateText.includes(`path = "${dataRoot}/generations/fixture-1/db0/server-db"`));
+  assert.ok(candidateText.includes(`proof_dir = "${dataRoot}/generations/fixture-1/db1"`));
+  assert.equal(
+    readFileSync(path.join(dataRoot, "generations/fixture-1/db0/server-db/MANIFEST.toml"), "utf8"),
+    "db0 manifest\n",
+  );
+
+  const mismatchRoot = path.join(tempRoot, "mismatch");
+  const mismatchData = path.join(mismatchRoot, "data");
+  const marker = path.join(mismatchRoot, "oramctl-invoked");
+  const oramctl = path.join(mismatchRoot, "oramctl");
+  const unifiedServer = path.join(mismatchRoot, "unified_server");
+  const bhtmProof = path.join(mismatchRoot, "height-940611.leaf-proof.json");
+  write(oramctl, `#!/bin/sh\nprintf invoked > "${marker}"\n`);
+  write(unifiedServer, "#!/bin/sh\nexit 0\n");
+  chmodSync(oramctl, 0o755);
+  chmodSync(unifiedServer, 0o755);
+  write(bhtmProof, "{}\n");
+  write(path.join(mismatchData, "runtime-db0/MANIFEST.toml"), "runtime manifest\n");
+  write(path.join(mismatchData, "proof-db0/server-db/MANIFEST.toml"), "proof manifest\n");
+  write(
+    path.join(mismatchData, "databases.toml"),
+    `[[database]]\nname = "main"\ntype = "full"\npath = "runtime-db0"\nproof_dir = "proof-db0"\nbase_height = 0\nheight = 948454\n\n[[database]]\nname = "delta"\ntype = "delta"\npath = "runtime-db1"\nproof_dir = "proof-db1"\nbase_height = 940611\nheight = 948454\n`,
+  );
+
+  const fixtureRunScript = path.join(mismatchRoot, "unified-server-run.sh");
+  const transformed = readFileSync(tier3RunScript, "utf8")
+    .replaceAll("/home/pir/data", mismatchData)
+    .replace("/usr/share/bitcoinpir/proofs/height-940611.leaf-proof.json", bhtmProof)
+    .replace("ORAMCTL=/usr/local/bin/oramctl", `ORAMCTL=${oramctl}`)
+    .replace("UNIFIED_SERVER=/usr/local/bin/unified_server", `UNIFIED_SERVER=${unifiedServer}`)
+    .replace("TRUSTED_INPUT_ROOT=/run/bitcoinpir-oram-inputs", `TRUSTED_INPUT_ROOT=${mismatchRoot}/trusted-inputs`)
+    .replace("TRUSTED_STATE_ROOT=/run/bitcoinpir-oram-state", `TRUSTED_STATE_ROOT=${mismatchRoot}/trusted-state`)
+    .replace("VPSBG_DPF_ONLY_FUNCTIONAL_BETA=1", "VPSBG_DPF_ONLY_FUNCTIONAL_BETA=0")
+    .replaceAll("sleep 5", ":");
+  writeFileSync(fixtureRunScript, transformed);
+  chmodSync(fixtureRunScript, 0o755);
+  const mismatch = run("sh", [fixtureRunScript]);
+  assert.notEqual(mismatch.status, 0, mismatch.stdout + mismatch.stderr);
+  assert.match(mismatch.stderr, /db0 runtime\/proof MANIFEST bytes differ/);
+  assert.equal(existsSync(marker), false, "oramctl must not run after manifest mismatch");
+
+  execFileSync("sh", ["-n", stageHelper]);
+  execFileSync("sh", ["-n", tier3RunScript]);
+  console.log("vpsbg Tier3 generation fixtures: ok");
+} finally {
+  rmSync(tempRoot, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What changed

- add a candidate-only helper that stages complete db0/db1 attested build outputs as one immutable VPSBG Tier3 generation
- make the Tier3 ORAM startup path derive runtime and proof inputs from the active `databases.toml` catalog instead of independent legacy path candidates
- reject runtime/proof manifest mismatch before invoking `oramctl`
- add a small fixture for candidate-only staging and pre-dial mismatch rejection
- document the generation staging boundary

## Root cause

Production canary run 31347296343 showed DPF, Harmony, and Onion passing. ORAM completed VCEK, encrypted-channel, and operator-identity verification, then correctly rejected both database proofs because the live runtime manifest roots did not match the proof sidecar roots. The measured startup path could select runtime and proof artifacts from different build generations.

## Scope boundary

This PR prepares a consistent generation and startup contract. It deliberately keeps `VPSBG_DPF_ONLY_FUNCTIONAL_BETA=1`, does not activate ORAM, does not build or deploy a UKI, and never replaces the active catalog automatically.

Production ORAM remains blocked on native full-build-v2 outputs for both snapshot and delta databases from the external attested builder.

## Validation

- shell syntax checks for the staging helper and Tier3 startup script
- `node scripts/vpsbg-tier3-generation.test.mjs`
- deployment template gate and its 30 tests
- focused `payment_v1_tee_oram_process_e2e` measured-startup test
- `git diff --check`
