### PR TITLE
Split Onion and ORAM proof producer pins

### DIFF
--- a/crates/sdk/client/tests/common/mod.rs
+++ b/crates/sdk/client/tests/common/mod.rs
@@ -109,10 +109,10 @@ pub fn production_db0_onion_v2_proof_policy() -> DatabaseProofPolicy {
         "a600f33fa0e644aab533a050eabf9c03882aa00f1b293ddf9d7f4bf7c8142563",
     ));
     policy.allowed_builder_binary_sha256 = vec![decode_hex_array(
-        "cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f",
+        "1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c",
     )];
     policy.allowed_builder_git_commits =
-        vec!["8d9d21a6be560236cb666269cf1f93a3de53bb1f".to_owned()];
+        vec!["d49a199e290ccbb05b6481c5ba691cb516aa76bb".to_owned()];
     policy
 }
 

--- a/crates/sdk/client/tests/integration_test.rs
+++ b/crates/sdk/client/tests/integration_test.rs
@@ -161,8 +161,8 @@ fn production_onion_v2_pin(mut pin: ProductionDatabasePin) -> ProductionDatabase
         id => panic!("no production OnionPIR v2 pin for db {id}"),
     };
     pin.builder_binary_sha256_hex =
-        "cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f";
-    pin.builder_git_commit = "8d9d21a6be560236cb666269cf1f93a3de53bb1f";
+        "1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c";
+    pin.builder_git_commit = "d49a199e290ccbb05b6481c5ba691cb516aa76bb";
     pin
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-0w7YjVZghOpfY94aY/B7EWr1yo/4P3uiYRVia4hzajE=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-tmZneQSAFslgwVqYZIJvzMdgjthIbWI+Q2YdKzx2424=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
     <title>Bitcoin PIR</title>
     <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>
@@ -1674,7 +1674,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
     </section>
 
     <script type="module">
-        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, PRODUCTION_ONION_DB_PROOF_V2_PINS, DELTA_940611_948454_DB_PROOF_PIN, MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN, databaseProofAnchorLabel, databaseProofAnchorPoints, mempoolSpaceBlockUrl, verifyProductionTrustChain, verifyOramSourceProof, AdmissionCredentialVaultV1, DirectoryRollbackVaultV1, DirectoryRefreshIntentGuardV1, ProviderAdmissionSessionV1, ProductAdmissionControllerV1, ProductAdmissionPanelV1, assertIndependentProviderDialPairV1, assertSelectableDirectoryCatalogFreshV1, parseProductTrustedBootstrapV1, manualProviderAdmissionTrustAnchorV1, directoryBoundProviderTrustAnchorV1, providerArkFingerprintV1, providerLightningPayeeTrustV1, providerOperatorKeyV1, defaultProviderIdsForAdmissionRoutesV1, refreshNostrDirectoryV1, directoryRefreshFailureStateV1, publicAdmissionError, renderSecurityBadgeTextRowsV1, prepareQueryInspectorRenderDataV1, requireVerifiedQueryResultsV1, resourceBindingToHarmonyHintCacheBindingV1 } from './src/index.ts';
+        import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, PRODUCTION_ONION_DB_PROOF_V2_PINS, PRODUCTION_ORAM_DB_PROOF_V2_PINS, DELTA_940611_948454_DB_PROOF_PIN, MAINNET_948454_ORAM_SOURCE_DB_PROOF_PIN, databaseProofAnchorLabel, databaseProofAnchorPoints, mempoolSpaceBlockUrl, verifyProductionTrustChain, verifyOramSourceProof, AdmissionCredentialVaultV1, DirectoryRollbackVaultV1, DirectoryRefreshIntentGuardV1, ProviderAdmissionSessionV1, ProductAdmissionControllerV1, ProductAdmissionPanelV1, assertIndependentProviderDialPairV1, assertSelectableDirectoryCatalogFreshV1, parseProductTrustedBootstrapV1, manualProviderAdmissionTrustAnchorV1, directoryBoundProviderTrustAnchorV1, providerArkFingerprintV1, providerLightningPayeeTrustV1, providerOperatorKeyV1, defaultProviderIdsForAdmissionRoutesV1, refreshNostrDirectoryV1, directoryRefreshFailureStateV1, publicAdmissionError, renderSecurityBadgeTextRowsV1, prepareQueryInspectorRenderDataV1, requireVerifiedQueryResultsV1, resourceBindingToHarmonyHintCacheBindingV1 } from './src/index.ts';
         import FUNCTIONAL_BETA_TRUSTED_BOOTSTRAP from './src/functional-beta-trusted-bootstrap.json';
         window.__bitcoinPirPrepareQueryInspectorRenderDataV1 = prepareQueryInspectorRenderDataV1;
         // Initialize SDK WASM (optional - falls back to TS if unavailable)
