### PR TITLE
Wire builder UKI to native full-build v2 pipelines

### DIFF
--- a/apps/server/tests/payment_v1_tee_oram_process_e2e.rs
+++ b/apps/server/tests/payment_v1_tee_oram_process_e2e.rs
@@ -641,32 +641,28 @@ fn measured_boot_copies_exact_manifest_and_sources_before_strict_build() {
 }
 
 #[test]
-fn measured_builder_binds_direct_sources_before_evidence_and_quote() {
+fn measured_builder_requires_native_full_build_v2_before_staging() {
     let script =
         include_str!("../../../scripts/dracut/97bpir-builder-tier3-init/bpir-builder-run.sh");
     assert!(script.contains("export ROOTS_ONLY=0"));
     assert!(script.contains("export STAGE_SERVER_DB=1"));
-    assert!(script.contains("export WRITE_BUILD_EVIDENCE=0"));
-    assert!(script.contains("export EMIT_SEV_SNP_QUOTE=0"));
-    assert!(script
-        .contains("PIPELINE=/usr/local/lib/attested-builder/scripts/build-snapshot-database.sh"));
+    assert!(script.contains("export RUN_ONION_FFI=1"));
+    assert!(script.contains("export BUILD_EVIDENCE_VERSION=2"));
+    assert!(script.contains("export WRITE_BUILD_EVIDENCE=1"));
+    assert!(script.contains("export EMIT_SEV_SNP_QUOTE=1"));
+    assert!(script.contains("native-full-build-v2-snapshot"));
+    assert!(script.contains("native-full-build-v2-delta"));
+    assert!(script.contains("PIPELINE=$SNAPSHOT_PIPELINE"));
+    assert!(script.contains("PIPELINE=$DELTA_PIPELINE"));
     assert!(script.contains("direct_oram_eligible=no"));
     assert!(script.contains(
         "direct_oram_blocker=requires-new-measured-snapshot-or-delta-build-with-typed-manifest-before-evidence"
     ));
     assert!(script.contains("direct_oram_blocker=attested-builder-full-build-v2-required"));
     assert!(script.contains("direct_oram_eligible=yes"));
-    assert!(script.contains("augment_server_db_manifest_with_direct_oram"));
-    assert!(script.contains("Direct ORAM INDEX source size must be a positive multiple of 25"));
-    assert!(script.contains("Direct ORAM CHUNK source size must be a positive multiple of 40"));
+    assert!(!script.contains("augment_server_db_manifest_with_direct_oram"));
 
     let pipeline = script.find("/bin/bash \"$PIPELINE\"").unwrap();
-    let bind = script
-        .rfind("augment_server_db_manifest_with_direct_oram \\")
-        .unwrap();
-    let evidence = script.rfind("\"$BIN\" write-build-evidence \\").unwrap();
-    let report_data = script.rfind("\"$BIN\" write-tee-report-data \\").unwrap();
-    let quote = script.rfind("\"$BIN\" emit-sev-snp-quote \\").unwrap();
     let version_gate = script
         .rfind("evidence_version=$(verified_evidence_field")
         .unwrap();
@@ -677,14 +673,23 @@ fn measured_builder_binds_direct_sources_before_evidence_and_quote() {
         .rfind("ln -sfn \"$OUT_DIR\" \"$OUT_BASE/latest\"")
         .unwrap();
     let eligible = script.rfind("direct_oram_eligible=yes").unwrap();
-    assert!(pipeline < bind && bind < evidence && evidence < report_data && report_data < quote);
     assert!(
-        quote < version_gate && version_gate < blocker && blocker < publish && publish < eligible
+        pipeline < version_gate
+            && version_gate < blocker
+            && blocker < publish
+            && publish < eligible
     );
     assert!(script.contains("\"$evidence_version\" != 2"));
     assert!(script.contains("\"$evidence_mode\" != full_build"));
     assert!(script.contains("\"$predecessor_evidence\" != none"));
     assert!(script.contains("\"$predecessor_report\" != none"));
+
+    let recipe = include_str!("../../../scripts/build_uki_attested_builder_tier3.sh");
+    assert!(recipe.contains(
+        "ATTESTED_BUILDER_REQUIRED_GIT_COMMIT=${ATTESTED_BUILDER_REQUIRED_GIT_COMMIT:-e0870e84e40bd8fd94c8a78b2a73f8c0bc6eed9d}"
+    ));
+    assert!(recipe.contains("build-delta-database.sh"));
+    assert!(recipe.contains("usr/local/bin/onionffi"));
 }
 
 #[test]

--- a/apps/server/tests/payment_v1_tee_oram_process_e2e.rs
+++ b/apps/server/tests/payment_v1_tee_oram_process_e2e.rs
@@ -686,7 +686,7 @@ fn measured_builder_requires_native_full_build_v2_before_staging() {
 
     let recipe = include_str!("../../../scripts/build_uki_attested_builder_tier3.sh");
     assert!(recipe.contains(
-        "ATTESTED_BUILDER_REQUIRED_GIT_COMMIT=${ATTESTED_BUILDER_REQUIRED_GIT_COMMIT:-e0870e84e40bd8fd94c8a78b2a73f8c0bc6eed9d}"
+        "ATTESTED_BUILDER_REQUIRED_GIT_COMMIT=${ATTESTED_BUILDER_REQUIRED_GIT_COMMIT:-8d9d21a6be560236cb666269cf1f93a3de53bb1f}"
     ));
     assert!(recipe.contains("build-delta-database.sh"));
     assert!(recipe.contains("usr/local/bin/onionffi"));

--- a/scripts/build_uki_attested_builder_tier3.sh
+++ b/scripts/build_uki_attested_builder_tier3.sh
@@ -80,8 +80,11 @@ OUT=${OUT:-/tmp/bpir-attested-builder-tier3.efi}
 CUSTOM_INITRD=${CUSTOM_INITRD:-/tmp/bpir-attested-builder-tier3-initrd.img}
 ATTESTED_BUILDER_REPO=${ATTESTED_BUILDER_REPO:-/home/pir/bitcoin-pir/attested-builder}
 ATTESTED_BUILDER_BIN=${ATTESTED_BUILDER_BIN:-$ATTESTED_BUILDER_REPO/target/release/pir-attested-builder}
+ATTESTED_BUILDER_ONIONFFI_BIN=${ATTESTED_BUILDER_ONIONFFI_BIN:-$ATTESTED_BUILDER_REPO/target/release/onionffi}
 SKIP_BUILDER_CARGO_BUILD=${SKIP_BUILDER_CARGO_BUILD:-0}
-ATTESTED_BUILDER_GIT_COMMIT=${ATTESTED_BUILDER_GIT_COMMIT:-}
+# Phase A/B stacked head. This is deliberately an explicit external pin, not
+# a claim that the unmerged attested-builder work is available from main.
+ATTESTED_BUILDER_REQUIRED_GIT_COMMIT=${ATTESTED_BUILDER_REQUIRED_GIT_COMMIT:-e0870e84e40bd8fd94c8a78b2a73f8c0bc6eed9d}
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 DRACUT_MODULE_DIR="$SCRIPT_DIR/dracut"
@@ -95,9 +98,9 @@ if [ ! -d "$ATTESTED_BUILDER_REPO" ]; then
     echo "error: attested-builder repo not found: $ATTESTED_BUILDER_REPO" >&2
     exit 1
 fi
-if [ ! -f "$ATTESTED_BUILDER_REPO/scripts/build-snapshot-database.sh" ]; then
-    echo "error: missing attested-builder pipeline script" >&2
-    echo "       $ATTESTED_BUILDER_REPO/scripts/build-snapshot-database.sh" >&2
+if [ ! -f "$ATTESTED_BUILDER_REPO/scripts/build-snapshot-database.sh" ] ||
+    [ ! -f "$ATTESTED_BUILDER_REPO/scripts/build-delta-database.sh" ]; then
+    echo "error: missing native full-build-v2 attested-builder pipeline script" >&2
     exit 1
 fi
 
@@ -108,6 +111,8 @@ if ! is_truthy "$SKIP_BUILDER_CARGO_BUILD"; then
         cd "$ATTESTED_BUILDER_REPO"
         run_as_path_owner "$ATTESTED_BUILDER_REPO" \
             cargo build -q --release -p pir-attested-builder
+        run_as_path_owner "$ATTESTED_BUILDER_REPO" \
+            cargo build -q --release -p onionffi --features ffi
     )
 fi
 
@@ -115,9 +120,20 @@ fi
     echo "error: $ATTESTED_BUILDER_BIN not executable" >&2
     exit 1
 }
+[ -x "$ATTESTED_BUILDER_ONIONFFI_BIN" ] || {
+    echo "error: $ATTESTED_BUILDER_ONIONFFI_BIN not executable" >&2
+    exit 1
+}
 
-if [ -z "$ATTESTED_BUILDER_GIT_COMMIT" ]; then
-    ATTESTED_BUILDER_GIT_COMMIT=$(current_git_commit "$ATTESTED_BUILDER_REPO")
+ATTESTED_BUILDER_GIT_COMMIT=$(current_git_commit "$ATTESTED_BUILDER_REPO")
+[[ "$ATTESTED_BUILDER_REQUIRED_GIT_COMMIT" =~ ^[0-9a-f]{40}$ ]] || {
+    echo "error: ATTESTED_BUILDER_REQUIRED_GIT_COMMIT must be a 40-char lowercase SHA" >&2
+    exit 1
+}
+if [ "$ATTESTED_BUILDER_GIT_COMMIT" != "$ATTESTED_BUILDER_REQUIRED_GIT_COMMIT" ]; then
+    echo "error: native full-build-v2 requires attested-builder $ATTESTED_BUILDER_REQUIRED_GIT_COMMIT" >&2
+    echo "       build host has $ATTESTED_BUILDER_GIT_COMMIT (Phase B is not merged into upstream main)" >&2
+    exit 1
 fi
 ATTESTED_BUILDER_BIN_SHA256=$(hash_one "$ATTESTED_BUILDER_BIN")
 
@@ -175,7 +191,9 @@ done
 
 export ATTESTED_BUILDER_REPO
 export ATTESTED_BUILDER_BIN
+export ATTESTED_BUILDER_ONIONFFI_BIN
 export ATTESTED_BUILDER_GIT_COMMIT
+export ATTESTED_BUILDER_REQUIRED_GIT_COMMIT
 export ATTESTED_BUILDER_BIN_SHA256
 
 echo "kernel:                     $KERNEL"
@@ -183,6 +201,7 @@ echo "kernel version:             $KVER"
 echo "attested-builder repo:      $ATTESTED_BUILDER_REPO"
 echo "attested-builder commit:    $ATTESTED_BUILDER_GIT_COMMIT"
 echo "attested-builder binary:    $ATTESTED_BUILDER_BIN"
+echo "attested-builder onionffi:  $ATTESTED_BUILDER_ONIONFFI_BIN"
 echo "attested-builder sha256:    $ATTESTED_BUILDER_BIN_SHA256"
 echo "SEV modules:                $REQUIRED_SEV_MODS"
 echo
@@ -203,8 +222,10 @@ INITRD_LISTING=$(/usr/bin/lsinitrd "$CUSTOM_INITRD" 2>/dev/null)
 MISSING_ITEMS=""
 for item in \
     "usr/local/bin/pir-attested-builder" \
+    "usr/local/bin/onionffi" \
     "usr/local/bin/bpir-builder-run" \
     "usr/local/lib/attested-builder/scripts/build-snapshot-database.sh" \
+    "usr/local/lib/attested-builder/scripts/build-delta-database.sh" \
     "sbin/bpir-builder-tier3-init" \
     "etc/bpir-builder/baked.env"; do
     if ! grep -q "$item" <<< "$INITRD_LISTING"; then
@@ -242,6 +263,7 @@ echo "builder Tier 3 UKI sha256:  $UKI_SHA"
     "kernel_version=$KVER" \
     "builder_repo=$ATTESTED_BUILDER_REPO" \
     "builder_git_commit=$ATTESTED_BUILDER_GIT_COMMIT" \
+    "builder_required_git_commit=$ATTESTED_BUILDER_REQUIRED_GIT_COMMIT" \
     "builder_binary_sha256=$ATTESTED_BUILDER_BIN_SHA256"
 echo
 cat <<EOF
@@ -266,10 +288,11 @@ The v2 mode scans and hashes the retained final serving images; it does not
 rebuild the snapshot or delta. On success, both output directories contain the
 new evidence, SNP report, verifier transcript, and SHA256SUMS.
 
-For a full roots-only snapshot rebuild instead:
+For a native full-build-v2 snapshot generation suitable for Tier 3 staging:
 
   sudo mkdir -p /home/pir/data/attested-builder/inputs /home/pir/data/attested-builder-runs
   sudo tee /home/pir/data/attested-builder/config.env >/dev/null <<'CONFIG'
+MODE=native-full-build-v2-snapshot
 SNAPSHOT=/home/pir/data/attested-builder/inputs/txoutset_<height>.dat
 EXPECTED_MUHASH=<64-byte-Core-display-muhash>
 NETWORK_MAGIC=f9beb4d9
@@ -280,6 +303,24 @@ RUN_ID=mainnet_<height>_sev_snp
 MIN_FREE_KB=50000000
 CONFIG
 
+For a native full-build-v2 delta generation, use the same config file with:
+
+  MODE=native-full-build-v2-delta
+  FROM_SNAPSHOT=/home/pir/data/attested-builder/inputs/txoutset_<from-height>.dat
+  FROM_EXPECTED_MUHASH=<64-byte-Core-display-muhash>
+  FROM_ANCHOR_HEIGHT=<from-height>
+  TO_SNAPSHOT=/home/pir/data/attested-builder/inputs/txoutset_<to-height>.dat
+  TO_EXPECTED_MUHASH=<64-byte-Core-display-muhash>
+  TO_ANCHOR_HEIGHT=<to-height>
+  NETWORK_MAGIC=f9beb4d9
+  CORE_VERSION=<bitcoind-version-string>
+  RUN_ID=delta_<from-height>_<to-height>_sev_snp
+  MIN_FREE_KB=50000000
+
+The wrapper rejects every other full-build mode. The native pipeline must emit
+the server DB, proof sidecars, Direct ORAM inputs, final BuildEvidence v2, and
+SNP quote before this runner marks its output eligible for staging.
+
 Upload $OUT in VPSBG Measured Boot as a temporary UKI and reboot.
 The UKI will power off after completion. Then switch Measured Boot back to
 "None", boot Slice 2, and collect:
@@ -288,9 +329,6 @@ The UKI will power off after completion. Then switch Measured Boot back to
   /home/pir/data/attested-builder-runs/latest/build-evidence.bin
   /home/pir/data/attested-builder-runs/latest/build-evidence.sev-snp-report.bin
   /home/pir/data/attested-builder-runs/latest/server-db/MANIFEST.toml
-
-This UKI runs ROOTS_ONLY=1. server-db/MANIFEST.toml is an evidence manifest,
-not a server-loadable database manifest.
 
 Archive policy:
 

--- a/scripts/build_uki_attested_builder_tier3.sh
+++ b/scripts/build_uki_attested_builder_tier3.sh
@@ -82,9 +82,9 @@ ATTESTED_BUILDER_REPO=${ATTESTED_BUILDER_REPO:-/home/pir/bitcoin-pir/attested-bu
 ATTESTED_BUILDER_BIN=${ATTESTED_BUILDER_BIN:-$ATTESTED_BUILDER_REPO/target/release/pir-attested-builder}
 ATTESTED_BUILDER_ONIONFFI_BIN=${ATTESTED_BUILDER_ONIONFFI_BIN:-$ATTESTED_BUILDER_REPO/target/release/onionffi}
 SKIP_BUILDER_CARGO_BUILD=${SKIP_BUILDER_CARGO_BUILD:-0}
-# Phase A/B stacked head. This is deliberately an explicit external pin, not
-# a claim that the unmerged attested-builder work is available from main.
-ATTESTED_BUILDER_REQUIRED_GIT_COMMIT=${ATTESTED_BUILDER_REQUIRED_GIT_COMMIT:-e0870e84e40bd8fd94c8a78b2a73f8c0bc6eed9d}
+# Merged attested-builder main containing the native snapshot and delta v2
+# full-build producers. Keep the measured UKI recipe pinned to this exact tree.
+ATTESTED_BUILDER_REQUIRED_GIT_COMMIT=${ATTESTED_BUILDER_REQUIRED_GIT_COMMIT:-8d9d21a6be560236cb666269cf1f93a3de53bb1f}
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 DRACUT_MODULE_DIR="$SCRIPT_DIR/dracut"
@@ -132,7 +132,7 @@ ATTESTED_BUILDER_GIT_COMMIT=$(current_git_commit "$ATTESTED_BUILDER_REPO")
 }
 if [ "$ATTESTED_BUILDER_GIT_COMMIT" != "$ATTESTED_BUILDER_REQUIRED_GIT_COMMIT" ]; then
     echo "error: native full-build-v2 requires attested-builder $ATTESTED_BUILDER_REQUIRED_GIT_COMMIT" >&2
-    echo "       build host has $ATTESTED_BUILDER_GIT_COMMIT (Phase B is not merged into upstream main)" >&2
+    echo "       build host has $ATTESTED_BUILDER_GIT_COMMIT" >&2
     exit 1
 fi
 ATTESTED_BUILDER_BIN_SHA256=$(hash_one "$ATTESTED_BUILDER_BIN")

--- a/scripts/dracut/96bpir-attested-builder/module-setup.sh
+++ b/scripts/dracut/96bpir-attested-builder/module-setup.sh
@@ -17,18 +17,31 @@ builder_bin() {
     printf '%s\n' "${ATTESTED_BUILDER_BIN:-$repo/target/release/pir-attested-builder}"
 }
 
+onionffi_bin() {
+    local repo
+    repo=$(builder_repo)
+    printf '%s\n' "${ATTESTED_BUILDER_ONIONFFI_BIN:-$repo/target/release/onionffi}"
+}
+
 check() {
-    local repo bin
+    local repo bin onionffi
     repo=$(builder_repo)
     bin=$(builder_bin)
+    onionffi=$(onionffi_bin)
 
     if [ ! -x "$bin" ]; then
         derror "bpir-attested-builder: $bin not executable on build host"
         derror "  run: cargo build --release -p pir-attested-builder in $repo"
         return 1
     fi
-    if [ ! -f "$repo/scripts/build-snapshot-database.sh" ]; then
-        derror "bpir-attested-builder: missing $repo/scripts/build-snapshot-database.sh"
+    if [ ! -f "$repo/scripts/build-snapshot-database.sh" ] ||
+        [ ! -f "$repo/scripts/build-delta-database.sh" ]; then
+        derror "bpir-attested-builder: missing snapshot or delta pipeline script under $repo/scripts"
+        return 1
+    fi
+    if [ ! -x "$onionffi" ]; then
+        derror "bpir-attested-builder: $onionffi not executable"
+        derror "  run: cargo build --release -p onionffi --features ffi in $repo"
         return 1
     fi
     command -v sha256sum >/dev/null 2>&1 || {
@@ -44,24 +57,31 @@ depends() {
 }
 
 install() {
-    local repo bin git_commit bin_sha
+    local repo bin onionffi git_commit required_git_commit bin_sha
     repo=$(builder_repo)
     bin=$(builder_bin)
+    onionffi=$(onionffi_bin)
     git_commit=${ATTESTED_BUILDER_GIT_COMMIT:-unknown}
+    required_git_commit=${ATTESTED_BUILDER_REQUIRED_GIT_COMMIT:-unknown}
     bin_sha=${ATTESTED_BUILDER_BIN_SHA256:-$(sha256sum "$bin" | awk '{print $1}')}
 
     # `inst` copies the binary plus all dynamic library dependencies.
     inst "$bin" /usr/local/bin/pir-attested-builder
+    inst "$onionffi" /usr/local/bin/onionffi
 
     inst_dir /usr/local/lib/attested-builder/scripts
     inst_simple "$repo/scripts/build-snapshot-database.sh" \
         /usr/local/lib/attested-builder/scripts/build-snapshot-database.sh
+    inst_simple "$repo/scripts/build-delta-database.sh" \
+        /usr/local/lib/attested-builder/scripts/build-delta-database.sh
     chmod 0755 "${initdir}/usr/local/lib/attested-builder/scripts/build-snapshot-database.sh"
+    chmod 0755 "${initdir}/usr/local/lib/attested-builder/scripts/build-delta-database.sh"
 
     inst_dir /etc/bpir-builder
     {
         printf 'BAKED_BUILDER_REPO=%s\n' "$repo"
         printf 'BAKED_BUILDER_GIT_COMMIT=%s\n' "$git_commit"
+        printf 'BAKED_BUILDER_REQUIRED_GIT_COMMIT=%s\n' "$required_git_commit"
         printf 'BAKED_BUILDER_BIN_SHA256=%s\n' "$bin_sha"
     } > "${initdir}/etc/bpir-builder/baked.env"
     chmod 0644 "${initdir}/etc/bpir-builder/baked.env"

--- a/scripts/dracut/97bpir-builder-tier3-init/bpir-builder-run.sh
+++ b/scripts/dracut/97bpir-builder-tier3-init/bpir-builder-run.sh
@@ -9,7 +9,10 @@ export PATH
 BAKED_ENV=/etc/bpir-builder/baked.env
 CONFIG=${BPIR_BUILDER_CONFIG:-/home/pir/data/attested-builder/config.env}
 BIN=/usr/local/bin/pir-attested-builder
-PIPELINE=/usr/local/lib/attested-builder/scripts/build-snapshot-database.sh
+ONIONFFI_BIN=/usr/local/bin/onionffi
+PIPELINE_DIR=/usr/local/lib/attested-builder/scripts
+SNAPSHOT_PIPELINE=$PIPELINE_DIR/build-snapshot-database.sh
+DELTA_PIPELINE=$PIPELINE_DIR/build-delta-database.sh
 
 fail() {
     printf '[bpir-builder-run] FATAL: %s\n' "$*" >&2
@@ -88,74 +91,6 @@ verified_evidence_field() {
             if (count == 1) print value
         }
     ' "$report"
-}
-
-augment_server_db_manifest_with_direct_oram() {
-    local manifest=$1
-    local index_source=$2
-    local chunk_source=$3
-    local index_sha chunk_sha index_bytes chunk_bytes index_records chunk_records
-    local files_sections manifest_tmp section_tmp
-
-    [[ -f "$manifest" ]] || fail "server DB manifest missing before Direct ORAM binding: $manifest"
-    [[ -f "$index_source" ]] || fail "Direct ORAM INDEX source missing: $index_source"
-    [[ -f "$chunk_source" ]] || fail "Direct ORAM CHUNK source missing: $chunk_source"
-    if grep -Eq '^\[direct_oram\][[:space:]]*$' "$manifest"; then
-        fail "server DB manifest already contains [direct_oram]; refusing ambiguous rewrite: $manifest"
-    fi
-    files_sections=$(awk '$0 == "[files]" { count++ } END { print count + 0 }' "$manifest")
-    [[ "$files_sections" == 1 ]] ||
-        fail "server DB manifest must contain exactly one [files] section: $manifest"
-
-    index_sha=$(sha256sum "$index_source" | awk '{print $1}')
-    chunk_sha=$(sha256sum "$chunk_source" | awk '{print $1}')
-    index_bytes=$(wc -c < "$index_source" | tr -d ' ')
-    chunk_bytes=$(wc -c < "$chunk_source" | tr -d ' ')
-    ((index_bytes > 0 && index_bytes % 25 == 0)) ||
-        fail "Direct ORAM INDEX source size must be a positive multiple of 25 bytes"
-    ((chunk_bytes > 0 && chunk_bytes % 40 == 0)) ||
-        fail "Direct ORAM CHUNK source size must be a positive multiple of 40 bytes"
-    index_records=$((index_bytes / 25))
-    chunk_records=$((chunk_bytes / 40))
-
-    manifest_tmp=$(mktemp "${manifest}.tmp.XXXXXX")
-    section_tmp=$(mktemp "${manifest}.direct-oram.XXXXXX")
-    if ! {
-        printf '[direct_oram]\n'
-        printf 'version = 1\n'
-        printf 'index_sha256 = "%s"\n' "$index_sha"
-        printf 'index_bytes = %s\n' "$index_bytes"
-        printf 'index_records = %s\n' "$index_records"
-        printf 'chunk_sha256 = "%s"\n' "$chunk_sha"
-        printf 'chunk_bytes = %s\n' "$chunk_bytes"
-        printf 'chunk_records = %s\n' "$chunk_records"
-        printf 'index_slots_per_bin = %s\n' "$DIRECT_ORAM_INDEX_SLOTS_PER_BIN"
-        printf 'index_hash_fns = %s\n' "$DIRECT_ORAM_INDEX_HASH_FNS"
-        printf 'index_load_factor_ppb = %s\n' "$DIRECT_ORAM_INDEX_LOAD_FACTOR_PPB"
-        printf 'index_seed = %s\n\n' "$DIRECT_ORAM_INDEX_SEED"
-    } > "$section_tmp"; then
-        rm -f -- "$manifest_tmp" "$section_tmp"
-        fail "could not render Direct ORAM manifest section"
-    fi
-    if ! awk -v section="$section_tmp" '
-        $0 == "[files]" && !inserted {
-            while ((getline line < section) > 0) print line
-            close(section)
-            inserted = 1
-        }
-        { print }
-        END { if (!inserted) exit 42 }
-    ' "$manifest" > "$manifest_tmp"; then
-        rm -f -- "$manifest_tmp" "$section_tmp"
-        fail "could not atomically augment server DB manifest"
-    fi
-    rm -f -- "$section_tmp"
-    chmod 0644 "$manifest_tmp"
-    mv -f -- "$manifest_tmp" "$manifest"
-
-    printf 'server_db_direct_oram_bound=1\n' >> "$OUT_DIR/build-summary.txt"
-    printf 'server_db_manifest_bound_sha256=%s\n' \
-        "$(sha256sum "$manifest" | awk '{print $1}')" >> "$OUT_DIR/build-summary.txt"
 }
 
 run_reattest_v2_job() {
@@ -270,36 +205,71 @@ run_reattest_v2() {
 
 [[ -r "$BAKED_ENV" ]] || fail "missing baked metadata: $BAKED_ENV"
 load_kv_file "$BAKED_ENV" \
-    "BAKED_BUILDER_REPO BAKED_BUILDER_GIT_COMMIT BAKED_BUILDER_BIN_SHA256"
+    "BAKED_BUILDER_REPO BAKED_BUILDER_GIT_COMMIT BAKED_BUILDER_REQUIRED_GIT_COMMIT BAKED_BUILDER_BIN_SHA256"
+[[ "${BAKED_BUILDER_REQUIRED_GIT_COMMIT:-}" =~ ^[0-9a-f]{40}$ ]] ||
+    fail "baked builder required commit is missing or malformed"
+[[ "${BAKED_BUILDER_GIT_COMMIT:-}" == "$BAKED_BUILDER_REQUIRED_GIT_COMMIT" ]] ||
+    fail "baked builder commit does not match required native-full-build-v2 pin"
 
 [[ -r "$CONFIG" ]] || fail "missing runtime config: $CONFIG"
 load_kv_file "$CONFIG" \
-    "MODE SNAPSHOT EXPECTED_MUHASH NETWORK_MAGIC ANCHOR_HEIGHT ANCHOR_HASH CORE_VERSION OUT_BASE OUT_DIR RUN_ID MIN_FREE_KB REFERENCE_DATABASE_MANIFEST REFERENCE_ALL_ARTIFACTS_MANIFEST ONION_ENTRY_SIZE PARTITIONS ISSUED_AT PUSH_BATCH_ENTRIES ORAM_DIRECT_INPUT_DIR KEEP_ORAM_DIRECT_INPUTS DIRECT_ORAM_INDEX_SLOTS_PER_BIN DIRECT_ORAM_INDEX_HASH_FNS DIRECT_ORAM_INDEX_LOAD_FACTOR_PPB DIRECT_ORAM_INDEX_SEED V2_JOB_COUNT V2_DB0_PREDECESSOR_PROOF_DIR V2_DB0_ARTIFACT_DIR V2_DB0_OUT_DIR V2_DB1_PREDECESSOR_PROOF_DIR V2_DB1_ARTIFACT_DIR V2_DB1_OUT_DIR"
+    "MODE SNAPSHOT EXPECTED_MUHASH NETWORK_MAGIC ANCHOR_HEIGHT ANCHOR_HASH FROM_SNAPSHOT FROM_EXPECTED_MUHASH FROM_ANCHOR_HEIGHT FROM_ANCHOR_HASH TO_SNAPSHOT TO_EXPECTED_MUHASH TO_ANCHOR_HEIGHT TO_ANCHOR_HASH CORE_VERSION OUT_BASE OUT_DIR RUN_ID MIN_FREE_KB REFERENCE_DATABASE_MANIFEST REFERENCE_ALL_ARTIFACTS_MANIFEST ONION_ENTRY_SIZE PARTITIONS ISSUED_AT PUSH_BATCH_ENTRIES ORAM_DIRECT_INPUT_DIR DIRECT_ORAM_INDEX_SLOTS_PER_BIN DIRECT_ORAM_INDEX_HASH_FNS DIRECT_ORAM_INDEX_LOAD_FACTOR_PPB DIRECT_ORAM_INDEX_SEED V2_JOB_COUNT V2_DB0_PREDECESSOR_PROOF_DIR V2_DB0_ARTIFACT_DIR V2_DB0_OUT_DIR V2_DB1_PREDECESSOR_PROOF_DIR V2_DB1_ARTIFACT_DIR V2_DB1_OUT_DIR"
 
 [[ -x "$BIN" ]] || fail "builder binary missing or not executable: $BIN"
+[[ -x "$ONIONFFI_BIN" ]] || fail "onionffi binary missing or not executable: $ONIONFFI_BIN"
 [[ -c /dev/sev-guest ]] || fail "/dev/sev-guest missing"
 
-MODE=${MODE:-full-build}
+MODE=${MODE:-}
 if [[ "$MODE" == reattest-existing-v2 ]]; then
     run_reattest_v2
     exit 0
 fi
-[[ "$MODE" == full-build ]] || fail "unsupported MODE: $MODE"
+case "$MODE" in
+    native-full-build-v2-snapshot)
+        BUILD_KIND=snapshot
+        PIPELINE=$SNAPSHOT_PIPELINE
+        require_env SNAPSHOT
+        require_env EXPECTED_MUHASH
+        require_env NETWORK_MAGIC
+        require_env ANCHOR_HEIGHT
+        require_data_path SNAPSHOT
+        [[ -f "$SNAPSHOT" ]] || fail "snapshot not found: $SNAPSHOT"
+        [[ "$EXPECTED_MUHASH" =~ ^[0-9a-fA-F]{64}$ ]] || fail "EXPECTED_MUHASH must be 64 hex chars"
+        [[ "$NETWORK_MAGIC" =~ ^[0-9a-fA-F]{8}$ ]] || fail "NETWORK_MAGIC must be 8 hex chars"
+        [[ "$ANCHOR_HEIGHT" =~ ^[0-9]+$ ]] || fail "ANCHOR_HEIGHT must be an integer"
+        ;;
+    native-full-build-v2-delta)
+        BUILD_KIND=delta
+        PIPELINE=$DELTA_PIPELINE
+        require_env FROM_SNAPSHOT
+        require_env FROM_EXPECTED_MUHASH
+        require_env FROM_ANCHOR_HEIGHT
+        require_env TO_SNAPSHOT
+        require_env TO_EXPECTED_MUHASH
+        require_env TO_ANCHOR_HEIGHT
+        require_env NETWORK_MAGIC
+        require_data_path FROM_SNAPSHOT
+        require_data_path TO_SNAPSHOT
+        [[ -f "$FROM_SNAPSHOT" ]] || fail "from snapshot not found: $FROM_SNAPSHOT"
+        [[ -f "$TO_SNAPSHOT" ]] || fail "to snapshot not found: $TO_SNAPSHOT"
+        [[ "$FROM_EXPECTED_MUHASH" =~ ^[0-9a-fA-F]{64}$ ]] || fail "FROM_EXPECTED_MUHASH must be 64 hex chars"
+        [[ "$TO_EXPECTED_MUHASH" =~ ^[0-9a-fA-F]{64}$ ]] || fail "TO_EXPECTED_MUHASH must be 64 hex chars"
+        [[ "$NETWORK_MAGIC" =~ ^[0-9a-fA-F]{8}$ ]] || fail "NETWORK_MAGIC must be 8 hex chars"
+        [[ "$FROM_ANCHOR_HEIGHT" =~ ^[0-9]+$ && "$TO_ANCHOR_HEIGHT" =~ ^[0-9]+$ ]] ||
+            fail "delta anchor heights must be integers"
+        ((FROM_ANCHOR_HEIGHT < TO_ANCHOR_HEIGHT)) || fail "FROM_ANCHOR_HEIGHT must be < TO_ANCHOR_HEIGHT"
+        SNAPSHOT=$TO_SNAPSHOT
+        EXPECTED_MUHASH=$TO_EXPECTED_MUHASH
+        ANCHOR_HEIGHT=$TO_ANCHOR_HEIGHT
+        ANCHOR_HASH=${TO_ANCHOR_HASH:-}
+        ;;
+    *) fail "MODE must be native-full-build-v2-snapshot, native-full-build-v2-delta, or reattest-existing-v2" ;;
+esac
 
-require_env SNAPSHOT
-require_env EXPECTED_MUHASH
-require_env NETWORK_MAGIC
-require_env ANCHOR_HEIGHT
 require_env CORE_VERSION
 
-require_data_path SNAPSHOT
 require_data_path REFERENCE_DATABASE_MANIFEST
 require_data_path REFERENCE_ALL_ARTIFACTS_MANIFEST
-
-[[ -f "$SNAPSHOT" ]] || fail "snapshot not found: $SNAPSHOT"
-[[ "$EXPECTED_MUHASH" =~ ^[0-9a-fA-F]{64}$ ]] || fail "EXPECTED_MUHASH must be 64 hex chars"
-[[ "$NETWORK_MAGIC" =~ ^[0-9a-fA-F]{8}$ ]] || fail "NETWORK_MAGIC must be 8 hex chars"
-[[ "$ANCHOR_HEIGHT" =~ ^[0-9]+$ ]] || fail "ANCHOR_HEIGHT must be an integer"
 [[ -x "$PIPELINE" ]] || fail "pipeline script missing or not executable: $PIPELINE"
 
 OUT_BASE=${OUT_BASE:-/home/pir/data/attested-builder-runs}
@@ -309,7 +279,11 @@ mkdir -p "$OUT_BASE"
 RUN_ID=${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}
 [[ "$RUN_ID" =~ ^[A-Za-z0-9._=-]+$ ]] || fail "RUN_ID contains unsafe characters: $RUN_ID"
 
-OUT_DIR=${OUT_DIR:-"$OUT_BASE/mainnet_${ANCHOR_HEIGHT}_${RUN_ID}"}
+if [[ "$BUILD_KIND" == delta ]]; then
+    OUT_DIR=${OUT_DIR:-"$OUT_BASE/delta_${FROM_ANCHOR_HEIGHT}_${TO_ANCHOR_HEIGHT}_${RUN_ID}"}
+else
+    OUT_DIR=${OUT_DIR:-"$OUT_BASE/mainnet_${ANCHOR_HEIGHT}_${RUN_ID}"}
+fi
 require_data_path OUT_DIR
 case "$OUT_DIR" in
     "$OUT_BASE"/*) ;;
@@ -319,10 +293,8 @@ esac
 
 ORAM_DIRECT_INPUT_DIR=${ORAM_DIRECT_INPUT_DIR:-"$OUT_DIR/oram-direct-inputs"}
 require_data_path ORAM_DIRECT_INPUT_DIR
-case "$ORAM_DIRECT_INPUT_DIR" in
-    "$OUT_DIR"/*) ;;
-    *) fail "ORAM_DIRECT_INPUT_DIR must be under OUT_DIR ($OUT_DIR): $ORAM_DIRECT_INPUT_DIR" ;;
-esac
+[[ "$ORAM_DIRECT_INPUT_DIR" == "$OUT_DIR/oram-direct-inputs" ]] ||
+    fail "ORAM_DIRECT_INPUT_DIR must be the native pipeline path $OUT_DIR/oram-direct-inputs"
 
 DIRECT_ORAM_INDEX_SLOTS_PER_BIN=${DIRECT_ORAM_INDEX_SLOTS_PER_BIN:-4}
 DIRECT_ORAM_INDEX_HASH_FNS=${DIRECT_ORAM_INDEX_HASH_FNS:-2}
@@ -340,7 +312,8 @@ require_unsigned_integer DIRECT_ORAM_INDEX_SEED
 STATUS_FILE="$OUT_BASE/builder-tier3-$RUN_ID.status"
 {
     printf 'status=running\n'
-    printf 'mode=full-snapshot-build\n'
+    printf 'mode=%s\n' "$MODE"
+    printf 'build_kind=%s\n' "$BUILD_KIND"
     printf 'direct_oram_eligible=pending\n'
     printf 'run_id=%s\n' "$RUN_ID"
     printf 'out_dir=%s\n' "$OUT_DIR"
@@ -376,17 +349,14 @@ export SNAPSHOT EXPECTED_MUHASH NETWORK_MAGIC ANCHOR_HEIGHT CORE_VERSION
 export OUT_DIR
 export SKIP_CARGO_BUILD=1
 export BIN
+export ONIONFFI_BIN
 export RELEASE=1
-export RUN_ONION_FFI=0
+export RUN_ONION_FFI=1
 export ROOTS_ONLY=0
 export STAGE_SERVER_DB=1
-export KEEP_ORAM_DIRECT_INPUTS=1
-export ORAM_DIRECT_INPUT_DIR
-# BuildEvidence must commit the final typed server-db manifest. The pipeline
-# stages the exact server-loadable tree first; this wrapper adds [direct_oram]
-# and only then writes evidence/report_data and asks /dev/sev-guest for a quote.
-export WRITE_BUILD_EVIDENCE=0
-export EMIT_SEV_SNP_QUOTE=0
+export BUILD_EVIDENCE_VERSION=2
+export WRITE_BUILD_EVIDENCE=1
+export EMIT_SEV_SNP_QUOTE=1
 export TEE_PLATFORM=sev-snp
 export TEE_IMAGE_MEASUREMENT=none
 export BUILDER_GIT_COMMIT=${BAKED_BUILDER_GIT_COMMIT:-unknown}
@@ -394,6 +364,13 @@ export ONION_ENTRY_SIZE=${ONION_ENTRY_SIZE:-3328}
 export PARTITIONS=${PARTITIONS:-4}
 export ISSUED_AT=${ISSUED_AT:-0}
 export PUSH_BATCH_ENTRIES=${PUSH_BATCH_ENTRIES:-256}
+export DIRECT_ORAM_INDEX_SLOTS_PER_BIN DIRECT_ORAM_INDEX_HASH_FNS
+export DIRECT_ORAM_INDEX_LOAD_FACTOR_PPB DIRECT_ORAM_INDEX_SEED
+
+if [[ "$BUILD_KIND" == delta ]]; then
+    export FROM_SNAPSHOT FROM_EXPECTED_MUHASH FROM_ANCHOR_HEIGHT
+    export TO_SNAPSHOT TO_EXPECTED_MUHASH TO_ANCHOR_HEIGHT
+fi
 
 if [[ -n "${REFERENCE_DATABASE_MANIFEST:-}" ]]; then
     export REFERENCE_DATABASE_MANIFEST
@@ -405,29 +382,6 @@ fi
 echo "[bpir-builder-run] running attested-builder pipeline"
 echo "[bpir-builder-run] out_dir=$OUT_DIR"
 /bin/bash "$PIPELINE"
-
-augment_server_db_manifest_with_direct_oram \
-    "$OUT_DIR/server-db/MANIFEST.toml" \
-    "$ORAM_DIRECT_INPUT_DIR/utxo_chunks_index_nodust.bin" \
-    "$ORAM_DIRECT_INPUT_DIR/utxo_chunks_nodust.bin"
-
-echo "[bpir-builder-run] writing evidence after Direct ORAM manifest binding"
-"$BIN" write-build-evidence \
-    "$OUT_DIR" \
-    "$SNAPSHOT" \
-    "$CORE_VERSION" \
-    "$BUILDER_GIT_COMMIT" \
-    "$BIN" \
-    "$TEE_PLATFORM" \
-    "$TEE_IMAGE_MEASUREMENT" \
-    "$OUT_DIR/build-evidence.bin"
-"$BIN" write-tee-report-data \
-    "$OUT_DIR/build-evidence.bin" \
-    "$OUT_DIR/build-evidence.report-data"
-"$BIN" emit-sev-snp-quote \
-    "$OUT_DIR/build-evidence.bin" \
-    "$OUT_DIR/build-evidence.sev-snp-report.bin" \
-    "$OUT_DIR/build-evidence.report-data"
 
 VERIFY_ARGS=(
     "$OUT_DIR/build-evidence.bin"
@@ -448,12 +402,9 @@ fi
 echo "[bpir-builder-run] verifying build evidence and SEV-SNP report_data"
 "$BIN" verify-build-evidence "${VERIFY_ARGS[@]}" | tee "$OUT_DIR/build-evidence.verify.txt"
 
-# Production Direct ORAM requires a native full-build-v2 producer.  Merely
-# augmenting a v1 pipeline's manifest and asking its legacy
-# `write-build-evidence` command for another quote does not upgrade the root
-# payload or params domain to v2.  Fail closed before publishing `latest` or an
-# eligibility claim.  The predecessor checks also prevent re-attestation from
-# being mistaken for a fresh measured build.
+# Production Direct ORAM requires the native pipeline to have emitted
+# predecessor-free full-build-v2 evidence. Fail closed before publishing
+# `latest` or an eligibility claim.
 evidence_version=$(verified_evidence_field "$OUT_DIR/build-evidence.verify.txt" evidence_version)
 evidence_mode=$(verified_evidence_field "$OUT_DIR/build-evidence.verify.txt" evidence_mode)
 predecessor_evidence=$(verified_evidence_field \
@@ -475,7 +426,8 @@ ln -sfn "$OUT_DIR" "$OUT_BASE/latest"
 {
     printf 'status=ok\n'
     printf 'exit_code=0\n'
-    printf 'mode=full-snapshot-build\n'
+    printf 'mode=%s\n' "$MODE"
+    printf 'build_kind=%s\n' "$BUILD_KIND"
     printf 'direct_oram_eligible=yes\n'
     printf 'out_dir=%s\n' "$OUT_DIR"
     printf 'summary=%s\n' "$OUT_DIR/build-summary.txt"


### PR DESCRIPTION
## Summary

- bake both snapshot and delta native full-build v2 pipelines plus `onionffi` into the one-shot builder UKI
- require explicit snapshot or delta modes and run the producer-owned v2 evidence and SEV quote path
- remove the obsolete wrapper-side Direct ORAM manifest augmentation
- update the existing Rust CI contract for the producer-native ordering

## Dependency

The native snapshot and delta producers were merged through `Bitcoin-PIR/attested-builder` #8 and #7. This PR is pinned to the resulting upstream `main` commit `8d9d21a6be560236cb666269cf1f93a3de53bb1f`.

## Validation

- focused Rust test `measured_builder_requires_native_full_build_v2_before_staging` (1/1)
- `bash -n` on the UKI recipe and both dracut scripts
- `git diff --check`

No UKI, SEV report, mainnet dataset, browser, or production deployment was run.
