### PR TITLE
Simplify Payment CI and local checks

### DIFF
--- a/.github/workflows/directory-relay-artifact.yml
+++ b/.github/workflows/directory-relay-artifact.yml
@@ -1,0 +1,106 @@
+name: Directory relay selection artifact
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'rust-toolchain.toml'
+      - '.cargo/**'
+      - 'vendor/**'
+      - 'apps/directory-relay/**'
+      - 'crates/directory/nostr/**'
+      - 'crates/protocol/service/**'
+      - 'crates/security/private-files/**'
+      - 'deploy/payment-v1/relay-selection.toml.example'
+      - 'deploy/payment-v1/directory-relay.toml.example'
+      - 'scripts/build-payment-v1-directory-relay.sh'
+      - 'scripts/payment-v1-renameat2-noreplace.rs'
+      - 'scripts/payment-v1-directory-relay-artifact-gate.mjs'
+      - 'scripts/payment-v1-directory-relay-artifact-gate.test.mjs'
+      - 'scripts/payment-v1-deployment-template-gate.mjs'
+      - '.github/workflows/directory-relay-artifact.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'rust-toolchain.toml'
+      - '.cargo/**'
+      - 'vendor/**'
+      - 'apps/directory-relay/**'
+      - 'crates/directory/nostr/**'
+      - 'crates/protocol/service/**'
+      - 'crates/security/private-files/**'
+      - 'deploy/payment-v1/relay-selection.toml.example'
+      - 'deploy/payment-v1/directory-relay.toml.example'
+      - 'scripts/build-payment-v1-directory-relay.sh'
+      - 'scripts/payment-v1-renameat2-noreplace.rs'
+      - 'scripts/payment-v1-directory-relay-artifact-gate.mjs'
+      - 'scripts/payment-v1-directory-relay-artifact-gate.test.mjs'
+      - 'scripts/payment-v1-deployment-template-gate.mjs'
+      - '.github/workflows/directory-relay-artifact.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  directory-relay-artifact:
+    name: Reproduce directory-relay selection artifact
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24.18.0'
+      - name: Pull the exact reviewed build image
+        run: >-
+          docker pull
+          docker.io/library/rust@sha256:4ec71e955e6c08aeb238885083222ddff79d82eb87654a96c76e38e94da1a53b
+      - name: Build, atomically publish, and fully reverify the preparation artifact
+        run: |
+          mapfile -t bpir_relay_selection < <(
+            node --input-type=module <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { validateRelaySelection } from "./scripts/payment-v1-deployment-template-gate.mjs";
+          const selection = validateRelaySelection(
+            readFileSync("deploy/payment-v1/relay-selection.toml.example", "utf8"),
+          );
+          console.log(selection.status);
+          console.log(selection.status === "RESOLVED" ? selection.sourceCommit : "");
+          NODE
+          )
+          bpir_selection_status="${bpir_relay_selection[0]}"
+          if [[ "$bpir_selection_status" == "RESOLVED" ]]; then
+            bpir_source_commit="${bpir_relay_selection[1]}"
+          elif [[ "$bpir_selection_status" == "UNRESOLVED" ]]; then
+            bpir_source_commit="$(git rev-parse HEAD)"
+          else
+            echo 'directory relay selection parser returned an impossible status' >&2
+            exit 1
+          fi
+          test "$(git rev-parse --verify "$bpir_source_commit^{commit}")" = "$bpir_source_commit"
+          bpir_artifact_parent="$(mktemp -d "${RUNNER_TEMP}/bpir-directory-relay-build.XXXXXX")"
+          bash scripts/build-payment-v1-directory-relay.sh \
+            --repository "$GITHUB_WORKSPACE" \
+            --source-commit "$bpir_source_commit" \
+            --output "$bpir_artifact_parent/artifact"
+          test -f "$bpir_artifact_parent/artifact/build-manifest.json"
+          test -x "$bpir_artifact_parent/artifact/bitcoinpir-directory-relay"
+          if [[ "$bpir_selection_status" == "RESOLVED" ]]; then
+            node scripts/payment-v1-directory-relay-artifact-gate.mjs verify-selection \
+              --repository "$GITHUB_WORKSPACE" \
+              --artifacts "$bpir_artifact_parent/artifact" \
+              --source-commit "$bpir_source_commit" \
+              --docker "$(command -v docker)" \
+              --selection "$GITHUB_WORKSPACE/deploy/payment-v1/relay-selection.toml.example" \
+              --config "$GITHUB_WORKSPACE/deploy/payment-v1/directory-relay.toml.example"
+          fi