@@ -2982,7 +2982,12 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             el.innerHTML = rows.join('');
         }
 
-        async function verifyAndRenderBitcoinAnchorBadge(idElem, label, dbInfo) {
+        async function verifyAndRenderBitcoinAnchorBadge(
+            idElem,
+            label,
+            dbInfo,
+            v2PinSet = PRODUCTION_ONION_DB_PROOF_V2_PINS,
+        ) {
             if (!dbInfo || dbInfo.state !== 'verified' || !dbInfo.proof) {
                 renderBitcoinAnchorBadge(idElem, label, {
                     state: 'unavailable',
@@ -3027,7 +3032,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             });
 
             const expectedPinSet = dbInfo.proof.proofVersion === 2
-                ? PRODUCTION_ONION_DB_PROOF_V2_PINS
+                ? v2PinSet
                 : PRODUCTION_DB_PROOF_PINS;
             const expectedPin = expectedPinSet.find(pin => pin.dbId === dbInfo.proof.dbId);
             if (!expectedPin) {
@@ -6113,7 +6118,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     expectedServerId: provider.stableServerId,
                     pinnedOperatorPubkey: providerOperatorKeyV1(provider),
                     verifyOperatorIdentity: true,
-                    databaseProofPins: PRODUCTION_ONION_DB_PROOF_V2_PINS,
+                    databaseProofPins: PRODUCTION_ORAM_DB_PROOF_V2_PINS,
                     batchPlanner: {
                         accessBudget: 75,
                         indexReadsPerScriptHash: 2,
@@ -6147,7 +6152,12 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                                 error: info.error || 'live db 0 proof was not verified',
                             });
                         }
-                        verifyAndRenderBitcoinAnchorBadge('oram-bitcoinAnchorBadge', 'ORAM TEE', info)
+                        verifyAndRenderBitcoinAnchorBadge(
+                            'oram-bitcoinAnchorBadge',
+                            'ORAM TEE',
+                            info,
+                            PRODUCTION_ORAM_DB_PROOF_V2_PINS,
+                        )
                             .catch(e => log(`ORAM Bitcoin/MuHash anchor check failed: ${e?.message || e}`, 'error'));
                     },
                     onAttestation: (info) => {

--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -72,7 +72,8 @@ describe('bundled functional-beta trusted bootstrap', () => {
     expect(end).toBeGreaterThan(start);
 
     const oramConnect = html.slice(start, end);
-    expect(oramConnect).toContain('databaseProofPins: PRODUCTION_ONION_DB_PROOF_V2_PINS');
+    expect(oramConnect).toContain('databaseProofPins: PRODUCTION_ORAM_DB_PROOF_V2_PINS');
+    expect(oramConnect).not.toContain('databaseProofPins: PRODUCTION_ONION_DB_PROOF_V2_PINS');
     expect(oramConnect).not.toContain('databaseProofPins: provider.databaseProofPins');
   });
 });

