### PR TITLE
Scope canary failures to individual log entries

### DIFF
--- a/web/e2e/strict-production.spec.ts
+++ b/web/e2e/strict-production.spec.ts
@@ -63,9 +63,9 @@ async function expectLogContains(page: Page, ...messages: string[]): Promise<voi
 }
 
 async function expectNoFatalLog(page: Page): Promise<void> {
-  const fatal = page.locator('#log').getByText(
-    /(?:UNVERIFIED|chain validation failed|DB proof .* unavailable|ORAM source-binding proof check failed|WASM module required|query error:|batch error:|(?:connection|connect) failed:)/i,
-  );
+  const fatalPattern =
+    /(?:UNVERIFIED|chain validation failed|DB proof .* unavailable|ORAM source-binding proof check failed|WASM module required|query error:|batch error:|(?:connection|connect) failed:)/i;
+  const fatal = page.locator('#log .log-entry').filter({ hasText: fatalPattern });
   await expect(fatal).toHaveCount(0);
 }
 

--- a/web/scripts/verify-production-canary-readiness.mjs
+++ b/web/scripts/verify-production-canary-readiness.mjs
@@ -47,4 +47,17 @@ if (!/locator\('#bitcoinPirApp'\)[\s\S]*data-module-readiness', 'ready'[\s\S]*ar
   throw new Error('openBackend must wait for the explicit interaction-ready state');
 }
 
-process.stdout.write('verified strict production canary waits for post-listener module readiness\n');
+const noFatalLog = strictCanary.match(
+  /async function expectNoFatalLog[\s\S]*?\n}\n\n(?:test|async function)/,
+)?.[0];
+if (!noFatalLog) throw new Error('strict production canary has no expectNoFatalLog helper');
+if (!/locator\('#log \.log-entry'\)\.filter\(\{ hasText: fatalPattern \}\)/.test(noFatalLog)) {
+  throw new Error('fatal canary matching must stay scoped to individual log entries');
+}
+if (/locator\('#log'\)\.getByText/.test(noFatalLog)) {
+  throw new Error('fatal canary matching must not aggregate text across the log container');
+}
+
+process.stdout.write(
+  'verified strict production canary readiness and line-scoped fatal log matching\n',
+);


### PR DESCRIPTION
## What changed

- match fatal production-canary messages only within individual log entries
- preserve the complete existing fatal-pattern vocabulary
- add a browserless policy check that rejects parent-container text aggregation

## Root cause

The ORAM production query succeeded, including strict database proofs, encrypted transport, a verified 1,600 sat result, and disconnect. The canary still failed because its locator applied DB proof .* unavailable to the entire log container. Playwright normalized text across child entries, joining a successful DB-proof line to the separate informational source-proof 404 line and creating a false match.

The optional ORAM source artifact remains explicitly unavailable as documented; this change does not call it verified and does not weaken any product verifier.

## Validation

- Web unit suite: 527 passed, 2 skipped
- TypeScript no-emit check passed
- strict production Playwright list contains all four backend tests
- browserless canary policy check passed
- git diff check passed
- production canary run 31546531066: DPF, Harmony and Onion passed; ORAM completed the query and failed only on the cross-entry matcher