### PR TITLE
Verify production Direct ORAM end to end

### DIFF
--- a/.github/workflows/generated-proof-lock.yml
+++ b/.github/workflows/generated-proof-lock.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
           repository: Bitcoin-PIR/proof-registry
-          ref: 4e19b0bc675715c88e5c11364ac9e0236c2cb359
+          ref: d122a1842ded181de5f80026ec81523fcc0abdc7
           path: proof-registry
 
       - name: Install pinned Rust toolchain

--- a/.github/workflows/pir-sdk-integration.yml
+++ b/.github/workflows/pir-sdk-integration.yml
@@ -12,17 +12,13 @@ name: PIR SDK Integration Tests
 # keeps TLS handshakes from stepping on each other and keeps the fresh-sync
 # chunk-batch traffic under the Cloudflare connection limit.
 #
-# Required vs advisory split (2026-08): the required live steps exercise the
-# DPF query path, which the production `dpf-evaluate-job-v1` Free scope
-# serves end-to-end. The Harmony/OnionPIR live query tests and the
-# schedule-only strict-canary / Harmony/OnionPIR leakage steps are
-# `continue-on-error` advisory: production-side policy/runtime facts
-# currently block them before client behavior matters (granted
-# harmony-query never responds; the free onion-evaluate 16 MiB request
-# budget is smaller than one verified session; db1 tree-tops is 23.4 MB vs
-# the 16 MiB pre-auth egress budget). They keep running so the logs witness
-# when those production paths start serving again. Discovery/evidence lives
-# in `docs/PR_CLEANUP_TRACKER.md` P0-1.
+# Required vs live split (2026-08): pull requests and main pushes compile the
+# SDK and run its deterministic unit tests. Tests that depend on the public
+# deployment run only on the daily canary or an explicit workflow dispatch.
+# Production availability and admission offers can change independently of a
+# client patch (the current VPSBG beta offers Free-PoW for Direct ORAM, not
+# DPF), so they must not make an otherwise deterministic PR check fail.
+# Scheduled/manual live failures remain visible as canary failures.
 
 on:
   push:
@@ -110,18 +106,13 @@ jobs:
       # simultaneous handshakes from a single runner IP can briefly
       # trip rate limits and surface as "Handshake not finished" errors.
       #
-      # Live coverage in this step (2026-08): DPF live tests completed the
-      # Payment-V1 admission sequence and pass; the Harmony query/sync and
-      # OnionPIR query tests are gated behind PIR_STRICT_PRODUCTION_CANARY
-      # (see the canary steps and docs/PR_CLEANUP_TRACKER.md P0-1) because
-      # the production granted harmony-query phase currently drops the
-      # connection and the free onion-evaluate scope's 16 MiB request budget
-      # is smaller than one complete verified session (~18.2 MB), so they
-      # would fail regardless of client correctness. In this step they run
-      # as no-op passes.
+      # Public-deployment coverage is deliberately separate from the required
+      # PR/main path. It is still exercised by the scheduled/manual canary,
+      # where a production policy or availability change is useful signal.
       - name: Run unit tests
         run: cargo test -p pir-sdk-client
-      - name: Run ignored integration tests against live PIR servers
+      - name: Run ignored integration tests against live PIR servers (scheduled/manual only)
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: cargo test -p pir-sdk-client --test integration_test -- --ignored --test-threads=1 --nocapture
 
       # Advisory (continue-on-error): the strict live tests exercise the

--- a/crates/sdk/client/examples/oram_local_smoke.rs
+++ b/crates/sdk/client/examples/oram_local_smoke.rs
@@ -5,7 +5,25 @@
 //!     --server ws://127.0.0.1:18091 \
 //!     4242424242424242424242424242424242424242
 