--- a/.github/workflows/payment-platform.yml
+++ b/.github/workflows/payment-platform.yml
@@ -28,14 +28,10 @@ on:
       - 'crates/sdk/wasm/**'
       - 'crates/security/**'
       - 'crates/trust/**'
-      - 'docs/payment/**'
       - 'deploy/payment-v1/**'
       - 'scripts/fixtures/**'
       - 'scripts/payment-v1-deployment-template-gate.mjs'
       - 'scripts/payment-v1-deployment-template-gate.test.mjs'
-      - 'scripts/build-payment-v1-directory-relay.sh'
-      - 'scripts/payment-v1-directory-relay-artifact-gate.mjs'
-      - 'scripts/payment-v1-directory-relay-artifact-gate.test.mjs'
       - 'scripts/payment-v1-renameat2-noreplace.rs'
       - 'scripts/payment-v1-rendered-artifact-gate.mjs'
       - 'scripts/payment-v1-rendered-artifact-gate.test.mjs'
@@ -56,8 +52,7 @@ on:
       - 'scripts/payment-v1-publisher-*'
       - 'scripts/payment-v1-directory-publisher-*'
       - 'scripts/payment-v1-systemd-255-*'
-      - 'web/**'
-      - '.github/workflows/**'
+      - '.github/workflows/payment-platform.yml'
   pull_request:
     branches: [main]
     paths:
@@ -85,14 +80,10 @@ on:
       - 'crates/sdk/wasm/**'
       - 'crates/security/**'
       - 'crates/trust/**'
-      - 'docs/payment/**'
       - 'deploy/payment-v1/**'
       - 'scripts/fixtures/**'
       - 'scripts/payment-v1-deployment-template-gate.mjs'
       - 'scripts/payment-v1-deployment-template-gate.test.mjs'
-      - 'scripts/build-payment-v1-directory-relay.sh'
-      - 'scripts/payment-v1-directory-relay-artifact-gate.mjs'
-      - 'scripts/payment-v1-directory-relay-artifact-gate.test.mjs'
       - 'scripts/payment-v1-renameat2-noreplace.rs'
       - 'scripts/payment-v1-rendered-artifact-gate.mjs'
       - 'scripts/payment-v1-rendered-artifact-gate.test.mjs'
@@ -113,8 +104,7 @@ on:
       - 'scripts/payment-v1-publisher-*'
       - 'scripts/payment-v1-directory-publisher-*'
       - 'scripts/payment-v1-systemd-255-*'
-      - 'web/**'
-      - '.github/workflows/**'
+      - '.github/workflows/payment-platform.yml'
   workflow_dispatch:
     inputs:
       run_browser_checks:
@@ -209,64 +199,6 @@ jobs:
           rustup target add wasm32-unknown-unknown
       - name: Check WASM without native provider storage
         run: cargo check --locked --offline --target wasm32-unknown-unknown -p pir-sdk-wasm
