### PR TITLE
Bound and instrument Direct ORAM initialization

### DIFF
--- a/docs/ORAM_DIRECT_TEE_DEBUG_RUNBOOK.md
+++ b/docs/ORAM_DIRECT_TEE_DEBUG_RUNBOOK.md
@@ -1,0 +1,186 @@
+# Direct ORAM TEE Debug Runbook
+
+This document records the August 2026 VPSBG Direct ORAM incident, the known-good
+build baseline, and the bounded workflow for the next measured-boot test. It is
+the operator source of truth for this debug cycle. It does not authorize a
+production deployment.
+
+## Completed debug boundary
+
+The dedicated debug UKI completed one small encrypted Direct ORAM build inside
+SEV-SNP. Its progress, result, and failed-attempt diagnostics were copied from
+`/home/pir/data/oram-tee-debug/` to the external archive described below. The
+server was then detached from measured boot and returned to stock/none mode.
+
+The next boundary is planning only: prepare the full-production UKI preflight,
+but do not build or attach it until every blocker in
+`ORAM_FULL_UKI_PREFLIGHT_2026-08-11.md` is closed and the operator explicitly
+authorizes a new build/deployment cycle.
+
+Time limits are part of acceptance:
+
+| Stage | Expected | Hard stop |
+| --- | ---: | ---: |
+| Local/stock UKI build | under 10 minutes | 20 minutes |
+| VPSBG upload and measured boot | under 5 minutes | 10 minutes |
+| Minimal TEE Direct ORAM build | under 1 minute | 5 minutes |
+| No progress heartbeat | never more than 30 seconds | fail after 90 seconds |
+
+An overrun is a failure to diagnose, not a reason to wait indefinitely.
+
+## What happened
+
+Three independent issues were initially conflated:
+
+1. The historical Direct ORAM builds were unencrypted. Strict source binding
+   later required encrypted bulk and authentication pages. The initial Merkle
+   builder updated every 32-byte hash by reading, decrypting, modifying,
+   encrypting, and rewriting an entire 4096-byte page. That pre-existing
+   algorithmic cost became visible only when encryption became mandatory.
+2. A candidate db1 `server-db` omitted generated
+   `merkle_bucket_{index,chunk}_sib_L*.bin` files. `unified_server` therefore
+   loaded db0 and then panicked on db1. Runit restarted it every second, hiding
+   the deterministic three-minute load-and-panic cycle behind a persistent 502.
+3. The db0 manifest also contained large Onion artifacts that the secondary
+   runtime did not use. Manifest verification read those files in full before
+   startup. This increased startup time and memory, but it was not the db1
+   panic's root cause.
+
+The Direct ORAM placement algorithm itself was not replaced. The August 11
+change only optimizes the trusted, offline Merkle construction path: compute the
+tree in memory, then write each packed hash page once in order. Runtime reads,
+writes, authentication, and eviction remain disk-backed and unchanged.
+
+## Known-good none-mode baseline
+
+VPSBG stock/none mode used the production db0 direct inputs:
+
+```text
+index bytes  = 1,345,875,975
+index sha256 = d0b9573488abdda8e17dc52bb52bf5ff11520b4511683020f5f1a22bc8d8d26c
+chunk bytes  = 3,239,380,480
+chunk sha256 = 9a81a02bf82af49414b5f2ae6380c97c1f231fcac6890b605f6cde22b0adc521
+MuHash       = cf4fc1f1dd400622a5b6f39eca7f764a30570c30cc668e04f00e8a3356c2a2ee
+```
+
+The strict, encrypted build completed successfully:
+
+```text
+wall time        3:53.82
+index elapsed    29.318 seconds
+chunk elapsed    127.588 seconds
+maximum RSS      3,778,228 KiB
+swap             0
+exit status      0
+source binding   true for index and chunk authentication stores
+```
+
+For comparison, the old encrypted path required 115.303 seconds for index
+alone and did not finish chunk before a five-minute diagnostic cutoff. The old
+unencrypted complete build took 2:47.48. The optimized encrypted result is
+therefore within the established operational range.
+
+## Artifact retention
+
+The irreplaceable inputs and small evidence are retained; generated ORAM images
+are disposable.
+
+Retain:
+
+- `/Volumes/Bitcoin/data/archive/local-oram-repro-20260811/db0/oram-direct-inputs/`
+- db0 `build-evidence.bin`, `root-bundle-payload.bin`, and exact
+  `server-db/MANIFEST.toml`
+- the none-mode logs and successful `oram-build-evidence.{json,bin}`
+- this runbook and the external archive README
+
+Safe to remove after evidence is copied:
+
+- VPSBG `/home/pir/data/oram-debug/stock-none-20260811/db0-old-method`
+- VPSBG `/home/pir/data/oram-debug/stock-none-20260811/db0-encrypted`
+- VPSBG `/home/pir/data/oram-debug/stock-none-20260811/db0-encrypted-batched`
+- local external `builds/current-unencrypted`
+
+These paths contain derived, reproducible images only. Deleting them is not a
+database or proof deletion.
+
+## Bounded workflow
+
+1. Confirm the server is in stock/none mode, no `oramctl` or `unified_server`
+   remains, and enough disk is free for exactly one output generation.
+2. Verify the two source hashes and all source-binding evidence before the
+   timer starts.
+3. Start one supervised build. Record `started_at`, current phase, last
+   heartbeat, process elapsed time, RSS, output bytes, and final exit status.
+4. Enforce the hard stop externally. Never rely on the worker to stop itself.
+5. Require both `built_direct` records, both `source_bound=true` auth records,
+   `oram-build-evidence.{json,bin}`, and all controller/auth state files.
+6. Preserve logs and small evidence, then remove only the derived bulk images.
+
+## Runit failure suppression
+
+The Tier 3 service must stop after three consecutive short-lived failures.
+Runit's `finish` hook records the start time and consecutive-failure count under
+`/run`; a runtime that survives the stability window resets the old sequence.
+On the third short failure, the hook runs `sv down` for `unified_server` and
+leaves a reason/status file. It must not reboot the machine or delete data.
+
+The dedicated debug UKI uses a one-shot ORAM service instead of the production
+server loop. Its result must remain readable after returning to stock mode.
+
+## Dedicated TEE debug UKI acceptance
+
+The debug image must:
+
+- contain the exact locally tested `oramctl` build;
+- mount only `/home/pir/data` from the unmeasured root filesystem;
+- copy a small deterministic Direct INDEX/CHUNK fixture into protected tmpfs;
+- create a fresh in-guest page key and never print it;
+- run encrypted Direct ORAM with sidecar authentication and a five-minute hard
+  timeout;
+- write atomic `status.env`, an append-only `progress.log`, and the small build
+  evidence under `/home/pir/data/oram-tee-debug/<run-id>/`;
+- record SEV-SNP availability, binary hash, phase times, final status, output
+  sizes, and peak RSS without recording the page key;
+- execute the builder exactly once; after it exits, keep the read-only status
+  endpoint available for collection without restarting the builder.
+
+## TEE result and archive
+
+The accepted image was VPSBG measured-boot image `239`, built from repository
+revision prefix `2bf7810c`:
+
+```text
+image file      bpir-oram-debug-2bf7810c-oramdebug4-20260810T1800Z-original.efi
+image bytes     94,717,440
+image sha256    40547d4130bbd455dc4b208b2cb08cd23de81038e0834a141ef8ff30426e7568
+result          success / complete
+SEV device      present
+runner exit     0
+oramctl sha256  fb16d45437a13d51851daa9b626c58abc79c16884b24eb4dafb3646467b52b7e
+output bytes    19,190
+page key        guest urandom; never recorded
+```
+
+The fixture completed within a one-second sampling interval, so
+`elapsed_seconds=0` is a coarse observation rather than a claim of zero work.
+`progress.log` records `prepare`, `build-direct`, `verify-output`, and
+`complete` in order. The small fixture is intentionally non-strict; it proves
+that the exact encrypted Direct ORAM executable can initialize and finish in a
+SEV guest, not that production db0/db1 have been rebuilt.
+
+Two earlier attempts are retained because they explain control-plane fixes:
+
+- `oramdebug2` stopped during `network-and-sev` before the runner could report
+  a result;
+- `oramdebug3` reached `sev-device-validate`, exposing init/runner output and
+  timeout handling that was corrected in `oramdebug4`.
+
+The byte-for-byte archive is:
+
+```text
+/Volumes/Bitcoin/data/archive/uki-debug/tee-runs-20260810T1800Z/
+```
+
+Its `SHA256SUMS` covers all 27 collected evidence/output files. The successful
+UKI is retained next to that directory. VPSBG is currently in stock/none mode;
+image `239` remains available as the known-good debug rollback artifact.

--- a/docs/ORAM_FULL_UKI_PREFLIGHT_2026-08-11.md
+++ b/docs/ORAM_FULL_UKI_PREFLIGHT_2026-08-11.md
@@ -1,6 +1,6 @@
 # Full Direct ORAM UKI preflight — 2026-08-11
 
-Status: **NOT READY — preflight only; no full build was started.**
+Status: **BUILD BLOCKED — control path prepared; no full build was started.**
 
 This report freezes the exact input, capacity, time, observability, and VPSBG
 conditions for a future full db0/db1 Direct ORAM UKI. It is not deployment
@@ -47,8 +47,8 @@ No candidate-generation pointer was present; this is the active generation.
 | --- | --- | ---: | --- |
 | db0 | `utxo_chunks_index_nodust.bin` | 1,345,875,975 | `d0b9573488abdda8e17dc52bb52bf5ff11520b4511683020f5f1a22bc8d8d26c` |
 | db0 | `utxo_chunks_nodust.bin` | 3,239,380,480 | `9a81a02bf82af49414b5f2ae6380c97c1f231fcac6890b605f6cde22b0adc521` |
-| db1 | `utxo_chunks_index_nodust.bin` | 125,867,300 | `e06fc3c9f79919fd3d4e501337cf2797b88853835d2a6a9a8f06a24f827a6a16` |
-| db1 | `utxo_chunks_nodust.bin` | 340,230,840 | `536acba7438940577e84c098d3d7c72f59f32536d4fdc84193c2d166883d3e0a` |
+| db1 | `utxo_chunks_index_nodust.bin` | 125,867,300 | `e06fc3dedf30096124888acef3024f21a9c049d59fd8c7d518aaf8a58ac6aa16` |
+| db1 | `utxo_chunks_nodust.bin` | 340,230,840 | `536acb605396056118c7c0836988f369c5abbfc3f7e90732ad93e819d5188e0a` |
 
 The two `direct-inputs.sha256` manifests passed. Every nonzero file named by
 each runtime `server-db/MANIFEST.toml` also passed. The read-only runtime-closure
@@ -112,33 +112,50 @@ cycle should budget 8–12 minutes and enforce these failure boundaries:
 Crossing a limit is a failure requiring interruption and diagnosis. It is not
 permission to wait longer.
 
-## Blocking conditions
+## Control-path implementation update
 
-The future full build is **not ready** until all of the following are closed:
+The follow-up change on PR #168 now:
 
-1. `scripts/dracut/97bpir-tier3-init/unified-server-run.sh` currently fixes
-   `VPSBG_DPF_ONLY_FUNCTIONAL_BETA=1`. A newly built production UKI would remain
-   DPF-only and would not execute the Direct ORAM construction path.
-2. The full runtime path lacks the debug image's phase heartbeat and per-db /
-   overall watchdog. The new runit finish hook limits repeated process exits,
-   but cannot interrupt one hung builder invocation. Observability and hard
-   timeouts must be ported before building.
-3. VPSBG has 5/5 image slots occupied. One obsolete image must be explicitly
+1. fixes the measured runtime profile to `direct-oram-v1`, while retaining the
+   old DPF-only branch only as dormant rollback source code;
+2. supervises db0 and db1 separately with 480-second and 180-second limits,
+   15-second heartbeats, and a 90-second stale-heartbeat cutoff;
+3. adds an independent 900-second full-bootstrap watchdog and preserves
+   per-database status, heartbeat, progress, and build logs; and
+4. exercises both database paths with a small fake builder, verifies the final
+   server receives both Direct ORAM bindings, and proves a hung worker exits
+   with status 124 rather than running indefinitely; and
+5. makes the UKI builder reject an initrd missing the supervisor, runit run or
+   finish hooks, `unified_server`, `oramctl`, or the locked BHTM leaf proof.
+
+These are browserless control-path tests. They do not claim that a new UKI has
+been built or that production db0/db1 have run inside it.
+
+## Remaining blocking conditions
+
+The future full build remains blocked until all of the following are closed:
+
+1. The PR update must pass CI and be reviewed/merged; a fresh checkout and
+   exact binary hashes must then be recorded before building.
+2. VPSBG has 5/5 image slots occupied. One obsolete image must be explicitly
    selected and deleted by the operator before an upload can succeed.
-4. The staged runtime closure is complete and verified, but its broader
+3. The staged runtime closure is complete and verified, but its broader
    `all-artifacts.manifest.sha256` refers to historical build-only intermediates
    not retained in the active generation. This does not block runtime startup;
    it is an archival reproducibility gap that must be documented or satisfied
    before claiming a self-contained rebuild archive.
+4. Building, deleting an image, uploading, attaching, and rebooting each still
+   require explicit operator authorization. This report grants none of them.
 
 ## Required go/no-go sequence
 
 Before a later full build, produce one fresh report that:
 
 1. re-confirms stock/none mode, capacity, no running builder, and source hashes;
