### PR TITLE
Prevent repeated ORAM rebuilds after server abort

### DIFF
--- a/docs/ORAM_VPSBG_TEST_RUN.md
+++ b/docs/ORAM_VPSBG_TEST_RUN.md
@@ -204,6 +204,16 @@ The generated direct ORAM image directories are disposable:
 Boot-time build logs are written under:
   /home/pir/data/oram-boot-logs/
 
+After both images have been verified and atomically published, the measured
+startup writes a boot-id-bound publication marker in that directory. A later
+`unified_server` exit in the same Linux boot is immediately taken down by the
+runit finish hook; a new boot has a new kernel boot id and rebuilds normally.
+`unified-server.runtime.log` is mode 0600 and records only a boot-id/timestamp
+attempt header plus server stdout/stderr (never the server command line or
+ORAM page key). The 900-second bootstrap watchdog remains active through
+`127.0.0.1:8091` readiness, writes `direct-oram-bootstrap.status.env`, and
+terminates the exec-preserved server PID on timeout.
+
 Trusted runtime state is held only in SEV-protected tmpfs:
   /run/bitcoinpir-oram-state/db0-mainnet-948454
   /run/bitcoinpir-oram-state/db1-delta-940611-948454

--- a/scripts/dracut/97bpir-tier3-init/unified-server-finish.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-finish.sh
@@ -15,6 +15,22 @@ STATE_DIR=${BPIR_RUNIT_GUARD_STATE_DIR:-/run/bitcoinpir-runit/unified_server}
 STATUS_DIR=${BPIR_RUNIT_GUARD_STATUS_DIR:-/home/pir/data/oram-boot-logs}
 SV_BIN=${BPIR_RUNIT_GUARD_SV_BIN:-/usr/bin/sv}
 SERVICE_DIR=${BPIR_RUNIT_GUARD_SERVICE_DIR:-/etc/service/unified_server}
+ORAM_BOOT_ID_FILE=${BPIR_ORAM_BOOT_ID_FILE:-/proc/sys/kernel/random/boot_id}
+ORAM_PUBLISHED_MARKER=${BPIR_ORAM_PUBLISHED_MARKER:-/home/pir/data/oram-boot-logs/oram-published.boot-id.env}
+
+published_marker_matches_current_boot() {
+    [ -r "$ORAM_PUBLISHED_MARKER" ] || return 1
+    boot_id=$(cat "$ORAM_BOOT_ID_FILE" 2>/dev/null || true)
+    case "$boot_id" in
+        ????????-????-????-????-????????????) ;;
+        *) return 1 ;;
+    esac
+    marker_boot_id=$(awk -F= '$1 == "boot_id" { if (++seen == 1) print $2; else exit 2 } END { if (seen != 1) exit 1 }' "$ORAM_PUBLISHED_MARKER") \
+        || return 1
+    marker_status=$(awk -F= '$1 == "status" { if (++seen == 1) print $2; else exit 2 } END { if (seen != 1) exit 1 }' "$ORAM_PUBLISHED_MARKER") \
+        || return 1
+    [ "$marker_status" = published ] && [ "$marker_boot_id" = "$boot_id" ]
+}
 
 mkdir -p "$STATE_DIR" || exit 0
 
@@ -40,9 +56,15 @@ mv "$STATE_DIR/failure_count.tmp" "$STATE_DIR/failure_count"
 
 status=retrying
 action=restart
-if [ "$count" -ge "$MAX_FAILURES" ]; then
+reason=failure-threshold-not-reached
+if published_marker_matches_current_boot; then
     status=restart_suppressed
     action=down
+    reason=oram-published-same-boot
+elif [ "$count" -ge "$MAX_FAILURES" ]; then
+    status=restart_suppressed
+    action=down
+    reason=failure-threshold-reached
 fi
 
 if mkdir -p "$STATUS_DIR" 2>/dev/null; then
@@ -55,12 +77,13 @@ if mkdir -p "$STATUS_DIR" 2>/dev/null; then
         printf 'exit_code=%s\n' "${1:-unknown}"
         printf 'signal=%s\n' "${2:-unknown}"
         printf 'action=%s\n' "$action"
