### PR TITLE
Allow root-bound Merkle proof auxiliaries

### DIFF
--- a/crates/protocol/runtime/src/manifest.rs
+++ b/crates/protocol/runtime/src/manifest.rs
@@ -25,8 +25,11 @@
 //! Verification rules:
 //! - Every file listed under `[files]` must exist and hash-match.
 //! - Every regular file in the dir (recursively, excluding `MANIFEST.toml`)
-//!   must appear under `[files]`. Stray files are an error — the server
-//!   should refuse to start rather than silently mmap unaccounted bytes.
+//!   must appear under `[files]`. The only exception is a canonically named
+//!   per-bucket Merkle sibling table in a typed Direct-ORAM manifest that
+//!   already binds the complete root, ordered roots, and tree-top cache.
+//!   Sibling rows are untrusted proof auxiliaries: clients verify them against
+//!   that bound root.
 //! - The version must match `SUPPORTED_VERSION`.
 //!
 //! Back-compat: an absent `MANIFEST.toml` is `Ok(None)` so existing DBs
@@ -289,7 +292,9 @@ impl DbManifest {
     }
 
     /// Verify every listed file matches its expected SHA-256, and that no
-    /// unlisted regular file is present in the directory tree.
+    /// unlisted regular file is present in the directory tree except a
+    /// narrowly named bucket-Merkle sibling table whose Direct-ORAM manifest
+    /// lists and hash-verifies all of its commitments.
     ///
     /// Files ending in `_cuckoo.bin` are the large cuckoo table mmap files
     /// (several GB each). Reading them into memory just to SHA-256 them at
@@ -341,11 +346,44 @@ impl DbManifest {
             if path == MANIFEST_FILENAME {
                 continue;
             }
-            if !listed.contains(path.as_str()) {
+            if !listed.contains(path.as_str()) && !self.allows_unlisted_bucket_merkle_sibling(path)
+            {
                 return Err(ManifestError::UnexpectedFile { path: path.clone() });
             }
         }
         Ok(())
+    }
+
+    /// Bucket-Merkle sibling rows are proof material rather than trusted DB
+    /// contents. A malicious row can only make client verification fail: the
+    /// runtime validates its shape and clients fold it into the manifest-bound
+    /// tree-top/root before releasing a result. Keep this exception exact and
+    /// unavailable unless all three commitment artifacts are manifest-bound.
+    fn allows_unlisted_bucket_merkle_sibling(&self, path: &str) -> bool {
+        const COMMITMENTS: [&str; 3] = [
+            "merkle_bucket_root.bin",
+            "merkle_bucket_roots.bin",
+            "merkle_bucket_tree_tops.bin",
+        ];
+        if self.direct_oram.is_none()
+            || !COMMITMENTS
+                .iter()
+                .all(|name| self.files.contains_key(*name))
+        {
+            return false;
+        }
+        let Some(level) = path
+            .strip_prefix("merkle_bucket_index_sib_L")
+            .or_else(|| path.strip_prefix("merkle_bucket_chunk_sib_L"))
+            .and_then(|rest| rest.strip_suffix(".bin"))
+        else {
+            return false;
+        };
+        !level.is_empty()
+            && level.bytes().all(|byte| byte.is_ascii_digit())
+            && level
+                .parse::<u32>()
+                .is_ok_and(|parsed| parsed.to_string() == level)
     }
 }
 
@@ -426,6 +464,22 @@ mod tests {
         fs::write(dir.join(MANIFEST_FILENAME), s).unwrap();
     }
 