-2. closes the DPF-only flag and validates that db0 and db1 take the Direct path;
-3. demonstrates heartbeat fields and automatic 8/3/15-minute hard stops on a
-   bounded fixture without running production data;
+2. confirms the merged script still selects `direct-oram-v1` and that its
+   bounded dual-database fixture remains green;
+3. confirms the 8/3/15-minute hard stops and 15/90-second heartbeat policy in
+   the measured initrd inventory;
 4. records the exact release commit, `unified_server`/`oramctl` hashes, BHTM
    proof hash, UKI path/size/hash, and selected rollback image;
 5. obtains explicit operator authorization for image deletion, upload, attach,

--- a/docs/ORAM_FULL_UKI_PREFLIGHT_2026-08-11.md
+++ b/docs/ORAM_FULL_UKI_PREFLIGHT_2026-08-11.md
@@ -1,0 +1,147 @@
+# Full Direct ORAM UKI preflight — 2026-08-11
+
+Status: **NOT READY — preflight only; no full build was started.**
+
+This report freezes the exact input, capacity, time, observability, and VPSBG
+conditions for a future full db0/db1 Direct ORAM UKI. It is not deployment
+authorization. Re-run all volatile checks immediately before a later build.
+
+## Current VPSBG state
+
+The target is VPSBG server `25285` (`pir-server-vpsbg`). The API reported it
+active, unlocked, running, reachable, and booted from the Ubuntu 26.04 stock
+image with `state.measured_boot = null`. This is the required `none` state.
+
+All five measured-boot slots are occupied and inactive:
+
+| ID | Name | Bytes | Role |
+| ---: | --- | ---: | --- |
+| 229 | `vpsbg-harmony-respon` | 314,208,768 | historical runtime |
+| 231 | `attested-builder-nat` | 310,477,824 | historical builder |
+| 233 | `bpir-tier3-oram-v2-2` | 314,055,680 | prior Tier 3 runtime |
+| 237 | `bpir-oram-debug-2bf7` | 94,718,976 | failed debug attempt |
+| 239 | `bpir-oram-debug-2bf7` | 94,717,440 | known-good TEE debug |
+
+A future upload is blocked until the operator separately authorizes deletion
+of one reviewed obsolete image. Do not delete `239`; do not infer deletion
+authority from this report.
+
+## Exact active database generation
+
+`/home/pir/data/databases.toml` points both entries at:
+
+```text
+/home/pir/data/generations/native-v2-948454/
+```
+
+| DB | Meaning | Base height | End height | Generation bytes | `server-db` bytes |
+| --- | --- | ---: | ---: | ---: | ---: |
+| db0 | full main database | 0 | 948,454 | 52,235,207,383 | 47,649,940,332 |
+| db1 | delta database | 940,611 | 948,454 | 5,063,750,813 | 4,597,642,244 |
+
+No candidate-generation pointer was present; this is the active generation.
+
+### Direct inputs
+
+| DB | File | Bytes | SHA-256 |
+| --- | --- | ---: | --- |
+| db0 | `utxo_chunks_index_nodust.bin` | 1,345,875,975 | `d0b9573488abdda8e17dc52bb52bf5ff11520b4511683020f5f1a22bc8d8d26c` |
+| db0 | `utxo_chunks_nodust.bin` | 3,239,380,480 | `9a81a02bf82af49414b5f2ae6380c97c1f231fcac6890b605f6cde22b0adc521` |
+| db1 | `utxo_chunks_index_nodust.bin` | 125,867,300 | `e06fc3c9f79919fd3d4e501337cf2797b88853835d2a6a9a8f06a24f827a6a16` |
+| db1 | `utxo_chunks_nodust.bin` | 340,230,840 | `536acba7438940577e84c098d3d7c72f59f32536d4fdc84193c2d166883d3e0a` |
+
+The two `direct-inputs.sha256` manifests passed. Every nonzero file named by
+each runtime `server-db/MANIFEST.toml` also passed. The read-only runtime-closure
+verification took 151 seconds under a 300-second hard timeout.
+
+### Evidence identity
+
+| DB | Artifact | SHA-256 |
+| --- | --- | --- |
+| db0 | `build-evidence.bin` | `3b9e38d5422e5a3983e5ab356d540f5fcb0ba8bc71992f6ae4f4d2916b9c3394` |
+| db0 | `build-evidence.sev-snp-report.bin` | `9fd1daa48952e41662630627115e092b0d4ccc758503d0e40e2dc551d83b513d` |
+| db0 | root bundle | `a1902bd2173801b6af4a00533d633f8b4e27b48726267ecc4a63ccad4ec8ef78` |
+| db0 | server manifest | `91421138ba94e44665bef2617af296b1c1847dea13c4df29b565012d1e0b74a6` |
+| db1 | `build-evidence.bin` | `06f4ebe959aec371fc2ad35a7ee51b6ee2f02768ccef7e1f5896792a61bc382c` |
+| db1 | `build-evidence.sev-snp-report.bin` | `25476442a39b01ad9440acff719310785e37702e09eaab13dd3f103b0d217f51` |
+| db1 | root bundle | `8cc8e7c20b13521df0060bf5c2bf547d827ac11af1aa49dcaa438a869a518362` |
+| db1 | server manifest | `047a5b6713bf0df29d9de308fb47ff757243e365a9818cf746f399bea457d00c` |
+
+The BHTM leaf proof for height 940,611 is 4,294 bytes with SHA-256
+`2e54cb56ae63d89036c1e74754b68a72e012ed775dff8b0204a6efc023b08195`.
+It binds block hash
+`000000000000000000002c41243b3d74d135942031ef15f547bca1ce8f85eb99`,
+Core MuHash
+`aebb29df12e045ef5279036263aba3b8f8e9e816e05b04a58f57e63b3b25756b`,
+and tree root
+`babeea635812c3b1a2d5f352ab0a5d1ee8a4e9c668c43c05d6603ef3c3766ba6`.
+The proof records `verified_against_tree_root=true`.
+
+## Capacity and bounded timing
+
+The read-only capacity snapshot was:
+
+```text
+RAM total       66,397,003,776 bytes
+RAM available   65,387,905,024 bytes
+swap            0
+/run tmpfs       13,279,404,032 bytes total
+disk free       70,251,692,032 bytes
+running builder none
+```
+
+`oramctl size-direct` projected:
+
+- db0 combined AEAD image: 14,736,682,388 bytes; historical split/auth output:
+  16,217,140,572 bytes;
+- db1 combined AEAD image: 1,842,081,172 bytes; split/auth output estimate:
+  approximately 2.03 GB;
+- both final outputs: approximately 18.24 GB, leaving roughly 52 GB from the
+  observed free-space snapshot.
+
+The real db0 stock/none encrypted build completed in 3:53.82. A future full
+cycle should budget 8–12 minutes and enforce these failure boundaries:
+
+| Boundary | Hard limit |
+| --- | ---: |
+| db0 Direct ORAM | 8 minutes |
+| db1 Direct ORAM | 3 minutes |
+| total full build path | 15 minutes |
+| no progress heartbeat | 90 seconds |
+
+Crossing a limit is a failure requiring interruption and diagnosis. It is not
+permission to wait longer.
+
+## Blocking conditions
+
+The future full build is **not ready** until all of the following are closed:
+
+1. `scripts/dracut/97bpir-tier3-init/unified-server-run.sh` currently fixes
+   `VPSBG_DPF_ONLY_FUNCTIONAL_BETA=1`. A newly built production UKI would remain
+   DPF-only and would not execute the Direct ORAM construction path.
+2. The full runtime path lacks the debug image's phase heartbeat and per-db /
+   overall watchdog. The new runit finish hook limits repeated process exits,
+   but cannot interrupt one hung builder invocation. Observability and hard
+   timeouts must be ported before building.
+3. VPSBG has 5/5 image slots occupied. One obsolete image must be explicitly
+   selected and deleted by the operator before an upload can succeed.
+4. The staged runtime closure is complete and verified, but its broader
+   `all-artifacts.manifest.sha256` refers to historical build-only intermediates
+   not retained in the active generation. This does not block runtime startup;
+   it is an archival reproducibility gap that must be documented or satisfied
+   before claiming a self-contained rebuild archive.
+
+## Required go/no-go sequence
+
+Before a later full build, produce one fresh report that:
+
+1. re-confirms stock/none mode, capacity, no running builder, and source hashes;
+2. closes the DPF-only flag and validates that db0 and db1 take the Direct path;
+3. demonstrates heartbeat fields and automatic 8/3/15-minute hard stops on a
+   bounded fixture without running production data;
+4. records the exact release commit, `unified_server`/`oramctl` hashes, BHTM
+   proof hash, UKI path/size/hash, and selected rollback image;
+5. obtains explicit operator authorization for image deletion, upload, attach,
+   and reboot as separate mutations.
+
+No full ORAM or production UKI build was started while preparing this report.

--- a/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
+++ b/docs/payment/HETZNER_VPSBG_DEPLOYMENT.md
@@ -113,7 +113,10 @@ The preparation leaves the following active definitions unchanged:
 - `deploy/systemd/dev-issuer.service`;
 - `deploy/systemd/cloudflared.service`; or
 - `scripts/dracut/97bpir-tier3-init/unified-server-run.sh`, except for the
-  separately reviewed VPSBG Premium + Free-PoW measured suffix described below.
+  separately reviewed VPSBG Premium + Free-PoW measured suffix described below;
+  and
+- `scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh`, the separately
+  reviewed measured worker watchdog and heartbeat recorder.
 
 The deployment-template gate pins the SHA-256 of each file. It rejects Payment
 V1 enforcement flags in every other active definition and, for the measured

