### PR TITLE
Pin VPSBG image 253 measurement

### DIFF
--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -24,7 +24,7 @@ describe('bundled functional-beta trusted bootstrap', () => {
       '256fb106c039f8009d3caa431a9634ff3fe5db3b9e4d9ae7282bbde66772c97a',
     );
     expect(parsed.providers[1].serverPin.measurementHex).toBe(
-      'ccc1d71f4a8619e9663baf6c008f1325b0c8ba13690f8ec31a32f50f73a261f8eeb7174128ce6431c2887623dd6b4ea9',
+      'fe62552705658cd48c403c3c3c0c144ecb7a0cd0367afe3da0eb6c804a219a1715b78932a48bfe9e465551415424009e',
     );
     expect(parsed.providers[0].supportedWorkloads).toEqual([
       'dpf-query', 'harmony-hint', 'onion-session',

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -128,16 +128,16 @@ export interface ServerAttestPin {
 /**
  * weikeng2.bitcoinpir.org — VPSBG Tier 3 Payment V1 beta UKI, pinned
  * 2026-08-11 after the native full-build-v2 Direct ORAM rollout. Image 249
- * serves DPF, Harmony-query and TEE ORAM with the reviewed epoch-5 policy.
+ * serves DPF, Harmony-query and TEE ORAM with the reviewed epoch-6 policy.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // Captured from image 249 after validating the AMD chain, REPORT_DATA,
+  // Captured from image 253 after validating the AMD chain, REPORT_DATA,
   // exact unified_server binary and both attested database manifest roots.
   measurementHex:
-    'ccc1d71f4a8619e9663baf6c008f1325b0c8ba13690f8ec31a32f50f73a261f8eeb7174128ce6431c2887623dd6b4ea9',
+    'fe62552705658cd48c403c3c3c0c144ecb7a0cd0367afe3da0eb6c804a219a1715b78932a48bfe9e465551415424009e',
   binarySha256Hex:
     'cc82574e3547eea5176f7ecd1813c9dc8b8cc247ab8cc20a0cde3837fc8de65d',
-  description: 'weikeng2.bitcoinpir.org (VPSBG image 249, SEV-SNP, Tier 3 DPF + Harmony + Direct ORAM, epoch-5)',
+  description: 'weikeng2.bitcoinpir.org (VPSBG image 253, SEV-SNP, Tier 3 DPF + Harmony + Direct ORAM, epoch-6)',
 };
 
 /**

--- a/web/src/functional-beta-trusted-bootstrap.json
+++ b/web/src/functional-beta-trusted-bootstrap.json
@@ -69,7 +69,7 @@
       "stableServerId": "pir2-vpsbg-dpf-v1",
       "serverPin": {
         "binarySha256Hex": "cc82574e3547eea5176f7ecd1813c9dc8b8cc247ab8cc20a0cde3837fc8de65d",
-        "measurementHex": "ccc1d71f4a8619e9663baf6c008f1325b0c8ba13690f8ec31a32f50f73a261f8eeb7174128ce6431c2887623dd6b4ea9"
+        "measurementHex": "fe62552705658cd48c403c3c3c0c144ecb7a0cd0367afe3da0eb6c804a219a1715b78932a48bfe9e465551415424009e"
       },
       "hardwareAttestation": "required",
       "expectedArkFingerprintHex": "1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a",


### PR DESCRIPTION
## What changed

- pin the live VPSBG image 253 SEV-SNP launch measurement in the Web verifier
- update the bundled functional-beta provider bootstrap to the same measurement
- update the focused bootstrap regression and the operator-facing image/policy description

## Why

Image 253 contains the merged private persistent identity-path fix and the reviewed epoch-6 combined Free-PoW policy. The old image 249 measurement correctly fails closed against the newly verified UKI.

## Live evidence

- AMD ARK to ASK to VCEK chain and report signature verified
- REPORT_DATA and exact unified-server binary verified
- launch measurement verified as `fe62552705658cd48c403c3c3c0c144ecb7a0cd0367afe3da0eb6c804a219a1715b78932a48bfe9e465551415424009e`
- db0 and db1 manifest roots verified
- encrypted channel ping and get-info passed
- real Free-PoW Direct ORAM queries passed for db0 and db1

## Checks

- focused functional-beta bootstrap tests (4/4)
- TypeScript no-emit check
- Web build
- CSP verification
- `git diff --check`