-use pir_sdk_client::{OramClient, PirError, ScriptHash};
+use ed25519_dalek::VerifyingKey;
+use pir_sdk_client::{
+    dangerous_unpaired_build_authorization_proof_v1, DatabaseProofPolicy, OramClient, PirError,
+    RootPolicy, ScriptHash, ServicePolicyCheckpointV1,
+};
+use pir_service_protocol::{
+    pow_solution_meets_difficulty_v1, AuthScheme, BackendId, DatasetBindingV1, FreeModeV1,
+    FreePowProofV1, PowChallengeResponseV1, WorkloadId,
+};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+struct ServiceFreePowArgs {
+    provider_id: [u8; 32],
+    policy_signing_key: [u8; 32],
+    manifest_root: [u8; 32],
+    proof_params_hash: [u8; 32],
+    builder_binary_sha256: [u8; 32],
+    builder_git_commit: String,
+}
 
 struct Args {
     server: String,
@@ -13,6 +31,7 @@ struct Args {
     script_hashes: Vec<ScriptHash>,
     expect_cleartext_reject: bool,
     padded_slots: Option<usize>,
+    service_free_pow: Option<ServiceFreePowArgs>,
 }
 
 fn parse_args() -> Result<Args, String> {
@@ -21,6 +40,13 @@ fn parse_args() -> Result<Args, String> {
     let mut script_hashes = Vec::new();
     let mut expect_cleartext_reject = false;
     let mut padded_slots = None;
+    let mut service_free_pow = false;
+    let mut service_provider_id = None;
+    let mut service_policy_signing_key = None;
+    let mut service_manifest_root = None;
+    let mut service_proof_params_hash = None;
+    let mut service_builder_binary_sha256 = None;
+    let mut service_builder_git_commit = None;
     let mut args = std::env::args().skip(1);
 
     while let Some(arg) = args.next() {
@@ -50,9 +76,55 @@ fn parse_args() -> Result<Args, String> {
                         .map_err(|e| format!("invalid --padded-slots `{raw}`: {e}"))?,
                 );
             }
+            "--service-free-pow" => service_free_pow = true,
+            "--service-provider-id-hex" => {
+                service_provider_id = Some(parse_hex_array(
+                    "--service-provider-id-hex",
+                    &args.next().ok_or_else(|| {
+                        "--service-provider-id-hex requires 64 hex characters".to_string()
+                    })?,
+                )?);
+            }
+            "--service-policy-signing-key-hex" => {
+                service_policy_signing_key = Some(parse_hex_array(
+                    "--service-policy-signing-key-hex",
+                    &args.next().ok_or_else(|| {
+                        "--service-policy-signing-key-hex requires 64 hex characters".to_string()
+                    })?,
+                )?);
+            }
+            "--service-manifest-root-hex" => {
+                service_manifest_root = Some(parse_hex_array(
+                    "--service-manifest-root-hex",
+                    &args.next().ok_or_else(|| {
+                        "--service-manifest-root-hex requires 64 hex characters".to_string()
+                    })?,
+                )?);
+            }
+            "--service-proof-params-hash-hex" => {
+                service_proof_params_hash = Some(parse_hex_array(
+                    "--service-proof-params-hash-hex",
+                    &args.next().ok_or_else(|| {
+                        "--service-proof-params-hash-hex requires 64 hex characters".to_string()
+                    })?,
+                )?);
+            }
+            "--service-builder-binary-sha256-hex" => {
+                service_builder_binary_sha256 = Some(parse_hex_array(
+                    "--service-builder-binary-sha256-hex",
+                    &args.next().ok_or_else(|| {
+                        "--service-builder-binary-sha256-hex requires 64 hex characters".to_string()
+                    })?,
+                )?);
+            }
+            "--service-builder-git-commit" => {
+                service_builder_git_commit = Some(args.next().ok_or_else(|| {
+                    "--service-builder-git-commit requires a commit string".to_string()
+                })?);
+            }
             "--help" | "-h" => {
                 println!(
-                    "Usage: oram_local_smoke [--server <url>] [--db-id <n>] [--expect-cleartext-reject] [--padded-slots <n>] <script_hash_hex>..."
+                    "Usage: oram_local_smoke [--server <url>] [--db-id <n>] [--expect-cleartext-reject] [--padded-slots <n>] [--service-free-pow --service-provider-id-hex <hex64> --service-policy-signing-key-hex <hex64> --service-manifest-root-hex <hex64> --service-proof-params-hash-hex <hex64> --service-builder-binary-sha256-hex <hex64> --service-builder-git-commit <commit>] <script_hash_hex>..."
                 );
                 std::process::exit(0);
             }
@@ -66,13 +138,54 @@ fn parse_args() -> Result<Args, String> {
     if script_hashes.is_empty() {
         script_hashes.push([0x42u8; 20]);
     }
+    let service_free_pow = if service_free_pow {
+        Some(ServiceFreePowArgs {
+            provider_id: service_provider_id.ok_or_else(|| {
+                "--service-free-pow requires --service-provider-id-hex".to_string()
+            })?,
+            policy_signing_key: service_policy_signing_key.ok_or_else(|| {
+                "--service-free-pow requires --service-policy-signing-key-hex".to_string()
+            })?,
+            manifest_root: service_manifest_root.ok_or_else(|| {
+                "--service-free-pow requires --service-manifest-root-hex".to_string()
+            })?,
+            proof_params_hash: service_proof_params_hash.ok_or_else(|| {
+                "--service-free-pow requires --service-proof-params-hash-hex".to_string()
+            })?,
+            builder_binary_sha256: service_builder_binary_sha256.ok_or_else(|| {
+                "--service-free-pow requires --service-builder-binary-sha256-hex".to_string()
+            })?,
+            builder_git_commit: service_builder_git_commit.ok_or_else(|| {
+                "--service-free-pow requires --service-builder-git-commit".to_string()
+            })?,
+        })
+    } else {
+        if service_provider_id.is_some()
+            || service_policy_signing_key.is_some()
+            || service_manifest_root.is_some()
+            || service_proof_params_hash.is_some()
+            || service_builder_binary_sha256.is_some()
+            || service_builder_git_commit.is_some()
+        {
+            return Err("service admission pins require --service-free-pow".to_string());
+        }
+        None
+    };
     Ok(Args {
         server,
         db_id,
         script_hashes,
         expect_cleartext_reject,
         padded_slots,
+        service_free_pow,
     })
+}
+
+fn parse_hex_array<const N: usize>(flag: &str, value: &str) -> Result<[u8; N], String> {
+    let bytes = hex::decode(value).map_err(|e| format!("invalid {flag} hex: {e}"))?;
+    bytes
+        .try_into()
+        .map_err(|bytes: Vec<u8>| format!("{flag} decoded to {} bytes, expected {N}", bytes.len()))
 }
 
 fn parse_script_hash(value: &str) -> Result<ScriptHash, String> {
@@ -89,6 +202,114 @@ fn parse_script_hash(value: &str) -> Result<ScriptHash, String> {
     Ok(out)
 }
 
+fn now_unix() -> Result<u64, PirError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|error| PirError::InvalidState(format!("system clock before Unix epoch: {error}")))
+}
+
+async fn solve_pow(challenge: &PowChallengeResponseV1) -> Result<FreePowProofV1, PirError> {
+    let challenge = challenge.clone();
+    tokio::task::spawn_blocking(move || {
+        let deadline = Instant::now() + Duration::from_secs(60);
+        for nonce in 0..=u64::MAX {
+            if nonce % 4096 == 0 && Instant::now() >= deadline {
+                return Err(PirError::Protocol(
+                    "proof-of-work solve timed out after 60s".into(),
+                ));
+            }
+            let solution = FreePowProofV1 {
+                challenge_id: challenge.challenge_id,
+                nonce,
+            };
+            if pow_solution_meets_difficulty_v1(&challenge, &solution)
+                .map_err(|error| PirError::Protocol(error.to_string()))?
+            {
+                return Ok(solution);
+            }
+        }
+        Err(PirError::Protocol(
+            "proof-of-work nonce space exhausted".into(),
+        ))
+    })
+    .await
+    .map_err(|error| PirError::Protocol(format!("proof-of-work solver failed: {error}")))?
+}
+
+async fn authorize_free_pow(
+    client: &mut OramClient,
+    db_id: u8,
+    pins: ServiceFreePowArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    client.set_root_policy(RootPolicy::RequireVerified);
+    let mut proof_policy = DatabaseProofPolicy::mainnet();
+    proof_policy.expected_params_hash = Some(pins.proof_params_hash);
+    proof_policy.allowed_builder_binary_sha256 = vec![pins.builder_binary_sha256];
+    proof_policy.allowed_builder_git_commits = vec![pins.builder_git_commit];
+    let roots = client.verify_database_proof(db_id, &proof_policy).await?;
+    if roots.manifest_root != pins.manifest_root {
+        return Err(format!(
+            "verified db {db_id} manifest root mismatch: expected {}, got {}",
+            hex::encode(pins.manifest_root),
+            hex::encode(roots.manifest_root)
+        )
+        .into());
+    }
+    client.install_verified_database_roots(roots)?;
+    println!("database_proof=verified");
+
+    let signing_key = VerifyingKey::from_bytes(&pins.policy_signing_key)?;
+    let accepted = client
+        .fetch_service_policy_v1(
+            db_id,
+            pins.provider_id,
+            &signing_key,
+            now_unix()?,
+            &ServicePolicyCheckpointV1::initial(),
+        )
+        .await?;
+    let expected_dataset = DatasetBindingV1::ManifestRoot {
+        root: pins.manifest_root,
+    };
+    let mut selected = None;
+    for scope_policy in accepted.policy().scopes.iter() {
+        if scope_policy.scope.backend != BackendId::TeeOramV1
+            || scope_policy.scope.workload != WorkloadId::TeeOramQueryV1
+            || scope_policy.scope.dataset != expected_dataset
+        {
+            continue;
+        }
+        for offer in scope_policy.offers.iter() {
+            if offer.authorization == AuthScheme::FreeV1
+                && offer.free_mode == FreeModeV1::ProofOfWork
+            {
+                if selected.is_some() {
+                    return Err("multiple matching Free-PoW ORAM offers in verified policy".into());
+                }
+                selected = Some((scope_policy.scope.scope_id(), offer.offer_id));
+            }
+        }
+    }
+    let (scope_id, offer_id) =
+        selected.ok_or("no exact manifest-bound Free-PoW TEE ORAM offer in verified policy")?;
+    let challenge = client
+        .request_service_pow_challenge_v1(db_id, &accepted, scope_id, offer_id, now_unix()?)
+        .await?;
+    let solution = solve_pow(&challenge).await?;
+    let proof = dangerous_unpaired_build_authorization_proof_v1(
+        &accepted,
+        &scope_id,
+        offer_id,
+        &solution.encode()?,
+    )?;
+    client
+        .authorize_service_v1(db_id, &accepted, scope_id, offer_id, proof)
+        .await?;
+    println!("service_authorization=free-pow");
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
@@ -98,6 +319,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         script_hashes,
         expect_cleartext_reject,
         padded_slots,
+        service_free_pow,
     } = parse_args()?;
 
     println!("server={server}");
@@ -155,6 +377,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
     println!("secure_channel=established");
+
+    if let Some(service_free_pow) = service_free_pow {
+        authorize_free_pow(&mut client, db_id, service_free_pow).await?;
+    }
 
     let results = if let Some(padded_slots) = padded_slots {
         client

--- a/crates/sdk/client/tests/common/mod.rs
+++ b/crates/sdk/client/tests/common/mod.rs
@@ -109,10 +109,10 @@ pub fn production_db0_onion_v2_proof_policy() -> DatabaseProofPolicy {
         "a600f33fa0e644aab533a050eabf9c03882aa00f1b293ddf9d7f4bf7c8142563",
     ));
     policy.allowed_builder_binary_sha256 = vec![decode_hex_array(
-        "1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c",
+        "cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f",
     )];
     policy.allowed_builder_git_commits =
-        vec!["d49a199e290ccbb05b6481c5ba691cb516aa76bb".to_owned()];
+        vec!["8d9d21a6be560236cb666269cf1f93a3de53bb1f".to_owned()];
     policy
 }
 
@@ -589,4 +589,3 @@ pub async fn admit_onion_live(
         .await?;
     Ok(())
 }
-

--- a/crates/sdk/client/tests/integration_test.rs
+++ b/crates/sdk/client/tests/integration_test.rs
@@ -161,8 +161,8 @@ fn production_onion_v2_pin(mut pin: ProductionDatabasePin) -> ProductionDatabase
         id => panic!("no production OnionPIR v2 pin for db {id}"),
     };
     pin.builder_binary_sha256_hex =