+    fn write_direct_oram_manifest_for(dir: &Path, files: &[(&str, &[u8])]) {
+        write_manifest_for(dir, files);
+        let manifest_path = dir.join(MANIFEST_FILENAME);
+        let mut manifest = fs::read_to_string(&manifest_path).unwrap();
+        manifest.push_str(
+            "\n[direct_oram]\nversion = 1\n\
+             index_sha256 = \"1111111111111111111111111111111111111111111111111111111111111111\"\n\
+             index_bytes = 25\nindex_records = 1\n\
+             chunk_sha256 = \"2222222222222222222222222222222222222222222222222222222222222222\"\n\
+             chunk_bytes = 40\nchunk_records = 1\n\
+             index_slots_per_bin = 4\nindex_hash_fns = 2\n\
+             index_load_factor_ppb = 200000000\nindex_seed = 7\n",
+        );
+        fs::write(manifest_path, manifest).unwrap();
+    }
+
     #[test]
     fn no_manifest_returns_none() {
         let dir = tempfile::tempdir().unwrap();
@@ -503,6 +557,92 @@ mod tests {
             "got {:?}",
             err
         );
+    }
+
+    #[test]
+    fn accepts_unlisted_bucket_merkle_siblings_bound_by_manifest_commitments() {
+        let dir = tempfile::tempdir().unwrap();
+        let committed: &[(&str, &[u8])] = &[
+            ("merkle_bucket_root.bin", b"root"),
+            ("merkle_bucket_roots.bin", b"ordered-roots"),
+            ("merkle_bucket_tree_tops.bin", b"tree-tops"),
+        ];
+        write_files(dir.path(), committed);
+        write_files(
+            dir.path(),
+            &[
+                ("merkle_bucket_index_sib_L0.bin", b"index-proof-rows"),
+                ("merkle_bucket_chunk_sib_L1.bin", b"chunk-proof-rows"),
+            ],
+        );
+        write_direct_oram_manifest_for(dir.path(), committed);
+
+        DbManifest::load_and_verify(dir.path()).unwrap().unwrap();
+    }
+
+    #[test]
+    fn rejects_unlisted_bucket_merkle_sibling_without_direct_oram_or_all_commitments() {
+        let all_commitments: &[(&str, &[u8])] = &[
+            ("merkle_bucket_root.bin", b"root"),
+            ("merkle_bucket_roots.bin", b"ordered-roots"),
+            ("merkle_bucket_tree_tops.bin", b"tree-tops"),
+        ];
+        let ordinary = tempfile::tempdir().unwrap();
+        write_files(ordinary.path(), all_commitments);
+        write_files(
+            ordinary.path(),
+            &[("merkle_bucket_index_sib_L0.bin", b"index-proof-rows")],
+        );
+        write_manifest_for(ordinary.path(), all_commitments);
+        assert!(matches!(
+            DbManifest::load_and_verify(ordinary.path()).unwrap_err(),
+            ManifestError::UnexpectedFile { .. }
+        ));
+
+        let dir = tempfile::tempdir().unwrap();
+        let committed: &[(&str, &[u8])] = &[
+            ("merkle_bucket_root.bin", b"root"),
+            ("merkle_bucket_roots.bin", b"ordered-roots"),
+        ];
+        write_files(dir.path(), committed);
+        write_files(
+            dir.path(),
+            &[("merkle_bucket_index_sib_L0.bin", b"index-proof-rows")],
+        );
+        write_direct_oram_manifest_for(dir.path(), committed);
+
+        let err = DbManifest::load_and_verify(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, ManifestError::UnexpectedFile { .. }),
+            "got {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn rejects_noncanonical_or_nested_unlisted_bucket_merkle_siblings() {
+        let committed: &[(&str, &[u8])] = &[
+            ("merkle_bucket_root.bin", b"root"),
+            ("merkle_bucket_roots.bin", b"ordered-roots"),
+            ("merkle_bucket_tree_tops.bin", b"tree-tops"),
+        ];
+        for unexpected in [
+            "merkle_bucket_index_sib_L00.bin",
+            "merkle_bucket_chunk_sib_Lx.bin",
+            "nested/merkle_bucket_index_sib_L0.bin",
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            write_files(dir.path(), committed);
+            write_files(dir.path(), &[(unexpected, b"proof-rows")]);
+            write_direct_oram_manifest_for(dir.path(), committed);
+
+            let err = DbManifest::load_and_verify(dir.path()).unwrap_err();
+            assert!(
+                matches!(err, ManifestError::UnexpectedFile { .. }),
+                "{unexpected}: got {:?}",
+                err
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Production image 253 proved that the native-v2 db1 Direct-ORAM generation has the same bucket-Merkle root, ordered roots, and tree-top cache as pir1, but omits the lower sibling tables from its attested manifest. Adding the matching sibling files currently trips the strict stray-file gate before the runtime can validate and serve them.

This patch permits only canonical top-level INDEX/CHUNK sibling filenames, only for a typed Direct-ORAM manifest, and only when all three Merkle commitments are already listed and hash-verified. The sibling rows remain untrusted proof data: runtime shape checks and client verification against the bound root remain unchanged. Every other unlisted file still fails closed.

Validated locally:
- cargo test --locked --offline -p pir-runtime-core manifest::tests --lib (19/19)
- cargo test --locked --offline -p pir-runtime-core bucket_merkle --lib (7/7)
- rustfmt check
- git diff --check