### PR TITLE
Use semantic production canary checks

### DIFF
--- a/.github/workflows/web-strict-production-canary.yml
+++ b/.github/workflows/web-strict-production-canary.yml
@@ -1,10 +1,9 @@
 name: Web strict production canary
 
 on:
-  schedule:
-    # Run after the native production canary's normal window so both do not
-    # compete for the same PIR servers.
-    - cron: '17 8 * * *'
+  # Live browser queries are intentionally opt-in.  Normal CI verifies the
+  # semantic contract without opening a browser or contacting production.
+  # Dispatch this after a deployment when a user asks for an end-to-end check.
   workflow_dispatch:
 
 permissions:

--- a/web/e2e/strict-production.spec.ts
+++ b/web/e2e/strict-production.spec.ts
@@ -8,18 +8,19 @@ test.skip(
   'Set BPIR_PRODUCTION_CANARY=1 to run live queries against production.',
 );
 
-test.describe.configure({ mode: 'serial' });
+// Each provider has its own page and strict session.  Parallel execution
+// means a failure reports the remaining independent backends instead of
+// serially skipping them; the production config caps this at two workers.
+test.describe.configure({ mode: 'parallel' });
 
 async function openBackend(page: Page, tabName: string): Promise<void> {
   await page.goto(`/?strict-canary=${Date.now()}`, { waitUntil: 'domcontentloaded' });
-  // The production bundle binds all backend/admission controls near the end
-  // of its module. DOMContentLoaded can fire while it is still evaluating;
-  // wait for its explicit, backend-independent interaction-ready state.
   const app = page.locator('#bitcoinPirApp');
   await expect(app).toHaveAttribute('data-module-readiness', 'ready');
   await expect(app).toHaveAttribute('aria-busy', 'false');
-  await expect(page.getByRole('tab', { name: tabName, exact: true })).toBeVisible();
-  await page.getByRole('tab', { name: tabName, exact: true }).click();
+  const tab = page.getByRole('tab', { name: tabName, exact: true });
+  await expect(tab).toBeVisible();
+  await tab.click();
 }
 
 async function queryOnce(
@@ -33,109 +34,77 @@ async function queryOnce(
 
   await page.locator(inputSelector).fill(CANARY_ADDRESS);
   await button.click();
-  await expect(button).toHaveText('Querying…');
-  await expect(button).toBeEnabled({ timeout: QUERY_TIMEOUT });
-  await expectNoFatalLog(page);
+  await expect(results).toHaveAttribute('data-query-batch-state', 'complete', {
+    timeout: QUERY_TIMEOUT,
+  });
+  await expect(results).toHaveAttribute('data-query-result-verification', 'verified');
   await expect(results).toContainText(CANARY_ADDRESS);
   return results;
 }
 
-async function expectVerifiedResult(results: Locator): Promise<void> {
-  await expect(results.locator('.merkle-result-badge.verified')).toHaveText('✓ Verified', {
-    timeout: QUERY_TIMEOUT,
-  });
+async function expectVerified(...locators: Locator[]): Promise<void> {
+  for (const locator of locators) {
+    await expect(locator).toHaveAttribute('data-verification-state', 'verified', {
+      timeout: QUERY_TIMEOUT,
+    });
+  }
 }
 
-async function expectTornDown(
+async function expectTransportDisconnected(
   page: Page,
+  statusSelector: string,
   connectSelector: string,
   disconnectSelector: string,
 ): Promise<void> {
+  await expect(page.locator(statusSelector)).toHaveAttribute('data-transport-state', 'disconnected', {
+    timeout: QUERY_TIMEOUT,
+  });
   await expect(page.locator(connectSelector)).toBeEnabled();
   await expect(page.locator(disconnectSelector)).toBeDisabled();
 }
 
-async function expectLogContains(page: Page, ...messages: string[]): Promise<void> {
-  const log = page.locator('#log');
-  for (const message of messages) {
-    await expect(log).toContainText(message, { timeout: QUERY_TIMEOUT });
-  }
-}
-
-async function expectNoFatalLog(page: Page): Promise<void> {
-  const fatalPattern =
-    /(?:UNVERIFIED|chain validation failed|DB proof .* unavailable|ORAM source-binding proof check failed|WASM module required|query error:|batch error:|(?:connection|connect) failed:)/i;
-  const fatal = page.locator('#log .log-entry').filter({ hasText: fatalPattern });
-  await expect(fatal).toHaveCount(0);
-}
-
-test('DPF-PIR verifies both servers, the result, and tears down transport', async ({ page }) => {
+test('DPF-PIR releases a strictly verified result and closes both transports', async ({ page }) => {
   await openBackend(page, 'DPF-PIR');
-  const results = await queryOnce(page, '#scriptPubkeys', '#queryBtn', '#resultsContainer');
+  await queryOnce(page, '#scriptPubkeys', '#queryBtn', '#resultsContainer');
 
-  await expect(page.locator('#dpfVerification0')).toHaveText('YES');
-  await expect(page.locator('#dpfVerification1')).toHaveText('YES');
-  await expectVerifiedResult(results);
-  await expectLogContains(
-    page,
-    'operator-endorsed identity verified (pir1-payment-beta)',
-    'operator-endorsed identity verified (pir2-vpsbg-dpf-v1)',
-    'Bitcoin/MuHash anchor verified',
-    'Batch complete: 1/1 found',
+  await expectVerified(
+    page.locator('#dpfVerification0'),
+    page.locator('#dpfVerification1'),
+    page.locator('#dbProofBadge'),
   );
-  await expectTornDown(page, '#connectBtn', '#disconnectBtn');
-  await expectNoFatalLog(page);
-  await expectLogContains(
-    page,
-    'Disconnected',
-  );
+  await expectTransportDisconnected(page, '#status', '#connectBtn', '#disconnectBtn');
 });
 
-test('HarmonyPIR verifies both roles, the result, and preserves no socket', async ({ page }) => {
+test('HarmonyPIR releases a strictly verified result and closes both transports', async ({ page }) => {
   await openBackend(page, 'HarmonyPIR');
-  const results = await queryOnce(page, '#hp-scriptPubkeys', '#hp-queryBtn', '#hp-resultsContainer');
+  await queryOnce(page, '#hp-scriptPubkeys', '#hp-queryBtn', '#hp-resultsContainer');
 
-  await expect(page.locator('#hpVerificationHint')).toHaveText('YES');
-  await expect(page.locator('#hpVerificationQuery')).toHaveText('YES');
-  await expectVerifiedResult(results);
-  await expectLogContains(
-    page,
-    'HarmonyPIR hint: operator-endorsed identity verified (pir1-payment-beta)',
-    'HarmonyPIR query: operator-endorsed identity verified (pir2-vpsbg-dpf-v1)',
-    'HarmonyPIR batch complete: 1/1 found',
+  await expectVerified(
+    page.locator('#hpVerificationHint'),
+    page.locator('#hpVerificationQuery'),
+    page.locator('#hp-dbProofBadge'),
   );
-  await expectTornDown(page, '#hp-connectBtn', '#hp-disconnectBtn');
-  await expect(page.locator('#hp-status')).toContainText('Status: Disconnected');
-  await expectNoFatalLog(page);
+  await expectTransportDisconnected(page, '#hp-status', '#hp-connectBtn', '#hp-disconnectBtn');
 });
 
-test('OnionPIR passes strict layout/tree-top preflight and verifies the result', async ({ page }) => {
+test('OnionPIR releases a strictly verified result and closes its transport', async ({ page }) => {
   await openBackend(page, 'OnionPIR');
-  const results = await queryOnce(page, '#op-scriptPubkeys', '#op-queryBtn', '#op-resultsContainer');
+  await queryOnce(page, '#op-scriptPubkeys', '#op-queryBtn', '#op-resultsContainer');
 
-  await expect(page.locator('#onionVerification')).toHaveText('YES');
-  await expectVerifiedResult(results);
-  await expectLogContains(page, 'OnionPIR batch complete: 1/1 found');
-  await expectTornDown(page, '#op-connectBtn', '#op-disconnectBtn');
-  await expectNoFatalLog(page);
+  await expectVerified(
+    page.locator('#onionVerification'),
+    page.locator('#op-dbProofBadge'),
+  );
+  await expectTransportDisconnected(page, '#op-status', '#op-connectBtn', '#op-disconnectBtn');
 });
 
-test('ORAM TEE verifies the runtime, completes a lookup, and disconnects', async ({ page }) => {
+test('ORAM TEE releases a strictly verified result and closes its transport', async ({ page }) => {
   await openBackend(page, 'ORAM TEE');
   await queryOnce(page, '#oram-scriptPubkeys', '#oram-queryBtn', '#oram-resultsContainer');
 
-  await expect(page.locator('#oramVerification')).toHaveText('YES');
-  await expectLogContains(
-    page,
-    'ORAM upgraded to encrypted channel',
-    'ORAM: operator-endorsed identity verified (pir2-vpsbg-dpf-v1)',
-    'ORAM batch complete: 1/1 found',
+  await expectVerified(
+    page.locator('#oramVerification'),
+    page.locator('#oram-dbProofBadge'),
   );
-  await expectTornDown(page, '#oram-connectBtn', '#oram-disconnectBtn');
-  await expect(page.locator('#oram-status')).toContainText('Status: Disconnected');
-  await expectNoFatalLog(page);
-  await expectLogContains(
-    page,
-    'ORAM: Disconnected',
-  );
+  await expectTransportDisconnected(page, '#oram-status', '#oram-connectBtn', '#oram-disconnectBtn');
 });

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-9Y7n9JqpWxP+sVYJckTEEFEdALgfBlY9OjsqctYtO5I=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-Y4fPxpcC/z9YcgXTKVCgAwe88Bs1XudeGnQfv3V5W8g=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
     <title>Bitcoin PIR</title>
     <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>
@@ -964,7 +964,7 @@
                 <section class="card">
                     <div class="card-head">
                         <div class="card-title"><span class="num">02</span><span>Query composer</span></div>
-                        <div id="status" class="status disconnected" hidden>Disconnected</div>
+                        <div id="status" class="status disconnected" data-transport-state="disconnected" hidden>Disconnected</div>
                     </div>
                     <div class="card-body">
                         <div class="step">
@@ -1138,7 +1138,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     <div class="card-title"><span class="num">03</span><span>Results</span></div>
                 </div>
                 <div class="card-body">
-                    <div id="resultsContainer" class="results-container"></div>
+                    <div id="resultsContainer" class="results-container" data-query-batch-state="idle"></div>
                 </div>
             </section>
           </div>
@@ -1151,7 +1151,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 <section class="card">
                     <div class="card-head">
                         <div class="card-title"><span class="num">02</span><span>Query composer</span></div>
-                        <div id="op-status" class="status disconnected" hidden>Disconnected</div>
+                        <div id="op-status" class="status disconnected" data-transport-state="disconnected" hidden>Disconnected</div>
                     </div>
                     <div class="card-body">
                         <div class="step">
@@ -1310,7 +1310,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     <div class="card-title"><span class="num">03</span><span>Results</span></div>
                 </div>
                 <div class="card-body">
-                    <div id="op-resultsContainer" class="results-container"></div>
+                    <div id="op-resultsContainer" class="results-container" data-query-batch-state="idle"></div>
                 </div>
             </section>
           </div>
@@ -1323,7 +1323,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 <section class="card">
                     <div class="card-head">
                         <div class="card-title"><span class="num">02</span><span>Query composer</span></div>
-                        <div id="hp-status" class="status disconnected" hidden>Disconnected</div>
+                        <div id="hp-status" class="status disconnected" data-transport-state="disconnected" hidden>Disconnected</div>
                     </div>
                     <div class="card-body">
                         <div class="step">
@@ -1519,7 +1519,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     <div class="card-title"><span class="num">03</span><span>Results</span></div>
                 </div>
                 <div class="card-body">
-                    <div id="hp-resultsContainer" class="results-container"></div>
+                    <div id="hp-resultsContainer" class="results-container" data-query-batch-state="idle"></div>
                 </div>
             </section>
           </div>
@@ -1532,7 +1532,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 <section class="card">
                     <div class="card-head">
                         <div class="card-title"><span class="num">02</span><span>Query composer</span></div>
-                        <div id="oram-status" class="status disconnected" hidden>Disconnected</div>
+                        <div id="oram-status" class="status disconnected" data-transport-state="disconnected" hidden>Disconnected</div>
                     </div>
                     <div class="card-body">
                         <div class="step">
@@ -1638,7 +1638,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     <div class="card-title"><span class="num">03</span><span>Results</span></div>
                 </div>
                 <div class="card-body">
-                    <div id="oram-resultsContainer" class="results-container"></div>
+                    <div id="oram-resultsContainer" class="results-container" data-query-batch-state="idle"></div>
                 </div>
             </section>
           </div>
@@ -2699,12 +2699,15 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             if (state.attestation === false || state.operator === false) {
                 el.textContent = 'NO';
                 el.className = 'verification-result no';
+                el.dataset.verificationState = 'unverified';
             } else if (state.attestation === true && state.operator === true) {
                 el.textContent = 'YES';
                 el.className = 'verification-result yes';
+                el.dataset.verificationState = 'verified';
             } else {
                 el.textContent = 'Not checked';
                 el.className = 'verification-result pending';
+                el.dataset.verificationState = 'pending';
             }
         }
 
@@ -2764,6 +2767,14 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         function setButtons(connected) {
             document.getElementById('connectBtn').disabled = connected;
             document.getElementById('disconnectBtn').disabled = !connected;
+        }
+
+        function publishTransportDisconnected(statusId) {
+            const statusDiv = document.getElementById(statusId);
+            if (!statusDiv) return;
+            statusDiv.textContent = 'Status: Disconnected';
+            statusDiv.className = 'status disconnected';
+            statusDiv.dataset.transportState = 'disconnected';
         }
 
         // Slice 3: persistent attestation badge per server. Called from
@@ -2905,6 +2916,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     : `DB proof unavailable — ${anchor}`;
 
             el.className = `attest-badge attest-badge-db-${info.state}`;
+            el.dataset.verificationState = info.state;
             el.style.display = 'block';
 
             const rows = [];
@@ -3564,6 +3576,29 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             badge.textContent = labels[state] || state;
         }
 
+        // Stable outcome contract for the explicit production canary.  A
+        // completed batch means the backend released a result only after its
+        // strict query path succeeded; `verified` is never set for a partial
+        // or failed batch.  The visible result badges remain the detailed
+        // user-facing evidence for PBC backends.
+        function beginQueryBatch(container) {
+            if (!container) return;
+            container.dataset.queryBatchState = 'running';
+            delete container.dataset.queryResultVerification;
+        }
+
+        function completeVerifiedQueryBatch(container) {
+            if (!container) return;
+            container.dataset.queryResultVerification = 'verified';
+            container.dataset.queryBatchState = 'complete';
+        }
+
+        function failQueryBatch(container) {
+            if (!container) return;
+            container.dataset.queryBatchState = 'failed';
+            delete container.dataset.queryResultVerification;
+        }
+
         function waitForResultPaint() {
             return new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
         }
@@ -3749,6 +3784,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                         const statusDiv = document.getElementById('status');
                         statusDiv.textContent = `Status: ${state.charAt(0).toUpperCase() + state.slice(1)}${message ? ' - ' + message : ''}`;
                         statusDiv.className = `status ${state}`;
+                        statusDiv.dataset.transportState = state;
 
                         if (state === 'connected') setButtons(true);
                         else if (state === 'disconnected') setButtons(false);
@@ -3862,6 +3898,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 log('Disconnected', 'info');
                 setButtons(false);
             }
+            publishTransportDisconnected('status');
             dpfAdmissionProviders[0] = null;
             dpfAdmissionProviders[1] = null;
             dpfAdmissionDbId = null;
@@ -3926,6 +3963,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             // Reset results
             const resultsContainer = document.getElementById('resultsContainer');
             resultsContainer.innerHTML = '';
+            beginQueryBatch(resultsContainer);
             document.getElementById('queryBtn').disabled = true;
 
             const N = lines.length;
@@ -4019,11 +4057,13 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     }
                 }
 
+                completeVerifiedQueryBatch(resultsContainer);
                 const verb = isDelta ? 'changed' : 'found';
                 setProgress(100, `Done! ${found}/${N} addresses ${verb}`);
                 setTimeout(hideProgress, 2000);
                 log(`Batch complete: ${found}/${N} ${verb}`, 'success');
             } catch (error) {
+                failQueryBatch(resultsContainer);
                 log(`Batch error: ${error.message}`, 'error');
                 setProgress(0, '');
                 hideProgress();
@@ -4415,12 +4455,15 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             if (state === 'yes') {
                 el.textContent = 'YES';
                 el.className = 'verification-result yes';
+                el.dataset.verificationState = 'verified';
             } else if (state === 'no') {
                 el.textContent = 'NO';
                 el.className = 'verification-result no';
+                el.dataset.verificationState = 'unverified';
             } else {
                 el.textContent = state === 'checking' ? 'Checking' : 'Not checked';
                 el.className = 'verification-result pending';
+                el.dataset.verificationState = 'pending';
             }
             el.title = title;
         }
@@ -4573,6 +4616,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                         const statusDiv = document.getElementById('op-status');
                         statusDiv.textContent = `Status: ${state.charAt(0).toUpperCase() + state.slice(1)}${message ? ' - ' + message : ''}`;
                         statusDiv.className = `status ${state}`;
+                        statusDiv.dataset.transportState = state;
                         if (state === 'connected') opSetButtons(true);
                         else if (state === 'disconnected') opSetButtons(false);
                     },
@@ -4615,6 +4659,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             document.getElementById('op-syncBtn').disabled = true;
             opPendingSync = null;
             opSetButtons(false);
+            publishTransportDisconnected('op-status');
         }
 
         // ─── OnionPIR sync flow (mirrors DPF) ─────────────────────────────
@@ -4860,6 +4905,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
 
             const resultsContainer = document.getElementById('op-resultsContainer');
             resultsContainer.innerHTML = '';
+            beginQueryBatch(resultsContainer);
             document.getElementById('op-queryBtn').disabled = true;
 
             const N = lines.length;
@@ -4903,10 +4949,12 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     setResultMerkleState(section, 'verified');
                 }
 
+                completeVerifiedQueryBatch(resultsContainer);
                 opSetProgress(100, `Done! ${found}/${N} addresses found`);
                 setTimeout(opHideProgress, 2000);
                 log(`OnionPIR batch complete: ${found}/${N} found`, 'success');
             } catch (error) {
+                failQueryBatch(resultsContainer);
                 log(`OnionPIR error: ${error.message}`, 'error');
                 opSetDataIntegrity('no', error.message);
                 opSetProgress(0, '');
@@ -5206,6 +5254,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 const statusDiv = document.getElementById('hp-status');
                 statusDiv.textContent = 'Status: Connecting...';
                 statusDiv.className = 'status connecting';
+                statusDiv.dataset.transportState = 'connecting';
                 log(`HarmonyPIR: connecting ${providerIndex === 0 ? 'hint' : 'query'} provider only...`);
 
                 // A prior wrapper without usable hints is not a reconnect
@@ -5317,6 +5366,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     ? 'Status: Hint provider verified; hint admission required'
                     : 'Status: Pair verified; capability admission required before preflight';
                 statusDiv.className = 'status connected';
+                statusDiv.dataset.transportState = 'connected';
                 if (providerIndex === 0) {
                     document.getElementById('hp-offlineContainer').style.display = 'none';
                 } else {
@@ -5325,6 +5375,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                         if (hpClient !== connectedCandidate) return;
                         statusDiv.textContent = 'Status: Query provider disconnected (hints preserved)';
                         statusDiv.className = 'status disconnected';
+                        statusDiv.dataset.transportState = 'disconnected';
                     });
                 }
 
@@ -5345,6 +5396,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     ? 'Status: Disconnected'
                     : 'Status: Hint provider remains authorized; query provider failed';
                 statusDiv.className = 'status disconnected';
+                statusDiv.dataset.transportState = 'disconnected';
                 if (providerIndex === 0) {
                     hpSetButtons(false);
                     document.getElementById('hp-offlineContainer').style.display = 'none';
@@ -5387,6 +5439,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 ? 'Status: Disconnected (hints preserved)'
                 : 'Status: Disconnected';
             statusDiv.className = 'status disconnected';
+            statusDiv.dataset.transportState = 'disconnected';
             hpSetButtons(false);
             document.getElementById('hp-connectBtn').disabled = false;
             hpHideProgress();
@@ -5838,6 +5891,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
 
             const resultsContainer = document.getElementById('hp-resultsContainer');
             resultsContainer.innerHTML = '';
+            beginQueryBatch(resultsContainer);
             document.getElementById('hp-queryBtn').disabled = true;
 
             const N = lines.length;
@@ -5911,10 +5965,12 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     setResultMerkleState(section, 'verified');
                 }
 
+                completeVerifiedQueryBatch(resultsContainer);
                 hpSetProgress(100, `Done! ${found}/${N} addresses found`);
                 setTimeout(hpHideProgress, 2000);
                 log(`HarmonyPIR batch complete: ${found}/${N} found`, 'success');
             } catch (error) {
+                failQueryBatch(resultsContainer);
                 log(`HarmonyPIR error: ${error.message}`, 'error');
                 hpSetProgress(0, '');
                 hpHideProgress();
@@ -6109,6 +6165,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 const statusDiv = document.getElementById('oram-status');
                 statusDiv.textContent = 'Status: Connecting';
                 statusDiv.className = 'status connecting';
+                statusDiv.dataset.transportState = 'connecting';
                 document.getElementById('oram-connectBtn').disabled = true;
 
                 oramClient = new OramPirClientAdapter({
@@ -6179,6 +6236,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                             state === 'disconnected' ? 'error' : 'info');
                         statusDiv.textContent = `Status: ${state.charAt(0).toUpperCase() + state.slice(1)}${message ? ' - ' + message : ''}`;
                         statusDiv.className = `status ${state}`;
+                        statusDiv.dataset.transportState = state;
                         if (state === 'connected') oramSetButtons(true);
                         else if (state === 'disconnected') oramSetButtons(false);
                     },
@@ -6198,7 +6256,12 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 if (sourceDbStatus?.state !== 'verified' || !sourceDbStatus.proof || !manifestRootHex) {
                     throw new Error('strict ORAM connection did not produce a source db proof and attested manifest root');
                 }
-                await verifyAndRenderOramSourceProofBadge(
+                // The source ceremony is useful historical provenance, but
+                // the live attestation, verified database proof, and
+                // attested manifest root above are the query admission
+                // boundary.  Do not close an otherwise strict connection if
+                // optional source-proof artifacts are unavailable.
+                void verifyAndRenderOramSourceProofBadge(
                     'oram-sourceProofBadge',
                     'ORAM TEE',
                     sourceDbStatus.proof,
@@ -6209,13 +6272,23 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                         pinStatus: oramClient.attestation.pinStatus,
                         manifestRootHex,
                     },
-                );
+                ).catch(error => {
+                    const message = error?.message || String(error);
+                    renderOramSourceProofBadge('oram-sourceProofBadge', 'ORAM TEE', {
+                        state: 'unavailable',
+                        checks: [],
+                        mismatches: [],
+                        error: `informational source proof unavailable: ${message}`,
+                    });
+                    log(`ORAM source proof unavailable (informational): ${message}`, 'info');
+                });
             } catch (error) {
                 log(`ORAM connection failed: ${error.message}`, 'error');
                 oramClient = null;
                 const statusDiv = document.getElementById('oram-status');
                 statusDiv.textContent = 'Status: Disconnected';
                 statusDiv.className = 'status disconnected';
+                statusDiv.dataset.transportState = 'disconnected';
                 oramSetButtons(false);
                 throw error;
             }
@@ -6234,6 +6307,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             }
             document.getElementById('oram-advancedDbDetails').style.display = 'none';
             oramSetButtons(false);