+        printf 'reason=%s\n' "$reason"
     } >"$STATUS_DIR/unified-server-runit.status.tmp"
     mv "$STATUS_DIR/unified-server-runit.status.tmp" "$STATUS_DIR/unified-server-runit.status"
 fi
 
 if [ "$action" = down ]; then
-    echo "[unified-server-finish] suppressing restart after $count failures within ${FAILURE_WINDOW_SECONDS}s" >&2
+    echo "[unified-server-finish] suppressing restart: $reason" >&2
     # `sv down` sends the control byte immediately. The one-second wait may
     # expire because this finish hook must return before runsv becomes down.
     "$SV_BIN" -w 1 down "$SERVICE_DIR" >/dev/null 2>&1 || true

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -87,6 +87,10 @@ VPSBG_RUNTIME_PROFILE=direct-oram-v1
 
 ORAM_BOOT_ROOT=/home/pir/data/.oram-boot
 ORAM_BUILD_LOG_DIR=/home/pir/data/oram-boot-logs
+ORAM_BOOT_ID_FILE=${BPIR_ORAM_BOOT_ID_FILE:-/proc/sys/kernel/random/boot_id}
+ORAM_PUBLISHED_MARKER="$ORAM_BUILD_LOG_DIR/oram-published.boot-id.env"
+ORAM_WATCHDOG_PHASE_FILE="$ORAM_BUILD_LOG_DIR/direct-oram-bootstrap.phase"
+ORAM_SERVER_RUNTIME_LOG="$ORAM_BUILD_LOG_DIR/unified-server.runtime.log"
 ORAM_STAGING_DIR="$ORAM_BOOT_ROOT/staging.$$"
 ORAM_CURRENT_DIR="$ORAM_BOOT_ROOT/current"
 ORAM_FULL_DIR="$ORAM_CURRENT_DIR/db0-mainnet-948454"
@@ -110,6 +114,8 @@ ORAM_HEARTBEAT_INTERVAL_SECONDS=15
 ORAM_HEARTBEAT_DEADLINE_SECONDS=90
 ORAM_KILL_GRACE_SECONDS=5
 ORAM_SUPERVISOR=/usr/local/bin/direct-oram-supervisor
+ORAM_SERVER_READY_HOST=127.0.0.1
+ORAM_SERVER_READY_PORT=8091
 ORAM_ACTIVE_SUPERVISOR_PID_FILE="$TRUSTED_STATE_ROOT/active-supervisor.pid"
 DIRECT_INDEX_SLOTS_PER_BIN=4
 DIRECT_INDEX_HASH_FNS=2
