### PR TITLE
Pin VPSBG Harmony policy epoch 8

### DIFF
--- a/deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in
+++ b/deploy/payment-v1/vpsbg/vpsbg-premium-free-pow-beta-policy.toml.in
@@ -130,6 +130,8 @@ root_hex = "@VPSBG_DPF_DB0_MANIFEST_ROOT_HEX@"
 max_logical_inputs = @VPSBG_HARMONY_QUERY_MAX_LOGICAL_INPUTS@
 max_frames = @VPSBG_HARMONY_QUERY_MAX_FRAMES@
 max_request_bytes = @VPSBG_HARMONY_QUERY_MAX_REQUEST_BYTES@
+# This is cumulative across the four main responses and strict Merkle
+# follow-ups. The reviewed production beta uses 134217728 (128 MiB).
 max_response_bytes = @VPSBG_HARMONY_QUERY_MAX_RESPONSE_BYTES@
 max_wall_time_ms = @VPSBG_HARMONY_QUERY_MAX_WALL_TIME_MS@
 max_concurrent_sockets = @VPSBG_HARMONY_QUERY_MAX_CONCURRENT_SOCKETS@

--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -24,7 +24,7 @@ describe('bundled functional-beta trusted bootstrap', () => {
       '256fb106c039f8009d3caa431a9634ff3fe5db3b9e4d9ae7282bbde66772c97a',
     );
     expect(parsed.providers[1].serverPin.measurementHex).toBe(
-      'a8191c82a62b2ffdfe6d6deafaef16dda150f0b87810cf1c6526677c224450ef5e779fbad041cc4e41147a14697ddfbd',
+      'b8b9e724b244a52a2f87dfcde3edb895cbf5eec1c9b08f964eaefc8160c8be4988c7814fe424cbbd3158ff2e7928db53',
     );
     expect(parsed.providers[1].serverPin.binarySha256Hex).toBe(
       '8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355',

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -128,16 +128,16 @@ export interface ServerAttestPin {
 /**
  * weikeng2.bitcoinpir.org — VPSBG Tier 3 Payment V1 beta UKI, pinned
  * 2026-08-12 after separating the legacy V1 and native V2 proof slots. Image
- * 259 serves DPF, Harmony-query and TEE ORAM with the reviewed epoch-7 policy.
+ * 261 serves DPF, Harmony-query and TEE ORAM with the reviewed epoch-8 policy.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // Captured from image 259 after validating the AMD chain, REPORT_DATA,
+  // Captured from image 261 after validating the AMD chain, REPORT_DATA,
   // exact unified_server binary and both attested database manifest roots.
   measurementHex:
-    'a8191c82a62b2ffdfe6d6deafaef16dda150f0b87810cf1c6526677c224450ef5e779fbad041cc4e41147a14697ddfbd',
+    'b8b9e724b244a52a2f87dfcde3edb895cbf5eec1c9b08f964eaefc8160c8be4988c7814fe424cbbd3158ff2e7928db53',
   binarySha256Hex:
     '8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355',
-  description: 'weikeng2.bitcoinpir.org (VPSBG image 259, SEV-SNP, Tier 3 DPF + Harmony + Direct ORAM, epoch-7)',
+  description: 'weikeng2.bitcoinpir.org (VPSBG image 261, SEV-SNP, Tier 3 DPF + Harmony + Direct ORAM, epoch-8)',
 };
 
 /**

--- a/web/src/functional-beta-trusted-bootstrap.json
+++ b/web/src/functional-beta-trusted-bootstrap.json
@@ -69,7 +69,7 @@
       "stableServerId": "pir2-vpsbg-dpf-v1",
       "serverPin": {
         "binarySha256Hex": "8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355",
-        "measurementHex": "a8191c82a62b2ffdfe6d6deafaef16dda150f0b87810cf1c6526677c224450ef5e779fbad041cc4e41147a14697ddfbd"
+        "measurementHex": "b8b9e724b244a52a2f87dfcde3edb895cbf5eec1c9b08f964eaefc8160c8be4988c7814fe424cbbd3158ff2e7928db53"
       },
       "hardwareAttestation": "required",
       "expectedArkFingerprintHex": "1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a",


### PR DESCRIPTION
## Summary
- pin VPSBG image 261 and its verified SEV-SNP measurement
- keep the functional-beta bootstrap pin in sync
- document that the Harmony response budget is cumulative and production uses 128 MiB

## Production evidence
- AMD ARK/ASK/VCEK chain, REPORT_DATA, binary, measurement, and both manifest roots verified
- encrypted channel passed
- exact full strict Harmony production query passed in 27.12s

## Local checks
- focused bootstrap and proof-registry tests: 5 passed
- Web typecheck/build passed
- deployment template gate: 30 passed
- CSP verification and diff check passed