--- a/web/src/__tests__/proof-registry-lock.test.ts
+++ b/web/src/__tests__/proof-registry-lock.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-import { PRODUCTION_ONION_DB_PROOF_V2_PINS } from '../attest-pin.js';
+import {
+  PRODUCTION_ONION_DB_PROOF_V2_PINS,
+  PRODUCTION_ORAM_DB_PROOF_V2_PINS,
+} from '../attest-pin.js';
 
 interface GeneratedProofLock {
   registry: { commit: string };
@@ -16,18 +19,33 @@ const lock = JSON.parse(
 ) as GeneratedProofLock;
 
 describe('generated proof registry lock', () => {
-  it('pins an immutable registry commit and exactly matches the Onion v2 frontend pins', () => {
+  it('pins an immutable registry commit and exactly matches the ORAM v2 frontend pins', () => {
     expect(lock.registry.commit).toMatch(/^[0-9a-f]{40}$/);
     expect(lock.bundles.map((bundle) => bundle.dbId)).toEqual([0, 1]);
-    expect(PRODUCTION_ONION_DB_PROOF_V2_PINS).toHaveLength(lock.bundles.length);
+    expect(PRODUCTION_ORAM_DB_PROOF_V2_PINS).toHaveLength(lock.bundles.length);
 
     for (const bundle of lock.bundles) {
-      const pin = PRODUCTION_ONION_DB_PROOF_V2_PINS.find(({ dbId }) => dbId === bundle.dbId);
+      const pin = PRODUCTION_ORAM_DB_PROOF_V2_PINS.find(({ dbId }) => dbId === bundle.dbId);
       expect(pin).toBeDefined();
       for (const [field, expected] of Object.entries(bundle.proofFields)) {
         expect((pin as unknown as Record<string, unknown>)[field], `db ${bundle.dbId} ${field}`)
           .toBe(expected);
       }
     }
+  });
+
+  it('keeps the Hetzner Onion and VPSBG ORAM proof producers distinct', () => {
+    expect(PRODUCTION_ONION_DB_PROOF_V2_PINS.map((pin) => pin.builderBinarySha256Hex))
+      .toEqual(Array(2).fill(
+        '1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c',
+      ));
+    expect(PRODUCTION_ORAM_DB_PROOF_V2_PINS.map((pin) => pin.builderBinarySha256Hex))
+      .toEqual(Array(2).fill(
+        'cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f',
+      ));
+    expect(PRODUCTION_ONION_DB_PROOF_V2_PINS.map((pin) => pin.builderGitCommit))
+      .toEqual(Array(2).fill('d49a199e290ccbb05b6481c5ba691cb516aa76bb'));
+    expect(PRODUCTION_ORAM_DB_PROOF_V2_PINS.map((pin) => pin.builderGitCommit))
+      .toEqual(Array(2).fill('8d9d21a6be560236cb666269cf1f93a3de53bb1f'));
   });
 });

--- a/web/src/__tests__/trust-chain-proof.test.ts
+++ b/web/src/__tests__/trust-chain-proof.test.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
 import {
   DELTA_940611_948454_DB_PROOF_PIN,
-  PRODUCTION_ONION_DB_PROOF_V2_PINS,
+  PRODUCTION_ORAM_DB_PROOF_V2_PINS,
 } from '../attest-pin.js';
 import {
   DEFAULT_TRUST_CHAIN_MANIFEST_PATH,
@@ -96,7 +96,7 @@ describe('database trust-chain proof', () => {
   });
 
   it('bridges the historical trust-chain manifest to a fully pinned v2 proof', async () => {
-    const v2Pin = PRODUCTION_ONION_DB_PROOF_V2_PINS.find(({ dbId }) => dbId === 1);
+    const v2Pin = PRODUCTION_ORAM_DB_PROOF_V2_PINS.find(({ dbId }) => dbId === 1);
     expect(v2Pin).toBeDefined();
 
     const status = await verifyProductionTrustChain({

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -231,9 +231,9 @@ export const PRODUCTION_DB_PROOF_PINS: DatabaseProofPin[] = [
   DELTA_940611_948454_DB_PROOF_PIN,
 ];
 
-/** Strict v2 pins for OnionPIR and Direct ORAM. Unlike the v1 pins above
+/** Strict v2 pins for the Hetzner OnionPIR service. Unlike the v1 pins above
  * (retained for DPF/Harmony compatibility), these bind the complete typed
- * Onion query layout and the native full-build producer. */
+ * Onion query layout and the reviewed re-attestation producer. */
 export const PRODUCTION_ONION_DB_PROOF_V2_PINS: DatabaseProofPin[] = [
   {
     dbId: 0,
@@ -247,8 +247,8 @@ export const PRODUCTION_ONION_DB_PROOF_V2_PINS: DatabaseProofPin[] = [
     onionSuperRootHex: MAINNET_948454_DB_PROOF_PIN.onionSuperRootHex,
     paramsHashHex: 'a600f33fa0e644aab533a050eabf9c03882aa00f1b293ddf9d7f4bf7c8142563',
     networkMagicHex: 'f9beb4d9',
-    builderBinarySha256Hex: 'cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f',
-    builderGitCommit: '8d9d21a6be560236cb666269cf1f93a3de53bb1f',
+    builderBinarySha256Hex: '1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c',
+    builderGitCommit: 'd49a199e290ccbb05b6481c5ba691cb516aa76bb',
     onionEntrySize: 3_328,
     proofVersion: 2,
     onionTotalPackedEntries: 948_640,
@@ -271,8 +271,8 @@ export const PRODUCTION_ONION_DB_PROOF_V2_PINS: DatabaseProofPin[] = [
     onionSuperRootHex: DELTA_940611_948454_DB_PROOF_PIN.onionSuperRootHex,
     paramsHashHex: 'fe6f516696bafaa2226cc1bdc7888c7c69dd263a84817dd0f18cf8027123c45d',
     networkMagicHex: 'f9beb4d9',
-    builderBinarySha256Hex: 'cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f',
-    builderGitCommit: '8d9d21a6be560236cb666269cf1f93a3de53bb1f',
+    builderBinarySha256Hex: '1150d6a2d746398d9046e677e1f0d36f4c4ccb3c390265ea8cf14d7c1f23671c',
+    builderGitCommit: 'd49a199e290ccbb05b6481c5ba691cb516aa76bb',
     onionEntrySize: 3_328,
     proofVersion: 2,
     onionTotalPackedEntries: 116_030,
@@ -283,6 +283,17 @@ export const PRODUCTION_ONION_DB_PROOF_V2_PINS: DatabaseProofPin[] = [
     description: 'delta_940611_948454 database proof v2 with complete OnionPIR layout binding',
   },
 ];
+
+/** Strict v2 pins for the VPSBG Direct ORAM service. The layout and database
+ * roots match the Onion service, while the native full-build producer is
+ * independently bound to the proof-registry lock. */
+export const PRODUCTION_ORAM_DB_PROOF_V2_PINS: DatabaseProofPin[] =
+  PRODUCTION_ONION_DB_PROOF_V2_PINS.map((pin) => ({
+    ...pin,
+    builderBinarySha256Hex: 'cf973a833f9b892743e451da4c2937c82865b12d8901c48ac4483b5e0696ba6f',
+    builderGitCommit: '8d9d21a6be560236cb666269cf1f93a3de53bb1f',
+    description: `${pin.description}; VPSBG native full-build producer`,
+  }));
 
 /**
  * Operator identity pin (Tier-1) for the REQ_ANNOUNCE operator-signed

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -132,6 +132,7 @@ export {
   PIR2_TIER3_PIN,
   PRODUCTION_DB_PROOF_PINS,
   PRODUCTION_ONION_DB_PROOF_V2_PINS,
+  PRODUCTION_ORAM_DB_PROOF_V2_PINS,
   type ServerAttestPin,
 } from './attest-pin.js';
 


### PR DESCRIPTION
## What changed

- restore the reviewed Hetzner Onion V2 proof producer pins
- keep VPSBG Direct ORAM on the native full-build proof-registry pins
- route each Web client and trust-chain check through its own pin set
- add regression coverage that prevents the two producer identities from being conflated again

## Root cause

The Direct ORAM rollout reused the Onion pin collection and replaced its producer identity with the VPSBG native builder. The database roots and V2 layout are shared, but the live Hetzner Onion proof was produced by the separately reviewed re-attestation builder, so strict verification correctly rejected it.

## Validation

- Web unit suite: 527 passed, 2 skipped
- Web production build and CSP verification passed
- Rust integration test target compiled with onion and fastprp features
- live native Onion check passed both database-proof installs and tree-top preflight; its later sync was reset by the service and is outside this producer-pin fix
- git diff check passed