@@ -132,6 +138,61 @@ fatal() {
     echo "[unified-server-run] FATAL: $*" >&2
     sleep 5
     exit 1
+}
+
+read_current_boot_id() {
+    ORAM_BOOT_ID=$(cat "$ORAM_BOOT_ID_FILE" 2>/dev/null || true)
+    case "$ORAM_BOOT_ID" in
+        ????????-????-????-????-????????????) ;;
+        *) return 1 ;;
+    esac
+    case "$ORAM_BOOT_ID" in
+        *[!0-9a-f-]*) return 1 ;;
+    esac
+}
+
+published_marker_matches_current_boot() {
+    [ -e "$ORAM_PUBLISHED_MARKER" ] || return 1
+    marker_boot_id=$(awk -F= '$1 == "boot_id" { if (++seen == 1) print $2; else exit 2 } END { if (seen != 1) exit 1 }' "$ORAM_PUBLISHED_MARKER") \
+        || fatal "published ORAM marker is malformed; refusing destructive retry"
+    marker_status=$(awk -F= '$1 == "status" { if (++seen == 1) print $2; else exit 2 } END { if (seen != 1) exit 1 }' "$ORAM_PUBLISHED_MARKER") \
+        || fatal "published ORAM marker is malformed; refusing destructive retry"
+    [ "$marker_status" = published ] \
+        || fatal "published ORAM marker has unsupported status; refusing destructive retry"
+    [ "$marker_boot_id" = "$ORAM_BOOT_ID" ]
+}
+
+write_current_boot_published_marker() {
+    marker_tmp="$ORAM_PUBLISHED_MARKER.tmp.$$"
+    umask 077
+    {
+        printf 'boot_id=%s\n' "$ORAM_BOOT_ID"
+        printf 'status=published\n'
+        printf 'published_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } >"$marker_tmp" || fatal "failed to write published ORAM marker"
+    chmod 600 "$marker_tmp" || fatal "failed to protect published ORAM marker"
+    mv "$marker_tmp" "$ORAM_PUBLISHED_MARKER" || fatal "failed to publish ORAM marker"
+}
+
+write_watchdog_phase() {
+    watchdog_phase="$1"
+    {
+        printf 'phase=%s\n' "$watchdog_phase"
+        printf 'updated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } >"$ORAM_WATCHDOG_PHASE_FILE.tmp" || fatal "failed to write watchdog phase"
+    mv "$ORAM_WATCHDOG_PHASE_FILE.tmp" "$ORAM_WATCHDOG_PHASE_FILE" \
+        || fatal "failed to publish watchdog phase"
+}
+
+start_unified_server_runtime_log() {
+    umask 077
+    : >>"$ORAM_SERVER_RUNTIME_LOG" || fatal "failed to open unified_server runtime log"
+    chmod 600 "$ORAM_SERVER_RUNTIME_LOG" || fatal "failed to protect unified_server runtime log"
+    {
+        printf '\n[unified-server-run] attempt boot_id=%s started_at=%s\n' \
+            "$ORAM_BOOT_ID" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    } >>"$ORAM_SERVER_RUNTIME_LOG" || fatal "failed to write unified_server runtime log header"
+    exec >>"$ORAM_SERVER_RUNTIME_LOG" 2>&1
 }
 
 require_file() {
@@ -266,11 +327,29 @@ start_total_watchdog() {
     (
         total_deadline=$(( $(date -u +%s) + ORAM_TOTAL_MAX_SECONDS ))
         while [ "$(date -u +%s)" -lt "$total_deadline" ]; do
+            kill -0 "$parent_pid" 2>/dev/null || exit 0
+            if nc -z -w 1 "$ORAM_SERVER_READY_HOST" "$ORAM_SERVER_READY_PORT" >/dev/null 2>&1; then
+                {
+                    printf 'status=ready\n'
+                    printf 'phase=server-readiness\n'
+                    printf 'reason=port-ready\n'
+                    printf 'timeout_seconds=%s\n' "$ORAM_TOTAL_MAX_SECONDS"
+                    printf 'updated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                } >"$ORAM_BUILD_LOG_DIR/direct-oram-bootstrap.status.env.tmp"
+                mv "$ORAM_BUILD_LOG_DIR/direct-oram-bootstrap.status.env.tmp" \
+                    "$ORAM_BUILD_LOG_DIR/direct-oram-bootstrap.status.env"
+                exit 0
+            fi
             sleep 1
         done
+        watchdog_phase=direct-oram-bootstrap
+        if [ -r "$ORAM_WATCHDOG_PHASE_FILE" ]; then
+            recorded_phase=$(awk -F= '$1 == "phase" { print $2; exit }' "$ORAM_WATCHDOG_PHASE_FILE" 2>/dev/null || true)
+            case "$recorded_phase" in direct-oram-build|server-readiness) watchdog_phase=$recorded_phase ;; esac
+        fi
         {
             printf 'status=timed_out\n'
-            printf 'phase=direct-oram-bootstrap\n'
+            printf 'phase=%s\n' "$watchdog_phase"
             printf 'reason=total-timeout\n'
             printf 'timeout_seconds=%s\n' "$ORAM_TOTAL_MAX_SECONDS"
             printf 'updated_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -286,6 +365,8 @@ start_total_watchdog() {
         [ "${supervisor_pid:-0}" -gt 1 ] \
             && kill -KILL "$supervisor_pid" 2>/dev/null || true
         kill -TERM "$parent_pid" 2>/dev/null || true
+        sleep "$ORAM_KILL_GRACE_SECONDS"
+        kill -KILL "$parent_pid" 2>/dev/null || true
     ) </dev/null >/dev/null 2>&1 &
     ORAM_TOTAL_WATCHDOG_PID=$!
 }
@@ -479,6 +560,11 @@ verify_direct_oram_publish() {
 [ -x "$UNIFIED_SERVER" ] || fatal "$UNIFIED_SERVER missing from UKI"
 case "$VPSBG_RUNTIME_PROFILE" in
 dpf-only-functional-beta-v1)
+    umask 077
+    mkdir -p "$ORAM_BUILD_LOG_DIR" || fatal "failed to create unified_server runtime log directory"
+    chmod 700 "$ORAM_BUILD_LOG_DIR" || fatal "failed to protect unified_server runtime log directory"
+    read_current_boot_id || fatal "kernel boot_id missing or invalid"
+    start_unified_server_runtime_log
     echo "[unified-server-run] starting VPSBG db0 functional beta; Direct ORAM is not advertised" >&2
     exec "$UNIFIED_SERVER" \
         --port 8091 \
@@ -521,7 +607,14 @@ esac
 [ -x "$ORAMCTL" ] || fatal "$ORAMCTL missing from UKI"
 [ -x "$ORAM_SUPERVISOR" ] || fatal "$ORAM_SUPERVISOR missing from UKI"
 require_file "$DELTA_BHTM_FROM_LEAF_PROOF"
+umask 077
 mkdir -p "$ORAM_BOOT_ROOT" "$ORAM_BUILD_LOG_DIR" || fatal "failed to create ORAM boot directories"
+chmod 700 "$ORAM_BUILD_LOG_DIR" || fatal "failed to protect ORAM boot log directory"
+read_current_boot_id || fatal "kernel boot_id missing or invalid"
+if published_marker_matches_current_boot; then
+    echo "[unified-server-run] ORAM was already published for boot $ORAM_BOOT_ID; refusing destructive retry" >&2
+    exit 0
+fi
 for stale_staging in "$ORAM_BOOT_ROOT"/staging.*; do
     [ -e "$stale_staging" ] || continue
     safe_remove_boot_path "$stale_staging"
@@ -536,6 +629,7 @@ ORAM_PAGE_KEY_HEX="$(random_seed_hex)"
 ORAM_TOTAL_WATCHDOG_PID=
 trap cleanup_build_staging EXIT
 trap 'exit 124' HUP INT TERM
+write_watchdog_phase direct-oram-build
 start_total_watchdog
 
 load_active_database_generation 0 db0
@@ -563,9 +657,11 @@ mv "$ORAM_STAGING_DIR" "$ORAM_CURRENT_DIR" || fatal "failed to publish regenerat
 verify_direct_oram_publish "$ORAM_FULL_DIR" "$ORAM_FULL_TRUSTED_STATE_DIR" mainnet-948454
 verify_direct_oram_publish "$ORAM_DELTA_DIR" "$ORAM_DELTA_TRUSTED_STATE_DIR" delta-940611-948454
 safe_remove_runtime_path "$TRUSTED_INPUT_ROOT"
-stop_total_watchdog
+write_current_boot_published_marker
+write_watchdog_phase server-readiness
 trap - EXIT
 trap - HUP INT TERM
+start_unified_server_runtime_log
 
 # VPSBG is query-only and has no Harmony V2 hint pool, so the measured
 # invocation keeps online V2Full authorization disabled (limit 0).

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,7 +26,9 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "9fae280658e6c133ca8c613c394698b9ad4e92dc76eb5fe02b15754e7f5a6fbb",
+    "b59809a643a618a5c06b01656d432d1467ca244497570b87805b077ec3f2bc67",
+  "scripts/dracut/97bpir-tier3-init/unified-server-finish.sh":
+    "06b763099ce2828603763ec45e1cdcec406659a3fb0cd413c28ac85af9cf6444",
   "scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh":
     "571fd7005f5941abaeecdbcf4e363bb0bcd6ff005f471d3d4f0402306c0b8181",
 });
@@ -2446,6 +2448,14 @@ export function validateVpsbgPremiumFreePowMeasuredFinalExec(text) {
       "ORAM_HEARTBEAT_DEADLINE_SECONDS=90",
       "ORAM_KILL_GRACE_SECONDS=5",
       "ORAM_SUPERVISOR=/usr/local/bin/direct-oram-supervisor",
+    ].join("\n"),
+    label,
+  );
+  requireText(
+    text,
+    [
+      "ORAM_SERVER_READY_HOST=127.0.0.1",
+      "ORAM_SERVER_READY_PORT=8091",
     ].join("\n"),
     label,
   );

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -8,6 +8,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -116,11 +117,13 @@ try {
   const oramctl = path.join(mismatchRoot, "oramctl");
   const unifiedServer = path.join(mismatchRoot, "unified_server");
   const bhtmProof = path.join(mismatchRoot, "height-940611.leaf-proof.json");
+  const mismatchBootId = path.join(mismatchRoot, "boot_id");
   write(oramctl, `#!/bin/sh\nprintf invoked > "${marker}"\n`);
   write(unifiedServer, "#!/bin/sh\nexit 0\n");
   chmodSync(oramctl, 0o755);
   chmodSync(unifiedServer, 0o755);
   write(bhtmProof, "{}\n");
+  writeFileSync(mismatchBootId, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\n");
   write(path.join(mismatchData, "runtime-db0/MANIFEST.toml"), "runtime manifest\n");
   write(path.join(mismatchData, "proof-db0/server-db/MANIFEST.toml"), "proof manifest\n");
   write(
@@ -143,7 +146,9 @@ try {
     .replaceAll("sleep 5", ":");
   writeFileSync(fixtureRunScript, transformed);
   chmodSync(fixtureRunScript, 0o755);
-  const mismatch = run("sh", [fixtureRunScript]);
+  const mismatch = run("sh", [fixtureRunScript], {
+    env: { ...process.env, BPIR_ORAM_BOOT_ID_FILE: mismatchBootId },
+  });
   assert.notEqual(mismatch.status, 0, mismatch.stdout + mismatch.stderr);
   assert.match(mismatch.stderr, /db0 runtime\/proof MANIFEST bytes differ/);
   assert.equal(existsSync(marker), false, "oramctl must not run after manifest mismatch");
@@ -152,6 +157,10 @@ try {
   const directData = path.join(directRoot, "data");
   const directMarker = path.join(directRoot, "oramctl.calls");
   const unifiedArgs = path.join(directRoot, "unified-server.args");
+  const unifiedStarts = path.join(directRoot, "unified-server.starts");
+  const readySignal = path.join(directRoot, "unified-server.ready");
+  const bootIdFile = path.join(directRoot, "boot_id");
+  const fixtureBin = path.join(directRoot, "bin");
   const directOramctl = path.join(directRoot, "oramctl");
   const directUnifiedServer = path.join(directRoot, "unified_server");
   const directBhtmProof = path.join(directRoot, "height-940611.leaf-proof.json");
@@ -217,10 +226,24 @@ printf '%s|%s\n' "$out" "$state" >> "${directMarker}"
     directUnifiedServer,
     `#!/bin/sh
 printf '%s\n' "$@" > "${unifiedArgs}"
+printf started >> "${unifiedStarts}"
+printf ready > "${readySignal}"
+printf 'fixture server stdout\n'
+printf 'fixture server stderr\n' >&2
+sleep 1
 `,
   );
+  write(
+    path.join(fixtureBin, "nc"),
+    `#!/bin/sh
+[ -e "${readySignal}" ] && exit 0
+exit 1
+`,
+  );
+  writeFileSync(bootIdFile, "11111111-1111-1111-1111-111111111111\n");
   chmodSync(directOramctl, 0o755);
   chmodSync(directUnifiedServer, 0o755);
+  chmodSync(path.join(fixtureBin, "nc"), 0o755);
 
   const directRunScript = path.join(directRoot, "unified-server-run.sh");
   const directTransformed = readFileSync(tier3RunScript, "utf8")
@@ -245,10 +268,11 @@ printf '%s\n' "$@" > "${unifiedArgs}"
     )
     .replace("ORAM_DB0_MAX_SECONDS=480", "ORAM_DB0_MAX_SECONDS=5")
     .replace("ORAM_DB1_MAX_SECONDS=180", "ORAM_DB1_MAX_SECONDS=5")
-    .replace("ORAM_TOTAL_MAX_SECONDS=900", "ORAM_TOTAL_MAX_SECONDS=20")
+    .replace("ORAM_TOTAL_MAX_SECONDS=900", "ORAM_TOTAL_MAX_SECONDS=5")
     .replace("ORAM_HEARTBEAT_INTERVAL_SECONDS=15", "ORAM_HEARTBEAT_INTERVAL_SECONDS=1")
     .replace("ORAM_HEARTBEAT_DEADLINE_SECONDS=90", "ORAM_HEARTBEAT_DEADLINE_SECONDS=3")
     .replace("ORAM_KILL_GRACE_SECONDS=5", "ORAM_KILL_GRACE_SECONDS=0")
+    .replace('ORAM_PAGE_KEY_HEX="$(random_seed_hex)"', "ORAM_PAGE_KEY_HEX=test-page-key")
     .replace(
       /MAINNET_EXPECTED_INDEX_SHA256=[0-9a-f]{64}/,
       `MAINNET_EXPECTED_INDEX_SHA256=${sha256(db0Index)}`,
@@ -268,7 +292,12 @@ printf '%s\n' "$@" > "${unifiedArgs}"
     .replaceAll("sleep 5", ":");
   writeFileSync(directRunScript, directTransformed);
   chmodSync(directRunScript, 0o755);
-  const directSuccess = run("sh", [directRunScript]);
+  const directEnv = {
+    ...process.env,
+    BPIR_ORAM_BOOT_ID_FILE: bootIdFile,
+    PATH: `${fixtureBin}:${process.env.PATH}`,
+  };
+  const directSuccess = run("sh", [directRunScript], { env: directEnv });
   assert.equal(directSuccess.status, 0, directSuccess.stdout + directSuccess.stderr);
   const directCalls = readFileSync(directMarker, "utf8");
   assert.match(directCalls, /db0-mainnet-948454/);
@@ -282,6 +311,60 @@ printf '%s\n' "$@" > "${unifiedArgs}"
       /status=success[\s\S]*reason=none/,
     );
   }
+  assert.match(
+    readFileSync(path.join(directData, "oram-boot-logs", "direct-oram-bootstrap.status.env"), "utf8"),
+    /status=ready[\s\S]*phase=server-readiness[\s\S]*reason=port-ready/,
+  );
+  const runtimeLog = path.join(directData, "oram-boot-logs", "unified-server.runtime.log");
+  const runtimeLogText = readFileSync(runtimeLog, "utf8");
+  assert.match(runtimeLogText, /attempt boot_id=11111111-1111-1111-1111-111111111111/);
+  assert.match(runtimeLogText, /fixture server stdout[\s\S]*fixture server stderr/);
+  assert.doesNotMatch(runtimeLogText, /test-page-key/);
+  assert.equal(statSync(runtimeLog).mode & 0o777, 0o600);
+  assert.equal(readFileSync(unifiedStarts, "utf8"), "started");
+
+  const callsBeforeSameBootRetry = readFileSync(directMarker, "utf8");
+  const sameBootRetry = run("sh", [directRunScript], { env: directEnv });
+  assert.equal(sameBootRetry.status, 0, sameBootRetry.stdout + sameBootRetry.stderr);
+  assert.equal(readFileSync(directMarker, "utf8"), callsBeforeSameBootRetry);
+  assert.equal(readFileSync(unifiedStarts, "utf8"), "started");
+  assert.match(sameBootRetry.stderr, /already published.*refusing destructive retry/);
+
+  writeFileSync(bootIdFile, "22222222-2222-2222-2222-222222222222\n");
+  rmSync(readySignal);
+  const newBootRun = run("sh", [directRunScript], { env: directEnv });
+  assert.equal(newBootRun.status, 0, newBootRun.stdout + newBootRun.stderr);
+  assert.notEqual(readFileSync(directMarker, "utf8"), callsBeforeSameBootRetry);
+  assert.equal(readFileSync(directMarker, "utf8").trim().split("\n").length, 4);
+  assert.equal(readFileSync(unifiedStarts, "utf8"), "startedstarted");
+
+  const timeoutUnifiedServer = path.join(directRoot, "timeout-unified_server");
+  write(
+    timeoutUnifiedServer,
+    `#!/bin/sh
+printf 'timeout server stdout\\n'
+printf 'timeout server stderr\\n' >&2
+exec sleep 5
+`,
+  );
+  chmodSync(timeoutUnifiedServer, 0o755);
+  writeFileSync(bootIdFile, "33333333-3333-3333-3333-333333333333\n");
+  rmSync(readySignal);
+  const timeoutRunScript = path.join(directRoot, "unified-server-timeout-run.sh");
+  writeFileSync(
+    timeoutRunScript,
+    directTransformed
+      .replace(`UNIFIED_SERVER=${directUnifiedServer}`, `UNIFIED_SERVER=${timeoutUnifiedServer}`)
+      .replace("ORAM_TOTAL_MAX_SECONDS=5", "ORAM_TOTAL_MAX_SECONDS=1"),
+  );
+  chmodSync(timeoutRunScript, 0o755);
+  const serverReadinessTimeout = run("sh", [timeoutRunScript], { env: directEnv });
+  assert.notEqual(serverReadinessTimeout.status, 0, serverReadinessTimeout.stdout + serverReadinessTimeout.stderr);
+  assert.match(
+    readFileSync(path.join(directData, "oram-boot-logs", "direct-oram-bootstrap.status.env"), "utf8"),
+    /status=timed_out[\s\S]*phase=server-readiness[\s\S]*reason=total-timeout[\s\S]*timeout_seconds=1/,
+  );
+  assert.doesNotMatch(readFileSync(runtimeLog, "utf8"), /test-page-key/);
 
   const guardRoot = path.join(tempRoot, "runit-guard");
   const guardState = path.join(guardRoot, "state");
@@ -321,6 +404,35 @@ printf '%s\n' "$@" > "${unifiedArgs}"
   assert.equal(afterStableWindow.status, 0, afterStableWindow.stdout + afterStableWindow.stderr);
   assert.equal(readFileSync(path.join(guardState, "failure_count"), "utf8"), "1\n");
   assert.equal(existsSync(svLog), false);
+
+  const markerBootId = path.join(guardRoot, "boot_id");
+  const markerPath = path.join(guardStatus, "oram-published.boot-id.env");
+  rmSync(guardState, { recursive: true, force: true });
+  writeFileSync(markerBootId, "44444444-4444-4444-4444-444444444444\n");
+  write(
+    markerPath,
+    "boot_id=44444444-4444-4444-4444-444444444444\nstatus=published\npublished_at=fixture\n",
+  );
+  const fixtureFinishScript = path.join(guardRoot, "unified-server-finish.sh");
+  writeFileSync(
+    fixtureFinishScript,
+    readFileSync(tier3FinishScript, "utf8")
+      .replaceAll("/home/pir/data/oram-boot-logs", guardStatus),
+  );
+  chmodSync(fixtureFinishScript, 0o755);
+  const publishedAbort = run("sh", [fixtureFinishScript, "134", "6"], {
+    env: {
+      ...guardEnv,
+      BPIR_ORAM_BOOT_ID_FILE: markerBootId,
+      BPIR_ORAM_PUBLISHED_MARKER: markerPath,
+    },
+  });
+  assert.equal(publishedAbort.status, 0, publishedAbort.stdout + publishedAbort.stderr);
+  assert.equal(readFileSync(svLog, "utf8"), `-w 1 down ${guardService}\n`);
+  assert.match(
+    readFileSync(path.join(guardStatus, "unified-server-runit.status"), "utf8"),
+    /status=restart_suppressed[\s\S]*failure_count=1[\s\S]*action=down[\s\S]*reason=oram-published-same-boot/,
+  );
 
   const supervisorRoot = path.join(tempRoot, "direct-oram-supervisor");
   const supervisorStatus = path.join(supervisorRoot, "status");


### PR DESCRIPTION
## Summary

- persist unified_server stdout/stderr in a root-only per-host log with a boot-id attempt header
- bind successful ORAM publication to the current Linux boot and suppress runit immediately after the first post-publication server exit
- extend the 900-second bootstrap watchdog through TCP readiness on 127.0.0.1:8091
- add deterministic browserless fixtures for same-boot suppression, new-boot recovery, runtime logging, and readiness timeout

## Validation

- sh -n for both Tier3 runit shell scripts
- node scripts/vpsbg-tier3-generation.test.mjs
- node scripts/payment-v1-deployment-template-gate.mjs
- node --test scripts/payment-v1-deployment-template-gate.test.mjs (30/30)
- git diff --check

## Operational boundary

This PR does not guess or change the unified_server panic root cause. It makes the next failure diagnosable and prevents another expensive same-boot ORAM rebuild loop. No UKI was built, uploaded, selected, or booted; no browser or production canary was run.