### PR TITLE
Use a private VPSBG identity path

### DIFF
--- a/scripts/dracut/97bpir-tier3-init/module-setup.sh
+++ b/scripts/dracut/97bpir-tier3-init/module-setup.sh
@@ -70,9 +70,10 @@ install() {
     # blkid for the FATAL-path diagnostic when rootfs mount fails.
     # awk/cmp/dd/od/tr/tail/rm/mv are used by unified-server-run.sh to derive
     # fresh ORAM seeds, parse the active catalog, bind its runtime/proof
-    # manifests byte-for-byte, and publish boot images. date and du are used by
-    # the bounded Direct ORAM supervisor and runit failure guard.
-    inst_multiple ip modprobe mount sleep ln mkdir cat sh nc blkid awk cmp dd od tr tail rm mv date du
+    # manifests byte-for-byte, and publish boot images. stat validates the
+    # persistent identity boundary before an expensive ORAM build. date and du
+    # are used by the bounded Direct ORAM supervisor and runit failure guard.
+    inst_multiple ip modprobe mount sleep ln mkdir cat sh nc blkid awk cmp dd od tr tail rm mv stat date du
 
     # udhcpc is a busybox applet, NOT a standalone binary on Ubuntu.
     # Bake busybox itself in (statically linked, ~1.5 MB) and create

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -60,15 +60,19 @@ if [ ! -x "$UNIFIED_SERVER" ] && [ -x /home/pir/BitcoinPIR/target/release/unifie
     UNIFIED_SERVER=/home/pir/BitcoinPIR/target/release/unified_server
 fi
 
-# Prefer an explicitly measured identity pair when one is present. The
-# persistent data-mount fallback remains for existing Tier 3 deployments.
-# The selected cert is signed for the public Payment V1 stable server ID.
-IDENTITY_KEY_PATH=/home/pir/data/pir2-identity.key
-IDENTITY_CERT_PATH=/home/pir/data/pir2.cert
+# Prefer an explicitly measured identity pair when one is present. Otherwise
+# read the persistent pair from a private root-owned directory on the mounted
+# stock rootfs. Keeping the secret below /sysroot/root avoids both embedding a
+# long-lived identity key in the public UKI and the intentionally non-private
+# /home/pir/data parent that the shared private-file loader rejects.
+IDENTITY_ROOT=${BPIR_TIER3_IDENTITY_ROOT:-/sysroot/root/bitcoinpir-identity}
+IDENTITY_OWNER_UID=${BPIR_TIER3_IDENTITY_UID:-0}
 if [ -r /etc/bitcoinpir/identity/server.key ] && [ -r /etc/bitcoinpir/identity/server.cert ]; then
-    IDENTITY_KEY_PATH=/etc/bitcoinpir/identity/server.key
-    IDENTITY_CERT_PATH=/etc/bitcoinpir/identity/server.cert
+    IDENTITY_ROOT=/etc/bitcoinpir/identity
+    IDENTITY_OWNER_UID=0
 fi
+IDENTITY_KEY_PATH="$IDENTITY_ROOT/server.key"
+IDENTITY_CERT_PATH="$IDENTITY_ROOT/server.cert"
 
 # Existing deployments load their signed policy from the mutable data mount.
 # A release may instead embed the same public policy in the UKI so its exact
@@ -200,14 +204,32 @@ require_file() {
 }
 
 require_runtime_identity_and_policy() {
+    [ -d "$IDENTITY_ROOT" ] && [ ! -L "$IDENTITY_ROOT" ] \
+        || fatal "identity directory missing, not a directory, or a symlink: $IDENTITY_ROOT"
+    identity_root_uid=$(stat -c %u "$IDENTITY_ROOT") \
+        || fatal "failed to inspect identity directory owner"
+    identity_root_mode=$(stat -c %a "$IDENTITY_ROOT") \
+        || fatal "failed to inspect identity directory mode"
+    [ "$identity_root_uid" = "$IDENTITY_OWNER_UID" ] && [ "$identity_root_mode" = 700 ] \
+        || fatal "identity directory must be owner-matched mode 0700"
     require_file "$IDENTITY_KEY_PATH"
     require_file "$IDENTITY_CERT_PATH"
-    require_file "$SERVICE_POLICY_PATH"
-    [ -f "$IDENTITY_KEY_PATH" ] || fatal "identity key is not a regular file: $IDENTITY_KEY_PATH"
-    [ -f "$IDENTITY_CERT_PATH" ] || fatal "identity certificate is not a regular file: $IDENTITY_CERT_PATH"
+    [ -f "$IDENTITY_KEY_PATH" ] && [ ! -L "$IDENTITY_KEY_PATH" ] \
+        || fatal "identity key is not a non-symlink regular file: $IDENTITY_KEY_PATH"
+    [ -f "$IDENTITY_CERT_PATH" ] && [ ! -L "$IDENTITY_CERT_PATH" ] \
+        || fatal "identity certificate is not a non-symlink regular file: $IDENTITY_CERT_PATH"
+    identity_key_stat=$(stat -c '%u:%a:%h' "$IDENTITY_KEY_PATH") \
+        || fatal "failed to inspect identity key metadata"
+    identity_cert_stat=$(stat -c '%u:%a:%h' "$IDENTITY_CERT_PATH") \
+        || fatal "failed to inspect identity certificate metadata"
+    [ "$identity_key_stat" = "$IDENTITY_OWNER_UID:600:1" ] \
+        || fatal "identity key must be owner-matched mode 0600 with one link"
+    [ "$identity_cert_stat" = "$IDENTITY_OWNER_UID:644:1" ] \
+        || fatal "identity certificate must be owner-matched mode 0644 with one link"
     identity_key_bytes=$(wc -c <"$IDENTITY_KEY_PATH" | tr -d '[:space:]')
     [ "$identity_key_bytes" = 32 ] || fatal "identity key must be exactly 32 bytes"
     [ -s "$IDENTITY_CERT_PATH" ] || fatal "identity certificate is empty"
+    require_file "$SERVICE_POLICY_PATH"
 }
 
 direct_input_hash() {

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,7 +26,7 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "aba3eed639a1c119784b1709cbc3c5ba80d780e6872c2a2db76eb6b7789337a4",
+    "6b5343bf478716cd2cc5df8b6b17808788c2c160a5a4c5722acb0464ba742bf8",
   "scripts/dracut/97bpir-tier3-init/unified-server-finish.sh":
     "06b763099ce2828603763ec45e1cdcec406659a3fb0cd413c28ac85af9cf6444",
   "scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh":
@@ -2477,6 +2477,14 @@ export function validateVpsbgPremiumFreePowMeasuredFinalExec(text) {
     fail(`${label} must require identity and policy before either runtime profile and Direct ORAM bootstrap`);
   }
   const statePolicyPath = `${VPSBG_PREMIUM_FREE_POW_STATE_ROOT}/service-policy.bin`;
+  requireText(
+    text,
+    [
+      "IDENTITY_ROOT=${BPIR_TIER3_IDENTITY_ROOT:-/sysroot/root/bitcoinpir-identity}",
+      "IDENTITY_OWNER_UID=${BPIR_TIER3_IDENTITY_UID:-0}",
+    ].join("\n"),
+    label,
+  );
   requireText(
     text,
     `SERVICE_POLICY_PATH=${statePolicyPath}\nif [ -r /etc/bitcoinpir/payment/service-policy.bin ]; then\n    SERVICE_POLICY_PATH=/etc/bitcoinpir/payment/service-policy.bin\nfi`,

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -21,6 +21,10 @@ const tier3RunScript = path.join(
   scriptsDir,
   "dracut/97bpir-tier3-init/unified-server-run.sh",
 );
+const tier3ModuleSetup = path.join(
+  scriptsDir,
+  "dracut/97bpir-tier3-init/module-setup.sh",
+);
 const tier3FinishScript = path.join(
   scriptsDir,
   "dracut/97bpir-tier3-init/unified-server-finish.sh",
@@ -69,7 +73,29 @@ function run(command, args, options = {}) {
 
 const tempRoot = mkdtempSync(path.join(os.tmpdir(), "bpir-tier3-generation-"));
 try {
+  const compatBin = path.join(tempRoot, "compat-bin");
+  const compatStat = path.join(compatBin, "stat");
+  write(
+    compatStat,
+    `#!/bin/sh
+if /usr/bin/stat "$@" 2>/dev/null; then exit 0; fi
+[ "$1" = -c ] && [ "$#" = 3 ] || exit 2
+case "$2" in
+  %u) exec /usr/bin/stat -f %u "$3" ;;
+  %a) exec /usr/bin/stat -f %Lp "$3" ;;
+  %u:%a:%h) exec /usr/bin/stat -f %u:%Lp:%l "$3" ;;
+  *) exit 2 ;;
+esac
+`,
+  );
+  chmodSync(compatStat, 0o755);
   const tier3RunText = readFileSync(tier3RunScript, "utf8");
+  const tier3ModuleSetupText = readFileSync(tier3ModuleSetup, "utf8");
+  assert.match(
+    tier3ModuleSetupText,
+    /inst_multiple[^\n]*\bstat\b/,
+    "Tier3 initramfs must install stat for the identity preflight",
+  );
   const tier3CloudflaredText = readFileSync(tier3CloudflaredScript, "utf8");
   for (const [label, script] of [
     ["unified_server watchdog", tier3RunText],
@@ -144,8 +170,11 @@ try {
   writeFileSync(mismatchBootId, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\n");
   write(path.join(mismatchData, "runtime-db0/MANIFEST.toml"), "runtime manifest\n");
   write(path.join(mismatchData, "proof-db0/server-db/MANIFEST.toml"), "proof manifest\n");
-  write(path.join(mismatchData, "pir2-identity.key"), "k".repeat(32));
-  write(path.join(mismatchData, "pir2.cert"), "fixture certificate\n");
+  const mismatchIdentityRoot = path.join(mismatchRoot, "identity");
+  write(path.join(mismatchIdentityRoot, "server.key"), "k".repeat(32));
+  write(path.join(mismatchIdentityRoot, "server.cert"), "fixture certificate\n");
+  chmodSync(mismatchIdentityRoot, 0o700);
+  chmodSync(path.join(mismatchIdentityRoot, "server.key"), 0o600);
   write(
     path.join(mismatchData, "payment-v1/vpsbg-premium-free-pow-beta/service-policy.bin"),
     "fixture policy\n",
@@ -171,7 +200,13 @@ try {
   writeFileSync(fixtureRunScript, transformed);
   chmodSync(fixtureRunScript, 0o755);
   const mismatch = run("sh", [fixtureRunScript], {
-    env: { ...process.env, BPIR_ORAM_BOOT_ID_FILE: mismatchBootId },
+    env: {
+      ...process.env,
+      BPIR_ORAM_BOOT_ID_FILE: mismatchBootId,
+      BPIR_TIER3_IDENTITY_ROOT: mismatchIdentityRoot,
+      BPIR_TIER3_IDENTITY_UID: String(process.getuid()),
+      PATH: `${compatBin}:${process.env.PATH}`,
+    },
   });
   assert.notEqual(mismatch.status, 0, mismatch.stdout + mismatch.stderr);
   assert.match(mismatch.stderr, /db0 runtime\/proof MANIFEST bytes differ/);
@@ -216,8 +251,11 @@ try {
 
   writeDirectDb("db0", "db0 runtime manifest\n", db0Index, db0Chunks);
   writeDirectDb("db1", "db1 runtime manifest\n", db1Index, db1Chunks);
-  write(path.join(directData, "pir2-identity.key"), "k".repeat(32));
-  write(path.join(directData, "pir2.cert"), "fixture certificate\n");
+  const directIdentityRoot = path.join(directRoot, "identity");
+  write(path.join(directIdentityRoot, "server.key"), "k".repeat(32));
+  write(path.join(directIdentityRoot, "server.cert"), "fixture certificate\n");
+  chmodSync(directIdentityRoot, 0o700);
+  chmodSync(path.join(directIdentityRoot, "server.key"), 0o600);
   write(
     path.join(directData, "payment-v1/vpsbg-premium-free-pow-beta/service-policy.bin"),
     "fixture policy\n",
@@ -326,15 +364,23 @@ exit 1
   const directEnv = {
     ...process.env,
     BPIR_ORAM_BOOT_ID_FILE: bootIdFile,
-    PATH: `${fixtureBin}:${process.env.PATH}`,
+    BPIR_TIER3_IDENTITY_ROOT: directIdentityRoot,
+    BPIR_TIER3_IDENTITY_UID: String(process.getuid()),
+    PATH: `${compatBin}:${fixtureBin}:${process.env.PATH}`,
   };
-  rmSync(path.join(directData, "pir2.cert"));
+  chmodSync(directIdentityRoot, 0o755);
+  const unsafeIdentityParent = run("sh", [directRunScript], { env: directEnv });
+  assert.notEqual(unsafeIdentityParent.status, 0, unsafeIdentityParent.stdout + unsafeIdentityParent.stderr);
+  assert.match(unsafeIdentityParent.stderr, /identity directory must be owner-matched mode 0700/);
+  assert.equal(existsSync(directMarker), false, "oramctl must not run with an unsafe identity parent");
+  chmodSync(directIdentityRoot, 0o700);
+  rmSync(path.join(directIdentityRoot, "server.cert"));
   const missingIdentity = run("sh", [directRunScript], { env: directEnv });
   assert.notEqual(missingIdentity.status, 0, missingIdentity.stdout + missingIdentity.stderr);
-  assert.match(missingIdentity.stderr, /required file missing or unreadable: .*pir2\.cert/);
+  assert.match(missingIdentity.stderr, /required file missing or unreadable: .*server\.cert/);
   assert.equal(existsSync(directMarker), false, "oramctl must not run without the identity pair");
   assert.equal(existsSync(unifiedStarts), false, "unified_server must not start without the identity pair");
-  write(path.join(directData, "pir2.cert"), "fixture certificate\n");
+  write(path.join(directIdentityRoot, "server.cert"), "fixture certificate\n");
   const directSuccess = run("sh", [directRunScript], { env: directEnv });
   assert.equal(directSuccess.status, 0, directSuccess.stdout + directSuccess.stderr);
   const directCalls = readFileSync(directMarker, "utf8");


### PR DESCRIPTION
## What changed

- load the persistent VPSBG identity from `/sysroot/root/bitcoinpir-identity` instead of the non-private `/home/pir/data` parent
- validate the identity directory and both files before Direct ORAM regeneration
- install `stat` in the Tier3 initramfs for that preflight
- extend the focused Tier3 fixture and frozen deployment gate

## Why

Measured image 251 completed both Direct ORAM builds (241 seconds + 23 seconds), then the existing private-file loader would still reject the identity because `/home/pir/data` is not an effective-user-owned mode-0700 parent. The server would therefore serve without REQ_ANNOUNCE identity and the production Web canary would reject it.

The new path is on the already mounted stock rootfs, below root's mode-0700 home. It avoids embedding the long-lived identity key in the public UKI while satisfying the existing private-file ancestor and final-parent contract.

## Validation

- `sh -n scripts/dracut/97bpir-tier3-init/unified-server-run.sh`
- `bash -n scripts/dracut/97bpir-tier3-init/module-setup.sh`
- `node scripts/vpsbg-tier3-generation.test.mjs`
- `node scripts/payment-v1-deployment-template-gate.mjs`
- `node --test scripts/payment-v1-deployment-template-gate.test.mjs` (30/30)
- `git diff --check`