--- a/scripts/build_uki_oram_debug.sh
+++ b/scripts/build_uki_oram_debug.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Build a one-shot SEV-SNP UKI for a tiny encrypted Direct ORAM fixture.
+
+set -euo pipefail
+
+if [ "$EUID" != 0 ]; then
+    echo "error: build_uki_oram_debug.sh must run as root" >&2
+    exit 1
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+DRACUT_MODULE_DIR="$SCRIPT_DIR/dracut"
+ARCHIVE_SCRIPT="$SCRIPT_DIR/archive_uki_artifact.sh"
+KERNEL=${KERNEL:-}
+ORAMCTL_BIN=${ORAMCTL_BIN:-/home/pir/data/oram-debug/stock-none-20260811/source-current/vendor/bitcoinpir-oram/target/release/oramctl}
+RELEASE_ID=${RELEASE_ID:-$(git -C "$(dirname "$SCRIPT_DIR")" rev-parse --short HEAD 2>/dev/null || printf unknown)-$(date -u +%Y%m%dT%H%M%SZ)}
+RUN_ID=${RUN_ID:-oram-tee-debug-$RELEASE_ID}
+OUT=${OUT:-/tmp/bpir-oram-debug-$RELEASE_ID.efi}
+CUSTOM_INITRD=${CUSTOM_INITRD:-/tmp/bpir-oram-debug-$RELEASE_ID-initrd.img}
+FIXTURE_DIR=${FIXTURE_DIR:-/tmp/bpir-oram-debug-$RELEASE_ID-fixture}
+
+for tool in ukify dracut sha256sum awk grep lsinitrd python3 git; do
+    command -v "$tool" >/dev/null 2>&1 || {
+        echo "error: missing build tool: $tool" >&2
+        exit 1
+    }
+done
+[ -x "$ORAMCTL_BIN" ] || { echo "error: oramctl missing: $ORAMCTL_BIN" >&2; exit 1; }
+[[ "$RUN_ID" =~ ^[A-Za-z0-9._=-]+$ ]] || { echo "error: unsafe RUN_ID" >&2; exit 1; }
+
+mkdir -p "$FIXTURE_DIR"
+python3 - "$FIXTURE_DIR" <<'PY'
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+index = bytearray()
+chunks = bytearray()
+for record in range(16):
+    row = bytearray(25)
+    for offset in range(20):
+        row[offset] = (record * 31 + offset) & 0xff
+    row[20:24] = record.to_bytes(4, "little")
+    row[24] = 1
+    index.extend(row)
+    chunks.extend(bytes([record]) * 40)
+(root / "utxo_chunks_index_nodust.bin").write_bytes(index)
+(root / "utxo_chunks_nodust.bin").write_bytes(chunks)
+PY
+
+INDEX_FIXTURE="$FIXTURE_DIR/utxo_chunks_index_nodust.bin"
+CHUNK_FIXTURE="$FIXTURE_DIR/utxo_chunks_nodust.bin"
+ORAMCTL_SHA256=$(sha256sum "$ORAMCTL_BIN" | awk '{print $1}')
+INDEX_SHA256=$(sha256sum "$INDEX_FIXTURE" | awk '{print $1}')
+CHUNK_SHA256=$(sha256sum "$CHUNK_FIXTURE" | awk '{print $1}')
+
+if [ -z "$KERNEL" ]; then
+    KERNEL=$(ls -1 /boot/vmlinuz-*-generic 2>/dev/null | sort -V | tail -1)
+fi
+[ -r "$KERNEL" ] || { echo "error: no readable kernel" >&2; exit 1; }
+KVER=$(basename "$KERNEL" | sed 's/^vmlinuz-//')
+[ -d "/usr/lib/modules/$KVER" ] || { echo "error: modules missing for $KVER" >&2; exit 1; }
+
+SEV_MODULES_DIR="/usr/lib/modules/$KVER/kernel/drivers"
+REQUIRED_SEV_MODS="ccp sev-guest"
+SEV_DRIVER_LIST="ccp sev-guest"
+if find "$SEV_MODULES_DIR" -name 'tsm_report.ko*' -print -quit | grep -q .; then
+    REQUIRED_SEV_MODS="$REQUIRED_SEV_MODS tsm_report"
+    SEV_DRIVER_LIST="$SEV_DRIVER_LIST tsm_report"
+fi
+for mod in $REQUIRED_SEV_MODS; do
+    find "$SEV_MODULES_DIR" -name "${mod}.ko*" -print -quit | grep -q . || {
+        echo "error: missing SEV module $mod" >&2
+        exit 1
+    }
+done
+
+export BPIR_ORAM_DEBUG_ORAMCTL_BIN="$ORAMCTL_BIN"
+export BPIR_ORAM_DEBUG_INDEX_FIXTURE="$INDEX_FIXTURE"
+export BPIR_ORAM_DEBUG_CHUNK_FIXTURE="$CHUNK_FIXTURE"
+export BPIR_ORAM_DEBUG_ORAMCTL_SHA256="$ORAMCTL_SHA256"
+export BPIR_ORAM_DEBUG_INDEX_SHA256="$INDEX_SHA256"
+export BPIR_ORAM_DEBUG_CHUNK_SHA256="$CHUNK_SHA256"
+export BPIR_ORAM_DEBUG_RUN_ID="$RUN_ID"
+
+src="$DRACUT_MODULE_DIR/97bpir-oram-debug"
+dst=/usr/lib/dracut/modules.d/97bpir-oram-debug
+[ -d "$src" ] || { echo "error: missing dracut module: $src" >&2; exit 1; }
+mkdir -p "$dst"
+cp -fp "$src"/* "$dst/"
+chmod 0755 "$dst"/*
+find "$dst" -type f -exec touch -d @0 {} +
+
+DRIVER_LIST="virtio_net virtio_pci virtio_blk $SEV_DRIVER_LIST"
+echo "building Direct ORAM debug UKI"
+echo "run id:          $RUN_ID"
+echo "oramctl sha256:  $ORAMCTL_SHA256"
+echo "index sha256:    $INDEX_SHA256"
+echo "chunk sha256:    $CHUNK_SHA256"
+SOURCE_DATE_EPOCH=0 dracut --force --no-hostonly --reproducible --nostrip \
+    --add 'bpir-oram-debug' \
+    --omit 'bpir-cloudflared bpir-unified-server bpir-tier3-init bpir-attested-builder bpir-builder-tier3-init' \
+    --add-drivers " $DRIVER_LIST " \
+    --kver "$KVER" \
+    "$CUSTOM_INITRD"
+
+listing=$(lsinitrd "$CUSTOM_INITRD")
+for item in usr/local/bin/oramctl sbin/bpir-oram-debug-init \
+    usr/local/bin/bpir-oram-debug-run etc/bpir-oram-debug/baked.env \
+    usr/share/bitcoinpir/oram-debug/utxo_chunks_index_nodust.bin \
+    usr/share/bitcoinpir/oram-debug/utxo_chunks_nodust.bin; do
+    grep -q "$item" <<<"$listing" || { echo "error: initrd missing $item" >&2; exit 1; }
+done
+for mod in $REQUIRED_SEV_MODS; do
+    grep -q "${mod}\.ko" <<<"$listing" || { echo "error: initrd missing ${mod}.ko" >&2; exit 1; }
+done
+for forbidden in usr/local/bin/unified_server usr/local/bin/cloudflared \
+    usr/bin/runit usr/bin/runsvdir etc/sv/unified_server \
+    usr/local/bin/pir-attested-builder; do
+    if grep -q "$forbidden" <<<"$listing"; then
+        echo "error: debug initrd contains forbidden production component: $forbidden" >&2
+        exit 1
+    fi
+done
+
+CMDLINE='rdinit=/sbin/bpir-oram-debug-init console=ttyS0,115200 console=tty1 quiet loglevel=3'
+ukify build --linux="$KERNEL" --initrd="$CUSTOM_INITRD" --cmdline="$CMDLINE" --output="$OUT"
+UKI_SHA256=$(sha256sum "$OUT" | awk '{print $1}')
+UKI_BYTES=$(stat -c '%s' "$OUT")
+[ "$UKI_BYTES" -lt 1000000000 ] || { echo "error: UKI exceeds VPSBG upload limit" >&2; exit 1; }
+echo "UKI:             $OUT"
+echo "UKI bytes:       $UKI_BYTES"
+echo "UKI sha256:      $UKI_SHA256"
+"$ARCHIVE_SCRIPT" oram-debug "$OUT" \
+    "run_id=$RUN_ID" \
+    "kernel_version=$KVER" \
+    "oramctl_sha256=$ORAMCTL_SHA256" \
+    "index_sha256=$INDEX_SHA256" \
+    "chunk_sha256=$CHUNK_SHA256" \
+    "status_url=http://87.120.8.198:22/current/status.env"

--- a/scripts/build_uki_tier3.sh
+++ b/scripts/build_uki_tier3.sh
@@ -302,6 +302,26 @@ if [ -n "$MISSING_MODS" ]; then
 fi
 echo "SEV modules confirmed in initramfs: $REQUIRED_SEV_MODS"
 
+# The full Direct profile is not eligible for upload unless the measured
+# initramfs contains the exact runit entry points and bounded supervisor that
+# the startup script invokes. This is inventory validation only; it does not
+# execute the production database build.
+REQUIRED_TIER3_ITEMS=(
+    'usr/local/bin/unified_server$'
+    'usr/local/bin/oramctl$'
+    'usr/local/bin/direct-oram-supervisor$'
+    'etc/sv/unified_server/run$'
+    'etc/sv/unified_server/finish$'
+    'usr/share/bitcoinpir/proofs/height-940611\.leaf-proof\.json$'
+)
+for expected in "${REQUIRED_TIER3_ITEMS[@]}"; do
+    if ! grep -Eq -- "$expected" <<< "$INITRD_LISTING"; then
+        echo "ERROR: required Tier 3 measured item missing: $expected" >&2
+        exit 1
+    fi
+done
+echo "Direct ORAM supervisor, runit hooks, binaries, and BHTM proof confirmed in initramfs"
+
 # A measured identity key is optional, but when supplied it must retain the
 # exact private-parent permissions required by unified_server's private-file
 # loader.  Otherwise the guest can attest and serve an encrypted channel while

--- a/scripts/dracut/97bpir-oram-debug/bpir-oram-debug-init.sh
+++ b/scripts/dracut/97bpir-oram-debug/bpir-oram-debug-init.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# One-shot PID 1 for the Direct ORAM TEE debug UKI.
+
+set -u
+
+PATH=/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+export PATH
+
+mount -t proc proc /proc 2>/dev/null || true
+mount -t sysfs sysfs /sys 2>/dev/null || true
+mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
+mkdir -p /dev/pts /run /tmp
+mount -t devpts devpts /dev/pts 2>/dev/null || true
+mount -t tmpfs tmpfs /run 2>/dev/null || true
+mount -t tmpfs -o size=512m tmpfs /tmp 2>/dev/null || true
+echo 0 >/proc/sys/kernel/sysrq 2>/dev/null || true
+echo 0 >/proc/sys/kernel/ctrl-alt-del 2>/dev/null || true
+
+modprobe virtio_net 2>/dev/null || true
+modprobe virtio_pci 2>/dev/null || true
+modprobe virtio_blk 2>/dev/null || true
+modprobe ext4 2>/dev/null || true
+
+ip link set lo up 2>/dev/null || true
+i=0
+while [ ! -d /sys/class/net/eth0 ] && [ "$i" -lt 60 ]; do
+    sleep 0.2
+    i=$((i + 1))
+done
+if [ -d /sys/class/net/eth0 ]; then
+    ip link set eth0 up || true
+    ip addr add 87.120.8.198/32 dev eth0 || true
+    ip route add default via 172.16.0.1 dev eth0 onlink || true
+fi
+
+i=0
+while [ "$i" -lt 30 ] && ! grep -qE '(vda|sda|nvme)' /proc/partitions; do
+    sleep 0.2
+    i=$((i + 1))
+done
+mkdir -p /sysroot
+mounted=false
+for src in "LABEL=cloudimg-rootfs" /dev/vda1 /dev/sda1 /dev/vda /dev/sda; do
+    case "$src" in LABEL=*) flag="-L ${src#LABEL=}" ;; *) flag="$src" ;; esac
+    if mount $flag -o rw /sysroot 2>/dev/null; then
+        mounted=true
+        break
+    fi
+done
+if [ "$mounted" != true ]; then
+    echo '[bpir-oram-debug-init] FATAL: rootfs mount failed' >&2
+    while true; do sleep 3600; done
+fi
+mkdir -p /home/pir/data
+if ! mount --bind /sysroot/home/pir/data /home/pir/data; then
+    echo '[bpir-oram-debug-init] FATAL: data bind mount failed' >&2
+    while true; do sleep 3600; done
+fi
+
+# shellcheck disable=SC1091
+source /etc/bpir-oram-debug/baked.env
+STATUS_ROOT=/home/pir/data/oram-tee-debug
+RUN_DIR="$STATUS_ROOT/$BAKED_RUN_ID"
+if [ -e "$RUN_DIR" ]; then
+    echo "[bpir-oram-debug-init] FATAL: run directory already exists: $RUN_DIR" >&2
+    while true; do sleep 3600; done
+fi
+mkdir -p "$RUN_DIR"
+ln -sfn "$RUN_DIR" "$STATUS_ROOT/current"
+printf 'status=booting\nphase=network-and-sev\nrun_id=%s\nupdated_at=%s\n' \
+    "$BAKED_RUN_ID" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$RUN_DIR/status.env"
+
+# Public, credential-free debug status only. Port 22 is used because it is the
+# one VPSBG ingress port already known to be reachable in stock mode. No shell
+# or file upload endpoint exists in this image.
+/usr/bin/busybox httpd -f -p 0.0.0.0:22 -h "$STATUS_ROOT" \
+    >"$RUN_DIR/httpd.log" 2>&1 &
+httpd_pid=$!
+sleep 1
+if ! kill -0 "$httpd_pid" 2>/dev/null; then
+    printf 'status=failed\nphase=http-status\nreason=httpd-not-running\nupdated_at=%s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$RUN_DIR/status.env"
+    while true; do sleep 3600; done
+fi
+
+write_boot_status() {
+    {
+        printf 'status=booting\n'
+        printf 'phase=%s\n' "$1"
+        printf 'run_id=%s\n' "$BAKED_RUN_ID"
+        printf 'updated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } >"$RUN_DIR/status.env.tmp"
+    mv "$RUN_DIR/status.env.tmp" "$RUN_DIR/status.env"
+}
+
+# Some VPSBG kernels expose the device before PID 1 runs. Do not reload the
+# SEV stack in that case. Otherwise bound every module probe independently so
+# a wedged driver can never hide the useful HTTP status endpoint indefinitely.
+write_boot_status sev-device-probe
+if [ ! -c /dev/sev-guest ]; then
+    for module in ccp sev-guest tsm_report; do
+        write_boot_status "sev-modprobe-$module"
+        if ! /usr/bin/busybox timeout -k 2 10 modprobe "$module" \
+            >>"$RUN_DIR/sev-modprobe.log" 2>&1; then
+            printf '%s module=%s result=failed-or-timed-out\n' \
+                "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$module" \
+                >>"$RUN_DIR/sev-modprobe.log"
+        fi
+    done
+fi
+write_boot_status sev-device-validate
+if [ ! -c /dev/sev-guest ]; then
+    printf 'status=failed\nphase=sev\nreason=sev-guest-missing\nupdated_at=%s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$RUN_DIR/status.env"
+    while true; do sleep 3600; done
+fi
+
+echo "[bpir-oram-debug-init] starting runner; status URL: http://87.120.8.198:22/current/status.env"
+write_boot_status runner-start
+set +e
+BPIR_ORAM_DEBUG_RUN_DIR="$RUN_DIR" /usr/local/bin/bpir-oram-debug-run \
+    >>"$RUN_DIR/runner.log" 2>&1
+runner_status=$?
+set -e
+printf 'runner_exit=%s\n' "$runner_status" >>"$RUN_DIR/init.env"
+if [ "$runner_status" -ne 0 ] && ! grep -Fq 'status=failed' "$RUN_DIR/status.env"; then
+    printf 'status=failed\nphase=runner-bootstrap\nreason=runner-exit-%s\nrun_id=%s\nupdated_at=%s\n' \
+        "$runner_status" "$BAKED_RUN_ID" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        >"$RUN_DIR/status.env.tmp"
+    mv "$RUN_DIR/status.env.tmp" "$RUN_DIR/status.env"
+fi
+sync || true
+echo "[bpir-oram-debug-init] runner exited $runner_status; retaining live status endpoint"
+while true; do sleep 3600; done

--- a/scripts/dracut/97bpir-oram-debug/bpir-oram-debug-run.sh
+++ b/scripts/dracut/97bpir-oram-debug/bpir-oram-debug-run.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+# Bounded encrypted Direct ORAM fixture build inside the SEV-SNP debug UKI.
+
+set -Eeuo pipefail
+
+PATH=/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
+export PATH
+
+# shellcheck disable=SC1091
+source /etc/bpir-oram-debug/baked.env
+
+RUN_DIR=${BPIR_ORAM_DEBUG_RUN_DIR:?BPIR_ORAM_DEBUG_RUN_DIR is required}
+INPUT_DIR=/run/bitcoinpir-oram-debug-inputs
+STATE_DIR=/run/bitcoinpir-oram-debug-state
+BULK_DIR="$RUN_DIR/bulk"
+LOG_FILE="$RUN_DIR/oramctl.log"
+PROGRESS_FILE="$RUN_DIR/progress.log"
+HEARTBEAT_FILE="$RUN_DIR/heartbeat.env"
+STATUS_FILE="$RUN_DIR/status.env"
+ORAMCTL=/usr/local/bin/oramctl
+INDEX_BAKED=/usr/share/bitcoinpir/oram-debug/utxo_chunks_index_nodust.bin
+CHUNK_BAKED=/usr/share/bitcoinpir/oram-debug/utxo_chunks_nodust.bin
+MAX_BUILD_SECONDS=300
+
+phase=prepare
+heartbeat_pid=
+watchdog_pid=
+build_pid=
+
+timestamp() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+progress() {
+    phase=$1
+    printf '%s phase=%s\n' "$(timestamp)" "$phase" >>"$PROGRESS_FILE"
+}
+
+write_status() {
+    local status=$1
+    local reason=${2:-none}
+    {
+        printf 'status=%s\n' "$status"
+        printf 'phase=%s\n' "$phase"
+        printf 'reason=%s\n' "$reason"
+        printf 'run_id=%s\n' "$BAKED_RUN_ID"
+        printf 'updated_at=%s\n' "$(timestamp)"
+        printf 'sev_device=present\n'
+        printf 'oramctl_sha256=%s\n' "$BAKED_ORAMCTL_SHA256"
+        printf 'index_sha256=%s\n' "$BAKED_INDEX_SHA256"
+        printf 'chunk_sha256=%s\n' "$BAKED_CHUNK_SHA256"
+        printf 'max_build_seconds=%s\n' "$MAX_BUILD_SECONDS"
+    } >"$STATUS_FILE.tmp"
+    mv "$STATUS_FILE.tmp" "$STATUS_FILE"
+}
+
+cleanup() {
+    local status=$?
+    [ -n "$heartbeat_pid" ] && kill "$heartbeat_pid" 2>/dev/null || true
+    [ -n "$watchdog_pid" ] && kill "$watchdog_pid" 2>/dev/null || true
+    unset PAGE_KEY_HEX || true
+    if [ "$status" -ne 0 ]; then
+        progress failed
+        write_status failed "runner-exit-$status"
+    fi
+    return "$status"
+}
+trap cleanup EXIT
+
+progress prepare
+write_status running
+mkdir -p "$INPUT_DIR" "$STATE_DIR" "$BULK_DIR"
+
+[ "$(sha256sum "$ORAMCTL" | awk '{print $1}')" = "$BAKED_ORAMCTL_SHA256" ]
+[ "$(sha256sum "$INDEX_BAKED" | awk '{print $1}')" = "$BAKED_INDEX_SHA256" ]
+[ "$(sha256sum "$CHUNK_BAKED" | awk '{print $1}')" = "$BAKED_CHUNK_SHA256" ]
+cp "$INDEX_BAKED" "$INPUT_DIR/utxo_chunks_index_nodust.bin"
+cp "$CHUNK_BAKED" "$INPUT_DIR/utxo_chunks_nodust.bin"
+cmp "$INDEX_BAKED" "$INPUT_DIR/utxo_chunks_index_nodust.bin"
+cmp "$CHUNK_BAKED" "$INPUT_DIR/utxo_chunks_nodust.bin"
+
+PAGE_KEY_HEX=$(dd if=/dev/urandom bs=32 count=1 2>/dev/null | od -An -tx1 -v | tr -d ' \n')
+[ "${#PAGE_KEY_HEX}" -eq 64 ]
+
+progress build-direct
+write_status running
+started_epoch=$(date -u +%s)
+
+"$ORAMCTL" build-direct \
+    --index-file "$INPUT_DIR/utxo_chunks_index_nodust.bin" \
+    --chunks-file "$INPUT_DIR/utxo_chunks_nodust.bin" \
+    --out-dir "$BULK_DIR" \
+    --trusted-state-dir "$STATE_DIR" \
+    --level all \
+    --pack 4 \
+    --leaf-divisor 2 \
+    --bucket-size 2 \
+    --stash-capacity 128 \
+    --cache-levels 0 \
+    --index-slots-per-bin 4 \
+    --index-hash-fns 2 \
+    --index-load-factor 0.8 \
+    --index-seed 8030603977422561841 \
+    --encrypted \
+    --key-hex "$PAGE_KEY_HEX" \
+    --auth-store \
+    --auth-layout sidecar \
+    --auth-trusted-levels 1 \
+    --auth-hash-page-size 64 \
+    >"$LOG_FILE" 2>&1 &
+build_pid=$!
+
+(
+    max_rss_kib=0
+    while kill -0 "$build_pid" 2>/dev/null; do
+        rss_kib=$(awk '/^VmRSS:/ {print $2; exit}' "/proc/$build_pid/status" 2>/dev/null || echo 0)
+        case "$rss_kib" in ''|*[!0-9]*) rss_kib=0 ;; esac
+        [ "$rss_kib" -gt "$max_rss_kib" ] && max_rss_kib=$rss_kib
+        output_bytes=$(du -sb "$BULK_DIR" 2>/dev/null | awk '{print $1}' || echo 0)
+        {
+            printf 'phase=build-direct\n'
+            printf 'updated_at=%s\n' "$(timestamp)"
+            printf 'elapsed_seconds=%s\n' "$(( $(date -u +%s) - started_epoch ))"
+            printf 'output_bytes=%s\n' "$output_bytes"
+            printf 'rss_kib=%s\n' "$rss_kib"
+            printf 'max_rss_kib=%s\n' "$max_rss_kib"
+        } >"$HEARTBEAT_FILE.tmp"
+        mv "$HEARTBEAT_FILE.tmp" "$HEARTBEAT_FILE"
+        sleep 5
+    done
+    printf '%s\n' "$max_rss_kib" >"$RUN_DIR/max-rss-kib"
+) &
+heartbeat_pid=$!
+
+(
+    sleep "$MAX_BUILD_SECONDS"
+    if kill -0 "$build_pid" 2>/dev/null; then
+        printf '%s\n' timed-out >"$RUN_DIR/watchdog.result"
+        kill -TERM "$build_pid" 2>/dev/null || true
+        sleep 5
+        kill -KILL "$build_pid" 2>/dev/null || true
+    fi
+) &
+watchdog_pid=$!
+
+set +e
+wait "$build_pid"
+build_status=$?
+set -e
+unset PAGE_KEY_HEX
+kill "$heartbeat_pid" "$watchdog_pid" 2>/dev/null || true
+wait "$heartbeat_pid" 2>/dev/null || true
+wait "$watchdog_pid" 2>/dev/null || true
+heartbeat_pid=
+watchdog_pid=
+build_pid=
+
+[ ! -e "$RUN_DIR/watchdog.result" ] || {
+    progress timed-out
+    write_status failed build-timeout
+    exit 124
+}
+[ "$build_status" -eq 0 ] || {
+    tail -80 "$LOG_FILE" >&2 || true
+    exit "$build_status"
+}
+
+progress verify-output
+write_status running
+for level in direct-index direct-chunk; do
+    for suffix in meta.oram payload.oram meta.hash.oram payload.hash.oram; do
+        [ -s "$BULK_DIR/$level.$suffix" ]
+    done
+    for suffix in state auth.state metadata; do
+        [ -s "$STATE_DIR/$level.$suffix" ]
+    done
+done
+[ -s "$BULK_DIR/oram-build-evidence.json" ]
+[ -s "$BULK_DIR/oram-build-evidence.bin" ]
+grep -Fq 'direct_auth_built level=index' "$LOG_FILE"
+grep -Fq 'direct_auth_built level=chunk' "$LOG_FILE"
+grep -Fq 'built_direct level=index' "$LOG_FILE"
+grep -Fq 'built_direct level=chunk' "$LOG_FILE"
+
+finished_epoch=$(date -u +%s)
+output_bytes=$(du -sb "$BULK_DIR" | awk '{print $1}')
+max_rss_kib=$(cat "$RUN_DIR/max-rss-kib" 2>/dev/null || echo 0)
+phase=complete
+progress complete
+{
+    printf 'status=success\n'
+    printf 'phase=complete\n'
+    printf 'reason=none\n'
+    printf 'run_id=%s\n' "$BAKED_RUN_ID"
+    printf 'updated_at=%s\n' "$(timestamp)"
+    printf 'sev_device=present\n'
+    printf 'oramctl_sha256=%s\n' "$BAKED_ORAMCTL_SHA256"
+    printf 'index_sha256=%s\n' "$BAKED_INDEX_SHA256"
+    printf 'chunk_sha256=%s\n' "$BAKED_CHUNK_SHA256"
+    printf 'elapsed_seconds=%s\n' "$((finished_epoch - started_epoch))"
+    printf 'output_bytes=%s\n' "$output_bytes"
+    printf 'max_rss_kib=%s\n' "$max_rss_kib"
+    printf 'page_key_source=guest-urandom-not-recorded\n'
+    printf 'source_binding_mode=minimal-fixture-nonstrict\n'
+} >"$STATUS_FILE.tmp"
+mv "$STATUS_FILE.tmp" "$STATUS_FILE"
+sync
+trap - EXIT
+exit 0

--- a/scripts/dracut/97bpir-oram-debug/module-setup.sh
+++ b/scripts/dracut/97bpir-oram-debug/module-setup.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Dracut module for the one-shot Direct ORAM SEV-SNP debug image.
+
+# shellcheck shell=bash
+
+check() {
+    for name in BPIR_ORAM_DEBUG_ORAMCTL_BIN BPIR_ORAM_DEBUG_INDEX_FIXTURE \
+        BPIR_ORAM_DEBUG_CHUNK_FIXTURE BPIR_ORAM_DEBUG_ORAMCTL_SHA256 \
+        BPIR_ORAM_DEBUG_INDEX_SHA256 BPIR_ORAM_DEBUG_CHUNK_SHA256 \
+        BPIR_ORAM_DEBUG_RUN_ID; do
+        [ -n "${!name:-}" ] || {
+            derror "bpir-oram-debug: missing build variable $name"
+            return 1
+        }
+    done
+    [ -x "$BPIR_ORAM_DEBUG_ORAMCTL_BIN" ] || return 1
+    [ -r "$BPIR_ORAM_DEBUG_INDEX_FIXTURE" ] || return 1
+    [ -r "$BPIR_ORAM_DEBUG_CHUNK_FIXTURE" ] || return 1
+    [ -x /usr/bin/busybox ] || return 1
+    [ -x /usr/bin/time ] || return 1
+    return 0
+}
+
+depends() {
+    echo "busybox base"
+    return 0
+}
+
+install() {
+    inst_multiple bash env ip modprobe mount sleep ln mkdir cat sh blkid awk \
+        cmp dd od tr tail mv cp date sha256sum du sync grep stat tee
+    inst_simple /usr/bin/busybox
+    inst_simple /usr/bin/time
+    ln_r /usr/bin/busybox /sbin/poweroff
+    ln_r /usr/bin/busybox /sbin/reboot
+
+    inst_simple "$BPIR_ORAM_DEBUG_ORAMCTL_BIN" /usr/local/bin/oramctl
+    inst_simple "$BPIR_ORAM_DEBUG_INDEX_FIXTURE" \
+        /usr/share/bitcoinpir/oram-debug/utxo_chunks_index_nodust.bin
+    inst_simple "$BPIR_ORAM_DEBUG_CHUNK_FIXTURE" \
+        /usr/share/bitcoinpir/oram-debug/utxo_chunks_nodust.bin
+    inst_simple "$moddir/bpir-oram-debug-init.sh" /sbin/bpir-oram-debug-init
+    inst_simple "$moddir/bpir-oram-debug-run.sh" /usr/local/bin/bpir-oram-debug-run
+    chmod 0755 "${initdir}/sbin/bpir-oram-debug-init"
+    chmod 0755 "${initdir}/usr/local/bin/bpir-oram-debug-run"
+
+    inst_dir /etc/bpir-oram-debug
+    {
+        printf 'BAKED_RUN_ID=%q\n' "$BPIR_ORAM_DEBUG_RUN_ID"
+        printf 'BAKED_ORAMCTL_SHA256=%q\n' "$BPIR_ORAM_DEBUG_ORAMCTL_SHA256"
+        printf 'BAKED_INDEX_SHA256=%q\n' "$BPIR_ORAM_DEBUG_INDEX_SHA256"
+        printf 'BAKED_CHUNK_SHA256=%q\n' "$BPIR_ORAM_DEBUG_CHUNK_SHA256"
+    } >"${initdir}/etc/bpir-oram-debug/baked.env"
+    chmod 0444 "${initdir}/etc/bpir-oram-debug/baked.env"
+}

--- a/scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh
+++ b/scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh
@@ -1,0 +1,211 @@
+#!/bin/sh
+# Run one Direct ORAM build with persistent progress, heartbeat, and hard stops.
+
+# shellcheck shell=sh
+
+set -u
+umask 077
+
+usage() {
+    echo "usage: direct-oram-supervisor LABEL TIMEOUT HEARTBEAT_INTERVAL HEARTBEAT_DEADLINE KILL_GRACE STATUS_DIR OUTPUT_DIR LOG_FILE -- COMMAND [ARG ...]" >&2
+    exit 2
+}
+
+[ "$#" -ge 10 ] || usage
+label=$1
+timeout_seconds=$2
+heartbeat_interval_seconds=$3
+heartbeat_deadline_seconds=$4
+kill_grace_seconds=$5
+status_dir=$6
+output_dir=$7
+log_file=$8
+shift 8
+[ "${1:-}" = -- ] || usage
+shift
+[ "$#" -gt 0 ] || usage
+
+case "$label" in
+    ''|*[!A-Za-z0-9._-]*) usage ;;
+esac
+for value in "$timeout_seconds" "$heartbeat_interval_seconds" \
+    "$heartbeat_deadline_seconds" "$kill_grace_seconds"; do
+    case "$value" in
+        ''|*[!0-9]*) usage ;;
+    esac
+done
+[ "$timeout_seconds" -gt 0 ] || usage
+[ "$heartbeat_interval_seconds" -gt 0 ] || usage
+[ "$heartbeat_deadline_seconds" -gt "$heartbeat_interval_seconds" ] || usage
+
+log_dir=${log_file%/*}
+[ "$log_dir" = "$log_file" ] && log_dir=.
+mkdir -p "$status_dir" "$output_dir" "$log_dir" || exit 1
+
+status_file="$status_dir/$label.status.env"
+heartbeat_file="$status_dir/$label.heartbeat.env"
+progress_file="$status_dir/direct-oram.progress.log"
+reason_file="$status_dir/$label.watchdog-reason"
+rm -f "$reason_file"
+
+worker_pid=
+heartbeat_pid=
+watchdog_pid=
+final_written=0
+started_at_epoch=$(date -u +%s)
+
+timestamp() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+output_kib() {
+    du -sk "$output_dir" 2>/dev/null | awk '{ print $1; exit }'
+}
+
+write_status() {
+    status=$1
+    reason=$2
+    elapsed=$(( $(date -u +%s) - started_at_epoch ))
+    kib=$(output_kib)
+    case "$kib" in ''|*[!0-9]*) kib=0 ;; esac
+    {
+        printf 'status=%s\n' "$status"
+        printf 'phase=build-direct\n'
+        printf 'database=%s\n' "$label"
+        printf 'reason=%s\n' "$reason"
+        printf 'updated_at=%s\n' "$(timestamp)"
+        printf 'updated_at_epoch=%s\n' "$(date -u +%s)"
+        printf 'elapsed_seconds=%s\n' "$elapsed"
+        printf 'output_kib=%s\n' "$kib"
+        printf 'timeout_seconds=%s\n' "$timeout_seconds"
+        printf 'heartbeat_interval_seconds=%s\n' "$heartbeat_interval_seconds"
+        printf 'heartbeat_deadline_seconds=%s\n' "$heartbeat_deadline_seconds"
+    } >"$status_file.tmp"
+    mv "$status_file.tmp" "$status_file"
+}
+
+cleanup() {
+    cleanup_status=$?
+    trap - EXIT HUP INT TERM
+    [ -n "$heartbeat_pid" ] && kill "$heartbeat_pid" 2>/dev/null || true
+    [ -n "$watchdog_pid" ] && kill "$watchdog_pid" 2>/dev/null || true
+    if [ -n "$worker_pid" ] && kill -0 "$worker_pid" 2>/dev/null; then
+        kill -TERM "$worker_pid" 2>/dev/null || true
+        sleep "$kill_grace_seconds"
+        kill -KILL "$worker_pid" 2>/dev/null || true
+    fi
+    [ -n "$worker_pid" ] && wait "$worker_pid" 2>/dev/null || true
+    [ -n "$heartbeat_pid" ] && wait "$heartbeat_pid" 2>/dev/null || true
+    [ -n "$watchdog_pid" ] && wait "$watchdog_pid" 2>/dev/null || true
+    if [ "$cleanup_status" -ne 0 ] && [ "$final_written" -eq 0 ]; then
+        write_status failed "supervisor-exit-$cleanup_status"
+    fi
+    exit "$cleanup_status"
+}
+
+handle_signal() {
+    signal_name=$1
+    write_status failed "supervisor-signal-$signal_name"
+    final_written=1
+    exit 143
+}
+
+trap cleanup EXIT
+trap 'handle_signal HUP' HUP
+trap 'handle_signal INT' INT
+trap 'handle_signal TERM' TERM
+
+printf '%s database=%s phase=starting timeout_seconds=%s\n' \
+    "$(timestamp)" "$label" "$timeout_seconds" >>"$progress_file"
+: >"$log_file"
+"$@" >"$log_file" 2>&1 &
+worker_pid=$!
+write_status running none
+
+(
+    max_rss_kib=0
+    while kill -0 "$worker_pid" 2>/dev/null; do
+        now_epoch=$(date -u +%s)
+        rss_kib=$(awk '/^VmRSS:/ { print $2; exit }' "/proc/$worker_pid/status" 2>/dev/null || echo 0)
+        kib=$(output_kib)
+        case "$rss_kib" in ''|*[!0-9]*) rss_kib=0 ;; esac
+        case "$kib" in ''|*[!0-9]*) kib=0 ;; esac
+        [ "$rss_kib" -gt "$max_rss_kib" ] && max_rss_kib=$rss_kib
+        {
+            printf 'status=running\n'
+            printf 'phase=build-direct\n'
+            printf 'database=%s\n' "$label"
+            printf 'updated_at=%s\n' "$(timestamp)"
+            printf 'updated_at_epoch=%s\n' "$now_epoch"
+            printf 'elapsed_seconds=%s\n' "$((now_epoch - started_at_epoch))"
+            printf 'output_kib=%s\n' "$kib"
+            printf 'rss_kib=%s\n' "$rss_kib"
+            printf 'max_rss_kib=%s\n' "$max_rss_kib"
+        } >"$heartbeat_file.tmp"
+        mv "$heartbeat_file.tmp" "$heartbeat_file"
+        sleep "$heartbeat_interval_seconds"
+    done
+) </dev/null >/dev/null 2>&1 &
+heartbeat_pid=$!
+
+(
+    while kill -0 "$worker_pid" 2>/dev/null; do
+        sleep 1
+        kill -0 "$worker_pid" 2>/dev/null || exit 0
+        now_epoch=$(date -u +%s)
+        reason=
+        if [ $((now_epoch - started_at_epoch)) -ge "$timeout_seconds" ]; then
+            reason=build-timeout
+        else
+            heartbeat_epoch=$(awk -F= '$1 == "updated_at_epoch" { print $2; exit }' "$heartbeat_file" 2>/dev/null || echo 0)
+            case "$heartbeat_epoch" in ''|*[!0-9]*) heartbeat_epoch=0 ;; esac
+            if [ "$heartbeat_epoch" -eq 0 ]; then
+                [ $((now_epoch - started_at_epoch)) -ge "$heartbeat_deadline_seconds" ] \
+                    && reason=heartbeat-missing
+            elif [ $((now_epoch - heartbeat_epoch)) -ge "$heartbeat_deadline_seconds" ]; then
+                reason=heartbeat-stale
+            fi
+        fi
+        [ -n "$reason" ] || continue
+        printf '%s\n' "$reason" >"$reason_file.tmp"
+        mv "$reason_file.tmp" "$reason_file"
+        kill -TERM "$worker_pid" 2>/dev/null || true
+        sleep "$kill_grace_seconds"
+        kill -KILL "$worker_pid" 2>/dev/null || true
+        exit 0
+    done
+) </dev/null >/dev/null 2>&1 &
+watchdog_pid=$!
+
+wait "$worker_pid"
+worker_status=$?
+worker_pid=
+kill "$heartbeat_pid" "$watchdog_pid" 2>/dev/null || true
+wait "$heartbeat_pid" 2>/dev/null || true
+wait "$watchdog_pid" 2>/dev/null || true
+heartbeat_pid=
+watchdog_pid=
+
+reason=none
+[ -r "$reason_file" ] && reason=$(cat "$reason_file")
+case "$reason" in
+    build-timeout|heartbeat-missing|heartbeat-stale)
+        write_status timed_out "$reason"
+        printf '%s database=%s phase=timed-out reason=%s\n' \
+            "$(timestamp)" "$label" "$reason" >>"$progress_file"
+        final_written=1
+        exit 124
+        ;;
+esac
+if [ "$worker_status" -ne 0 ]; then
+    write_status failed "worker-exit-$worker_status"
+    printf '%s database=%s phase=failed worker_exit=%s\n' \
+        "$(timestamp)" "$label" "$worker_status" >>"$progress_file"
+    final_written=1
+    exit "$worker_status"
+fi
+
+write_status success none
+printf '%s database=%s phase=complete\n' "$(timestamp)" "$label" >>"$progress_file"
+final_written=1
+exit 0

--- a/scripts/dracut/97bpir-tier3-init/module-setup.sh
+++ b/scripts/dracut/97bpir-tier3-init/module-setup.sh
@@ -70,9 +70,9 @@ install() {
     # blkid for the FATAL-path diagnostic when rootfs mount fails.
     # awk/cmp/dd/od/tr/tail/rm/mv are used by unified-server-run.sh to derive
     # fresh ORAM seeds, parse the active catalog, bind its runtime/proof
-    # manifests byte-for-byte, and publish boot images. date is used by the
-    # runit finish hook's bounded consecutive-failure window.
-    inst_multiple ip modprobe mount sleep ln mkdir cat sh nc blkid awk cmp dd od tr tail rm mv date
+    # manifests byte-for-byte, and publish boot images. date and du are used by
+    # the bounded Direct ORAM supervisor and runit failure guard.
+    inst_multiple ip modprobe mount sleep ln mkdir cat sh nc blkid awk cmp dd od tr tail rm mv date du
 
     # udhcpc is a busybox applet, NOT a standalone binary on Ubuntu.
     # Bake busybox itself in (statically linked, ~1.5 MB) and create
@@ -111,6 +111,8 @@ install() {
     inst_dir /etc/sv/unified_server
     inst_simple "$moddir/unified-server-run.sh" /etc/sv/unified_server/run
     inst_simple "$moddir/unified-server-finish.sh" /etc/sv/unified_server/finish
+    inst_simple "$moddir/direct-oram-supervisor.sh" /usr/local/bin/direct-oram-supervisor
     chmod 0755 "${initdir}/etc/sv/unified_server/run"
     chmod 0755 "${initdir}/etc/sv/unified_server/finish"
+    chmod 0755 "${initdir}/usr/local/bin/direct-oram-supervisor"
 }

--- a/scripts/dracut/97bpir-tier3-init/module-setup.sh
+++ b/scripts/dracut/97bpir-tier3-init/module-setup.sh
@@ -70,8 +70,9 @@ install() {
     # blkid for the FATAL-path diagnostic when rootfs mount fails.
     # awk/cmp/dd/od/tr/tail/rm/mv are used by unified-server-run.sh to derive
     # fresh ORAM seeds, parse the active catalog, bind its runtime/proof
-    # manifests byte-for-byte, and publish boot images.
-    inst_multiple ip modprobe mount sleep ln mkdir cat sh nc blkid awk cmp dd od tr tail rm mv
+    # manifests byte-for-byte, and publish boot images. date is used by the
+    # runit finish hook's bounded consecutive-failure window.
+    inst_multiple ip modprobe mount sleep ln mkdir cat sh nc blkid awk cmp dd od tr tail rm mv date
 
     # udhcpc is a busybox applet, NOT a standalone binary on Ubuntu.
     # Bake busybox itself in (statically linked, ~1.5 MB) and create
@@ -109,4 +110,7 @@ install() {
     # run script.
     inst_dir /etc/sv/unified_server
     inst_simple "$moddir/unified-server-run.sh" /etc/sv/unified_server/run
+    inst_simple "$moddir/unified-server-finish.sh" /etc/sv/unified_server/finish
+    chmod 0755 "${initdir}/etc/sv/unified_server/run"
+    chmod 0755 "${initdir}/etc/sv/unified_server/finish"
 }

--- a/scripts/dracut/97bpir-tier3-init/unified-server-finish.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-finish.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Runit finish hook for unified_server.
+#
+# Stop supervising after three exits within ten minutes. A long stable interval
+# starts a new failure sequence. State in /run is per boot; the status copy on
+# /home/pir/data is only for operator visibility after returning to stock mode.
+
+# shellcheck shell=sh
+
+umask 077
+
+MAX_FAILURES=3
+FAILURE_WINDOW_SECONDS=600
+STATE_DIR=${BPIR_RUNIT_GUARD_STATE_DIR:-/run/bitcoinpir-runit/unified_server}
+STATUS_DIR=${BPIR_RUNIT_GUARD_STATUS_DIR:-/home/pir/data/oram-boot-logs}
+SV_BIN=${BPIR_RUNIT_GUARD_SV_BIN:-/usr/bin/sv}
+SERVICE_DIR=${BPIR_RUNIT_GUARD_SERVICE_DIR:-/etc/service/unified_server}
+
+mkdir -p "$STATE_DIR" || exit 0
+
+now=$(date +%s 2>/dev/null || echo 0)
+last=0
+count=0
+[ -r "$STATE_DIR/last_failure_at" ] && last=$(cat "$STATE_DIR/last_failure_at" 2>/dev/null || echo 0)
+[ -r "$STATE_DIR/failure_count" ] && count=$(cat "$STATE_DIR/failure_count" 2>/dev/null || echo 0)
+case "$now:$last:$count" in
+    *[!0-9:]*|::*|*::*) now=0; last=0; count=0 ;;
+esac
+
+if [ "$now" -gt 0 ] && [ "$last" -gt 0 ] && [ $((now - last)) -le "$FAILURE_WINDOW_SECONDS" ]; then
+    count=$((count + 1))
+else
+    count=1
+fi
+
+printf '%s\n' "$now" >"$STATE_DIR/last_failure_at.tmp"
+mv "$STATE_DIR/last_failure_at.tmp" "$STATE_DIR/last_failure_at"
+printf '%s\n' "$count" >"$STATE_DIR/failure_count.tmp"
+mv "$STATE_DIR/failure_count.tmp" "$STATE_DIR/failure_count"
+
+status=retrying
+action=restart
+if [ "$count" -ge "$MAX_FAILURES" ]; then
+    status=restart_suppressed
+    action=down
+fi
+
+if mkdir -p "$STATUS_DIR" 2>/dev/null; then
+    {
+        printf 'status=%s\n' "$status"
+        printf 'failure_count=%s\n' "$count"
+        printf 'max_failures=%s\n' "$MAX_FAILURES"
+        printf 'failure_window_seconds=%s\n' "$FAILURE_WINDOW_SECONDS"
+        printf 'last_failure_at_epoch=%s\n' "$now"
+        printf 'exit_code=%s\n' "${1:-unknown}"
+        printf 'signal=%s\n' "${2:-unknown}"
+        printf 'action=%s\n' "$action"
+    } >"$STATUS_DIR/unified-server-runit.status.tmp"
+    mv "$STATUS_DIR/unified-server-runit.status.tmp" "$STATUS_DIR/unified-server-runit.status"
+fi
+
+if [ "$action" = down ]; then
+    echo "[unified-server-finish] suppressing restart after $count failures within ${FAILURE_WINDOW_SECONDS}s" >&2
+    # `sv down` sends the control byte immediately. The one-second wait may
+    # expire because this finish hook must return before runsv becomes down.
+    "$SV_BIN" -w 1 down "$SERVICE_DIR" >/dev/null 2>&1 || true
+else
+    echo "[unified-server-finish] failure $count/$MAX_FAILURES; runit may retry" >&2
+fi
+
+exit 0

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -79,13 +79,11 @@ if [ -r /etc/bitcoinpir/payment/service-policy.bin ]; then
     SERVICE_POLICY_PATH=/etc/bitcoinpir/payment/service-policy.bin
 fi
 
-# Do not hold the usable db0 query path behind the separate Direct-ORAM ceremony: the
-# currently mounted db0 proof is V1 and deliberately lacks the typed
-# `direct_oram` data required by the newer Direct-ORAM bootstrap.  Direct ORAM
-# remains below as an explicit future path once a new attested full-build has
-# supplied that evidence; changing this constant requires a new measured UKI
-# review and release.
-VPSBG_DPF_ONLY_FUNCTIONAL_BETA=1
+# This measured constant selects exactly one startup path. The active v2
+# generation now carries proof-bound Direct inputs for both databases, so a
+# future UKI built from this script must fail closed into the Direct profile.
+# Changing the profile requires a new measured UKI review and release.
+VPSBG_RUNTIME_PROFILE=direct-oram-v1
 
 ORAM_BOOT_ROOT=/home/pir/data/.oram-boot
 ORAM_BUILD_LOG_DIR=/home/pir/data/oram-boot-logs
@@ -105,6 +103,14 @@ ORAM_STASH_CAPACITY=128
 ORAM_CACHE_LEVELS=0
 ORAM_AUTH_TRUSTED_LEVELS=1
 ORAM_AUTH_HASH_PAGE_SIZE=4096
+ORAM_DB0_MAX_SECONDS=480
+ORAM_DB1_MAX_SECONDS=180
+ORAM_TOTAL_MAX_SECONDS=900
+ORAM_HEARTBEAT_INTERVAL_SECONDS=15
+ORAM_HEARTBEAT_DEADLINE_SECONDS=90
+ORAM_KILL_GRACE_SECONDS=5
+ORAM_SUPERVISOR=/usr/local/bin/direct-oram-supervisor
+ORAM_ACTIVE_SUPERVISOR_PID_FILE="$TRUSTED_STATE_ROOT/active-supervisor.pid"
 DIRECT_INDEX_SLOTS_PER_BIN=4
 DIRECT_INDEX_HASH_FNS=2
 DIRECT_INDEX_LOAD_FACTOR=0.95
@@ -238,9 +244,76 @@ safe_remove_runtime_path() {
 }
 
 cleanup_build_staging() {
+    [ -n "${ORAM_TOTAL_WATCHDOG_PID:-}" ] \
+        && kill "$ORAM_TOTAL_WATCHDOG_PID" 2>/dev/null || true
+    [ -n "${ORAM_TOTAL_WATCHDOG_PID:-}" ] \
+        && wait "$ORAM_TOTAL_WATCHDOG_PID" 2>/dev/null || true
+    if [ -r "$ORAM_ACTIVE_SUPERVISOR_PID_FILE" ]; then
+        active_supervisor_pid=$(cat "$ORAM_ACTIVE_SUPERVISOR_PID_FILE" 2>/dev/null || echo 0)
+        case "$active_supervisor_pid" in ''|*[!0-9]*) active_supervisor_pid=0 ;; esac
+        [ "$active_supervisor_pid" -gt 1 ] \
+            && kill -TERM "$active_supervisor_pid" 2>/dev/null || true
+        [ "$active_supervisor_pid" -gt 1 ] \
+            && wait "$active_supervisor_pid" 2>/dev/null || true
+    fi
     safe_remove_boot_path "$ORAM_STAGING_DIR"
     safe_remove_runtime_path "$TRUSTED_INPUT_ROOT"
     safe_remove_runtime_path "$TRUSTED_STATE_ROOT"
+}
+
+start_total_watchdog() {
+    parent_pid=$$
+    (
+        total_deadline=$(( $(date -u +%s) + ORAM_TOTAL_MAX_SECONDS ))
+        while [ "$(date -u +%s)" -lt "$total_deadline" ]; do
+            sleep 1
+        done
+        {
+            printf 'status=timed_out\n'
+            printf 'phase=direct-oram-bootstrap\n'
+            printf 'reason=total-timeout\n'
+            printf 'timeout_seconds=%s\n' "$ORAM_TOTAL_MAX_SECONDS"
+            printf 'updated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        } >"$ORAM_BUILD_LOG_DIR/direct-oram-bootstrap.status.env.tmp"
+        mv "$ORAM_BUILD_LOG_DIR/direct-oram-bootstrap.status.env.tmp" \
+            "$ORAM_BUILD_LOG_DIR/direct-oram-bootstrap.status.env"
+        if [ -r "$ORAM_ACTIVE_SUPERVISOR_PID_FILE" ]; then
+            supervisor_pid=$(cat "$ORAM_ACTIVE_SUPERVISOR_PID_FILE" 2>/dev/null || echo 0)
+            case "$supervisor_pid" in ''|*[!0-9]*) supervisor_pid=0 ;; esac
+            [ "$supervisor_pid" -gt 1 ] && kill -TERM "$supervisor_pid" 2>/dev/null || true
+        fi
+        sleep "$ORAM_KILL_GRACE_SECONDS"
+        [ "${supervisor_pid:-0}" -gt 1 ] \
+            && kill -KILL "$supervisor_pid" 2>/dev/null || true
+        kill -TERM "$parent_pid" 2>/dev/null || true
+    ) </dev/null >/dev/null 2>&1 &
+    ORAM_TOTAL_WATCHDOG_PID=$!
+}
+
+stop_total_watchdog() {
+    [ -n "${ORAM_TOTAL_WATCHDOG_PID:-}" ] || return 0
+    kill "$ORAM_TOTAL_WATCHDOG_PID" 2>/dev/null || true
+    wait "$ORAM_TOTAL_WATCHDOG_PID" 2>/dev/null || true
+    ORAM_TOTAL_WATCHDOG_PID=
+}
+
+run_supervised_direct_build() {
+    supervised_label=$1
+    supervised_timeout=$2
+    supervised_out_dir=$3
+    supervised_log_file=$4
+    shift 4
+    "$ORAM_SUPERVISOR" "$supervised_label" "$supervised_timeout" \
+        "$ORAM_HEARTBEAT_INTERVAL_SECONDS" "$ORAM_HEARTBEAT_DEADLINE_SECONDS" \
+        "$ORAM_KILL_GRACE_SECONDS" "$ORAM_BUILD_LOG_DIR" "$supervised_out_dir" \
+        "$supervised_log_file" -- "$@" &
+    supervisor_pid=$!
+    printf '%s\n' "$supervisor_pid" >"$ORAM_ACTIVE_SUPERVISOR_PID_FILE.tmp"
+    mv "$ORAM_ACTIVE_SUPERVISOR_PID_FILE.tmp" "$ORAM_ACTIVE_SUPERVISOR_PID_FILE"
+    wait "$supervisor_pid"
+    supervised_status=$?
+    rm -f "$ORAM_ACTIVE_SUPERVISOR_PID_FILE"
+    return "$supervised_status"
 }
 
 copy_to_trusted_runtime() {
@@ -263,6 +336,7 @@ build_direct_oram() {
     expected_index_sha="$9"
     expected_chunks_sha="${10}"
     trusted_state_dir="${11}"
+    build_timeout_seconds="${12}"
     log_file="$ORAM_BUILD_LOG_DIR/${db_label}.build-direct.log"
     source_index_file="$source_dir/utxo_chunks_index_nodust.bin"
     source_chunks_file="$source_dir/utxo_chunks_nodust.bin"
@@ -311,7 +385,8 @@ build_direct_oram() {
     mkdir -p "$out_dir" || fatal "failed to create $out_dir"
     echo "[unified-server-run] regenerating $db_label direct ORAM from trusted tmpfs into $out_dir; trusted state: $trusted_state_dir" >&2
     if [ -n "$expected_from_muhash" ]; then
-        "$ORAMCTL" build-direct \
+        run_supervised_direct_build "$db_label" "$build_timeout_seconds" \
+            "$out_dir" "$log_file" "$ORAMCTL" build-direct \
             --index-file "$index_file" \
             --chunks-file "$chunks_file" \
             --out-dir "$out_dir" \
@@ -343,13 +418,13 @@ build_direct_oram() {
             --expected-bhtm-tree-root "$DELTA_EXPECTED_BHTM_TREE_ROOT" \
             --expected-index-sha256 "$expected_index_sha" \
             --expected-chunks-sha256 "$expected_chunks_sha" \
-            --strict-source-binding \
-            >"$log_file" 2>&1 || {
+            --strict-source-binding || {
                 tail -80 "$log_file" >&2 || true
                 fatal "$db_label direct ORAM regeneration failed; full log: $log_file"
             }
     else
-        "$ORAMCTL" build-direct \
+        run_supervised_direct_build "$db_label" "$build_timeout_seconds" \
+            "$out_dir" "$log_file" "$ORAMCTL" build-direct \
             --index-file "$index_file" \
             --chunks-file "$chunks_file" \
             --out-dir "$out_dir" \
@@ -376,8 +451,7 @@ build_direct_oram() {
             --expected-muhash "$expected_muhash" \
             --expected-index-sha256 "$expected_index_sha" \
             --expected-chunks-sha256 "$expected_chunks_sha" \
-            --strict-source-binding \
-            >"$log_file" 2>&1 || {
+            --strict-source-binding || {
                 tail -80 "$log_file" >&2 || true
                 fatal "$db_label direct ORAM regeneration failed; full log: $log_file"
             }
@@ -403,7 +477,8 @@ verify_direct_oram_publish() {
 }
 
 [ -x "$UNIFIED_SERVER" ] || fatal "$UNIFIED_SERVER missing from UKI"
-if [ "$VPSBG_DPF_ONLY_FUNCTIONAL_BETA" = 1 ]; then
+case "$VPSBG_RUNTIME_PROFILE" in
+dpf-only-functional-beta-v1)
     echo "[unified-server-run] starting VPSBG db0 functional beta; Direct ORAM is not advertised" >&2
     exec "$UNIFIED_SERVER" \
         --port 8091 \
@@ -435,9 +510,16 @@ if [ "$VPSBG_DPF_ONLY_FUNCTIONAL_BETA" = 1 ]; then
         --connection-idle-timeout-ms 300000 \
         --service-pre-auth-timeout-ms 300000 \
         2>&1
-fi
+    ;;
+direct-oram-v1)
+    ;;
+*)
+    fatal "unsupported measured VPSBG runtime profile: $VPSBG_RUNTIME_PROFILE"
+    ;;
+esac
 
 [ -x "$ORAMCTL" ] || fatal "$ORAMCTL missing from UKI"
+[ -x "$ORAM_SUPERVISOR" ] || fatal "$ORAM_SUPERVISOR missing from UKI"
 require_file "$DELTA_BHTM_FROM_LEAF_PROOF"
 mkdir -p "$ORAM_BOOT_ROOT" "$ORAM_BUILD_LOG_DIR" || fatal "failed to create ORAM boot directories"
 for stale_staging in "$ORAM_BOOT_ROOT"/staging.*; do
@@ -451,7 +533,10 @@ mkdir -p "$ORAM_STAGING_DIR" || fatal "failed to create $ORAM_STAGING_DIR"
 mkdir -p "$TRUSTED_INPUT_ROOT" "$TRUSTED_STATE_ROOT" \
     || fatal "failed to create SEV-protected ORAM runtime directories"
 ORAM_PAGE_KEY_HEX="$(random_seed_hex)"
+ORAM_TOTAL_WATCHDOG_PID=
 trap cleanup_build_staging EXIT
+trap 'exit 124' HUP INT TERM
+start_total_watchdog
 
 load_active_database_generation 0 db0
 MAINNET_SOURCE_DIR="$ACTIVE_DB_PROOF_DIR/oram-direct-inputs"
@@ -468,17 +553,19 @@ DELTA_ROOT_BUNDLE="$ACTIVE_DB_PROOF_DIR/root-bundle-payload.bin"
 build_direct_oram mainnet-948454 "$MAINNET_SOURCE_DIR" "$ORAM_STAGING_DIR/db0-mainnet-948454" \
     "$MAINNET_DB_EVIDENCE" "$MAINNET_DB_MANIFEST" "$MAINNET_ROOT_BUNDLE" "$MAINNET_EXPECTED_MUHASH" "" \
     "$MAINNET_EXPECTED_INDEX_SHA256" "$MAINNET_EXPECTED_CHUNKS_SHA256" \
-    "$ORAM_FULL_TRUSTED_STATE_DIR"
+    "$ORAM_FULL_TRUSTED_STATE_DIR" "$ORAM_DB0_MAX_SECONDS"
 build_direct_oram delta-940611-948454 "$DELTA_SOURCE_DIR" "$ORAM_STAGING_DIR/db1-delta-940611-948454" \
     "$DELTA_DB_EVIDENCE" "$DELTA_DB_MANIFEST" "$DELTA_ROOT_BUNDLE" "$DELTA_EXPECTED_MUHASH" "$DELTA_EXPECTED_FROM_MUHASH" \
     "$DELTA_EXPECTED_INDEX_SHA256" "$DELTA_EXPECTED_CHUNKS_SHA256" \
-    "$ORAM_DELTA_TRUSTED_STATE_DIR"
+    "$ORAM_DELTA_TRUSTED_STATE_DIR" "$ORAM_DB1_MAX_SECONDS"
 
 mv "$ORAM_STAGING_DIR" "$ORAM_CURRENT_DIR" || fatal "failed to publish regenerated ORAM image"
 verify_direct_oram_publish "$ORAM_FULL_DIR" "$ORAM_FULL_TRUSTED_STATE_DIR" mainnet-948454
 verify_direct_oram_publish "$ORAM_DELTA_DIR" "$ORAM_DELTA_TRUSTED_STATE_DIR" delta-940611-948454
 safe_remove_runtime_path "$TRUSTED_INPUT_ROOT"
+stop_total_watchdog
 trap - EXIT
+trap - HUP INT TERM
 
 # VPSBG is query-only and has no Harmony V2 hint pool, so the measured
 # invocation keeps online V2Full authorization disabled (limit 0).

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,7 +26,9 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "12dd0af352e7d6706f9249150c1c5d5f82995d1ac088ca30dd6277e0edcabca5",
+    "9fae280658e6c133ca8c613c394698b9ad4e92dc76eb5fe02b15754e7f5a6fbb",
+  "scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh":
+    "571fd7005f5941abaeecdbcf4e363bb0bcd6ff005f471d3d4f0402306c0b8181",
 });
 
 const VPSBG_MEASURED_RUN_PATH =
@@ -2431,12 +2433,25 @@ export function validateVpsbgPremiumFreePowMeasuredFinalExec(text) {
   ) {
     fail(`${label} must contain exactly one db0 DPF-only and one Direct ORAM fallback exec`);
   }
-  if (!/^VPSBG_DPF_ONLY_FUNCTIONAL_BETA=1$/mu.test(text)) {
-    fail(`${label} must keep the reviewed DPF-only functional-beta switch enabled`);
+  if (!/^VPSBG_RUNTIME_PROFILE=direct-oram-v1$/mu.test(text)) {
+    fail(`${label} must select the reviewed Direct ORAM runtime profile`);
   }
+  requireText(
+    text,
+    [
+      "ORAM_DB0_MAX_SECONDS=480",
+      "ORAM_DB1_MAX_SECONDS=180",
+      "ORAM_TOTAL_MAX_SECONDS=900",
+      "ORAM_HEARTBEAT_INTERVAL_SECONDS=15",
+      "ORAM_HEARTBEAT_DEADLINE_SECONDS=90",
+      "ORAM_KILL_GRACE_SECONDS=5",
+      "ORAM_SUPERVISOR=/usr/local/bin/direct-oram-supervisor",
+    ].join("\n"),
+    label,
+  );
   const dpfOnlyExec = dpfOnlyExecLines[0];
   const dpfOnlyBranchOffset = text.indexOf(
-    'if [ "$VPSBG_DPF_ONLY_FUNCTIONAL_BETA" = 1 ]; then',
+    'case "$VPSBG_RUNTIME_PROFILE" in',
   );
   const directOramBootstrapOffset = text.indexOf('[ -x "$ORAMCTL" ] || fatal');
   if (

--- a/scripts/payment-v1-deployment-template-gate.test.mjs
+++ b/scripts/payment-v1-deployment-template-gate.test.mjs
@@ -668,6 +668,16 @@ test("VPSBG measured final exec fixes the premium suffix while accepting rendere
   assert.doesNotThrow(() =>
     validateVpsbgPremiumFreePowMeasuredFinalExec(alternateRun),
   );
+
+  const dpfOnlyRun = measuredRun.replace(
+    "VPSBG_RUNTIME_PROFILE=direct-oram-v1",
+    "VPSBG_RUNTIME_PROFILE=dpf-only-functional-beta-v1",
+  );
+  assert.notEqual(dpfOnlyRun, measuredRun);
+  assert.throws(
+    () => validateVpsbgPremiumFreePowMeasuredFinalExec(dpfOnlyRun),
+    /must select the reviewed Direct ORAM runtime profile/,
+  );
 });
 
 test("VPSBG measured final exec rejects placeholders and forbidden payment material", () => {

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -23,10 +24,18 @@ const tier3FinishScript = path.join(
   scriptsDir,
   "dracut/97bpir-tier3-init/unified-server-finish.sh",
 );
+const directOramSupervisor = path.join(
+  scriptsDir,
+  "dracut/97bpir-tier3-init/direct-oram-supervisor.sh",
+);
 
 function write(pathname, contents = "fixture\n") {
   mkdirSync(path.dirname(pathname), { recursive: true });
   writeFileSync(pathname, contents);
+}
+
+function sha256(contents) {
+  return createHash("sha256").update(contents).digest("hex");
 }
 
 function createCompleteOutput(root, name, manifest) {
@@ -124,10 +133,13 @@ try {
     .replaceAll("/home/pir/data", mismatchData)
     .replace("/usr/share/bitcoinpir/proofs/height-940611.leaf-proof.json", bhtmProof)
     .replace("ORAMCTL=/usr/local/bin/oramctl", `ORAMCTL=${oramctl}`)
+    .replace(
+      "ORAM_SUPERVISOR=/usr/local/bin/direct-oram-supervisor",
+      `ORAM_SUPERVISOR=${directOramSupervisor}`,
+    )
     .replace("UNIFIED_SERVER=/usr/local/bin/unified_server", `UNIFIED_SERVER=${unifiedServer}`)
     .replace("TRUSTED_INPUT_ROOT=/run/bitcoinpir-oram-inputs", `TRUSTED_INPUT_ROOT=${mismatchRoot}/trusted-inputs`)
     .replace("TRUSTED_STATE_ROOT=/run/bitcoinpir-oram-state", `TRUSTED_STATE_ROOT=${mismatchRoot}/trusted-state`)
-    .replace("VPSBG_DPF_ONLY_FUNCTIONAL_BETA=1", "VPSBG_DPF_ONLY_FUNCTIONAL_BETA=0")
     .replaceAll("sleep 5", ":");
   writeFileSync(fixtureRunScript, transformed);
   chmodSync(fixtureRunScript, 0o755);
@@ -135,6 +147,141 @@ try {
   assert.notEqual(mismatch.status, 0, mismatch.stdout + mismatch.stderr);
   assert.match(mismatch.stderr, /db0 runtime\/proof MANIFEST bytes differ/);
   assert.equal(existsSync(marker), false, "oramctl must not run after manifest mismatch");
+
+  const directRoot = path.join(tempRoot, "direct-success");
+  const directData = path.join(directRoot, "data");
+  const directMarker = path.join(directRoot, "oramctl.calls");
+  const unifiedArgs = path.join(directRoot, "unified-server.args");
+  const directOramctl = path.join(directRoot, "oramctl");
+  const directUnifiedServer = path.join(directRoot, "unified_server");
+  const directBhtmProof = path.join(directRoot, "height-940611.leaf-proof.json");
+  const db0Index = "db0-index-fixture\n";
+  const db0Chunks = "db0-chunks-fixture\n";
+  const db1Index = "db1-index-fixture\n";
+  const db1Chunks = "db1-chunks-fixture\n";
+
+  function writeDirectDb(dbName, manifest, indexContents, chunksContents) {
+    const runtimeDir = path.join(directData, `${dbName}-runtime`);
+    const proofDir = path.join(directData, `${dbName}-proof`);
+    write(path.join(runtimeDir, "MANIFEST.toml"), manifest);
+    write(path.join(proofDir, "server-db/MANIFEST.toml"), manifest);
+    write(path.join(proofDir, "build-evidence.bin"));
+    write(path.join(proofDir, "root-bundle-payload.bin"));
+    write(
+      path.join(proofDir, "oram-direct-inputs/utxo_chunks_index_nodust.bin"),
+      indexContents,
+    );
+    write(
+      path.join(proofDir, "oram-direct-inputs/utxo_chunks_nodust.bin"),
+      chunksContents,
+    );
+    write(
+      path.join(proofDir, "oram-direct-inputs/direct-inputs.sha256"),
+      `${sha256(indexContents)}  utxo_chunks_index_nodust.bin\n${sha256(chunksContents)}  utxo_chunks_nodust.bin\n`,
+    );
+  }
+
+  writeDirectDb("db0", "db0 runtime manifest\n", db0Index, db0Chunks);
+  writeDirectDb("db1", "db1 runtime manifest\n", db1Index, db1Chunks);
+  write(
+    path.join(directData, "databases.toml"),
+    `[[database]]\nname = "main"\ntype = "full"\npath = "db0-runtime"\nproof_dir = "db0-proof"\nbase_height = 0\nheight = 948454\n\n[[database]]\nname = "delta"\ntype = "delta"\npath = "db1-runtime"\nproof_dir = "db1-proof"\nbase_height = 940611\nheight = 948454\n`,
+  );
+  write(directBhtmProof, "{}\n");
+  write(
+    directOramctl,
+    `#!/bin/sh
+out=
+state=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --out-dir) out=$2; shift 2 ;;
+    --trusted-state-dir) state=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ -n "$out" ] && [ -n "$state" ] || exit 2
+mkdir -p "$out" "$state"
+for level in direct-index direct-chunk; do
+  for suffix in meta.oram payload.oram meta.hash.oram payload.hash.oram; do
+    printf fixture > "$out/$level.$suffix"
+  done
+  for suffix in state auth.state metadata; do
+    printf fixture > "$state/$level.$suffix"
+  done
+done
+printf '%s|%s\n' "$out" "$state" >> "${directMarker}"
+`,
+  );
+  write(
+    directUnifiedServer,
+    `#!/bin/sh
+printf '%s\n' "$@" > "${unifiedArgs}"
+`,
+  );
+  chmodSync(directOramctl, 0o755);
+  chmodSync(directUnifiedServer, 0o755);
+
+  const directRunScript = path.join(directRoot, "unified-server-run.sh");
+  const directTransformed = readFileSync(tier3RunScript, "utf8")
+    .replaceAll("/home/pir/data", directData)
+    .replace("/usr/share/bitcoinpir/proofs/height-940611.leaf-proof.json", directBhtmProof)
+    .replace("ORAMCTL=/usr/local/bin/oramctl", `ORAMCTL=${directOramctl}`)
+    .replace(
+      "ORAM_SUPERVISOR=/usr/local/bin/direct-oram-supervisor",
+      `ORAM_SUPERVISOR=${directOramSupervisor}`,
+    )
+    .replace(
+      "UNIFIED_SERVER=/usr/local/bin/unified_server",
+      `UNIFIED_SERVER=${directUnifiedServer}`,
+    )
+    .replace(
+      "TRUSTED_INPUT_ROOT=/run/bitcoinpir-oram-inputs",
+      `TRUSTED_INPUT_ROOT=${directRoot}/trusted-inputs`,
+    )
+    .replace(
+      "TRUSTED_STATE_ROOT=/run/bitcoinpir-oram-state",
+      `TRUSTED_STATE_ROOT=${directRoot}/trusted-state`,
+    )
+    .replace("ORAM_DB0_MAX_SECONDS=480", "ORAM_DB0_MAX_SECONDS=5")
+    .replace("ORAM_DB1_MAX_SECONDS=180", "ORAM_DB1_MAX_SECONDS=5")
+    .replace("ORAM_TOTAL_MAX_SECONDS=900", "ORAM_TOTAL_MAX_SECONDS=20")
+    .replace("ORAM_HEARTBEAT_INTERVAL_SECONDS=15", "ORAM_HEARTBEAT_INTERVAL_SECONDS=1")
+    .replace("ORAM_HEARTBEAT_DEADLINE_SECONDS=90", "ORAM_HEARTBEAT_DEADLINE_SECONDS=3")
+    .replace("ORAM_KILL_GRACE_SECONDS=5", "ORAM_KILL_GRACE_SECONDS=0")
+    .replace(
+      /MAINNET_EXPECTED_INDEX_SHA256=[0-9a-f]{64}/,
+      `MAINNET_EXPECTED_INDEX_SHA256=${sha256(db0Index)}`,
+    )
+    .replace(
+      /MAINNET_EXPECTED_CHUNKS_SHA256=[0-9a-f]{64}/,
+      `MAINNET_EXPECTED_CHUNKS_SHA256=${sha256(db0Chunks)}`,
+    )
+    .replace(
+      /DELTA_EXPECTED_INDEX_SHA256=[0-9a-f]{64}/,
+      `DELTA_EXPECTED_INDEX_SHA256=${sha256(db1Index)}`,
+    )
+    .replace(
+      /DELTA_EXPECTED_CHUNKS_SHA256=[0-9a-f]{64}/,
+      `DELTA_EXPECTED_CHUNKS_SHA256=${sha256(db1Chunks)}`,
+    )
+    .replaceAll("sleep 5", ":");
+  writeFileSync(directRunScript, directTransformed);
+  chmodSync(directRunScript, 0o755);
+  const directSuccess = run("sh", [directRunScript]);
+  assert.equal(directSuccess.status, 0, directSuccess.stdout + directSuccess.stderr);
+  const directCalls = readFileSync(directMarker, "utf8");
+  assert.match(directCalls, /db0-mainnet-948454/);
+  assert.match(directCalls, /db1-delta-940611-948454/);
+  const finalArgs = readFileSync(unifiedArgs, "utf8");
+  assert.match(finalArgs, /--direct-oram-db\n0=.*db0-mainnet-948454/);
+  assert.match(finalArgs, /--direct-oram-db\n1=.*db1-delta-940611-948454/);
+  for (const label of ["mainnet-948454", "delta-940611-948454"]) {
+    assert.match(
+      readFileSync(path.join(directData, "oram-boot-logs", `${label}.status.env`), "utf8"),
+      /status=success[\s\S]*reason=none/,
+    );
+  }
 
   const guardRoot = path.join(tempRoot, "runit-guard");
   const guardState = path.join(guardRoot, "state");
@@ -175,9 +322,70 @@ try {
   assert.equal(readFileSync(path.join(guardState, "failure_count"), "utf8"), "1\n");
   assert.equal(existsSync(svLog), false);
 
+  const supervisorRoot = path.join(tempRoot, "direct-oram-supervisor");
+  const supervisorStatus = path.join(supervisorRoot, "status");
+  const successfulOutput = path.join(supervisorRoot, "successful-output");
+  const successfulLog = path.join(supervisorRoot, "successful.log");
+  const successfulWorker = path.join(supervisorRoot, "successful-worker.sh");
+  write(
+    successfulWorker,
+    `#!/bin/sh\nprintf fixture > "$1/output.bin"\nsleep 2\n`,
+  );
+  chmodSync(successfulWorker, 0o755);
+  const supervisedSuccess = run("sh", [
+    directOramSupervisor,
+    "fixture-db0",
+    "5",
+    "1",
+    "3",
+    "1",
+    supervisorStatus,
+    successfulOutput,
+    successfulLog,
+    "--",
+    successfulWorker,
+    successfulOutput,
+  ]);
+  assert.equal(supervisedSuccess.status, 0, supervisedSuccess.stdout + supervisedSuccess.stderr);
+  assert.match(
+    readFileSync(path.join(supervisorStatus, "fixture-db0.status.env"), "utf8"),
+    /status=success[\s\S]*reason=none[\s\S]*timeout_seconds=5/,
+  );
+  assert.match(
+    readFileSync(path.join(supervisorStatus, "fixture-db0.heartbeat.env"), "utf8"),
+    /status=running[\s\S]*database=fixture-db0[\s\S]*output_kib=[1-9][0-9]*/,
+  );
+
+  const timeoutOutput = path.join(supervisorRoot, "timeout-output");
+  const timeoutLog = path.join(supervisorRoot, "timeout.log");
+  const timeoutWorker = path.join(supervisorRoot, "timeout-worker.sh");
+  write(timeoutWorker, "#!/bin/sh\nsleep 5\nprintf late > \"$1/late\"\n");
+  chmodSync(timeoutWorker, 0o755);
+  const supervisedTimeout = run("sh", [
+    directOramSupervisor,
+    "fixture-db1-timeout",
+    "1",
+    "1",
+    "3",
+    "0",
+    supervisorStatus,
+    timeoutOutput,
+    timeoutLog,
+    "--",
+    timeoutWorker,
+    timeoutOutput,
+  ]);
+  assert.equal(supervisedTimeout.status, 124, supervisedTimeout.stdout + supervisedTimeout.stderr);
+  assert.match(
+    readFileSync(path.join(supervisorStatus, "fixture-db1-timeout.status.env"), "utf8"),
+    /status=timed_out[\s\S]*reason=build-timeout/,
+  );
+  assert.equal(existsSync(path.join(timeoutOutput, "late")), false);
+
   execFileSync("sh", ["-n", stageHelper]);
   execFileSync("sh", ["-n", tier3RunScript]);
   execFileSync("sh", ["-n", tier3FinishScript]);
