### PR TITLE
Fail early without VPSBG identity

### DIFF
--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -199,6 +199,17 @@ require_file() {
     [ -r "$1" ] || fatal "required file missing or unreadable: $1"
 }
 
+require_runtime_identity_and_policy() {
+    require_file "$IDENTITY_KEY_PATH"
+    require_file "$IDENTITY_CERT_PATH"
+    require_file "$SERVICE_POLICY_PATH"
+    [ -f "$IDENTITY_KEY_PATH" ] || fatal "identity key is not a regular file: $IDENTITY_KEY_PATH"
+    [ -f "$IDENTITY_CERT_PATH" ] || fatal "identity certificate is not a regular file: $IDENTITY_CERT_PATH"
+    identity_key_bytes=$(wc -c <"$IDENTITY_KEY_PATH" | tr -d '[:space:]')
+    [ "$identity_key_bytes" = 32 ] || fatal "identity key must be exactly 32 bytes"
+    [ -s "$IDENTITY_CERT_PATH" ] || fatal "identity certificate is empty"
+}
+
 direct_input_hash() {
     awk -v name="$1" '$2 == name || $2 == "./" name { print $1; exit }' "$2"
 }
@@ -561,6 +572,11 @@ verify_direct_oram_publish() {
 }
 
 [ -x "$UNIFIED_SERVER" ] || fatal "$UNIFIED_SERVER missing from UKI"
+# Identity announcement and admission policy are mandatory for both measured
+# runtime profiles. Check them before Direct ORAM regeneration so a missing
+# persistent secret or public policy cannot waste the bounded build window and
+# then leave the server silently unannounced.
+require_runtime_identity_and_policy
 case "$VPSBG_RUNTIME_PROFILE" in
 dpf-only-functional-beta-v1)
     umask 077

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,7 +26,7 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "74ff42981b4528e2e287b5df024308faa393add3cfa8cfc132a0db44788cc67c",
+    "aba3eed639a1c119784b1709cbc3c5ba80d780e6872c2a2db76eb6b7789337a4",
   "scripts/dracut/97bpir-tier3-init/unified-server-finish.sh":
     "06b763099ce2828603763ec45e1cdcec406659a3fb0cd413c28ac85af9cf6444",
   "scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh":
@@ -2463,13 +2463,18 @@ export function validateVpsbgPremiumFreePowMeasuredFinalExec(text) {
   const dpfOnlyBranchOffset = text.indexOf(
     'case "$VPSBG_RUNTIME_PROFILE" in',
   );
+  const identityPolicyPreflightOffset = text.indexOf(
+    "\nrequire_runtime_identity_and_policy\n",
+  );
   const directOramBootstrapOffset = text.indexOf('[ -x "$ORAMCTL" ] || fatal');
   if (
     dpfOnlyBranchOffset < 0 ||
+    identityPolicyPreflightOffset < 0 ||
+    identityPolicyPreflightOffset > dpfOnlyBranchOffset ||
     directOramBootstrapOffset < 0 ||
     directOramBootstrapOffset < dpfOnlyBranchOffset
   ) {
-    fail(`${label} must start the DPF-only path before Direct ORAM bootstrap`);
+    fail(`${label} must require identity and policy before either runtime profile and Direct ORAM bootstrap`);
   }
   const statePolicyPath = `${VPSBG_PREMIUM_FREE_POW_STATE_ROOT}/service-policy.bin`;
   requireText(

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -144,6 +144,12 @@ try {
   writeFileSync(mismatchBootId, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\n");
   write(path.join(mismatchData, "runtime-db0/MANIFEST.toml"), "runtime manifest\n");
   write(path.join(mismatchData, "proof-db0/server-db/MANIFEST.toml"), "proof manifest\n");
+  write(path.join(mismatchData, "pir2-identity.key"), "k".repeat(32));
+  write(path.join(mismatchData, "pir2.cert"), "fixture certificate\n");
+  write(
+    path.join(mismatchData, "payment-v1/vpsbg-premium-free-pow-beta/service-policy.bin"),
+    "fixture policy\n",
+  );
   write(
     path.join(mismatchData, "databases.toml"),
     `[[database]]\nname = "main"\ntype = "full"\npath = "runtime-db0"\nproof_dir = "proof-db0"\nbase_height = 0\nheight = 948454\n\n[[database]]\nname = "delta"\ntype = "delta"\npath = "runtime-db1"\nproof_dir = "proof-db1"\nbase_height = 940611\nheight = 948454\n`,
@@ -210,6 +216,12 @@ try {
 
   writeDirectDb("db0", "db0 runtime manifest\n", db0Index, db0Chunks);
   writeDirectDb("db1", "db1 runtime manifest\n", db1Index, db1Chunks);
+  write(path.join(directData, "pir2-identity.key"), "k".repeat(32));
+  write(path.join(directData, "pir2.cert"), "fixture certificate\n");
+  write(
+    path.join(directData, "payment-v1/vpsbg-premium-free-pow-beta/service-policy.bin"),
+    "fixture policy\n",
+  );
   write(
     path.join(directData, "databases.toml"),
     `[[database]]\nname = "main"\ntype = "full"\npath = "db0-runtime"\nproof_dir = "db0-proof"\nbase_height = 0\nheight = 948454\n\n[[database]]\nname = "delta"\ntype = "delta"\npath = "db1-runtime"\nproof_dir = "db1-proof"\nbase_height = 940611\nheight = 948454\n`,
@@ -316,6 +328,13 @@ exit 1
     BPIR_ORAM_BOOT_ID_FILE: bootIdFile,
     PATH: `${fixtureBin}:${process.env.PATH}`,
   };
+  rmSync(path.join(directData, "pir2.cert"));
+  const missingIdentity = run("sh", [directRunScript], { env: directEnv });
+  assert.notEqual(missingIdentity.status, 0, missingIdentity.stdout + missingIdentity.stderr);
+  assert.match(missingIdentity.stderr, /required file missing or unreadable: .*pir2\.cert/);
+  assert.equal(existsSync(directMarker), false, "oramctl must not run without the identity pair");
+  assert.equal(existsSync(unifiedStarts), false, "unified_server must not start without the identity pair");
+  write(path.join(directData, "pir2.cert"), "fixture certificate\n");
   const directSuccess = run("sh", [directRunScript], { env: directEnv });
   assert.equal(directSuccess.status, 0, directSuccess.stdout + directSuccess.stderr);
   const directCalls = readFileSync(directMarker, "utf8");


### PR DESCRIPTION
## What changed

- require the VPSBG runtime identity key, identity certificate, and signed service policy before either measured runtime profile starts
- reject non-regular identity files, an identity key that is not exactly 32 bytes, and an empty certificate
- run these checks before Direct ORAM regeneration
- extend the Tier3 fixture and frozen deployment gate to preserve the boundary

## Why

The active measured image completed the bounded ORAM rebuild but later started without an operator identity because the persistent identity pair was missing. The Web production canary correctly rejected that provider. This change makes the measured startup fail immediately, before spending the ORAM build window, instead of silently running without REQ_ANNOUNCE identity.

The signed epoch-6 combined Free-PoW policy and production identity remain external deployment inputs and are not included in this PR.

## Validation

- `sh -n scripts/dracut/97bpir-tier3-init/unified-server-run.sh`
- `node scripts/vpsbg-tier3-generation.test.mjs`
- `node scripts/payment-v1-deployment-template-gate.mjs`
- `node --test scripts/payment-v1-deployment-template-gate.test.mjs` (30/30)
- `git diff --check`