+            publishTransportDisconnected('oram-status');
         }
 
         async function oramQueryUtxos() {
@@ -6278,6 +6352,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
 
             const resultsContainer = document.getElementById('oram-resultsContainer');
             resultsContainer.innerHTML = '';
+            beginQueryBatch(resultsContainer);
             document.getElementById('oram-queryBtn').disabled = true;
 
             const N = lines.length;
@@ -6325,11 +6400,13 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                     }
                 }
 
+                completeVerifiedQueryBatch(resultsContainer);
                 const verb = isDelta ? 'changed' : 'found';
                 oramSetProgress(100, `Done! ${found}/${N} addresses ${verb}`);
                 setTimeout(oramHideProgress, 2000);
                 log(`ORAM batch complete: ${found}/${N} ${verb}`, 'success');
             } catch (error) {
+                failQueryBatch(resultsContainer);
                 log(`ORAM query error: ${error.message}`, 'error');
                 oramSetProgress(0, '');
                 oramHideProgress();

--- a/web/playwright.production.config.ts
+++ b/web/playwright.production.config.ts
@@ -5,8 +5,10 @@ const productionUrl = process.env.BPIR_WEB_URL ?? 'https://www.bitcoinpir.org/';
 export default defineConfig({
   testDir: './e2e',
   testMatch: 'strict-production.spec.ts',
-  fullyParallel: false,
-  workers: 1,
+  // A failing provider must not suppress the other independent backends, but
+  // keep live production load bounded.
+  fullyParallel: true,
+  workers: 2,
   retries: 0,
   timeout: 12 * 60 * 1000,
   expect: {

--- a/web/scripts/verify-production-canary-readiness.mjs
+++ b/web/scripts/verify-production-canary-readiness.mjs
@@ -7,10 +7,23 @@ function requireBefore(source, token, before, description) {
   return index;
 }
 
+function requireInOrder(source, tokens, description) {
+  let cursor = -1;
+  for (const token of tokens) {
+    const index = source.indexOf(token, cursor + 1);
+    if (index < 0) throw new Error(`missing ${description}: ${token}`);
+    cursor = index;
+  }
+}
+
 const indexHtmlUrl = new URL('../index.html', import.meta.url);
 const strictCanaryUrl = new URL('../e2e/strict-production.spec.ts', import.meta.url);
+const productionConfigUrl = new URL('../playwright.production.config.ts', import.meta.url);
+const workflowUrl = new URL('../../.github/workflows/web-strict-production-canary.yml', import.meta.url);
 const indexHtml = readFileSync(indexHtmlUrl, 'utf8');
 const strictCanary = readFileSync(strictCanaryUrl, 'utf8');
+const productionConfig = readFileSync(productionConfigUrl, 'utf8');
+const workflow = readFileSync(workflowUrl, 'utf8');
 const moduleSource = indexHtml.match(/<script type="module">([\s\S]*?)<\/script>/)?.[1];
 
 if (!moduleSource) throw new Error('index.html has no application module');
@@ -36,28 +49,141 @@ for (const [token, description] of [
   requireBefore(moduleSource, token, readinessIndex, description);
 }
 
-const openBackend = strictCanary.match(
-  /async function openBackend[\s\S]*?\n}\n\nasync function queryOnce/,
-)?.[0];
-if (!openBackend) throw new Error('strict production canary has no openBackend helper');
-if (/#log|ORAM source|source-binding|toContainText/.test(openBackend)) {
-  throw new Error('openBackend must not depend on a backend proof log');
+for (const id of [
+  'resultsContainer',
+  'op-resultsContainer',
+  'hp-resultsContainer',
+  'oram-resultsContainer',
+]) {
+  if (!new RegExp(`id="${id}"[^>]*data-query-batch-state="idle"`).test(indexHtml)) {
+    throw new Error(`${id} must expose its initial semantic batch state`);
+  }
 }
-if (!/locator\('#bitcoinPirApp'\)[\s\S]*data-module-readiness', 'ready'[\s\S]*aria-busy', 'false'/.test(openBackend)) {
-  throw new Error('openBackend must wait for the explicit interaction-ready state');
+for (const id of ['status', 'op-status', 'hp-status', 'oram-status']) {
+  if (!new RegExp(`id="${id}"[^>]*data-transport-state="disconnected"`).test(indexHtml)) {
+    throw new Error(`${id} must expose its initial transport state`);
+  }
+}
+const publishDisconnect = moduleSource.slice(
+  moduleSource.indexOf('function publishTransportDisconnected'),
+  moduleSource.indexOf('// Slice 3: persistent attestation badge'),
+);
+if (!publishDisconnect.includes("dataset.transportState = 'disconnected'")) {
+  throw new Error('the transport disconnect publisher must expose a semantic state');
+}
+for (const statusId of ['status', 'op-status', 'oram-status']) {
+  if (!moduleSource.includes(`publishTransportDisconnected('${statusId}')`)) {
+    throw new Error(`${statusId} must publish explicit disconnect state during teardown`);
+  }
 }
 
-const noFatalLog = strictCanary.match(
-  /async function expectNoFatalLog[\s\S]*?\n}\n\n(?:test|async function)/,
-)?.[0];
-if (!noFatalLog) throw new Error('strict production canary has no expectNoFatalLog helper');
-if (!/locator\('#log \.log-entry'\)\.filter\(\{ hasText: fatalPattern \}\)/.test(noFatalLog)) {
-  throw new Error('fatal canary matching must stay scoped to individual log entries');
+for (const [start, end, description] of [
+  ['function renderBasicVerification', 'function resetBasicVerification', 'runtime/provider verification'],
+  ['function opSetDataIntegrity', 'function opUpdateDataIntegritySummary', 'Onion database verification'],
+  ['function renderDatabaseProofBadge', 'function renderBitcoinAnchorBadge', 'database proof verification'],
+]) {
+  const section = moduleSource.slice(moduleSource.indexOf(start), moduleSource.indexOf(end));
+  if (!section.includes('dataset.verificationState')) {
+    throw new Error(`${description} has no stable verification-state contract`);
+  }
 }
-if (/locator\('#log'\)\.getByText/.test(noFatalLog)) {
-  throw new Error('fatal canary matching must not aggregate text across the log container');
+
+const batchContract = moduleSource.slice(
+  moduleSource.indexOf('function beginQueryBatch'),
+  moduleSource.indexOf('function waitForResultPaint'),
+);
+for (const token of [
+  "dataset.queryBatchState = 'running'",
+  "dataset.queryResultVerification = 'verified'",
+  "dataset.queryBatchState = 'complete'",
+  "dataset.queryBatchState = 'failed'",
+]) {
+  if (!batchContract.includes(token)) {
+    throw new Error(`missing query batch semantic transition: ${token}`);
+  }
+}
+
+for (const [start, end, container] of [
+  ['async function queryUtxos()', 'async function runDpfQueryOnce()', 'resultsContainer'],
+  ['async function opQueryUtxos()', 'async function runOnionQueryOnce()', 'resultsContainer'],
+  ['async function hpQueryUtxos()', 'async function runHarmonyQueryOnce()', 'resultsContainer'],
+  ['async function oramQueryUtxos()', 'async function runOramQueryOnce()', 'resultsContainer'],
+]) {
+  const query = moduleSource.slice(moduleSource.indexOf(start), moduleSource.indexOf(end));
+  requireInOrder(query, [
+    `beginQueryBatch(${container});`,
+    `completeVerifiedQueryBatch(${container});`,
+  ], `${start} success transition`);
+  if (!query.includes(`failQueryBatch(${container});`)) {
+    throw new Error(`${start} must not leave a failed batch as verified`);
+  }
+}
+
+const oramConnect = moduleSource.slice(
+  moduleSource.indexOf('async function oramConnect'),
+  moduleSource.indexOf('function oramDisconnect'),
+);
+for (const strictToken of [
+  'await oramClient.connect();',
+  "sourceDbStatus?.state !== 'verified'",
+  'sourceDbStatus.proof',
+  'manifestRootHex',
+]) {
+  if (!oramConnect.includes(strictToken)) {
+    throw new Error(`ORAM connection lost its strict live admission prerequisite: ${strictToken}`);
+  }
+}
+if (oramConnect.includes('await verifyAndRenderOramSourceProofBadge(')) {
+  throw new Error('ORAM source proof must not block a strict live connection');
+}
+if (!oramConnect.includes('void verifyAndRenderOramSourceProofBadge(')
+    || !oramConnect.includes('informational source proof unavailable')
+    || !oramConnect.includes("state: 'unavailable'")) {
+  throw new Error('ORAM source-proof rejection must be rendered as informational only');
+}
+const sourceProofStart = oramConnect.indexOf('void verifyAndRenderOramSourceProofBadge(');
+const sourceProofEnd = oramConnect.indexOf('\n            } catch (error) {', sourceProofStart);
+const sourceProofTask = oramConnect.slice(sourceProofStart, sourceProofEnd);
+if (sourceProofEnd < 0 || sourceProofTask.includes('oramClient = null')) {
+  throw new Error('ORAM source-proof rejection must not clear the strict live client');
+}
+
+if (/\bschedule\s*:/.test(workflow) || !/^\s*workflow_dispatch:\s*$/m.test(workflow)) {
+  throw new Error('live browser canary must be manual-only');
+}
+if (!/fullyParallel:\s*true/.test(productionConfig) || !/workers:\s*2/.test(productionConfig)) {
+  throw new Error('production browser canary must run independent tests with at most two workers');
+}
+if (!/test\.describe\.configure\(\{ mode: 'parallel' \}\)/.test(strictCanary)) {
+  throw new Error('strict production canary must not serially suppress other backends');
+}
+if ((strictCanary.match(/\ntest\('/g) ?? []).length !== 4) {
+  throw new Error('strict production canary must retain one independent test per backend');
+}
+for (const forbidden of [
+  '#log',
+  'expectLogContains',
+  'expectNoFatalLog',
+  'fatalPattern',
+  'operator-endorsed identity verified',
+  'source-binding',
+  'sourceProofBadge',
+]) {
+  if (strictCanary.includes(forbidden)) {
+    throw new Error(`strict production canary must not gate on diagnostics: ${forbidden}`);
+  }
+}
+for (const required of [
+  "data-query-batch-state', 'complete'",
+  "data-query-result-verification', 'verified'",
+  "data-verification-state', 'verified'",
+  "data-transport-state', 'disconnected'",
+]) {
+  if (!strictCanary.includes(required)) {
+    throw new Error(`strict production canary does not require semantic state: ${required}`);
+  }
 }
 
 process.stdout.write(
-  'verified strict production canary readiness and line-scoped fatal log matching\n',
+  'verified strict production canary semantic DOM contract and manual-only policy\n',
 );


### PR DESCRIPTION
## Summary

- make the live four-backend browser canary an explicit post-deployment/user-requested check instead of a daily job
- replace log prose, provider-name, fatal-regex, and source-proof assertions with stable DOM states emitted by the real verification and query paths
- run the four independent backend tests with at most two workers so one failure no longer suppresses the remaining evidence
- keep live ORAM attestation, database proof, and manifest-root admission strict while moving historical source-proof retrieval to a non-blocking informational badge

## Evidence

- TypeScript check
- Web production build and CSP verification
- 23 focused Vitest tests
- browserless production-canary semantic contract check
- Playwright discovery lists all 4 independent tests
- workflow supply-chain gate: 11 workflows, 41 pinned action uses, 18 checkouts
- `git diff --check`

No browser, production-network query, or deployment was run.

## History

This replaces the automatically closed stacked PR #190 after #189 merged and its temporary base branch was deleted.
