### PR TITLE
Separate VPSBG v1 and v2 proof slots

### DIFF
--- a/apps/server/tests/payment_v1_tee_oram_process_e2e.rs
+++ b/apps/server/tests/payment_v1_tee_oram_process_e2e.rs
@@ -621,7 +621,7 @@ fn measured_boot_copies_exact_manifest_and_sources_before_strict_build() {
     let script = include_str!("../../../scripts/dracut/97bpir-tier3-init/unified-server-run.sh");
     assert!(script.contains("load_active_database_generation 0 db0"));
     assert!(script.contains("load_active_database_generation 1 db1"));
-    assert!(script.contains("runtime/proof MANIFEST bytes differ"));
+    assert!(script.contains("runtime/proof-v2 MANIFEST bytes differ"));
     assert!(!script.contains("first_existing_dir"));
     assert!(!script.contains("first_existing_file"));
     assert!(!script.contains("attested-builder-runs/mainnet_948454_oram_948454_sev_snp"));

--- a/docs/DATABASE_ROOT_ROTATION_RUNBOOK.md
+++ b/docs/DATABASE_ROOT_ROTATION_RUNBOOK.md
@@ -134,14 +134,19 @@ and writes a candidate catalog. It never replaces the active
 ./scripts/stage_vpsbg_tier3_generation.sh \
   --generation <reviewed-generation> \
   --db0-output <complete-db0-build-output> \
+  --db0-proof-v1 <locked-db0-v1-proof-sidecars> \
   --db0-name <name> --db0-type full --db0-base-height 0 --db0-height <height> \
   --db1-output <complete-db1-build-output> \
+  --db1-proof-v1 <locked-db1-v1-proof-sidecars> \
   --db1-name <name> --db1-type delta --db1-base-height <height> --db1-height <height>
 ```
 
-The resulting candidate points `path` at that generation's `server-db` tree
-and `proof_dir` at the same generation root. Review it and use the maintenance
-window activation step below; never edit its generated path/proof pairing.
+The resulting candidate keeps the proof generations explicit: `path` points
+at the V2 generation's `server-db` tree, `proof_dir` points at the locked V1
+sidecars used by DPF/Harmony clients, and `proof_v2_dir` points at the complete
+V2 output used by Onion/ORAM and Direct ORAM reconstruction. Review it and use
+the maintenance-window activation step below; never collapse or manually edit
+these generated path/proof pairings.
 
 Hetzner can be staged over its normal SSH/operator path. VPSBG Tier 3 has no
 SSH, so a complete proof/root rotation must use a planned portal maintenance

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -293,20 +293,29 @@ load_active_database_generation() {
     database_label="$2"
     runtime_raw="$(toml_database_path "$database_index" path)" \
         || fatal "$database_label path missing or non-canonical in $TIER3_DATABASES_CONFIG"
-    proof_raw="$(toml_database_path "$database_index" proof_dir)" \
+    proof_v1_raw="$(toml_database_path "$database_index" proof_dir)" \
         || fatal "$database_label proof_dir missing or non-canonical in $TIER3_DATABASES_CONFIG"
+    proof_v2_raw="$(toml_database_path "$database_index" proof_v2_dir)" \
+        || fatal "$database_label proof_v2_dir missing or non-canonical in $TIER3_DATABASES_CONFIG"
     ACTIVE_DB_RUNTIME_DIR="$(resolve_tier3_data_path "$runtime_raw")"
-    ACTIVE_DB_PROOF_DIR="$(resolve_tier3_data_path "$proof_raw")"
+    ACTIVE_DB_PROOF_V1_DIR="$(resolve_tier3_data_path "$proof_v1_raw")"
+    ACTIVE_DB_PROOF_V2_DIR="$(resolve_tier3_data_path "$proof_v2_raw")"
     require_file "$ACTIVE_DB_RUNTIME_DIR/MANIFEST.toml"
-    require_file "$ACTIVE_DB_PROOF_DIR/server-db/MANIFEST.toml"
+    require_file "$ACTIVE_DB_PROOF_V1_DIR/server-db/MANIFEST.toml"
+    require_file "$ACTIVE_DB_PROOF_V1_DIR/build-evidence.bin"
+    require_file "$ACTIVE_DB_PROOF_V1_DIR/root-bundle-payload.bin"
+    require_file "$ACTIVE_DB_PROOF_V1_DIR/build-evidence.sev-snp-report.bin"
+    require_file "$ACTIVE_DB_PROOF_V1_DIR/database.manifest.sha256"
+    require_file "$ACTIVE_DB_PROOF_V1_DIR/all-artifacts.manifest.sha256"
+    require_file "$ACTIVE_DB_PROOF_V2_DIR/server-db/MANIFEST.toml"
     cmp -s "$ACTIVE_DB_RUNTIME_DIR/MANIFEST.toml" \
-        "$ACTIVE_DB_PROOF_DIR/server-db/MANIFEST.toml" \
-        || fatal "$database_label runtime/proof MANIFEST bytes differ"
-    require_file "$ACTIVE_DB_PROOF_DIR/build-evidence.bin"
-    require_file "$ACTIVE_DB_PROOF_DIR/root-bundle-payload.bin"
-    require_file "$ACTIVE_DB_PROOF_DIR/oram-direct-inputs/utxo_chunks_index_nodust.bin"
-    require_file "$ACTIVE_DB_PROOF_DIR/oram-direct-inputs/utxo_chunks_nodust.bin"
-    require_file "$ACTIVE_DB_PROOF_DIR/oram-direct-inputs/direct-inputs.sha256"
+        "$ACTIVE_DB_PROOF_V2_DIR/server-db/MANIFEST.toml" \
+        || fatal "$database_label runtime/proof-v2 MANIFEST bytes differ"
+    require_file "$ACTIVE_DB_PROOF_V2_DIR/build-evidence.bin"
+    require_file "$ACTIVE_DB_PROOF_V2_DIR/root-bundle-payload.bin"
+    require_file "$ACTIVE_DB_PROOF_V2_DIR/oram-direct-inputs/utxo_chunks_index_nodust.bin"
+    require_file "$ACTIVE_DB_PROOF_V2_DIR/oram-direct-inputs/utxo_chunks_nodust.bin"
+    require_file "$ACTIVE_DB_PROOF_V2_DIR/oram-direct-inputs/direct-inputs.sha256"
 }
 
 random_seed_hex() {
@@ -674,16 +683,16 @@ write_watchdog_phase direct-oram-build
 start_total_watchdog
 
 load_active_database_generation 0 db0
-MAINNET_SOURCE_DIR="$ACTIVE_DB_PROOF_DIR/oram-direct-inputs"
-MAINNET_DB_EVIDENCE="$ACTIVE_DB_PROOF_DIR/build-evidence.bin"
-MAINNET_DB_MANIFEST="$ACTIVE_DB_PROOF_DIR/server-db/MANIFEST.toml"
-MAINNET_ROOT_BUNDLE="$ACTIVE_DB_PROOF_DIR/root-bundle-payload.bin"
+MAINNET_SOURCE_DIR="$ACTIVE_DB_PROOF_V2_DIR/oram-direct-inputs"
+MAINNET_DB_EVIDENCE="$ACTIVE_DB_PROOF_V2_DIR/build-evidence.bin"
+MAINNET_DB_MANIFEST="$ACTIVE_DB_PROOF_V2_DIR/server-db/MANIFEST.toml"
+MAINNET_ROOT_BUNDLE="$ACTIVE_DB_PROOF_V2_DIR/root-bundle-payload.bin"
 
 load_active_database_generation 1 db1
-DELTA_SOURCE_DIR="$ACTIVE_DB_PROOF_DIR/oram-direct-inputs"
-DELTA_DB_EVIDENCE="$ACTIVE_DB_PROOF_DIR/build-evidence.bin"
-DELTA_DB_MANIFEST="$ACTIVE_DB_PROOF_DIR/server-db/MANIFEST.toml"
-DELTA_ROOT_BUNDLE="$ACTIVE_DB_PROOF_DIR/root-bundle-payload.bin"
+DELTA_SOURCE_DIR="$ACTIVE_DB_PROOF_V2_DIR/oram-direct-inputs"
+DELTA_DB_EVIDENCE="$ACTIVE_DB_PROOF_V2_DIR/build-evidence.bin"
+DELTA_DB_MANIFEST="$ACTIVE_DB_PROOF_V2_DIR/server-db/MANIFEST.toml"
+DELTA_ROOT_BUNDLE="$ACTIVE_DB_PROOF_V2_DIR/root-bundle-payload.bin"
 
 build_direct_oram mainnet-948454 "$MAINNET_SOURCE_DIR" "$ORAM_STAGING_DIR/db0-mainnet-948454" \
     "$MAINNET_DB_EVIDENCE" "$MAINNET_DB_MANIFEST" "$MAINNET_ROOT_BUNDLE" "$MAINNET_EXPECTED_MUHASH" "" \

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,7 +26,7 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "6b5343bf478716cd2cc5df8b6b17808788c2c160a5a4c5722acb0464ba742bf8",
+    "d1e33db31716d576b85847ba53dc0772307d1adc8f81a51839bd05c3ebe19053",
   "scripts/dracut/97bpir-tier3-init/unified-server-finish.sh":
     "06b763099ce2828603763ec45e1cdcec406659a3fb0cd413c28ac85af9cf6444",
   "scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh":

--- a/scripts/stage_vpsbg_tier3_generation.sh
+++ b/scripts/stage_vpsbg_tier3_generation.sh
@@ -10,6 +10,7 @@ usage() {
     cat <<'USAGE'
 usage: stage_vpsbg_tier3_generation.sh \
   --generation NAME --db0-output DIR --db1-output DIR \
+  --db0-proof-v1 DIR --db1-proof-v1 DIR \
   --db0-name NAME --db0-type full|delta --db0-base-height N --db0-height N \
   --db1-name NAME --db1-type full|delta --db1-base-height N --db1-height N \
   [--data-root DIR] [--candidate-config PATH]
@@ -19,8 +20,15 @@ Each --dbN-output must be one complete attested build output containing:
   build-evidence.sev-snp-report.bin, database.manifest.sha256,
   all-artifacts.manifest.sha256, and oram-direct-inputs/.
 
-The helper stages each output under DATA_ROOT/generations/NAME/dbN and writes
-a candidate catalog.  It never replaces DATA_ROOT/databases.toml.
+Each --dbN-proof-v1 must contain the locked V1 database-proof sidecars:
+  server-db/MANIFEST.toml, build-evidence.bin, root-bundle-payload.bin,
+  build-evidence.sev-snp-report.bin, database.manifest.sha256, and
+  all-artifacts.manifest.sha256.
+
+The helper stages V2 build outputs under DATA_ROOT/generations/NAME/dbN, V1
+sidecars under DATA_ROOT/generations/NAME/proof-v1/dbN, and writes a candidate
+catalog with separate proof_dir/proof_v2_dir fields.  It never replaces
+DATA_ROOT/databases.toml.
 USAGE
 }
 
@@ -79,9 +87,25 @@ validate_output() {
     done
 }
 
+validate_proof_v1() {
+    proof="$1"
+    require_directory "$proof"
+    for rel in \
+        server-db/MANIFEST.toml \
+        build-evidence.bin \
+        root-bundle-payload.bin \
+        build-evidence.sev-snp-report.bin \
+        database.manifest.sha256 \
+        all-artifacts.manifest.sha256; do
+        require_file "$proof/$rel"
+    done
+}
+
 GENERATION=''
 DB0_OUTPUT=''
 DB1_OUTPUT=''
+DB0_PROOF_V1=''
+DB1_PROOF_V1=''
 DB0_NAME=''
 DB1_NAME=''
 DB0_TYPE=''
@@ -98,6 +122,8 @@ while [ "$#" -gt 0 ]; do
         --generation) GENERATION="$(require_value "$@")"; shift 2 ;;
         --db0-output) DB0_OUTPUT="$(require_value "$@")"; shift 2 ;;
         --db1-output) DB1_OUTPUT="$(require_value "$@")"; shift 2 ;;
+        --db0-proof-v1) DB0_PROOF_V1="$(require_value "$@")"; shift 2 ;;
+        --db1-proof-v1) DB1_PROOF_V1="$(require_value "$@")"; shift 2 ;;
         --db0-name) DB0_NAME="$(require_value "$@")"; shift 2 ;;
         --db1-name) DB1_NAME="$(require_value "$@")"; shift 2 ;;
         --db0-type) DB0_TYPE="$(require_value "$@")"; shift 2 ;;
@@ -131,6 +157,8 @@ done
 
 validate_output "$DB0_OUTPUT" db0
 validate_output "$DB1_OUTPUT" db1
+validate_proof_v1 "$DB0_PROOF_V1"
+validate_proof_v1 "$DB1_PROOF_V1"
 
 STAGE_ROOT="$DATA_ROOT/generations"
 FINAL_DIR="$STAGE_ROOT/$GENERATION"
@@ -152,9 +180,12 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir "$STAGING_DIR"
-mkdir "$STAGING_DIR/db0" "$STAGING_DIR/db1"
+mkdir "$STAGING_DIR/db0" "$STAGING_DIR/db1" "$STAGING_DIR/proof-v1"
+mkdir "$STAGING_DIR/proof-v1/db0" "$STAGING_DIR/proof-v1/db1"
 cp -a "$DB0_OUTPUT/." "$STAGING_DIR/db0/"
 cp -a "$DB1_OUTPUT/." "$STAGING_DIR/db1/"
+cp -a "$DB0_PROOF_V1/." "$STAGING_DIR/proof-v1/db0/"
+cp -a "$DB1_PROOF_V1/." "$STAGING_DIR/proof-v1/db1/"
 
 for db in db0 db1; do
     source_output="$DB0_OUTPUT"
@@ -177,7 +208,8 @@ cat >"$candidate_tmp" <<EOF
 name = "$DB0_NAME"
 type = "$DB0_TYPE"
 path = "$STAGE_ROOT/$GENERATION/db0/server-db"
-proof_dir = "$STAGE_ROOT/$GENERATION/db0"
+proof_dir = "$STAGE_ROOT/$GENERATION/proof-v1/db0"
+proof_v2_dir = "$STAGE_ROOT/$GENERATION/db0"
 base_height = $DB0_BASE_HEIGHT
 height = $DB0_HEIGHT
 
@@ -185,7 +217,8 @@ height = $DB0_HEIGHT
 name = "$DB1_NAME"
 type = "$DB1_TYPE"
 path = "$STAGE_ROOT/$GENERATION/db1/server-db"
-proof_dir = "$STAGE_ROOT/$GENERATION/db1"
+proof_dir = "$STAGE_ROOT/$GENERATION/proof-v1/db1"
+proof_v2_dir = "$STAGE_ROOT/$GENERATION/db1"
 base_height = $DB1_BASE_HEIGHT
 height = $DB1_HEIGHT
 EOF

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -65,6 +65,21 @@ function createCompleteOutput(root, name, manifest) {
   return output;
 }
 
+function createProofV1(root, name, manifest = "v1 manifest\n") {
+  const proof = path.join(root, name);
+  for (const relative of [
+    "server-db/MANIFEST.toml",
+    "build-evidence.bin",
+    "root-bundle-payload.bin",
+    "build-evidence.sev-snp-report.bin",
+    "database.manifest.sha256",
+    "all-artifacts.manifest.sha256",
+  ]) {
+    write(path.join(proof, relative), relative.includes("MANIFEST") ? manifest : "v1 fixture\n");
+  }
+  return proof;
+}
+
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, { encoding: "utf8", ...options });
   if (result.error) throw result.error;
@@ -116,6 +131,8 @@ esac
 
   const db0 = createCompleteOutput(tempRoot, "db0-output", "db0 manifest\n");
   const db1 = createCompleteOutput(tempRoot, "db1-output", "db1 manifest\n");
+  const db0ProofV1 = createProofV1(tempRoot, "db0-proof-v1", "db0 v1 manifest\n");
+  const db1ProofV1 = createProofV1(tempRoot, "db1-proof-v1", "db1 v1 manifest\n");
   const stage = run("bash", [
     stageHelper,
     "--generation",
@@ -124,6 +141,10 @@ esac
     db0,
     "--db1-output",
     db1,
+    "--db0-proof-v1",
+    db0ProofV1,
+    "--db1-proof-v1",
+    db1ProofV1,
     "--db0-name",
     "main",
     "--db0-type",
@@ -149,10 +170,18 @@ esac
   assert.ok(existsSync(candidate));
   const candidateText = readFileSync(candidate, "utf8");
   assert.ok(candidateText.includes(`path = "${dataRoot}/generations/fixture-1/db0/server-db"`));
-  assert.ok(candidateText.includes(`proof_dir = "${dataRoot}/generations/fixture-1/db1"`));
+  assert.ok(candidateText.includes(`proof_dir = "${dataRoot}/generations/fixture-1/proof-v1/db1"`));
+  assert.ok(candidateText.includes(`proof_v2_dir = "${dataRoot}/generations/fixture-1/db1"`));
   assert.equal(
     readFileSync(path.join(dataRoot, "generations/fixture-1/db0/server-db/MANIFEST.toml"), "utf8"),
     "db0 manifest\n",
+  );
+  assert.equal(
+    readFileSync(
+      path.join(dataRoot, "generations/fixture-1/proof-v1/db1/root-bundle-payload.bin"),
+      "utf8",
+    ),
+    "v1 fixture\n",
   );
 
   const mismatchRoot = path.join(tempRoot, "mismatch");
@@ -169,7 +198,9 @@ esac
   write(bhtmProof, "{}\n");
   writeFileSync(mismatchBootId, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\n");
   write(path.join(mismatchData, "runtime-db0/MANIFEST.toml"), "runtime manifest\n");
-  write(path.join(mismatchData, "proof-db0/server-db/MANIFEST.toml"), "proof manifest\n");
+  createProofV1(mismatchData, "proof-v1-db0");
+  createProofV1(mismatchData, "proof-v1-db1");
+  write(path.join(mismatchData, "proof-v2-db0/server-db/MANIFEST.toml"), "proof manifest\n");
   const mismatchIdentityRoot = path.join(mismatchRoot, "identity");
   write(path.join(mismatchIdentityRoot, "server.key"), "k".repeat(32));
   write(path.join(mismatchIdentityRoot, "server.cert"), "fixture certificate\n");
@@ -181,7 +212,7 @@ esac
   );
   write(
     path.join(mismatchData, "databases.toml"),
-    `[[database]]\nname = "main"\ntype = "full"\npath = "runtime-db0"\nproof_dir = "proof-db0"\nbase_height = 0\nheight = 948454\n\n[[database]]\nname = "delta"\ntype = "delta"\npath = "runtime-db1"\nproof_dir = "proof-db1"\nbase_height = 940611\nheight = 948454\n`,
+    `[[database]]\nname = "main"\ntype = "full"\npath = "runtime-db0"\nproof_dir = "proof-v1-db0"\nproof_v2_dir = "proof-v2-db0"\nbase_height = 0\nheight = 948454\n\n[[database]]\nname = "delta"\ntype = "delta"\npath = "runtime-db1"\nproof_dir = "proof-v1-db1"\nproof_v2_dir = "proof-v2-db1"\nbase_height = 940611\nheight = 948454\n`,
   );
 
   const fixtureRunScript = path.join(mismatchRoot, "unified-server-run.sh");
@@ -209,7 +240,7 @@ esac
     },
   });
   assert.notEqual(mismatch.status, 0, mismatch.stdout + mismatch.stderr);
-  assert.match(mismatch.stderr, /db0 runtime\/proof MANIFEST bytes differ/);
+  assert.match(mismatch.stderr, /db0 runtime\/proof-v2 MANIFEST bytes differ/);
   assert.equal(existsSync(marker), false, "oramctl must not run after manifest mismatch");
 
   const directRoot = path.join(tempRoot, "direct-success");
@@ -251,6 +282,8 @@ esac
 
   writeDirectDb("db0", "db0 runtime manifest\n", db0Index, db0Chunks);
   writeDirectDb("db1", "db1 runtime manifest\n", db1Index, db1Chunks);
+  createProofV1(directData, "db0-proof-v1");
+  createProofV1(directData, "db1-proof-v1");
   const directIdentityRoot = path.join(directRoot, "identity");
   write(path.join(directIdentityRoot, "server.key"), "k".repeat(32));
   write(path.join(directIdentityRoot, "server.cert"), "fixture certificate\n");
@@ -262,7 +295,7 @@ esac
   );
   write(
     path.join(directData, "databases.toml"),
-    `[[database]]\nname = "main"\ntype = "full"\npath = "db0-runtime"\nproof_dir = "db0-proof"\nbase_height = 0\nheight = 948454\n\n[[database]]\nname = "delta"\ntype = "delta"\npath = "db1-runtime"\nproof_dir = "db1-proof"\nbase_height = 940611\nheight = 948454\n`,
+    `[[database]]\nname = "main"\ntype = "full"\npath = "db0-runtime"\nproof_dir = "db0-proof-v1"\nproof_v2_dir = "db0-proof"\nbase_height = 0\nheight = 948454\n\n[[database]]\nname = "delta"\ntype = "delta"\npath = "db1-runtime"\nproof_dir = "db1-proof-v1"\nproof_v2_dir = "db1-proof"\nbase_height = 940611\nheight = 948454\n`,
   );
   write(directBhtmProof, "{}\n");
   write(


### PR DESCRIPTION
## Summary
- keep DPF/Harmony v1 proof sidecars separate from Onion/ORAM v2 proof outputs
- make the Tier3 boot path validate both proof slots before Direct ORAM construction
- teach the generation staging helper and runbook to emit the dual-slot catalog

## Validation
- `sh -n scripts/dracut/97bpir-tier3-init/unified-server-run.sh`
- `bash -n scripts/stage_vpsbg_tier3_generation.sh`
- `node scripts/vpsbg-tier3-generation.test.mjs`
- `node scripts/payment-v1-deployment-template-gate.mjs`
- `node --test scripts/payment-v1-deployment-template-gate.test.mjs`
- `git diff --check`

No database build, UKI build, browser test, or production switch was performed by this PR.