### PR TITLE
Pin the production ORAM canary identity

### DIFF
--- a/web/e2e/strict-production.spec.ts
+++ b/web/e2e/strict-production.spec.ts
@@ -128,7 +128,7 @@ test('ORAM TEE verifies the runtime, completes a lookup, and disconnects', async
   await expectLogContains(
     page,
     'ORAM upgraded to encrypted channel',
-    'ORAM: operator-endorsed identity verified (pir2)',
+    'ORAM: operator-endorsed identity verified (pir2-vpsbg-dpf-v1)',
     'ORAM batch complete: 1/1 found',
   );
   await expectTornDown(page, '#oram-connectBtn', '#oram-disconnectBtn');


### PR DESCRIPTION
## What changed

Update the strict ORAM production canary to require the complete reviewed server identity pir2-vpsbg-dpf-v1.

## Why

Production canary run 31547765387 reached the final ORAM identity assertion after all four real queries. The assertion still expected the obsolete abbreviated value pir2. Because the expected string included the closing parenthesis, it was not a substring of the current complete identity and would wait for the ten-minute assertion timeout. The run was cancelled at the four-minute diagnostic checkpoint instead of waiting blindly.

This is test-only. It does not change the production Web bundle, UKI, server, proof verification, or fatal-log vocabulary.

## Validation

- production canary readiness policy passed
- TypeScript no-emit check passed
- Playwright lists all four strict production tests
- git diff check passed
- prior canary evidence already records the exact current identity and a successful ORAM query result