### PR TITLE
Use V2 proofs for Direct ORAM and pin VPSBG image 259

### DIFF
--- a/crates/sdk/client/src/oram.rs
+++ b/crates/sdk/client/src/oram.rs
@@ -14,7 +14,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 use crate::connection::WsConnection;
 use crate::db_proof::{
-    fetch_database_proof, verify_database_proof, DatabaseProofPolicy, VerifiedDatabaseRoots,
+    fetch_database_proof_v2, verify_database_proof_v2, DatabaseProofPolicy, VerifiedDatabaseRoots,
 };
 use crate::protocol::{
     decode_catalog, encode_request, REQ_GET_DB_CATALOG, RESP_DB_CATALOG, RESP_ERROR,
@@ -186,11 +186,10 @@ impl OramClient {
         }
     }
 
-    /// Fetch and verify the attested-builder proof bundle for `db_id`.
+    /// Fetch and verify the V2 attested-builder proof bundle for `db_id`.
     ///
-    /// ORAM uses the same catalog and proof envelope as the DPF/Harmony
-    /// backends; this method keeps the single-server browser path on the
-    /// same attested-root policy surface.
+    /// Direct ORAM is bound to the native V2 layout and must not silently
+    /// consume the legacy V1 proof slot used by DPF/Harmony clients.
     pub async fn verify_database_proof(
         &mut self,
         db_id: u8,
@@ -209,8 +208,8 @@ impl OramClient {
             .find(|db| db.db_id == db_id)
             .cloned()
             .ok_or_else(|| PirError::Protocol(format!("db_id {} not present in catalog", db_id)))?;
-        let bundle = fetch_database_proof(self.conn_mut()?.as_mut(), db_id).await?;
-        verify_database_proof(&db_info, &bundle, policy)
+        let bundle = fetch_database_proof_v2(self.conn_mut()?.as_mut(), db_id).await?;
+        verify_database_proof_v2(&db_info, &bundle, policy)
     }
 
     pub fn root_policy(&self) -> RootPolicy {

--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -24,7 +24,7 @@ describe('bundled functional-beta trusted bootstrap', () => {
       '256fb106c039f8009d3caa431a9634ff3fe5db3b9e4d9ae7282bbde66772c97a',
     );
     expect(parsed.providers[1].serverPin.measurementHex).toBe(
-      '4474af1ae2eb49f8a4d9bdf9285abf91a30bee47ac3dd0614634790402500e503208d2e4a36074d3c822d24ea089046a',
+      'a8191c82a62b2ffdfe6d6deafaef16dda150f0b87810cf1c6526677c224450ef5e779fbad041cc4e41147a14697ddfbd',
     );
     expect(parsed.providers[1].serverPin.binarySha256Hex).toBe(
       '8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355',

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -127,17 +127,17 @@ export interface ServerAttestPin {
 
 /**
  * weikeng2.bitcoinpir.org — VPSBG Tier 3 Payment V1 beta UKI, pinned
- * 2026-08-12 after restoring the db1 bucket-Merkle proof auxiliaries. Image
- * 255 serves DPF, Harmony-query and TEE ORAM with the reviewed epoch-6 policy.
+ * 2026-08-12 after separating the legacy V1 and native V2 proof slots. Image
+ * 259 serves DPF, Harmony-query and TEE ORAM with the reviewed epoch-7 policy.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // Captured from image 255 after validating the AMD chain, REPORT_DATA,
+  // Captured from image 259 after validating the AMD chain, REPORT_DATA,
   // exact unified_server binary and both attested database manifest roots.
   measurementHex:
-    '4474af1ae2eb49f8a4d9bdf9285abf91a30bee47ac3dd0614634790402500e503208d2e4a36074d3c822d24ea089046a',
+    'a8191c82a62b2ffdfe6d6deafaef16dda150f0b87810cf1c6526677c224450ef5e779fbad041cc4e41147a14697ddfbd',
   binarySha256Hex:
     '8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355',
-  description: 'weikeng2.bitcoinpir.org (VPSBG image 255, SEV-SNP, Tier 3 DPF + Harmony + Direct ORAM, epoch-6)',
+  description: 'weikeng2.bitcoinpir.org (VPSBG image 259, SEV-SNP, Tier 3 DPF + Harmony + Direct ORAM, epoch-7)',
 };
 
 /**

--- a/web/src/functional-beta-trusted-bootstrap.json
+++ b/web/src/functional-beta-trusted-bootstrap.json
@@ -69,7 +69,7 @@
       "stableServerId": "pir2-vpsbg-dpf-v1",
       "serverPin": {
         "binarySha256Hex": "8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355",
-        "measurementHex": "4474af1ae2eb49f8a4d9bdf9285abf91a30bee47ac3dd0614634790402500e503208d2e4a36074d3c822d24ea089046a"
+        "measurementHex": "a8191c82a62b2ffdfe6d6deafaef16dda150f0b87810cf1c6526677c224450ef5e779fbad041cc4e41147a14697ddfbd"
       },
       "hardwareAttestation": "required",
       "expectedArkFingerprintHex": "1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a",


### PR DESCRIPTION
## Summary
- make native Direct ORAM request and verify the V2 database-proof envelope
- keep the legacy V1 proof slot exclusive to DPF and Harmony
- pin the Web bootstrap to the live VPSBG image 259 measurement and epoch-7 description

## Acceptance evidence
- live image 259 strict attestation, V1 db0/db1 proof verification, V2 db0/db1 Direct ORAM proof verification, authorization and queries passed
- cargo check --locked --offline -p pir-sdk-client --example oram_local_smoke
- web focused bootstrap test: 4/4
- web TypeScript build
- git diff --check

No browser or production canary was run before this PR. The canary will run only after merge and Web deployment.