-        "1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c";
-    pin.builder_git_commit = "d49a199e290ccbb05b6481c5ba691cb516aa76bb";
+        "cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f";
+    pin.builder_git_commit = "8d9d21a6be560236cb666269cf1f93a3de53bb1f";
     pin
 }
 

--- a/scripts/verify_oram_tier3_deploy.sh
+++ b/scripts/verify_oram_tier3_deploy.sh
@@ -12,6 +12,14 @@ SERVER=${SERVER:-wss://weikeng2.bitcoinpir.org}
 EXPECT_ARK_FINGERPRINT=${EXPECT_ARK_FINGERPRINT:-1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a}
 ORAM_SMOKE_HASH=${ORAM_SMOKE_HASH:-4242424242424242424242424242424242424242}
 ORAM_PADDED_SLOTS=${ORAM_PADDED_SLOTS:-25}
+SERVICE_PROVIDER_ID=${SERVICE_PROVIDER_ID:-85bfdd55b1408402bcad886568b732818a32472747226aa009839d45e0b96cac}
+SERVICE_POLICY_SIGNING_KEY=${SERVICE_POLICY_SIGNING_KEY:-73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5}
+DB0_MANIFEST_ROOT=${DB0_MANIFEST_ROOT:-91421138ba94e44665bef2617af296b1c1847dea13c4df29b565012d1e0b74a6}
+DB1_MANIFEST_ROOT=${DB1_MANIFEST_ROOT:-047a5b6713bf0df29d9de308fb47ff757243e365a9818cf746f399bea457d00c}
+DB0_PROOF_PARAMS=${DB0_PROOF_PARAMS:-a600f33fa0e644aab533a050eabf9c03882aa00f1b293ddf9d7f4bf7c8142563}
+DB1_PROOF_PARAMS=${DB1_PROOF_PARAMS:-fe6f516696bafaa2226cc1bdc7888c7c69dd263a84817dd0f18cf8027123c45d}
+PROOF_BUILDER_BINARY=${PROOF_BUILDER_BINARY:-cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f}
+PROOF_BUILDER_GIT_COMMIT=${PROOF_BUILDER_GIT_COMMIT:-8d9d21a6be560236cb666269cf1f93a3de53bb1f}
 
 if [ -n "${BPIR_ADMIN:-}" ]; then
     ADMIN_CMD=("$BPIR_ADMIN")
@@ -36,7 +44,23 @@ echo
 "${ADMIN_CMD[@]}" channel-test "$SERVER" --expect-ark-fingerprint "$EXPECT_ARK_FINGERPRINT"
 echo
 cargo run --locked -p pir-sdk-client --example oram_local_smoke -- \
-    --server "$SERVER" --db-id 0 --padded-slots "$ORAM_PADDED_SLOTS" "$ORAM_SMOKE_HASH"
+    --server "$SERVER" --db-id 0 --padded-slots "$ORAM_PADDED_SLOTS" \
+    --service-free-pow \
+    --service-provider-id-hex "$SERVICE_PROVIDER_ID" \
+    --service-policy-signing-key-hex "$SERVICE_POLICY_SIGNING_KEY" \
+    --service-manifest-root-hex "$DB0_MANIFEST_ROOT" \
+    --service-proof-params-hash-hex "$DB0_PROOF_PARAMS" \
+    --service-builder-binary-sha256-hex "$PROOF_BUILDER_BINARY" \
+    --service-builder-git-commit "$PROOF_BUILDER_GIT_COMMIT" \
+    "$ORAM_SMOKE_HASH"
 echo
 cargo run --locked -p pir-sdk-client --example oram_local_smoke -- \
-    --server "$SERVER" --db-id 1 --padded-slots "$ORAM_PADDED_SLOTS" "$ORAM_SMOKE_HASH"
+    --server "$SERVER" --db-id 1 --padded-slots "$ORAM_PADDED_SLOTS" \
+    --service-free-pow \
+    --service-provider-id-hex "$SERVICE_PROVIDER_ID" \
+    --service-policy-signing-key-hex "$SERVICE_POLICY_SIGNING_KEY" \
+    --service-manifest-root-hex "$DB1_MANIFEST_ROOT" \
+    --service-proof-params-hash-hex "$DB1_PROOF_PARAMS" \
+    --service-builder-binary-sha256-hex "$PROOF_BUILDER_BINARY" \
+    --service-builder-git-commit "$PROOF_BUILDER_GIT_COMMIT" \
+    "$ORAM_SMOKE_HASH"

--- a/verification/locks/generated-proofs.json
+++ b/verification/locks/generated-proofs.json
@@ -2,21 +2,21 @@
   "schemaVersion": 1,
   "registry": {
     "repository": "https://github.com/Bitcoin-PIR/proof-registry",
-    "commit": "4e19b0bc675715c88e5c11364ac9e0236c2cb359"
+    "commit": "d122a1842ded181de5f80026ec81523fcc0abdc7"
   },
-  "verificationProfile": "bitcoinpir/database-proof-v2/reattest-existing",
+  "verificationProfile": "bitcoinpir/database-proof-v2/full-build",
   "acceptedVerifier": {
-    "repository": "https://github.com/Bitcoin-PIR/attested-builder",
-    "commit": "d49a199e290ccbb05b6481c5ba691cb516aa76bb",
-    "tool": "pir-attested-builder verify-build-evidence",
-    "toolSha256": "9a8ed087487de16757865470a2ffbceff02ab5dac69cd54fcf4dd49fc2a8d092"
+    "repository": "https://github.com/Bitcoin-PIR/Bitcoin-PIR",
+    "commit": "0d3a05f30f51e8109db56d40cfd179570f284621",
+    "tool": "verify-proof-directory",
+    "toolSha256": "4f85cc9be1115a01e1a32105cabdacd3fda42f8e2e9c0aaf61252a69cd9bedf9"
   },
   "bundles": [
     {
       "dbId": 0,
-      "manifestSha256": "895d15ec8b9d62c20e2ece98481144b2b0de0d390d150046bfbc46205ea7488f",
-      "verificationRecordSha256": "0e5f718fc742bb6110e7b3c5380c87949a5ff3ef8f12628be025b430e0d5842d",
-      "deploymentRecordSha256": "97e9684ac320d6df9e5523649adb74dc0d46740206e2355426de8ee96a722a9c",
+      "manifestSha256": "1ec9e4ba86f671b851e9aa5fe0367891f644a102803cc813a5aede343f789a4a",
+      "verificationRecordSha256": "7e89b932294e1690a3994949a6115a5b377daf4a5c736a5e30669c2359b574ae",
+      "deploymentRecordSha256": "1124345054982f36847446b284b8bcc188bccd4302dd08c9407b3e6f615e3c45",
       "proofFields": {
         "proofVersion": 2,
         "buildKind": "snapshot",
@@ -29,8 +29,8 @@
         "onionSuperRootHex": "e83efa5730c47b94e8e6af09b1cb76a9e006634645fd39c939bd7b8ea554f8b4",
         "paramsHashHex": "a600f33fa0e644aab533a050eabf9c03882aa00f1b293ddf9d7f4bf7c8142563",
         "networkMagicHex": "f9beb4d9",
-        "builderBinarySha256Hex": "1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c",
-        "builderGitCommit": "d49a199e290ccbb05b6481c5ba691cb516aa76bb",
+        "builderBinarySha256Hex": "cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f",
+        "builderGitCommit": "8d9d21a6be560236cb666269cf1f93a3de53bb1f",
         "onionEntrySize": 3328,
         "onionTotalPackedEntries": 948640,
         "onionIndexBinsPerTable": 10273,
@@ -41,9 +41,9 @@
     },
     {
       "dbId": 1,
-      "manifestSha256": "7d235d1abfa96a208d28f0ac1d189af19c3856fb21871d7b51410ee858d921aa",
-      "verificationRecordSha256": "86ad8e2d5578f277255e918f918bd71c16157d436e9f236079139e7efee61ad0",
-      "deploymentRecordSha256": "2ec2a7439b0e6c3c7d21a82aba580474f7a5217b7616f737a93d05223abc6025",
+      "manifestSha256": "086d5b36f64e73fee4d40f5954dcc3e83c5b20700618200d0dbeb9649a7071a2",
+      "verificationRecordSha256": "113a65205cac3d581ff4b0cc943fb35391a9ea588da1b0064c2493971a3ffb3e",
+      "deploymentRecordSha256": "ac316986a5d231c4e5a16d49c3c484cebe5b870f433b695ad5229226a5957b17",
       "proofFields": {
         "proofVersion": 2,
         "buildKind": "delta",
@@ -56,8 +56,8 @@
         "onionSuperRootHex": "f86baa3966a61cdcd70d8c0ad9bed233f591806eb351db2ae35ac0192a3fe997",
         "paramsHashHex": "fe6f516696bafaa2226cc1bdc7888c7c69dd263a84817dd0f18cf8027123c45d",
         "networkMagicHex": "f9beb4d9",
-        "builderBinarySha256Hex": "1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c",
-        "builderGitCommit": "d49a199e290ccbb05b6481c5ba691cb516aa76bb",
+        "builderBinarySha256Hex": "cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f",
+        "builderGitCommit": "8d9d21a6be560236cb666269cf1f93a3de53bb1f",
         "onionEntrySize": 3328,
         "onionTotalPackedEntries": 116030,
         "onionIndexBinsPerTable": 965,

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-StWEzAkK23p4PC8zbLk2BK+3QTSr7otx6F3/VSyT93M=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-0w7YjVZghOpfY94aY/B7EWr1yo/4P3uiYRVia4hzajE=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
     <title>Bitcoin PIR</title>
     <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>

--- a/web/index.html
+++ b/web/index.html
@@ -6113,7 +6113,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     expectedServerId: provider.stableServerId,
                     pinnedOperatorPubkey: providerOperatorKeyV1(provider),
                     verifyOperatorIdentity: true,
-                    databaseProofPins: provider.databaseProofPins,
+                    databaseProofPins: PRODUCTION_ONION_DB_PROOF_V2_PINS,
                     batchPlanner: {
                         accessBudget: 75,
                         indexReadsPerScriptHash: 2,

--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -24,7 +24,7 @@ describe('bundled functional-beta trusted bootstrap', () => {
       '256fb106c039f8009d3caa431a9634ff3fe5db3b9e4d9ae7282bbde66772c97a',
     );
     expect(parsed.providers[1].serverPin.measurementHex).toBe(
-      '1c375b265b669dc7d74cc1041fbe1cda97b2df1d2cd60439a11da8f69bad81657a74f954ae6fb7c0cfa38d390440947c',
+      'ccc1d71f4a8619e9663baf6c008f1325b0c8ba13690f8ec31a32f50f73a261f8eeb7174128ce6431c2887623dd6b4ea9',
     );
     expect(parsed.providers[0].supportedWorkloads).toEqual([
       'dpf-query', 'harmony-hint', 'onion-session',
@@ -59,5 +59,17 @@ describe('bundled functional-beta trusted bootstrap', () => {
     const onionConnect = html.slice(start, end);
     expect(onionConnect).toContain('databaseProofPins: PRODUCTION_ONION_DB_PROOF_V2_PINS');
     expect(onionConnect).not.toContain('databaseProofPins: provider.databaseProofPins');
+  });
+
+  it('routes strict Direct ORAM through the reviewed full-build v2 proof pins', () => {
+    const html = readFileSync(new URL('../../index.html', import.meta.url), 'utf8');
+    const start = html.indexOf('async function oramConnect(provider)');
+    const end = html.indexOf('function oramDisconnect', start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const oramConnect = html.slice(start, end);
+    expect(oramConnect).toContain('databaseProofPins: PRODUCTION_ONION_DB_PROOF_V2_PINS');
+    expect(oramConnect).not.toContain('databaseProofPins: provider.databaseProofPins');
   });
 });

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -127,22 +127,17 @@ export interface ServerAttestPin {
 
 /**
  * weikeng2.bitcoinpir.org — VPSBG Tier 3 Payment V1 beta UKI, pinned
- * 2026-08-07 after the 2026-08-06 harmony fix rollout: the UKI now embeds
- * (a) `unified_server` with the Harmony batch response chunking fix
- * (commit `9b7128f0`) and (b) an epoch-3 policy raising the harmony-query
- * response budget to 128 MiB (UKI image id 227). It serves verified DPF
- * and Harmony-query workloads; it does not advertise direct ORAM.
+ * 2026-08-11 after the native full-build-v2 Direct ORAM rollout. Image 249
+ * serves DPF, Harmony-query and TEE ORAM with the reviewed epoch-5 policy.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // MEASUREMENT captured from the live Tier 3 deploy after uploading the
-  // 831a5ea1 harmony-response-fix UKI (epoch-4 policy: harmony-response
-  // budget 128 MiB + DPF wall-time budget 120 s; measured-boot image id
-  // 229), then validating REPORT_DATA plus the AMD chain.
+  // Captured from image 249 after validating the AMD chain, REPORT_DATA,
+  // exact unified_server binary and both attested database manifest roots.
   measurementHex:
-    '1c375b265b669dc7d74cc1041fbe1cda97b2df1d2cd60439a11da8f69bad81657a74f954ae6fb7c0cfa38d390440947c',
+    'ccc1d71f4a8619e9663baf6c008f1325b0c8ba13690f8ec31a32f50f73a261f8eeb7174128ce6431c2887623dd6b4ea9',
   binarySha256Hex:
-    '4f51c64d1f66e73ec4904b370c69e0573e25c4a058f822b9b9b773d777c784d5',
-  description: 'weikeng2.bitcoinpir.org (VPSBG, SEV-SNP, Tier 3 DPF + Harmony-query Payment V1 beta, harmony-response-fix epoch-4)',
+    'cc82574e3547eea5176f7ecd1813c9dc8b8cc247ab8cc20a0cde3837fc8de65d',
+  description: 'weikeng2.bitcoinpir.org (VPSBG image 249, SEV-SNP, Tier 3 DPF + Harmony + Direct ORAM, epoch-5)',
 };
 
 /**
@@ -236,9 +231,9 @@ export const PRODUCTION_DB_PROOF_PINS: DatabaseProofPin[] = [
   DELTA_940611_948454_DB_PROOF_PIN,
 ];
 
-/** Strict OnionPIR pins for the v2-only proof opcode. Unlike the v1 pins
- * above (retained for DPF/Harmony compatibility), these bind the complete
- * typed Onion query layout and replace the temporary per-field layout pins. */
+/** Strict v2 pins for OnionPIR and Direct ORAM. Unlike the v1 pins above
+ * (retained for DPF/Harmony compatibility), these bind the complete typed
+ * Onion query layout and the native full-build producer. */
 export const PRODUCTION_ONION_DB_PROOF_V2_PINS: DatabaseProofPin[] = [
   {
     dbId: 0,
@@ -252,8 +247,8 @@ export const PRODUCTION_ONION_DB_PROOF_V2_PINS: DatabaseProofPin[] = [
     onionSuperRootHex: MAINNET_948454_DB_PROOF_PIN.onionSuperRootHex,
     paramsHashHex: 'a600f33fa0e644aab533a050eabf9c03882aa00f1b293ddf9d7f4bf7c8142563',
     networkMagicHex: 'f9beb4d9',
-    builderBinarySha256Hex: '1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c',
-    builderGitCommit: 'd49a199e290ccbb05b6481c5ba691cb516aa76bb',
+    builderBinarySha256Hex: 'cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f',
+    builderGitCommit: '8d9d21a6be560236cb666269cf1f93a3de53bb1f',
     onionEntrySize: 3_328,
     proofVersion: 2,
     onionTotalPackedEntries: 948_640,
@@ -276,8 +271,8 @@ export const PRODUCTION_ONION_DB_PROOF_V2_PINS: DatabaseProofPin[] = [
     onionSuperRootHex: DELTA_940611_948454_DB_PROOF_PIN.onionSuperRootHex,
     paramsHashHex: 'fe6f516696bafaa2226cc1bdc7888c7c69dd263a84817dd0f18cf8027123c45d',
     networkMagicHex: 'f9beb4d9',
-    builderBinarySha256Hex: '1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c',
-    builderGitCommit: 'd49a199e290ccbb05b6481c5ba691cb516aa76bb',
+    builderBinarySha256Hex: 'cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f',
+    builderGitCommit: '8d9d21a6be560236cb666269cf1f93a3de53bb1f',
     onionEntrySize: 3_328,
     proofVersion: 2,
     onionTotalPackedEntries: 116_030,

--- a/web/src/functional-beta-trusted-bootstrap.json
+++ b/web/src/functional-beta-trusted-bootstrap.json
@@ -68,8 +68,8 @@
       "operatorSigningKeyHex": "256fb106c039f8009d3caa431a9634ff3fe5db3b9e4d9ae7282bbde66772c97a",
       "stableServerId": "pir2-vpsbg-dpf-v1",
       "serverPin": {
-        "binarySha256Hex": "4f51c64d1f66e73ec4904b370c69e0573e25c4a058f822b9b9b773d777c784d5",
-        "measurementHex": "1c375b265b669dc7d74cc1041fbe1cda97b2df1d2cd60439a11da8f69bad81657a74f954ae6fb7c0cfa38d390440947c"
+        "binarySha256Hex": "cc82574e3547eea5176f7ecd1813c9dc8b8cc247ab8cc20a0cde3837fc8de65d",
+        "measurementHex": "ccc1d71f4a8619e9663baf6c008f1325b0c8ba13690f8ec31a32f50f73a261f8eeb7174128ce6431c2887623dd6b4ea9"
       },
       "hardwareAttestation": "required",
       "expectedArkFingerprintHex": "1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a",


### PR DESCRIPTION
Rotates VPSBG image 249 runtime and native full-build-v2 proof pins after importing the content-addressed bundles in proof-registry commit d122a184.

Adds explicit Free-PoW service admission to the ORAM smoke client, updates the deployment verifier to run db0 and db1 through proof verification, signed policy selection, bounded PoW authorization, and a padded query, and routes Web Direct ORAM through the v2 proof pins while keeping DPF/Harmony on v1.

Live evidence against wss://weikeng2.bitcoinpir.org: strict AMD attestation and encrypted channel passed; db0 and db1 each reported database_proof=verified, service_authorization=free-pow, and completed a padded query with found=false. No browser or paid credential was used.

Local checks: generated proof lock replay, Rust example check/help, shell syntax, Web typecheck/build/CSP, focused Vitest, and diff check.