+  execFileSync("sh", ["-n", directOramSupervisor]);
   console.log("vpsbg Tier3 generation fixtures: ok");
 } finally {
   rmSync(tempRoot, { recursive: true, force: true });

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -19,6 +19,10 @@ const tier3RunScript = path.join(
   scriptsDir,
   "dracut/97bpir-tier3-init/unified-server-run.sh",
 );
+const tier3FinishScript = path.join(
+  scriptsDir,
+  "dracut/97bpir-tier3-init/unified-server-finish.sh",
+);
 
 function write(pathname, contents = "fixture\n") {
   mkdirSync(path.dirname(pathname), { recursive: true });
@@ -132,8 +136,48 @@ try {
   assert.match(mismatch.stderr, /db0 runtime\/proof MANIFEST bytes differ/);
   assert.equal(existsSync(marker), false, "oramctl must not run after manifest mismatch");
 
+  const guardRoot = path.join(tempRoot, "runit-guard");
+  const guardState = path.join(guardRoot, "state");
+  const guardStatus = path.join(guardRoot, "status");
+  const guardService = path.join(guardRoot, "service");
+  const svLog = path.join(guardRoot, "sv.log");
+  const fakeSv = path.join(guardRoot, "sv");
+  write(fakeSv, `#!/bin/sh\nprintf '%s\\n' "$*" >> "${svLog}"\n`);
+  chmodSync(fakeSv, 0o755);
+  mkdirSync(guardService, { recursive: true });
+  const guardEnv = {
+    ...process.env,
+    BPIR_RUNIT_GUARD_STATE_DIR: guardState,
+    BPIR_RUNIT_GUARD_STATUS_DIR: guardStatus,
+    BPIR_RUNIT_GUARD_SV_BIN: fakeSv,
+    BPIR_RUNIT_GUARD_SERVICE_DIR: guardService,
+  };
+  for (let failure = 1; failure <= 3; failure += 1) {
+    const result = run("sh", [tier3FinishScript, "134", "6"], { env: guardEnv });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.equal(readFileSync(path.join(guardState, "failure_count"), "utf8"), `${failure}\n`);
+    assert.equal(existsSync(svLog), failure === 3);
+  }
+  assert.equal(readFileSync(svLog, "utf8"), `-w 1 down ${guardService}\n`);
+  assert.match(
+    readFileSync(path.join(guardStatus, "unified-server-runit.status"), "utf8"),
+    /status=restart_suppressed[\s\S]*failure_count=3[\s\S]*action=down/,
+  );
+
+  writeFileSync(path.join(guardState, "failure_count"), "2\n");
+  writeFileSync(
+    path.join(guardState, "last_failure_at"),
+    `${Math.floor(Date.now() / 1000) - 601}\n`,
+  );
+  rmSync(svLog);
+  const afterStableWindow = run("sh", [tier3FinishScript, "1", "0"], { env: guardEnv });
+  assert.equal(afterStableWindow.status, 0, afterStableWindow.stdout + afterStableWindow.stderr);
+  assert.equal(readFileSync(path.join(guardState, "failure_count"), "utf8"), "1\n");
+  assert.equal(existsSync(svLog), false);
+
   execFileSync("sh", ["-n", stageHelper]);
   execFileSync("sh", ["-n", tier3RunScript]);
+  execFileSync("sh", ["-n", tier3FinishScript]);
   console.log("vpsbg Tier3 generation fixtures: ok");
 } finally {
   rmSync(tempRoot, { recursive: true, force: true });

--- a/vendor/bitcoinpir-oram/src/merkle.rs
+++ b/vendor/bitcoinpir-oram/src/merkle.rs
@@ -473,25 +473,58 @@ impl<S: PageStore, H: PageStore> TieredMerklePageStore<S, H> {
     }
 
     fn rebuild_hashes(&mut self) -> Result<()> {
+        // Initial image construction is trusted and non-oblivious. Build the
+        // tree in memory, then write each packed hash page exactly once. The
+        // runtime update path below remains disk-backed.
+        //
+        // Writing each 32-byte node through `write_disk_hash` would otherwise
+        // turn every update into a full encrypted-page read/modify/write. For
+        // production-sized trees that means millions of redundant AEAD and IO
+        // operations even though the complete tree comfortably fits in the
+        // builder's trusted memory.
+        let total_nodes = self
+            .leaf_base
+            .checked_mul(2)
+            .ok_or_else(|| Error::InvalidInput("Merkle tree is too large".into()))?;
+        let mut hashes = Vec::new();
+        hashes
+            .try_reserve_exact(total_nodes)
+            .map_err(|_| Error::InvalidInput("Merkle tree does not fit in memory".into()))?;
+        hashes.resize(total_nodes, [0u8; 32]);
+
         let mut page = vec![0u8; self.page_size];
         for page_idx in 0..self.leaf_base {
-            let hash = if page_idx < self.page_count {
+            hashes[self.leaf_base + page_idx] = if page_idx < self.page_count {
                 self.inner.read_page(page_idx, &mut page)?;
                 hash_leaf(self.store_id, page_idx, &page)
             } else {
                 hash_empty_leaf(self.store_id, page_idx, self.page_size)
             };
-            self.write_hash(self.leaf_base + page_idx, hash)?;
         }
 
-        let height = self.height();
-        for level in (0..height).rev() {
-            for node_idx in (1usize << level)..(1usize << (level + 1)) {
-                let left = self.read_hash(node_idx * 2)?;
-                let right = self.read_hash(node_idx * 2 + 1)?;
-                self.write_hash(node_idx, hash_node(node_idx, left, right))?;
-            }
+        for node_idx in (1..self.leaf_base).rev() {
+            hashes[node_idx] = hash_node(node_idx, hashes[node_idx * 2], hashes[node_idx * 2 + 1]);
         }
+
+        self.trusted_hashes[1..self.trusted_node_limit]
+            .copy_from_slice(&hashes[1..self.trusted_node_limit]);
+
+        let hash_page_size = self.hash_store.page_size();
+        let mut hash_page = vec![0u8; hash_page_size];
+        let required_hash_pages = pages_for_hash_nodes(self.disk_hash_nodes, self.hashes_per_page);
+        let mut disk_offset = 0usize;
+        for hash_page_idx in 0..required_hash_pages {
+            hash_page.fill(0);
+            let page_nodes = (self.disk_hash_nodes - disk_offset).min(self.hashes_per_page);
+            for slot in 0..page_nodes {
+                let node_idx = self.trusted_node_limit + disk_offset + slot;
+                let offset = slot * 32;
+                hash_page[offset..offset + 32].copy_from_slice(&hashes[node_idx]);
+            }
+            self.hash_store.write_page(hash_page_idx, &hash_page)?;
+            disk_offset += page_nodes;
+        }
+        debug_assert_eq!(disk_offset, self.disk_hash_nodes);
         Ok(())
     }
 
@@ -509,10 +542,6 @@ impl<S: PageStore, H: PageStore> TieredMerklePageStore<S, H> {
             )));
         }
         Ok(())
-    }
-
-    fn height(&self) -> usize {
-        self.leaf_base.trailing_zeros() as usize
     }
 
     fn read_hash(&mut self, node_idx: usize) -> Result<[u8; 32]> {


### PR DESCRIPTION
## Outcome

- makes initial encrypted Merkle construction bounded by building the trusted tree in memory and writing packed hash pages sequentially;
- adds a one-shot SEV Direct ORAM debug UKI with phase/status evidence, a five-minute watchdog, and no builder restart loop;
- stops Tier 3 runit after three exits inside ten minutes instead of retrying forever;
- fixes the future measured runtime profile to `direct-oram-v1`, with db0/db1/overall hard limits and 15-second persistent heartbeats;
- makes the UKI builder reject an initrd missing the supervisor, runit hooks, binaries, or locked BHTM proof;
- records the accepted VPSBG TEE fixture result and an exact full-production UKI preflight.

## Measured result

The accepted debug image completed the encrypted Direct ORAM fixture inside SEV (`sev_device=present`, `runner_exit=0`, `status=success`). Evidence was copied to the external archive and verified with `SHA256SUMS`. VPSBG server 25285 has been returned to stock/none mode; no full-production build was started.

The production db0 none-mode baseline completed in 3:53.82 (index 29.318s, chunk 127.588s, peak RSS 3,778,228 KiB, no swap).

## Full UKI boundary

The checked-in preflight remains `BUILD BLOCKED`. The previous two code blockers are now closed locally: the measured script selects Direct ORAM, and the bounded supervisor enforces db0=480s, db1=180s, total=900s, heartbeat=15s, stale-heartbeat=90s.

Before a later full build it still requires:

1. green CI plus review/merge of this PR and a fresh release checkout;
2. separate operator authorization to free one VPSBG image slot;
3. resolving or documenting the build-only intermediate artifact retention gap; and
4. explicit authorization for the build and each later deployment mutation.

This PR does not build, upload, attach, or boot a full production UKI.

## Browserless validation

- all changed shell scripts pass syntax validation;
- `node scripts/vpsbg-tier3-generation.test.mjs`;
- dual-database success fixture proves both Direct bindings reach the final server;
- timeout fixture proves a hung worker is killed and returns 124;
- Payment deployment source gate and 30/30 mutation tests;
- BitcoinPIR ORAM library/CLI/strict privacy tests: 79/79;
- external TEE archive: every entry in `SHA256SUMS` verified;
- `git diff --check`.

No browser or production canary was run.