-
-  directory-relay-artifact:
-    name: Reproduce directory-relay selection artifact
-    runs-on: ubuntu-24.04
-    timeout-minutes: 90
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: '24.18.0'
-      - name: Pull the exact reviewed build image
-        run: >-
-          docker pull
-          docker.io/library/rust@sha256:4ec71e955e6c08aeb238885083222ddff79d82eb87654a96c76e38e94da1a53b
-      - name: Build, atomically publish, and fully reverify the preparation artifact
-        run: |
-          mapfile -t bpir_relay_selection < <(
-            node --input-type=module <<'NODE'
-          import { readFileSync } from "node:fs";
-          import { validateRelaySelection } from "./scripts/payment-v1-deployment-template-gate.mjs";
-          const selection = validateRelaySelection(
-            readFileSync("deploy/payment-v1/relay-selection.toml.example", "utf8"),
-          );
-          console.log(selection.status);
-          console.log(selection.status === "RESOLVED" ? selection.sourceCommit : "");
-          NODE
-          )
-          bpir_selection_status="${bpir_relay_selection[0]}"
-          if [[ "$bpir_selection_status" == "RESOLVED" ]]; then
-            bpir_source_commit="${bpir_relay_selection[1]}"
-          elif [[ "$bpir_selection_status" == "UNRESOLVED" ]]; then
-            bpir_source_commit="$(git rev-parse HEAD)"
-          else
-            echo 'directory relay selection parser returned an impossible status' >&2
-            exit 1
-          fi
-          test "$(git rev-parse --verify "$bpir_source_commit^{commit}")" = "$bpir_source_commit"
-          bpir_artifact_parent="$(mktemp -d "${RUNNER_TEMP}/bpir-directory-relay-build.XXXXXX")"
-          bash scripts/build-payment-v1-directory-relay.sh \
-            --repository "$GITHUB_WORKSPACE" \
-            --source-commit "$bpir_source_commit" \
-            --output "$bpir_artifact_parent/artifact"
-          test -f "$bpir_artifact_parent/artifact/build-manifest.json"
-          test -x "$bpir_artifact_parent/artifact/bitcoinpir-directory-relay"
-          if [[ "$bpir_selection_status" == "RESOLVED" ]]; then
-            node scripts/payment-v1-directory-relay-artifact-gate.mjs verify-selection \
-              --repository "$GITHUB_WORKSPACE" \
-              --artifacts "$bpir_artifact_parent/artifact" \
-              --source-commit "$bpir_source_commit" \
-              --docker "$(command -v docker)" \
-              --selection "$GITHUB_WORKSPACE/deploy/payment-v1/relay-selection.toml.example" \
-              --config "$GITHUB_WORKSPACE/deploy/payment-v1/directory-relay.toml.example"
-          fi
 
   browser-storage-boundary:
     name: Chromium vault and real no-funds issuer boundaries

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -6,19 +6,23 @@ Use the repository-owned payment check as the default local and agent entry:
 scripts/payment-v1-local-check.sh
 ```
 
-It is the `--quick` profile: locked/offline, no browser, no external network,
-and no privileged environment. It is the only profile agents should run by
-default.
+It is the `--quick` profile: one focused locked/offline service-admission test,
+no browser, no external network, and no privileged environment. It is the only
+profile agents should run by default.
 
 ```text
---quick    Default focused deterministic checks; no browser.
---pr       Quick plus deterministic offline Rust, process, WASM, Web typecheck,
-           Web unit tests, and production bundle; no Playwright/Chromium.
+--quick    Default focused service-admission check; no browser or deployment audit.
+--pr       Deterministic offline Rust, process, WASM, Web typecheck, Web unit
+           tests, and production bundle; it does not first run --quick.
+--deploy-template-audit
+           Explicit static deployment/template, renderer, runtime-evidence,
+           publisher, namespace, Caddy, and relay-gate audit; no deployment.
 --browser  Explicit opt-in: --pr plus local headless Chromium payment checks.
 --full     Explicit compatibility alias for --browser.
 ```
 
-Run `--browser` or `--full` only when browser coverage is explicitly requested.
+Run `--deploy-template-audit` only while changing or preparing a Payment
+deployment template. Run `--browser` or `--full` only when browser coverage is explicitly requested.
 AI manual browser inspection also requires an explicit user request. Automatic
 headless browser checks belong only to an explicit browser profile, nightly, or
 release validation.

--- a/docs/payment/LOCAL_ACCEPTANCE.md
+++ b/docs/payment/LOCAL_ACCEPTANCE.md
@@ -60,8 +60,9 @@ local acceptance into deployment approval.
   shell used for this check.
 
 The acceptance script forces Cargo offline and does not edit source. Quick mode
-starts no persistent service process, although focused unit tests briefly bind
-loopback TCP or Unix-domain listeners. The `--pr` profile starts temporary
+runs only the focused service-admission matrix and starts no persistent service
+process, although that unit test may briefly bind loopback TCP or Unix-domain
+listeners. The `--pr` profile does not first rerun quick mode; it starts temporary
 `unified_server` children, a fake `payment-issuer` and Vite test servers whose
 listeners are explicitly bound to `127.0.0.1`; only browser profiles start
 Playwright/Chromium. The runners kill and wait for every child before returning.
@@ -79,6 +80,14 @@ tests and bundle; still no Playwright/Chromium):
 
 ```sh
 scripts/payment-v1-local-check.sh --pr
