### PR TITLE
Pin VPSBG image 255 attestation

### DIFF
--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -24,7 +24,10 @@ describe('bundled functional-beta trusted bootstrap', () => {
       '256fb106c039f8009d3caa431a9634ff3fe5db3b9e4d9ae7282bbde66772c97a',
     );
     expect(parsed.providers[1].serverPin.measurementHex).toBe(
-      'fe62552705658cd48c403c3c3c0c144ecb7a0cd0367afe3da0eb6c804a219a1715b78932a48bfe9e465551415424009e',
+      '4474af1ae2eb49f8a4d9bdf9285abf91a30bee47ac3dd0614634790402500e503208d2e4a36074d3c822d24ea089046a',
+    );
+    expect(parsed.providers[1].serverPin.binarySha256Hex).toBe(
+      '8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355',
     );
     expect(parsed.providers[0].supportedWorkloads).toEqual([
       'dpf-query', 'harmony-hint', 'onion-session',

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -127,17 +127,17 @@ export interface ServerAttestPin {
 
 /**
  * weikeng2.bitcoinpir.org — VPSBG Tier 3 Payment V1 beta UKI, pinned
- * 2026-08-11 after the native full-build-v2 Direct ORAM rollout. Image 249
- * serves DPF, Harmony-query and TEE ORAM with the reviewed epoch-6 policy.
+ * 2026-08-12 after restoring the db1 bucket-Merkle proof auxiliaries. Image
+ * 255 serves DPF, Harmony-query and TEE ORAM with the reviewed epoch-6 policy.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // Captured from image 253 after validating the AMD chain, REPORT_DATA,
+  // Captured from image 255 after validating the AMD chain, REPORT_DATA,
   // exact unified_server binary and both attested database manifest roots.
   measurementHex:
-    'fe62552705658cd48c403c3c3c0c144ecb7a0cd0367afe3da0eb6c804a219a1715b78932a48bfe9e465551415424009e',
+    '4474af1ae2eb49f8a4d9bdf9285abf91a30bee47ac3dd0614634790402500e503208d2e4a36074d3c822d24ea089046a',
   binarySha256Hex:
-    'cc82574e3547eea5176f7ecd1813c9dc8b8cc247ab8cc20a0cde3837fc8de65d',
-  description: 'weikeng2.bitcoinpir.org (VPSBG image 253, SEV-SNP, Tier 3 DPF + Harmony + Direct ORAM, epoch-6)',
+    '8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355',
+  description: 'weikeng2.bitcoinpir.org (VPSBG image 255, SEV-SNP, Tier 3 DPF + Harmony + Direct ORAM, epoch-6)',
 };
 
 /**

--- a/web/src/functional-beta-trusted-bootstrap.json
+++ b/web/src/functional-beta-trusted-bootstrap.json
@@ -68,8 +68,8 @@
       "operatorSigningKeyHex": "256fb106c039f8009d3caa431a9634ff3fe5db3b9e4d9ae7282bbde66772c97a",
       "stableServerId": "pir2-vpsbg-dpf-v1",
       "serverPin": {
-        "binarySha256Hex": "cc82574e3547eea5176f7ecd1813c9dc8b8cc247ab8cc20a0cde3837fc8de65d",
-        "measurementHex": "fe62552705658cd48c403c3c3c0c144ecb7a0cd0367afe3da0eb6c804a219a1715b78932a48bfe9e465551415424009e"
+        "binarySha256Hex": "8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355",
+        "measurementHex": "4474af1ae2eb49f8a4d9bdf9285abf91a30bee47ac3dd0614634790402500e503208d2e4a36074d3c822d24ea089046a"
       },
       "hardwareAttestation": "required",
       "expectedArkFingerprintHex": "1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a",


### PR DESCRIPTION
## Summary
- pin the live VPSBG image 255 SEV-SNP launch measurement
- pin the exact `unified_server` binary from merge commit `545f4482`
- keep the bundled functional-beta bootstrap and runtime pin in lock-step

## Live acceptance evidence
- exact binary + launch measurement + AMD ARK/ASK/VCEK chain: PASS
- encrypted `channel-test`: PASS
- operator identity `pir2-vpsbg-dpf-v1`: PASS
- pir1/pir2 db0 + db1 query catalogs: exact compatibility PASS; both advertise bucket Merkle
- live db0 snapshot and db1 delta proof verification: PASS
- db0 + db1 Direct ORAM Free-PoW smoke: PASS

## Local checks
- `vitest` focused pin/proof/strict verification: 49/49
- TypeScript `--noEmit`: PASS
- Web build: PASS
- CSP verifier: PASS
- `git diff --check`: PASS
