### PR TITLE
Fix Tier3 BusyBox readiness probes

### DIFF
--- a/scripts/dracut/97bpir-tier3-init/cloudflared-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/cloudflared-run.sh
@@ -47,10 +47,11 @@ fi
 
 # Wait for unified_server to listen on 8091 before starting cloudflared.
 # Without this gate, the tunnel comes up to a dead origin and we serve
-# 502s for the first ~10s of every boot. busybox nc supports -z (port
-# scan, no data) — exit 0 if open, non-zero otherwise.
+# 502s for the first ~10s of every boot. The initramfs busybox nc does not
+# implement OpenBSD nc's -z, so use an EOF-only TCP connection: exit 0 if the
+# port is open, non-zero otherwise.
 i=0
-while ! nc -z 127.0.0.1 8091 2>/dev/null; do
+while ! nc -w 1 127.0.0.1 8091 </dev/null >/dev/null 2>&1; do
     if [ "$i" -ge 60 ]; then
         echo "[cloudflared-run] WARN: unified_server still not listening on 8091 after 60s — starting cloudflared anyway" >&2
         break

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -328,7 +328,10 @@ start_total_watchdog() {
         total_deadline=$(( $(date -u +%s) + ORAM_TOTAL_MAX_SECONDS ))
         while [ "$(date -u +%s)" -lt "$total_deadline" ]; do
             kill -0 "$parent_pid" 2>/dev/null || exit 0
-            if nc -z -w 1 "$ORAM_SERVER_READY_HOST" "$ORAM_SERVER_READY_PORT" >/dev/null 2>&1; then
+            # The initramfs busybox nc does not implement OpenBSD nc's -z.
+            # An EOF-only connection is portable across both implementations
+            # and still proves that the server has completed TCP bind/listen.
+            if nc -w 1 "$ORAM_SERVER_READY_HOST" "$ORAM_SERVER_READY_PORT" </dev/null >/dev/null 2>&1; then
                 {
                     printf 'status=ready\n'
                     printf 'phase=server-readiness\n'

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,7 +26,7 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "10a10b4b8449a4c9545fd3adf16526df4d98cf3b76e492abcf9b032ceb3d7a09",
+    "74ff42981b4528e2e287b5df024308faa393add3cfa8cfc132a0db44788cc67c",
   "scripts/dracut/97bpir-tier3-init/unified-server-finish.sh":
     "06b763099ce2828603763ec45e1cdcec406659a3fb0cd413c28ac85af9cf6444",
   "scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh":

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -25,6 +25,10 @@ const tier3FinishScript = path.join(
   scriptsDir,
   "dracut/97bpir-tier3-init/unified-server-finish.sh",
 );
+const tier3CloudflaredScript = path.join(
+  scriptsDir,
+  "dracut/97bpir-tier3-init/cloudflared-run.sh",
+);
 const directOramSupervisor = path.join(
   scriptsDir,
   "dracut/97bpir-tier3-init/direct-oram-supervisor.sh",
@@ -65,6 +69,20 @@ function run(command, args, options = {}) {
 
 const tempRoot = mkdtempSync(path.join(os.tmpdir(), "bpir-tier3-generation-"));
 try {
+  const tier3RunText = readFileSync(tier3RunScript, "utf8");
+  const tier3CloudflaredText = readFileSync(tier3CloudflaredScript, "utf8");
+  for (const [label, script] of [
+    ["unified_server watchdog", tier3RunText],
+    ["cloudflared readiness gate", tier3CloudflaredText],
+  ]) {
+    assert.doesNotMatch(script, /\bnc\s+-z\b/, `${label} must work with busybox nc`);
+    assert.match(
+      script,
+      /\bnc\s+-w\s+1\s+[^\n]+<\/dev\/null\s+>\/dev\/null\s+2>&1/,
+      `${label} must use the EOF-only portable TCP readiness probe`,
+    );
+  }
+
   const dataRoot = path.join(tempRoot, "data");
   mkdirSync(dataRoot, { recursive: true });
   const activeCatalog = path.join(dataRoot, "databases.toml");
@@ -236,6 +254,7 @@ sleep 1
   write(
     path.join(fixtureBin, "nc"),
     `#!/bin/sh
+case " $* " in *" -z "*) exit 64 ;; esac
 [ -e "${readySignal}" ] && exit 0
 exit 1
 `,


### PR DESCRIPTION
## Summary

- replace unsupported `nc -z` checks in the measured Tier3 watchdog and cloudflared gate with a portable EOF-only TCP connection
- add a regression assertion that rejects `-z` in either measured script
- refresh the reviewed measured-script digest

## Production evidence

VPSBG image 247 successfully built Direct ORAM (db0 243s, db1 24s), loaded both databases (199.54s), accepted service policy epoch 5, and printed `Listening on ws://[::]:8091`. The UKI nevertheless retained `phase=server-readiness` and external traffic stayed 502. Inspection showed `/usr/bin/nc -> busybox`; that BusyBox build has no `-z`, while `nc -w 1 HOST PORT </dev/null` succeeds against a local listener. The server was returned to stock before this change.

## Validation

- shell syntax for both measured scripts
- `node scripts/vpsbg-tier3-generation.test.mjs`
- `node scripts/payment-v1-deployment-template-gate.mjs`
- deployment template gate tests: 30/30
- `git diff --check`

No browser, database rebuild, UKI rebuild, or production restart is part of this PR.