+```
+
+Deployment/template renderer, runtime-evidence, publisher, namespace, Caddy and
+directory-relay static audits are deliberately separate from both default and
+PR checks:
+
+```sh
+scripts/payment-v1-local-check.sh --deploy-template-audit
 ```
 
 The explicit browser profile remains `scripts/payment-v1-local-check.sh --browser`;

--- a/scripts/payment-v1-directory-relay-artifact-gate.test.mjs
+++ b/scripts/payment-v1-directory-relay-artifact-gate.test.mjs
@@ -305,7 +305,7 @@ test("build recipe is pinned, offline, canonical, and invokes exactly two clean 
 
 test("CI rebuilds the selected source commit and fully verifies resolved selection", () => {
   const workflow = readFileSync(
-    join(SCRIPT_DIRECTORY, "..", ".github", "workflows", "payment-platform.yml"),
+    join(SCRIPT_DIRECTORY, "..", ".github", "workflows", "directory-relay-artifact.yml"),
     "utf8",
   );
   assert.match(workflow, /directory-relay-artifact:[\s\S]*?fetch-depth: 0/u);
@@ -321,6 +321,35 @@ test("CI rebuilds the selected source commit and fully verifies resolved selecti
     workflow,
     /if \[\[ "\$bpir_selection_status" == "RESOLVED" \]\]; then\s+bpir_source_commit="\$\{bpir_relay_selection\[1\]\}"/u,
   );
+});
+
+test("relay rebuild is isolated to relay inputs and its own workflow", () => {
+  const relayWorkflow = readFileSync(
+    join(SCRIPT_DIRECTORY, "..", ".github", "workflows", "directory-relay-artifact.yml"),
+    "utf8",
+  );
+  const paymentWorkflow = readFileSync(
+    join(SCRIPT_DIRECTORY, "..", ".github", "workflows", "payment-platform.yml"),
+    "utf8",
+  );
+  assert.match(relayWorkflow, /workflow_dispatch:/u);
+  for (const requiredPath of [
+    "apps/directory-relay/**",
+    "crates/protocol/service/**",
+    "crates/security/private-files/**",
+    "deploy/payment-v1/relay-selection.toml.example",
+    "scripts/build-payment-v1-directory-relay.sh",
+    "scripts/payment-v1-renameat2-noreplace.rs",
+    "scripts/payment-v1-directory-relay-artifact-gate.mjs",
+  ]) {
+    assert.match(relayWorkflow, new RegExp(requiredPath.replaceAll("*", "\\\\*"), "u"));
+  }
+  assert.doesNotMatch(relayWorkflow, /web\/\*\*/u);
+  assert.doesNotMatch(relayWorkflow, /docs\/payment\/\*\*/u);
+  assert.doesNotMatch(paymentWorkflow, /directory-relay-artifact:/u);
+  assert.doesNotMatch(paymentWorkflow, /\.github\/workflows\/\*\*/u);
+  assert.doesNotMatch(paymentWorkflow, /web\/\*\*/u);
+  assert.doesNotMatch(paymentWorkflow, /docs\/payment\/\*\*/u);
 });
 
 test("build recipe help executes before any environment or artifact preflight", () => {

--- a/scripts/payment-v1-local-check.sh
+++ b/scripts/payment-v1-local-check.sh
@@ -4,21 +4,22 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/payment-v1-local-check.sh [--quick|--pr|--browser|--full]
+Usage: scripts/payment-v1-local-check.sh [--quick|--pr|--deploy-template-audit|--browser|--full]
 
 Runs BitcoinPIR payment-v1 checks without contacting payment infrastructure or
 using real funds. Cargo is forced offline; `--pr` and browser profiles require
 a preinstalled `wasm-pack`/`wasm-bindgen` toolchain and refuse to bootstrap it
 from the network.
 
-  --quick  Default. Five-method × five-workload matrix plus focused persistence,
-           directory-relay, deployment-template and fake-Lightning checks.
-           It starts no service process; unit tests may briefly bind loopback
-           TCP or Unix-domain listeners.
-  --pr     Quick checks plus the deterministic offline payment-platform Rust
-           suite, operator tooling, loopback-only process E2E, WASM validation,
-           generated binding boundary, Web typecheck, Web unit tests, and Web
-           bundle. It does not install or run Playwright/Chromium.
+  --quick  Default. One focused service-admission Rust test; no deployment
+           template audit, browser, external network, or service process.
+  --pr     Deterministic offline payment-platform Rust suite, loopback-only
+           process E2E, WASM validation, Web typecheck, unit tests, and bundle.
+           It does not run --quick first, deployment-template audits, or a browser.
+  --deploy-template-audit
+           Explicit opt-in static deployment/template, renderer, runtime-evidence,
+           publisher, namespace, Caddy, and directory-relay gate audit. It does
+           not build, deploy, contact infrastructure, or run Chromium.
   --browser
            Explicit opt-in: run the --pr profile, then local Chromium payment
            boundaries. Requires preinstalled web dependencies and Chromium.
@@ -50,6 +51,7 @@ case "${1:-}" in
   "") ;;
   --quick) mode="quick" ;;
   --pr) mode="pr" ;;
+  --deploy-template-audit) mode="deploy-template-audit" ;;
   --browser) mode="browser" ;;
   --full) mode="full" ;;
   -h|--help) usage; exit 0 ;;
@@ -65,83 +67,8 @@ if [[ ! -f Cargo.toml || ! -f docs/payment/IMPLEMENTATION_STATUS.md ]]; then
 fi
 
 run_quick_checks() {
-echo "[quick] canonical five-method x five-workload admission matrix"
+echo "[quick] focused service-admission matrix"
 cargo test --locked --offline -p pir-runtime-core --test service_admission_matrix
-
-echo "[quick] real provider-store receipt/BAT adapters and durable replay boundary"
-cargo test --locked --offline -p pir-strict-https
-cargo test --locked --offline -p pir-private-files
-cargo test --locked --offline -p pir-rollback-authority-protocol
-cargo test --locked --offline -p pir-rollback-authority-client
-cargo test --locked --offline -p pir-rollback-authority-store
-cargo test --locked --offline -p rollback-authority
-cargo test --locked --offline -p pir-payment-crypto --features provider-store \
-  --test provider_store_bat_adapter
-cargo test --locked --offline -p pir-runtime-core --test service_admission_matrix \
-  direct_receipt_production_committer_spend_survives_store_restart
-
-echo "[quick] Free, standard Cashu, and experimental ARC persistence/concurrency"
-cargo test --locked --offline -p pir-service-store free_ip_rate_limit
-cargo test --locked --offline -p pir-cashu-client
-cargo test --locked --offline -p pir-cashu-custody
-cargo test --locked --offline -p pir-arc-adapter --features provider-store
-
-echo "[quick] fake-Lightning, quote/claim lifecycle, and native/WASM client boundaries"
-cargo test --locked --offline -p bitcoinpir-directory-relay
-cargo test --locked --offline -p bitcoinpir-cln-rpc-guard
-cargo test --locked --offline -p pir-lightning-backend
-cargo test --locked --offline -p pir-issuer-core
-cargo test --locked --offline -p pir-issuer-service
-cargo test --locked --offline -p payment-issuer
-cargo test --locked --offline -p payment-issuer --features test-only-fake-lightning
-cargo run --locked --offline -p payment-issuer \
-  --features test-only-fake-lightning -- serve-fake --help >/dev/null
-cargo test --locked --offline -p pir-sdk-client --all-targets
-cargo test --locked --offline -p pir-sdk-wasm --lib
-node --check scripts/payment-v1-deployment-template-gate.mjs
-node --test scripts/payment-v1-deployment-template-gate.test.mjs
-node scripts/payment-v1-deployment-template-gate.mjs
-bash -n scripts/build-payment-v1-directory-relay.sh
-bash scripts/build-payment-v1-directory-relay.sh --help >/dev/null
-node --check scripts/payment-v1-directory-relay-artifact-gate.mjs
-node --check scripts/payment-v1-directory-relay-artifact-gate.test.mjs
-node --test scripts/payment-v1-directory-relay-artifact-gate.test.mjs
-node --check scripts/payment-v1-rendered-artifact-gate.mjs
-node --check scripts/payment-v1-rendered-artifact-gate.test.mjs
-node --check scripts/payment-v1-linux-runtime-evidence.mjs
-node --check scripts/payment-v1-linux-runtime-evidence.test.mjs
-node --check scripts/payment-v1-publisher-netns-gate.mjs
-node --check scripts/payment-v1-publisher-netns-gate.test.mjs
-node --check scripts/payment-v1-publisher-netns-ceremony.mjs
-node --check scripts/payment-v1-publisher-netns-ceremony.test.mjs
-node --check scripts/payment-v1-publisher-netns-schema.test.mjs
-node --check scripts/payment-v1-publisher-private-health-probe.mjs
-node --check scripts/payment-v1-publisher-private-health-probe.test.mjs
-bash -n scripts/payment-v1-directory-publisher-oneshot-systemd.test.sh
-bash -n scripts/payment-v1-publisher-firewall-guard-systemd.test.sh
-bash -n scripts/payment-v1-publisher-netns-failed-recovery-systemd.test.sh
-bash -n scripts/payment-v1-systemd-255-pid1.test.sh
-bash -n scripts/payment-v1-publisher-netns-launcher.test.sh
-bash -n scripts/payment-v1-publisher-private-health-privileged-e2e.sh
-bash -n scripts/payment-v1-publisher-firewall-privileged-e2e.sh
-node scripts/payment-v1-publisher-netns-gate.mjs
-node --test \
-  scripts/payment-v1-publisher-netns-gate.test.mjs \
-  scripts/payment-v1-publisher-netns-ceremony.test.mjs \
-  scripts/payment-v1-publisher-netns-schema.test.mjs \
-  scripts/payment-v1-publisher-private-health-probe.test.mjs
-node --check scripts/payment-v1-directory-public-haproxy-artifact-gate.mjs
-node --check scripts/payment-v1-directory-public-haproxy-artifact-gate.test.mjs
-node --check scripts/payment-v1-directory-public-overlay-assets.test.mjs
-node --test --test-concurrency=1 \
-  scripts/payment-v1-directory-public-haproxy-artifact-gate.test.mjs \
-  scripts/payment-v1-directory-public-overlay-assets.test.mjs
-node --check scripts/payment-v1-source-fair-edge.test.mjs
-node --test --test-concurrency=1 scripts/payment-v1-source-fair-edge.test.mjs
-node --test --test-concurrency=1 \
-  scripts/payment-v1-rendered-artifact-gate.test.mjs
-node --test --test-concurrency=1 \
-  scripts/payment-v1-linux-runtime-evidence.test.mjs
 }
 
 run_pr_checks() {
@@ -175,6 +102,13 @@ cargo test --locked --offline \
   -p payment-issuer \
   -p rollback-authority \
   -p bpir-admin
+# These feature-only boundaries are not covered by the default package run above.
+cargo test --locked --offline -p pir-payment-crypto --features provider-store \
+  --test provider_store_bat_adapter
+cargo test --locked --offline -p pir-arc-adapter --features provider-store
+cargo test --locked --offline -p payment-issuer --features test-only-fake-lightning
+cargo run --locked --offline -p payment-issuer \
+  --features test-only-fake-lightning -- serve-fake --help >/dev/null
 cargo test --locked --offline -p runtime --lib hint_pool
 cargo test --locked --offline -p runtime --bin unified_server
 cargo test --locked --offline -p runtime \
@@ -408,53 +342,6 @@ fi
 node --check scripts/payment-v1-nostr-readback.mjs
 node --test scripts/payment-v1-nostr-readback.test.mjs
 node scripts/payment-v1-nostr-readback.mjs --help >/dev/null
-node --check scripts/payment-v1-pages-deploy-gate.mjs
-node scripts/payment-v1-pages-deploy-gate.mjs
-node --check scripts/payment-v1-deployment-template-gate.mjs
-node --test scripts/payment-v1-deployment-template-gate.test.mjs
-node scripts/payment-v1-deployment-template-gate.mjs
-bash -n scripts/build-payment-v1-directory-relay.sh
-bash scripts/build-payment-v1-directory-relay.sh --help >/dev/null
-node --check scripts/payment-v1-directory-relay-artifact-gate.mjs
-node --check scripts/payment-v1-directory-relay-artifact-gate.test.mjs
-node --test scripts/payment-v1-directory-relay-artifact-gate.test.mjs
-node --check scripts/payment-v1-rendered-artifact-gate.mjs
-node --check scripts/payment-v1-rendered-artifact-gate.test.mjs
-node --check scripts/payment-v1-linux-runtime-evidence.mjs
-node --check scripts/payment-v1-linux-runtime-evidence.test.mjs
-node --check scripts/payment-v1-publisher-netns-gate.mjs
-node --check scripts/payment-v1-publisher-netns-gate.test.mjs
-node --check scripts/payment-v1-publisher-netns-ceremony.mjs
-node --check scripts/payment-v1-publisher-netns-ceremony.test.mjs
-node --check scripts/payment-v1-publisher-netns-schema.test.mjs
-node --check scripts/payment-v1-publisher-private-health-probe.mjs
-node --check scripts/payment-v1-publisher-private-health-probe.test.mjs
-bash -n scripts/payment-v1-directory-publisher-oneshot-systemd.test.sh
-bash -n scripts/payment-v1-publisher-firewall-guard-systemd.test.sh
-bash -n scripts/payment-v1-publisher-netns-failed-recovery-systemd.test.sh
-bash -n scripts/payment-v1-systemd-255-pid1.test.sh
-bash -n scripts/payment-v1-publisher-netns-launcher.test.sh
-bash -n scripts/payment-v1-publisher-private-health-privileged-e2e.sh
-bash -n scripts/payment-v1-publisher-firewall-privileged-e2e.sh
-node scripts/payment-v1-publisher-netns-gate.mjs
-node --test \
-  scripts/payment-v1-publisher-netns-gate.test.mjs \
-  scripts/payment-v1-publisher-netns-ceremony.test.mjs \
-  scripts/payment-v1-publisher-netns-schema.test.mjs \
-  scripts/payment-v1-publisher-private-health-probe.test.mjs
-node --check scripts/payment-v1-directory-public-haproxy-artifact-gate.mjs
-node --check scripts/payment-v1-directory-public-haproxy-artifact-gate.test.mjs
-node --check scripts/payment-v1-directory-public-overlay-assets.test.mjs
-node --test --test-concurrency=1 \
-  scripts/payment-v1-directory-public-haproxy-artifact-gate.test.mjs \
-  scripts/payment-v1-directory-public-overlay-assets.test.mjs
-node --check scripts/payment-v1-source-fair-edge.test.mjs
-node --test --test-concurrency=1 scripts/payment-v1-source-fair-edge.test.mjs
-node --test --test-concurrency=1 \
-  scripts/payment-v1-rendered-artifact-gate.test.mjs
-node --test --test-concurrency=1 \
-  scripts/payment-v1-linux-runtime-evidence.test.mjs
-
 echo "[pr] warnings denied in dedicated Payment V1 crates and tools"
 cargo clippy --locked --offline --all-targets --no-deps \
   -p pir-strict-https \
@@ -513,6 +400,76 @@ CARGO_NET_OFFLINE=true wasm-pack build crates/sdk/wasm \
   -- --locked --offline
 }
 
+run_deploy_template_audit() {
+echo "[deploy-template-audit] static deployment and renderer contracts"
+node --check scripts/payment-v1-pages-deploy-gate.mjs
+node scripts/payment-v1-pages-deploy-gate.mjs
+node --check scripts/payment-v1-deployment-template-gate.mjs
+node --test scripts/payment-v1-deployment-template-gate.test.mjs
+node scripts/payment-v1-deployment-template-gate.mjs
+bash -n scripts/build-payment-v1-directory-relay.sh
+bash scripts/build-payment-v1-directory-relay.sh --help >/dev/null
+node --check scripts/payment-v1-directory-relay-artifact-gate.mjs
+node --check scripts/payment-v1-directory-relay-artifact-gate.test.mjs
+node --test scripts/payment-v1-directory-relay-artifact-gate.test.mjs
+node --check scripts/payment-v1-rendered-artifact-gate.mjs
+node --check scripts/payment-v1-rendered-artifact-gate.test.mjs
+node --check scripts/payment-v1-linux-runtime-evidence.mjs
+node --check scripts/payment-v1-linux-runtime-evidence.test.mjs
+node --check scripts/payment-v1-publisher-netns-gate.mjs
+node --check scripts/payment-v1-publisher-netns-gate.test.mjs
+node --check scripts/payment-v1-publisher-netns-ceremony.mjs
+node --check scripts/payment-v1-publisher-netns-ceremony.test.mjs
+node --check scripts/payment-v1-publisher-netns-schema.test.mjs
+node --check scripts/payment-v1-publisher-private-health-probe.mjs
+node --check scripts/payment-v1-publisher-private-health-probe.test.mjs
+bash -n scripts/payment-v1-directory-publisher-oneshot-systemd.test.sh
+bash -n scripts/payment-v1-publisher-firewall-guard-systemd.test.sh
+bash -n scripts/payment-v1-publisher-netns-failed-recovery-systemd.test.sh
+bash -n scripts/payment-v1-systemd-255-pid1.test.sh
+bash -n scripts/payment-v1-publisher-netns-launcher.test.sh
+bash -n scripts/payment-v1-publisher-private-health-privileged-e2e.sh
+bash -n scripts/payment-v1-publisher-firewall-privileged-e2e.sh
+node scripts/payment-v1-publisher-netns-gate.mjs
+node --test \
+  scripts/payment-v1-publisher-netns-gate.test.mjs \
+  scripts/payment-v1-publisher-netns-ceremony.test.mjs \
+  scripts/payment-v1-publisher-netns-schema.test.mjs \
+  scripts/payment-v1-publisher-private-health-probe.test.mjs
+node --check scripts/payment-v1-directory-public-haproxy-artifact-gate.mjs
+node --check scripts/payment-v1-directory-public-haproxy-artifact-gate.test.mjs
+node --check scripts/payment-v1-directory-public-overlay-assets.test.mjs
+node --test --test-concurrency=1 \
+  scripts/payment-v1-directory-public-haproxy-artifact-gate.test.mjs \
+  scripts/payment-v1-directory-public-overlay-assets.test.mjs
+node --check scripts/payment-v1-source-fair-edge.test.mjs
+node --test --test-concurrency=1 scripts/payment-v1-source-fair-edge.test.mjs
+node --test --test-concurrency=1 \
+  scripts/payment-v1-rendered-artifact-gate.test.mjs
+node --test --test-concurrency=1 \
+  scripts/payment-v1-linux-runtime-evidence.test.mjs
+node --check scripts/payment-v1-integrated-caddy-overlay-gate.mjs
+node --check scripts/payment-v1-integrated-caddy-overlay-gate.test.mjs
+node --check scripts/payment-v1-integrated-caddy-overlay-transaction.mjs
+node --check scripts/payment-v1-integrated-caddy-overlay-transaction.test.mjs
+node --check scripts/payment-v1-integrated-caddy-rename-exchange.test.mjs
+node --test --test-concurrency=1 \
+  scripts/payment-v1-integrated-caddy-overlay-gate.test.mjs \
+  scripts/payment-v1-integrated-caddy-overlay-transaction.test.mjs \
+  scripts/payment-v1-integrated-caddy-lock.test.mjs \
+  scripts/payment-v1-integrated-caddy-rename-exchange.test.mjs
+node --check scripts/payment-v1-caddy-admin-uds-gate.mjs
+node --check scripts/payment-v1-caddy-admin-uds-gate.test.mjs
+node --check scripts/payment-v1-caddy-admin-uds-probe.mjs
+node --check scripts/payment-v1-caddy-admin-uds-transaction.mjs
+node --check scripts/payment-v1-caddy-admin-uds-transaction.test.mjs
+node --check scripts/payment-v1-caddy-admin-uds-transaction.fs.test.mjs
+node --check scripts/payment-v1-caddy-admin-uds-real-adapter.test.mjs
+node --test scripts/payment-v1-caddy-admin-uds-gate.test.mjs
+node --test scripts/payment-v1-caddy-admin-uds-transaction.test.mjs
+node --test scripts/payment-v1-caddy-admin-uds-transaction.fs.test.mjs
+}
+
 run_web_checks() {
 echo "[web] typecheck, unit tests, and production bundle"
 (cd web \
@@ -529,16 +486,19 @@ echo "[browser] local Chromium payment boundaries"
   && npm run test:e2e:payment-two-provider)
 }
 
-run_quick_checks
-
 case "$mode" in
   quick)
+    run_quick_checks
     echo "payment-v1-local-check: quick profile complete (no external network, no funds, no browser)"
     ;;
   pr)
     run_pr_checks
     run_web_checks
     echo "payment-v1-local-check: pr profile complete (no external network, no funds, no browser)"
+    ;;
+  deploy-template-audit)
+    run_deploy_template_audit
+    echo "payment-v1-local-check: deploy-template-audit profile complete (no external network, no funds, no browser)"
     ;;
   browser|full)
     run_pr_checks


### PR DESCRIPTION
## Summary

- stop Web, general workflow, and payment documentation edits from starting the full Payment platform matrix
- move the reproducible directory-relay artifact job to a narrowly triggered standalone workflow while preserving its check name
- make the default local check one focused service-admission test and expose deployment/template auditing as an explicit profile

## Evidence

- default `--quick` passed 3/3 tests in 36.83 seconds from this clean worktree
- `bash -n scripts/payment-v1-local-check.sh`
- `scripts/payment-v1-local-check.sh --help`
- directory-relay artifact gate: 64 passed, 3 platform skips
- workflow supply-chain tests: 69 passed
- workflow supply-chain gate: 12 workflows, 41 pinned action uses, 18 checkouts
- `git diff --check`

No browser, external-network, deployment, or full Cargo matrix was run locally.
