### PR TITLE
Fix Direct ORAM startup with optional Merkle data

### DIFF
--- a/apps/server/src/bin/unified_server.rs
+++ b/apps/server/src/bin/unified_server.rs
@@ -43,7 +43,7 @@ use futures_util::{SinkExt, StreamExt};
 use libdpf::DpfKey;
 use pir_core::params::{self, CHUNK_PARAMS, INDEX_PARAMS};
 use rayon::prelude::*;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::File;
 use std::io::Read;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
@@ -8532,6 +8532,19 @@ fn cashu_inventory_within_limits_v1(
         && unsettled_notes <= limits.max_unsettled_notes())
 }
 
+fn load_runtime_database_v1(
+    db_id: u8,
+    base_dir: &Path,
+    descriptor: DatabaseDescriptor,
+    direct_oram_db_ids: &BTreeSet<u8>,
+) -> MappedDatabase {
+    if direct_oram_db_ids.contains(&db_id) {
+        MappedDatabase::load_for_direct_oram(base_dir, descriptor)
+    } else {
+        MappedDatabase::load(base_dir, descriptor)
+    }
+}
+
 // ─── Main ───────────────────────────────────────────────────────────────────
 
 #[tokio::main]
@@ -8611,6 +8624,21 @@ async fn main() {
 
     let total_start = Instant::now();
 
+    // A database explicitly configured for Direct ORAM may contain optional
+    // bucket-Merkle artifacts for the mmap backend without the sibling tables
+    // that backend requires. Only these exact DB ids may suppress that unused
+    // backend; the Direct ORAM image is still opened and manifest-bound before
+    // the listener starts. Builds without ORAM support never take this path.
+    #[cfg(feature = "cuckoo-oram")]
+    let direct_oram_db_ids: BTreeSet<u8> = args
+        .direct_oram_dir
+        .iter()
+        .map(|_| 0u8)
+        .chain(args.direct_oram_dbs.iter().map(|(db_id, _)| *db_id))
+        .collect();
+    #[cfg(not(feature = "cuckoo-oram"))]
+    let direct_oram_db_ids = BTreeSet::<u8>::new();
+
     // ── Load databases ─────────────────────────────────────────────────
     let mut all_databases: Vec<MappedDatabase> = Vec::new();
     // Per-DB source directories for OnionPIR loading (db_id, label, path).
@@ -8632,7 +8660,8 @@ async fn main() {
                 _ => DatabaseType::Full,
             };
             let db_path = config.db_path(i);
-            let mut db = MappedDatabase::load(
+            let mut db = load_runtime_database_v1(
+                i as u8,
                 &db_path,
                 DatabaseDescriptor {
                     name: db_cfg.name.clone(),
@@ -8642,6 +8671,7 @@ async fn main() {
                     index_params: INDEX_PARAMS,
                     chunk_params: CHUNK_PARAMS,
                 },
+                &direct_oram_db_ids,
             );
             if let Some(proof_dir) = db_cfg.proof_dir.as_ref() {
                 db.db_proof = Some(
@@ -8698,7 +8728,8 @@ async fn main() {
     } else {
         // Legacy CLI mode: --data-dir + --checkpoint + --delta
 
-        let main_db = MappedDatabase::load(
+        let main_db = load_runtime_database_v1(
+            0,
             &args.data_dir,
             DatabaseDescriptor {
                 name: "main".to_string(),
@@ -8708,6 +8739,7 @@ async fn main() {
                 index_params: INDEX_PARAMS,
                 chunk_params: CHUNK_PARAMS,
             },
+            &direct_oram_db_ids,
         );
 
         db_paths.push((0u8, "main".to_string(), args.data_dir.clone()));
@@ -8715,7 +8747,9 @@ async fn main() {
 
         for (path, height) in &args.checkpoints {
             let name = format!("checkpoint_{}", height);
-            let db = MappedDatabase::load(
+            let db_id = all_databases.len() as u8;
+            let db = load_runtime_database_v1(
+                db_id,
                 path,
                 DatabaseDescriptor {
                     name: name.clone(),
@@ -8725,6 +8759,7 @@ async fn main() {
                     index_params: INDEX_PARAMS,
                     chunk_params: CHUNK_PARAMS,
                 },
+                &direct_oram_db_ids,
             );
             println!(
                 "[Checkpoint:{}] INDEX bins={}, CHUNK bins={}, dpf_n_index={}, dpf_n_chunk={}",
@@ -8740,7 +8775,9 @@ async fn main() {
 
         for (path, base, tip) in &args.deltas {
             let name = format!("delta_{}_{}", base, tip);
-            let db = MappedDatabase::load(
+            let db_id = all_databases.len() as u8;
+            let db = load_runtime_database_v1(
+                db_id,
                 path,
                 DatabaseDescriptor {
                     name: name.clone(),
@@ -8750,6 +8787,7 @@ async fn main() {
                     index_params: INDEX_PARAMS,
                     chunk_params: CHUNK_PARAMS,
                 },
+                &direct_oram_db_ids,
             );
             println!(
                 "[Delta:{}→{}] INDEX bins={}, CHUNK bins={}, dpf_n_index={}, dpf_n_chunk={}",

--- a/apps/server/tests/payment_v1_tee_oram_process_e2e.rs
+++ b/apps/server/tests/payment_v1_tee_oram_process_e2e.rs
@@ -476,6 +476,28 @@ async fn paid_gate_reaches_real_direct_tee_oram_handler_and_replay_survives_rest
 }
 
 #[test]
+fn direct_oram_startup_hides_incomplete_bucket_merkle_backend() {
+    let root = tempfile::tempdir().expect("test root");
+    chmod(root.path(), 0o700);
+    let (db_path, manifest_root, oram) =
+        build_direct_oram_fixture_with_bucket_merkle(root.path(), true);
+    let provider = build_provider(root.path(), manifest_root, unix_now(), None);
+    let port = unused_loopback_port();
+    let server = ServerProcess::spawn(root.path(), &db_path, &oram, &provider, port, 20);
+    let (stdout, stderr) = server.stop();
+
+    assert!(
+        stderr.contains("Bucket Merkle unavailable for Direct-ORAM-only use")
+            && stderr.contains("will not be advertised or served"),
+        "missing direct-only suppression boundary\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("Direct ORAM: enabled for db_id=0"),
+        "Direct ORAM did not open after suppressing its unused mmap proof backend\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn production_direct_oram_startup_rejects_unbound_or_unsafe_configurations() {
     let root = tempfile::tempdir().expect("test root");
     chmod(root.path(), 0o700);
@@ -1290,6 +1312,13 @@ fn service_scope(
 }
 
 fn build_direct_oram_fixture(root: &Path) -> (PathBuf, [u8; 32], DirectOramFixture) {
+    build_direct_oram_fixture_with_bucket_merkle(root, false)
+}
+
+fn build_direct_oram_fixture_with_bucket_merkle(
+    root: &Path,
+    include_incomplete_bucket_merkle: bool,
+) -> (PathBuf, [u8; 32], DirectOramFixture) {
     let source_dir = root.join("direct-oram-source");
     let image_dir = root.join("direct-oram-images");
     let trusted_state_dir = root.join("direct-oram-trusted-state");
@@ -1336,6 +1365,7 @@ fn build_direct_oram_fixture(root: &Path) -> (PathBuf, [u8; 32], DirectOramFixtu
         chunk_sha256,
         chunk_bytes.len() as u64,
         chunks.len() as u64,
+        include_incomplete_bucket_merkle,
     );
     let binding = DirectOramDatasetBindingV1 {
         server_db_manifest_sha256: manifest_root,
@@ -1586,6 +1616,7 @@ fn write_tiny_manifest_database(
     chunk_sha256: [u8; 32],
     chunk_bytes: u64,
     chunk_records: u64,
+    include_incomplete_bucket_merkle: bool,
 ) -> (PathBuf, [u8; 32]) {
     let db = root.join("tiny-db");
     fs::create_dir(&db).unwrap();
@@ -1599,14 +1630,67 @@ fn write_tiny_manifest_database(
         &CHUNK_PARAMS.with_master_seed(0x5555_6666_7777_8888),
         0,
     );
+    let bucket_merkle_entries = if include_incomplete_bucket_merkle {
+        write_incomplete_bucket_merkle_fixture(&db)
+    } else {
+        String::new()
+    };
     let zero_hash = "0".repeat(64);
     let manifest = format!(
-        "[manifest]\nversion = 1\ngenerated_at = \"2026-07-29T00:00:00Z\"\n\n[direct_oram]\nversion = 1\nindex_sha256 = \"{}\"\nindex_bytes = {index_bytes}\nindex_records = {index_records}\nchunk_sha256 = \"{}\"\nchunk_bytes = {chunk_bytes}\nchunk_records = {chunk_records}\nindex_slots_per_bin = 4\nindex_hash_fns = 2\nindex_load_factor_ppb = 200000000\nindex_seed = 7235440056133222401\n\n[files]\n\"batch_pir_cuckoo.bin\" = \"{zero_hash}\"\n\"chunk_pir_cuckoo.bin\" = \"{zero_hash}\"\n",
+        "[manifest]\nversion = 1\ngenerated_at = \"2026-07-29T00:00:00Z\"\n\n[direct_oram]\nversion = 1\nindex_sha256 = \"{}\"\nindex_bytes = {index_bytes}\nindex_records = {index_records}\nchunk_sha256 = \"{}\"\nchunk_bytes = {chunk_bytes}\nchunk_records = {chunk_records}\nindex_slots_per_bin = 4\nindex_hash_fns = 2\nindex_load_factor_ppb = 200000000\nindex_seed = 7235440056133222401\n\n[files]\n\"batch_pir_cuckoo.bin\" = \"{zero_hash}\"\n\"chunk_pir_cuckoo.bin\" = \"{zero_hash}\"\n{bucket_merkle_entries}",
         hex::encode(index_sha256),
         hex::encode(chunk_sha256),
     );
     fs::write(db.join("MANIFEST.toml"), manifest.as_bytes()).unwrap();
     (db, sha256(manifest.as_bytes()))
+}
+
+fn write_incomplete_bucket_merkle_fixture(db: &Path) -> String {
+    let tree_count = INDEX_PARAMS.k + CHUNK_PARAMS.k;
+    let mut tree_tops = Vec::new();
+    tree_tops.extend_from_slice(&(tree_count as u32).to_le_bytes());
+    let mut roots = Vec::with_capacity(tree_count * 32);
+    for tree_index in 0..tree_count {
+        let mut nodes = TINY_BINS_PER_TABLE.div_ceil(8);
+        let mut level_sizes = vec![nodes];
+        while nodes > 1 {
+            nodes = nodes.div_ceil(8);
+            level_sizes.push(nodes);
+        }
+        let root = [(tree_index as u8).wrapping_add(1); 32];
+        roots.extend_from_slice(&root);
+        tree_tops.push(1); // L0 sibling table is intentionally absent.
+        tree_tops
+            .extend_from_slice(&(level_sizes.iter().copied().sum::<usize>() as u32).to_le_bytes());
+        tree_tops.extend_from_slice(&8u16.to_le_bytes());
+        tree_tops.push(level_sizes.len() as u8);
+        for (level, size) in level_sizes.into_iter().enumerate() {
+            tree_tops.extend_from_slice(&(size as u32).to_le_bytes());
+            for node in 0..size {
+                let hash = if size == 1 {
+                    root
+                } else {
+                    [((tree_index + level + node) as u8).wrapping_add(17); 32]
+                };
+                tree_tops.extend_from_slice(&hash);
+            }
+        }
+    }
+    let super_root = sha256(&roots);
+    let files = [
+        ("merkle_bucket_tree_tops.bin", tree_tops),
+        ("merkle_bucket_roots.bin", roots),
+        ("merkle_bucket_root.bin", super_root.to_vec()),
+    ];
+    let mut entries = String::new();
+    for (name, bytes) in files {
+        fs::write(db.join(name), &bytes).unwrap();
+        entries.push_str(&format!(
+            "\"{name}\" = \"{}\"\n",
+            hex::encode(sha256(&bytes))
+        ));
+    }
+    entries
 }
 
 fn write_tiny_table(path: &Path, params: &pir_core::params::TableParams, tag_seed: u64) {

--- a/crates/protocol/runtime/src/table.rs
+++ b/crates/protocol/runtime/src/table.rs
@@ -500,6 +500,31 @@ impl MappedDatabase {
     ///
     /// Automatically detects and loads Merkle sub-tables if present.
     pub fn load(base_dir: &Path, descriptor: DatabaseDescriptor) -> Self {
+        Self::load_inner(base_dir, descriptor, false)
+    }
+
+    /// Load a database that is explicitly backed by production Direct ORAM.
+    ///
+    /// The Direct ORAM image is bound to the verified `[direct_oram]` manifest
+    /// by the server before it starts listening. Some Direct ORAM build
+    /// products also contain bucket-Merkle files for the mmap query backend,
+    /// but omit the lower sibling tables that backend needs. In that one
+    /// configuration, keep the database and Direct ORAM binding available but
+    /// do not advertise or serve the incomplete bucket-Merkle backend.
+    ///
+    /// Callers must still open and validate the configured Direct ORAM image
+    /// before exposing the database to requests. Ordinary mmap-backed callers
+    /// must use [`Self::load`], which remains fail-closed on every malformed or
+    /// incomplete bucket-Merkle artifact set.
+    pub fn load_for_direct_oram(base_dir: &Path, descriptor: DatabaseDescriptor) -> Self {
+        Self::load_inner(base_dir, descriptor, true)
+    }
+
+    fn load_inner(
+        base_dir: &Path,
+        descriptor: DatabaseDescriptor,
+        direct_oram_configured: bool,
+    ) -> Self {
         println!(
             "[DB:{}] Loading from {}",
             descriptor.name,
@@ -628,7 +653,7 @@ impl MappedDatabase {
             bucket_merkle_chunk_siblings.push(MappedSubTable::load(&path, params));
         }
 
-        let bucket_merkle_tree_tops =
+        let mut bucket_merkle_tree_tops =
             read_optional_bucket_merkle_artifact(&base_dir.join("merkle_bucket_tree_tops.bin"))
                 .unwrap_or_else(|error| {
                     panic!(
@@ -636,7 +661,7 @@ impl MappedDatabase {
                         descriptor.name, error
                     )
                 });
-        let bucket_merkle_roots =
+        let mut bucket_merkle_roots =
             read_optional_bucket_merkle_artifact(&base_dir.join("merkle_bucket_roots.bin"))
                 .unwrap_or_else(|error| {
                     panic!(
@@ -644,7 +669,7 @@ impl MappedDatabase {
                         descriptor.name, error
                     )
                 });
-        let bucket_merkle_root =
+        let mut bucket_merkle_root =
             read_optional_bucket_merkle_artifact(&base_dir.join("merkle_bucket_root.bin"))
                 .unwrap_or_else(|error| {
                     panic!(
@@ -653,7 +678,7 @@ impl MappedDatabase {
                     )
                 });
 
-        let bucket_merkle_complete = validate_bucket_merkle_layout(
+        let bucket_merkle_result = validate_bucket_merkle_layout(
             index.bins_per_table,
             chunk.bins_per_table,
             descriptor.index_params.k,
@@ -663,13 +688,34 @@ impl MappedDatabase {
             bucket_merkle_tree_tops.as_deref(),
             bucket_merkle_roots.as_deref(),
             bucket_merkle_root.as_deref(),
-        )
-        .unwrap_or_else(|error| {
-            panic!(
-                "[DB:{}] incomplete or malformed bucket Merkle artifact set: {}. Refusing to serve.",
-                descriptor.name, error
-            )
-        });
+        );
+
+        let direct_manifest_bound = manifest
+            .as_ref()
+            .and_then(|manifest| manifest.direct_oram.as_ref())
+            .is_some();
+        let bucket_merkle_complete = match bucket_merkle_result {
+            Ok(complete) => complete,
+            Err(error) if direct_oram_configured && direct_manifest_bound => {
+                eprintln!(
+                    "[DB:{}] Bucket Merkle unavailable for Direct-ORAM-only use: {}. \
+                     The incomplete mmap proof backend will not be advertised or served.",
+                    descriptor.name, error
+                );
+                bucket_merkle_index_siblings.clear();
+                bucket_merkle_chunk_siblings.clear();
+                bucket_merkle_tree_tops = None;
+                bucket_merkle_roots = None;
+                bucket_merkle_root = None;
+                false
+            }
+            Err(error) => {
+                panic!(
+                    "[DB:{}] incomplete or malformed bucket Merkle artifact set: {}. Refusing to serve.",
+                    descriptor.name, error
+                )
+            }
+        };
 
         if bucket_merkle_complete {
             println!("  Bucket Merkle: {} INDEX sib levels, {} CHUNK sib levels, tree-tops={}, super-root={}",
@@ -858,11 +904,12 @@ mod tests {
     use pir_core::seeds::{ChainAnchor, CHAIN_ANCHOR_BYTES};
     use std::io::Write as _;
 
-    fn full_cached_bucket_merkle_fixture(
+    fn cached_bucket_merkle_fixture(
         index_bins: usize,
         chunk_bins: usize,
         index_k: usize,
         chunk_k: usize,
+        cache_from_level: usize,
     ) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
         let mut tree_tops = Vec::new();
         let tree_count = index_k + chunk_k;
@@ -874,6 +921,9 @@ mod tests {
             } else {
                 chunk_bins
             };
+            for _ in 0..cache_from_level {
+                nodes = nodes.div_ceil(8);
+            }
             let mut level_sizes = vec![nodes];
             while nodes > 1 {
                 nodes = nodes.div_ceil(8);
@@ -881,7 +931,7 @@ mod tests {
             }
             let root = [(tree_index as u8).wrapping_add(1); 32];
             roots.extend_from_slice(&root);
-            tree_tops.push(0); // complete tree is cached, no sibling tables
+            tree_tops.push(cache_from_level as u8);
             tree_tops.extend_from_slice(
                 &(level_sizes.iter().copied().sum::<usize>() as u32).to_le_bytes(),
             );
@@ -905,7 +955,7 @@ mod tests {
 
     #[test]
     fn fully_cached_bucket_merkle_without_sibling_tables_is_complete() {
-        let (tree_tops, roots, super_root) = full_cached_bucket_merkle_fixture(128, 128, 2, 3);
+        let (tree_tops, roots, super_root) = cached_bucket_merkle_fixture(128, 128, 2, 3, 0);
         assert!(validate_bucket_merkle_layout(
             128,
             128,
@@ -925,7 +975,7 @@ mod tests {
         assert!(
             !validate_bucket_merkle_layout(128, 128, 2, 3, &[], &[], None, None, None).unwrap()
         );
-        let (tree_tops, roots, mut super_root) = full_cached_bucket_merkle_fixture(128, 128, 2, 3);
+        let (tree_tops, roots, mut super_root) = cached_bucket_merkle_fixture(128, 128, 2, 3, 0);
         assert!(validate_bucket_merkle_layout(
             128,
             128,
@@ -953,6 +1003,27 @@ mod tests {
         )
         .unwrap_err()
         .contains("does not bind"));
+    }
+
+    #[test]
+    fn strict_bucket_merkle_rejects_level_one_cache_without_sibling_tables() {
+        let (tree_tops, roots, super_root) = cached_bucket_merkle_fixture(128, 128, 2, 3, 1);
+        let error = validate_bucket_merkle_layout(
+            128,
+            128,
+            2,
+            3,
+            &[],
+            &[],
+            Some(&tree_tops),
+            Some(&roots),
+            Some(&super_root),
+        )
+        .unwrap_err();
+        assert!(
+            error.contains("starts at level 1, but 0 sibling tables are loaded"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/docs/ORAM_VPSBG_TEST_RUN.md
+++ b/docs/ORAM_VPSBG_TEST_RUN.md
@@ -677,3 +677,60 @@ Disk rollback is not prevented by SEV-SNP itself. The authenticated page store
 detects tampering relative to the trusted state it has, but a full rollback of
 disk image plus trusted state requires an external freshness source or a
 regeneration-on-start policy.
+
+## Full UKI image 243 startup incident (2026-08-11)
+
+The first full db0/db1 boot from release `e23d3c3498a4362db687cf3ff95b140aff5652d8`
+completed both encrypted Direct ORAM builds successfully:
+
+```text
+db0 build: 241 seconds
+db1 build: 25 seconds
+publish:   2026-08-11T10:10:51Z
+```
+
+The later runtime abort was not a Direct ORAM build failure. The delta
+`server-db` contained `merkle_bucket_tree_tops.bin` with tree tops beginning at
+level 1, but no `merkle_bucket_*_sib_L0.bin` files. The mmap DPF/Harmony proof
+backend therefore was incomplete and the ordinary `MappedDatabase::load`
+correctly rejected it before the Direct ORAM images were opened:
+
+```text
+[DB:delta_940611_948454] incomplete or malformed bucket Merkle artifact set:
+bucket Merkle INDEX tree-top 0 starts at level 1, but 0 sibling tables are loaded.
+Refusing to serve.
+```
+
+Direct ORAM lookup does not consume those mmap sibling tables. The follow-up
+runtime fix therefore does not weaken the ordinary loader. Only a database id
+explicitly configured with `--direct-oram-db` may mark an invalid optional
+bucket-Merkle backend unavailable; it is not advertised, and startup still
+must open the encrypted Direct ORAM image and prove its exact binding to the
+verified `[direct_oram]` manifest before the listener is created. A database
+without that explicit Direct ORAM configuration continues to reject the same
+artifact set.
+
+The same-boot restart guard also behaved as designed after the abort:
+
+```text
+status=restart_suppressed
+failure_count=1
+signal=6
+action=down
+reason=oram-published-same-boot
+```
+
+No second database build ran. The server was returned to stock/none mode and
+all 21 boot-log files were copied before further work to:
+
+```text
+/Volumes/Bitcoin/data/archive/uki-release/
+  tier3-e23d3c34-full-direct-20260811T092319Z/
+  live-attempt-image-243-20260811T101412Z/
+```
+
+That directory's `README.md` records the boot id and failure boundary;
+`CURRENT_SHA256SUMS` verifies the current evidence files. Preserve the
+generation data and this archive until a corrected image has passed startup
+and query smoke. Do not regenerate db0/db1 merely to address this loader-mode
+misclassification.


### PR DESCRIPTION
## What changed

- Added a Direct-ORAM-aware database load path for database IDs explicitly configured with `--direct-oram-db`.
- When a manifest-bound Direct ORAM database contains an incomplete optional bucket-Merkle backend, the server now marks that backend unavailable and does not advertise or serve it.
- Kept the ordinary mmap-backed loader fail-closed for the same incomplete artifact set.
- Added a tiny browserless process regression that reproduces `cache_from_level=1` with no L0 sibling table, opens the manifest-bound Direct ORAM image, and reaches the listener.
- Recorded the image 243 incident, restart-suppression evidence, archive location, and recovery boundary in the VPSBG runbook.

## Root cause

The full UKI successfully built and published both encrypted Direct ORAM databases, then aborted before opening the listener. The db1 `server-db` contains bucket-Merkle tree tops beginning at level 1 but no corresponding L0 sibling tables. Those files belong to the mmap DPF/Harmony proof backend and are not consumed by Direct ORAM, but the generic database loader rejected them before the explicitly configured Direct ORAM image could be opened.

## Safety boundary

This does not relax the ordinary loader. Suppression is available only for an exact database ID configured for Direct ORAM and only when the verified manifest contains a valid `[direct_oram]` binding. The incomplete bucket-Merkle backend is cleared from the runtime catalog. Startup must still open the encrypted/authenticated Direct ORAM image and validate its exact dataset binding before the listener is created.

## Validation

- `cargo check --locked --offline -p runtime --bin unified_server`
- `cargo check --locked --offline -p runtime --bin unified_server --features cuckoo-oram`
- `cargo test --locked --offline -p pir-runtime-core table::tests::`
- `cargo test --locked --offline -p runtime --features cuckoo-oram --test payment_v1_tee_oram_process_e2e direct_oram_startup_hides_incomplete_bucket_merkle_backend -- --exact`
- `git diff --check`

No browser tests, database rebuild, UKI build, VPSBG image switch, or deployment was performed. VPSBG remains in stock/none mode; image 243 is retained inactive.
