### PR TITLE
Add bounded ORAM production status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ For a quick taste:
 
 ## Documentation
 
+- [`docs/PRODUCTION_OPERATIONS.md`](docs/PRODUCTION_OPERATIONS.md) — current
+  operator/agent entry point for read-only control-plane status, release,
+  rollback, and canary routing
+- [`docs/history/README.md`](docs/history/README.md) — historical preflights,
+  incidents, and plans; evidence only, not operating instructions
 - [`doc/DEPLOYMENT.md`](doc/DEPLOYMENT.md) — Production deployment guide
 - [`doc/WEB.md`](doc/WEB.md) — Web client details
 - [`docs/RATELIMIT_INTEGRATION.md`](docs/RATELIMIT_INTEGRATION.md) — Payment V1

--- a/docs/PRODUCTION_OPERATIONS.md
+++ b/docs/PRODUCTION_OPERATIONS.md
@@ -1,0 +1,44 @@
+# Production operations
+
+This is the operator/agent entry point. It routes observation and authorized
+release work; it is not deployment authorization.
+
+## Status first
+
+Run this before a browser, `502`, or log search:
+
+```bash
+scripts/vpsbg-production-status.sh
+```
+
+The default path makes read-only GET requests to the VPSBG control plane and
+`https://weikeng2.bitcoinpir.org/status.json`; it never uses SSH. Its current
+facts are control-plane state, boot mode, and attached image.
+
+`/status.json` is temporary: Direct ORAM build/switch exposes it from a
+loopback HTTP origin. Once `unified_server` owns port 8091, it is expected to
+be unavailable; the command still returns control-plane state and marks ORAM
+fields `unavailable`. Runtime profile, measurement, attestation, generation,
+database identity, and any unavailable field must not be inferred. `--root`
+reads an offline evidence directory for fixtures or post-incident review only.
+
+## Release routes
+
+Web publication only uses manual `deploy-web.yml` dispatch from `main` with
+its production confirmation; use the workflow deployment record as release
+evidence.
+
+VPSBG release and rollback use the measured-boot procedure in the
+[VPSBG measured-boot skill](../.agents/skills/vpsbg-measured-boot/SKILL.md).
+Use the reported attached image as the rollback reference; do not substitute a
+historical preflight for current state.
+
+Run a manual production canary only after a deliberate web or VPSBG release,
+never as the first diagnostic step.
+
+Mainnet Lightning activation is pending; source and functional-beta evidence
+are not proof of a deployed mainnet Lightning service. See
+[`docs/payment/IMPLEMENTATION_STATUS.md`](payment/IMPLEMENTATION_STATUS.md).
+
+Historical preflights, incidents, and plans are evidence only; use the
+[history index](history/README.md).

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -1,0 +1,22 @@
+# Historical operations evidence
+
+These records preserve prior observations, plans, and incidents. They are not
+current operating instructions and must not override
+[Production operations](../PRODUCTION_OPERATIONS.md) or its read-only
+control-plane status command. In particular, prior generation, database,
+measurement, attestation, and timing values are historical evidence, not values
+the current status command can infer.
+
+- [Full Direct ORAM UKI preflight (2026-08-11)](../ORAM_FULL_UKI_PREFLIGHT_2026-08-11.md)
+  — point-in-time preflight; its image slots, generation, capacities, and timing
+  are stale until queried again.
+- [ORAM Tier 3 production handoff](../ORAM_TIER3_PRODUCTION_HANDOFF.md)
+  — historical deployment evidence and superseded activation context.
+- [Production rollout remainder (2026-08-07)](../PROD_ROLLOUT_REMAINDER_2026-08-07.md)
+  — deferred rollout plan and notes, not an active checklist.
+- [Server warmup removal rollout](../SERVER_WARMUP_REMOVAL_ROLLOUT.md)
+  — completed/superseded rollout record.
+- [Phase 3 Slice 3 recovery](../PHASE3_SLICE3_RECOVERY.md)
+  — historical recovery procedure; not the supported measured-boot release path.
+- [ORAM live image binding plan](../ORAM_LIVE_IMAGE_BINDING_PLAN.md)
+  — design plan, not proof of a current live binding.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,18 @@
 
 Helper scripts for running and testing the PIR system.
 
+## Production status
+
+For production diagnosis, run this read-only command first:
+
+```bash
+./scripts/vpsbg-production-status.sh
+```
+
+It only GETs the VPSBG control plane and public `/status.json`; it never uses SSH.
+It reports control-plane state, boot mode, and attached image. The ORAM endpoint exists only during build/switch; after `unified_server` owns 8091, its fields are expected to be `unavailable`.
+Do not infer profile, attestation, generation, database identity, or other unavailable fields. `--root` reads an offline evidence directory only. See [`docs/PRODUCTION_OPERATIONS.md`](../docs/PRODUCTION_OPERATIONS.md) for release and canary routing.
+
 ## Scripts
 
 ### `start_pir_servers.sh`

--- a/scripts/dracut/97bpir-tier3-init/module-setup.sh
+++ b/scripts/dracut/97bpir-tier3-init/module-setup.sh
@@ -41,6 +41,11 @@ check() {
             return 1
         fi
     done
+    if [ ! -x /usr/bin/busybox ] || ! /usr/bin/busybox --list | grep -qx httpd; then
+        derror "bpir-tier3-init: /usr/bin/busybox with the httpd applet is required"
+        derror "  install with: apt install busybox-static"
+        return 1
+    fi
     return 0
 }
 
@@ -77,7 +82,9 @@ install() {
 
     # udhcpc is a busybox applet, NOT a standalone binary on Ubuntu.
     # Bake busybox itself in (statically linked, ~1.5 MB) and create
-    # a /sbin/udhcpc symlink to it. busybox dispatches based on argv[0].
+    # a /sbin/udhcpc symlink to it. busybox dispatches based on argv[0]. Its
+    # httpd applet also serves the transient loopback-only Direct ORAM status
+    # JSON before unified_server takes over port 8091.
     if [ -x /usr/bin/busybox ]; then
         inst_simple /usr/bin/busybox
         ln_r /usr/bin/busybox /sbin/udhcpc

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -94,6 +94,13 @@ ORAM_BUILD_LOG_DIR=/home/pir/data/oram-boot-logs
 ORAM_BOOT_ID_FILE=${BPIR_ORAM_BOOT_ID_FILE:-/proc/sys/kernel/random/boot_id}
 ORAM_PUBLISHED_MARKER="$ORAM_BUILD_LOG_DIR/oram-published.boot-id.env"
 ORAM_WATCHDOG_PHASE_FILE="$ORAM_BUILD_LOG_DIR/direct-oram-bootstrap.phase"
+ORAM_STATUS_HTTP_ROOT=/run/bitcoinpir-oram-status-api
+ORAM_STATUS_JSON_FILE="$ORAM_STATUS_HTTP_ROOT/status.json"
+ORAM_STATUS_HTTPD_PID_FILE=/run/bitcoinpir-oram-status-api.pid
+ORAM_STATUS_HTTPD=/usr/bin/busybox
+ORAM_STATUS_HTTPD_HOST=127.0.0.1
+ORAM_STATUS_HTTPD_PORT=8091
+ORAM_STATUS_HTTPD_PID=
 ORAM_SERVER_RUNTIME_LOG="$ORAM_BUILD_LOG_DIR/unified-server.runtime.log"
 ORAM_STAGING_DIR="$ORAM_BOOT_ROOT/staging.$$"
 ORAM_CURRENT_DIR="$ORAM_BOOT_ROOT/current"
@@ -121,6 +128,7 @@ ORAM_SUPERVISOR=/usr/local/bin/direct-oram-supervisor
 ORAM_SERVER_READY_HOST=127.0.0.1
 ORAM_SERVER_READY_PORT=8091
 ORAM_ACTIVE_SUPERVISOR_PID_FILE="$TRUSTED_STATE_ROOT/active-supervisor.pid"
+ORAM_STATUS_STARTED_AT_EPOCH=
 DIRECT_INDEX_SLOTS_PER_BIN=4
 DIRECT_INDEX_HASH_FNS=2
 DIRECT_INDEX_LOAD_FACTOR=0.95
@@ -139,9 +147,64 @@ DELTA_EXPECTED_INDEX_SHA256=e06fc3dedf30096124888acef3024f21a9c049d59fd8c7d518aa
 DELTA_EXPECTED_CHUNKS_SHA256=536acb605396056118c7c0836988f369c5abbfc3f7e90732ad93e819d5188e0a
 
 fatal() {
-    echo "[unified-server-run] FATAL: $*" >&2
+    if [ -n "${ORAM_STATUS_STARTED_AT_EPOCH:-}" ] && [ -d "$ORAM_STATUS_HTTP_ROOT" ]; then
+        write_direct_oram_status_json failed "${2:-$ORAM_TOTAL_MAX_SECONDS}" "${3:-bootstrap-failed}" || true
+    fi
+    echo "[unified-server-run] FATAL: $1" >&2
     sleep 5
     exit 1
+}
+
+write_direct_oram_status_json() {
+    stage_name=$1
+    hard_stop_seconds=$2
+    status_reason=$3
+    now_epoch=$(date -u +%s)
+    status_tmp="$ORAM_STATUS_JSON_FILE.tmp.$$"
+    {
+        printf '{"schema_version":1,"stage":"%s","started_at_epoch":%s,' \
+            "$stage_name" "$ORAM_STATUS_STARTED_AT_EPOCH"
+        printf '"updated_at_epoch":%s,"hard_stop_seconds":%s,"reason":"%s"}\n' \
+            "$now_epoch" "$hard_stop_seconds" "$status_reason"
+    } >"$status_tmp" || return 1
+    chmod 600 "$status_tmp" || return 1
+    mv "$status_tmp" "$ORAM_STATUS_JSON_FILE"
+}
+
+prepare_direct_oram_status_api() {
+    case "$ORAM_STATUS_HTTP_ROOT" in
+        /run/bitcoinpir-oram-status-api) ;;
+        *) fatal "unsupported Direct ORAM status API root: $ORAM_STATUS_HTTP_ROOT" ;;
+    esac
+    rm -rf "$ORAM_STATUS_HTTP_ROOT" || fatal "failed to clear Direct ORAM status API root"
+    mkdir -p "$ORAM_STATUS_HTTP_ROOT" || fatal "failed to create Direct ORAM status API root"
+    chmod 700 "$ORAM_STATUS_HTTP_ROOT" || fatal "failed to protect Direct ORAM status API root"
+}
+
+stop_direct_oram_status_api() {
+    [ -n "${ORAM_STATUS_HTTPD_PID:-}" ] || return 0
+    kill "$ORAM_STATUS_HTTPD_PID" 2>/dev/null || true
+    wait "$ORAM_STATUS_HTTPD_PID" 2>/dev/null || true
+    ORAM_STATUS_HTTPD_PID=
+    rm -f "$ORAM_STATUS_HTTPD_PID_FILE"
+}
+
+start_direct_oram_status_api() {
+    [ -x "$ORAM_STATUS_HTTPD" ] || fatal "$ORAM_STATUS_HTTPD missing from UKI"
+    "$ORAM_STATUS_HTTPD" httpd -f \
+        -p "$ORAM_STATUS_HTTPD_HOST:$ORAM_STATUS_HTTPD_PORT" \
+        -h "$ORAM_STATUS_HTTP_ROOT" </dev/null >/dev/null 2>&1 &
+    ORAM_STATUS_HTTPD_PID=$!
+    printf '%s\n' "$ORAM_STATUS_HTTPD_PID" >"$ORAM_STATUS_HTTPD_PID_FILE" \
+        || fatal "failed to record Direct ORAM status API process"
+    chmod 600 "$ORAM_STATUS_HTTPD_PID_FILE" || fatal "failed to protect Direct ORAM status API process"
+}
+
+remove_direct_oram_status_api_root() {
+    case "$ORAM_STATUS_HTTP_ROOT" in
+        /run/bitcoinpir-oram-status-api) rm -rf "$ORAM_STATUS_HTTP_ROOT" || return 1 ;;
+        *) return 1 ;;
+    esac
 }
 
 read_current_boot_id() {
@@ -347,6 +410,8 @@ safe_remove_runtime_path() {
 }
 
 cleanup_build_staging() {
+    stop_direct_oram_status_api || true
+    remove_direct_oram_status_api_root || true
     [ -n "${ORAM_TOTAL_WATCHDOG_PID:-}" ] \
         && kill "$ORAM_TOTAL_WATCHDOG_PID" 2>/dev/null || true
     [ -n "${ORAM_TOTAL_WATCHDOG_PID:-}" ] \
@@ -373,7 +438,8 @@ start_total_watchdog() {
             # The initramfs busybox nc does not implement OpenBSD nc's -z.
             # An EOF-only connection is portable across both implementations
             # and still proves that the server has completed TCP bind/listen.
-            if nc -w 1 "$ORAM_SERVER_READY_HOST" "$ORAM_SERVER_READY_PORT" </dev/null >/dev/null 2>&1; then
+            if [ ! -r "$ORAM_STATUS_HTTPD_PID_FILE" ] \
+                && nc -w 1 "$ORAM_SERVER_READY_HOST" "$ORAM_SERVER_READY_PORT" </dev/null >/dev/null 2>&1; then
                 {
                     printf 'status=ready\n'
                     printf 'phase=server-readiness\n'
@@ -546,7 +612,8 @@ build_direct_oram() {
             --expected-chunks-sha256 "$expected_chunks_sha" \
             --strict-source-binding || {
                 tail -80 "$log_file" >&2 || true
-                fatal "$db_label direct ORAM regeneration failed; full log: $log_file"
+                fatal "$db_label direct ORAM regeneration failed; full log: $log_file" \
+                    "$build_timeout_seconds" build-failed
             }
     else
         run_supervised_direct_build "$db_label" "$build_timeout_seconds" \
@@ -579,7 +646,8 @@ build_direct_oram() {
             --expected-chunks-sha256 "$expected_chunks_sha" \
             --strict-source-binding || {
                 tail -80 "$log_file" >&2 || true
-                fatal "$db_label direct ORAM regeneration failed; full log: $log_file"
+                fatal "$db_label direct ORAM regeneration failed; full log: $log_file" \
+                    "$build_timeout_seconds" build-failed
             }
     fi
     safe_remove_runtime_path "$trusted_input_dir"
@@ -680,7 +748,6 @@ ORAM_TOTAL_WATCHDOG_PID=
 trap cleanup_build_staging EXIT
 trap 'exit 124' HUP INT TERM
 write_watchdog_phase direct-oram-build
-start_total_watchdog
 
 load_active_database_generation 0 db0
 MAINNET_SOURCE_DIR="$ACTIVE_DB_PROOF_V2_DIR/oram-direct-inputs"
@@ -694,21 +761,35 @@ DELTA_DB_EVIDENCE="$ACTIVE_DB_PROOF_V2_DIR/build-evidence.bin"
 DELTA_DB_MANIFEST="$ACTIVE_DB_PROOF_V2_DIR/server-db/MANIFEST.toml"
 DELTA_ROOT_BUNDLE="$ACTIVE_DB_PROOF_V2_DIR/root-bundle-payload.bin"
 
+prepare_direct_oram_status_api
+ORAM_STATUS_STARTED_AT_EPOCH=$(date -u +%s)
+write_direct_oram_status_json input-validation "$ORAM_DB0_MAX_SECONDS" none \
+    || fatal "failed to publish Direct ORAM input-validation status"
+start_direct_oram_status_api
+start_total_watchdog
+write_direct_oram_status_json db0-build "$ORAM_DB0_MAX_SECONDS" none \
+    || fatal "failed to publish Direct ORAM db0-build status"
 build_direct_oram mainnet-948454 "$MAINNET_SOURCE_DIR" "$ORAM_STAGING_DIR/db0-mainnet-948454" \
     "$MAINNET_DB_EVIDENCE" "$MAINNET_DB_MANIFEST" "$MAINNET_ROOT_BUNDLE" "$MAINNET_EXPECTED_MUHASH" "" \
     "$MAINNET_EXPECTED_INDEX_SHA256" "$MAINNET_EXPECTED_CHUNKS_SHA256" \
     "$ORAM_FULL_TRUSTED_STATE_DIR" "$ORAM_DB0_MAX_SECONDS"
+write_direct_oram_status_json db1-build "$ORAM_DB1_MAX_SECONDS" none \
+    || fatal "failed to publish Direct ORAM db1-build status"
 build_direct_oram delta-940611-948454 "$DELTA_SOURCE_DIR" "$ORAM_STAGING_DIR/db1-delta-940611-948454" \
     "$DELTA_DB_EVIDENCE" "$DELTA_DB_MANIFEST" "$DELTA_ROOT_BUNDLE" "$DELTA_EXPECTED_MUHASH" "$DELTA_EXPECTED_FROM_MUHASH" \
     "$DELTA_EXPECTED_INDEX_SHA256" "$DELTA_EXPECTED_CHUNKS_SHA256" \
     "$ORAM_DELTA_TRUSTED_STATE_DIR" "$ORAM_DB1_MAX_SECONDS"
 
+write_direct_oram_status_json publish "$ORAM_TOTAL_MAX_SECONDS" none \
+    || fatal "failed to publish Direct ORAM publish status"
 mv "$ORAM_STAGING_DIR" "$ORAM_CURRENT_DIR" || fatal "failed to publish regenerated ORAM image"
 verify_direct_oram_publish "$ORAM_FULL_DIR" "$ORAM_FULL_TRUSTED_STATE_DIR" mainnet-948454
 verify_direct_oram_publish "$ORAM_DELTA_DIR" "$ORAM_DELTA_TRUSTED_STATE_DIR" delta-940611-948454
 safe_remove_runtime_path "$TRUSTED_INPUT_ROOT"
 write_current_boot_published_marker
 write_watchdog_phase server-readiness
+stop_direct_oram_status_api || fatal "Direct ORAM status API did not release port 8091"
+remove_direct_oram_status_api_root || fatal "failed to remove Direct ORAM status API root"
 trap - EXIT
 trap - HUP INT TERM
 start_unified_server_runtime_log

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,7 +26,7 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "d1e33db31716d576b85847ba53dc0772307d1adc8f81a51839bd05c3ebe19053",
+    "1d32d99f837ff0b0579c566bf8015b7ae684c4509856ec9c78a223255780be6a",
   "scripts/dracut/97bpir-tier3-init/unified-server-finish.sh":
     "06b763099ce2828603763ec45e1cdcec406659a3fb0cd413c28ac85af9cf6444",
   "scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh":

--- a/scripts/vpsbg-production-status.sh
+++ b/scripts/vpsbg-production-status.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Read-only VPSBG control-plane and Direct ORAM progress snapshot.
+set -euo pipefail
+
+readonly API_BASE='https://api.vpsbg.eu/v1'
+readonly DEFAULT_STATUS_URL='https://weikeng2.bitcoinpir.org/status.json'
+readonly DEFAULT_TOKEN_FILE="${XDG_CONFIG_HOME:-${HOME:?HOME is required}/.config}/bitcoinpir/secrets/vpsbg-api-token"
+
+usage() {
+  cat <<'USAGE'
+usage: vpsbg-production-status.sh [--server-id ID] [--status-url URL]
+       vpsbg-production-status.sh --root EVIDENCE_ROOT [--server-id ID]
+
+Default mode performs only GET /servers, GET /servers/{id}, and GET
+/status.json.  --root is an offline evidence directory containing servers.json
+and server.json; status.json is optional.
+USAGE
+}
+
+server_id="${VPSBG_SERVER_ID:-}"
+status_url="${VPSBG_ORAM_STATUS_URL:-$DEFAULT_STATUS_URL}"
+root=
+while (($#)); do
+  case "$1" in
+    --server-id) server_id=${2:?missing server ID}; shift 2 ;;
+    --status-url) status_url=${2:?missing status URL}; shift 2 ;;
+    --root) root=${2:?missing evidence root}; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage >&2; exit 2 ;;
+  esac
+done
+[[ -z "$server_id" || "$server_id" =~ ^[0-9]+$ ]] || { echo 'server ID must be numeric' >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo 'jq is required' >&2; exit 2; }
+
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/bpir-vpsbg-status.XXXXXX")
+trap 'rm -rf "$tmpdir"' EXIT
+servers_file="$tmpdir/servers.json"
+server_file="$tmpdir/server.json"
+status_file="$tmpdir/status.json"
+offline=0
+oram_status_source=unavailable
+
+copy_json() {
+  local source=$1 destination=$2
+  [[ -r "$source" ]] || { echo "offline JSON is unreadable: $source" >&2; exit 2; }
+  jq -e . "$source" >"$destination"
+}
+
+if [[ -n "$root" ]]; then
+  [[ -d "$root" ]] || { echo 'evidence root is not a directory' >&2; exit 2; }
+  offline=1
+  copy_json "$root/servers.json" "$servers_file"
+  copy_json "$root/server.json" "$server_file"
+  if [[ -e "$root/status.json" ]]; then
+    copy_json "$root/status.json" "$status_file"
+    oram_status_source=offline-evidence
+  else
+    printf '%s\n' '{}' >"$status_file"
+  fi
+else
+  token_file="${VPSBG_API_TOKEN_FILE:-$DEFAULT_TOKEN_FILE}"
+  [[ -r "$token_file" && -s "$token_file" ]] || { echo 'VPSBG API token file is missing or empty' >&2; exit 2; }
+  token=$(tr -d '\r\n' <"$token_file")
+  [[ -n "$token" ]] || { echo 'VPSBG API token is empty' >&2; exit 2; }
+  curl --fail --silent --show-error --max-time 20 --retry 0 -H 'Accept: application/json' -H "Authorization: Bearer $token" "$API_BASE/servers" | jq -e . >"$servers_file"
+fi
+
+list_filter='if type == "object" and (.data | type) == "array" then .data else error("expected {data:[...]}") end'
+server_count=$(jq -er "$list_filter | length" "$servers_file")
+if [[ -n "$server_id" ]]; then
+  selected_count=$(jq -er --argjson id "$server_id" "$list_filter | map(select(.id == \$id)) | length" "$servers_file")
+  [[ "$selected_count" == 1 ]] || { echo 'selected VPSBG server is absent or ambiguous' >&2; exit 2; }
+else
+  [[ "$server_count" == 1 ]] || { echo 'VPSBG server selection is ambiguous; pass --server-id or VPSBG_SERVER_ID' >&2; exit 2; }
+  server_id=$(jq -er "$list_filter | .[0].id | if type == \"number\" and floor == . and . >= 0 then tostring else error(\"invalid server id\") end" "$servers_file")
+fi
+
+if ((offline)); then
+  server=$(jq -ec --argjson id "$server_id" 'if type == "object" and .id == $id then . else error("detail does not match selected server") end' "$server_file")
+else
+  curl --fail --silent --show-error --max-time 20 --retry 0 -H 'Accept: application/json' -H "Authorization: Bearer $token" "$API_BASE/servers/$server_id" | jq -e 'if type == "object" then . else error("expected server detail object") end' >"$server_file"
+  server=$(cat "$server_file")
+  case "$status_url" in
+    *\?*) status_request_url="$status_url&ts=$(date -u +%s)" ;;
+    *) status_request_url="$status_url?ts=$(date -u +%s)" ;;
+  esac
+  if curl --fail --silent --max-time 20 --retry 0 \
+    -H 'Accept: application/json' -H 'Cache-Control: no-cache, no-store' \
+    -H 'Pragma: no-cache' "$status_request_url" | jq -e . >"$status_file"; then
+    oram_status_source=public-status-json
+  else
+    printf '%s\n' '[status] public /status.json unavailable' >&2
+    printf '%s\n' '{}' >"$status_file"
+  fi
+  unset token
+fi
+
+safe_string() { [[ ${1:-} =~ ^[A-Za-z0-9._:/@+=,-]+$ ]] && printf '%s\n' "$1" || printf '%s\n' unavailable; }
+json_string() { jq -er "$1 | if type == \"string\" then . else error(\"not string\") end" <<<"$2" 2>/dev/null | while IFS= read -r v; do safe_string "$v"; done || printf unavailable; }
+json_bool() { jq -r "$1 | if type == \"boolean\" then tostring else \"unavailable\" end" <<<"$2"; }
+json_uint() { jq -r "$1 | if type == \"number\" and floor == . and . >= 0 then tostring else \"unavailable\" end" <<<"$2"; }
+
+hostname=$(json_string '.hostname' "$server")
+state=$(json_string '.status' "$server")
+virtualization=$(json_string '.virtualization' "$server")
+reachable=$(json_bool '.state.node_reachable' "$server")
+running=$(json_bool '.state.running' "$server")
+sev_level=$(json_uint '.state.amd_sev_level' "$server")
+boot_mode=unavailable image_id=unavailable image_name=unavailable
+measured_boot_kind=$(jq -r '. as $server | if ($server.state | type) == "object" and ($server.state | has("measured_boot")) then if $server.state.measured_boot == null then "stock" else "measured" end else "unavailable" end' <<<"$server")
+if [[ "$measured_boot_kind" == stock ]]; then
+  boot_mode=stock
+elif [[ "$measured_boot_kind" == measured ]] && jq -e '.state.measured_boot.kernel_image | type == "object"' <<<"$server" >/dev/null; then
+  boot_mode=measured
+  image_id=$(json_uint '.state.measured_boot.kernel_image.id' "$server")
+  image_name=$(json_string '.state.measured_boot.kernel_image.name' "$server")
+fi
+
+progress_valid=0
+if [[ "$oram_status_source" != unavailable ]]; then
+  if jq -e '
+    type == "object" and (keys | sort) == ["hard_stop_seconds","reason","schema_version","stage","started_at_epoch","updated_at_epoch"] and
+    .schema_version == 1 and
+    (.stage as $s | ["input-validation","db0-build","db1-build","publish","failed"] | index($s)) and
+    ([.started_at_epoch,.updated_at_epoch,.hard_stop_seconds] | all(type == "number" and floor == . and . >= 0)) and
+    (.reason | type == "string" and test("^[A-Za-z0-9._-]+$"))
+  ' "$status_file" >/dev/null; then
+    progress_valid=1
+  else
+    if ((offline)); then
+      echo 'offline status.json violates the Direct ORAM progress schema' >&2
+      exit 2
+    fi
+    echo '[status] public /status.json violates the progress schema' >&2
+    oram_status_source=unavailable
+  fi
+fi
+
+oram_stage=unavailable oram_started_at_epoch=unavailable oram_updated_at_epoch=unavailable oram_elapsed_seconds=unavailable oram_hard_stop_seconds=unavailable oram_reason=unavailable
+if ((progress_valid)); then
+  oram_stage=$(jq -r '.stage' "$status_file")
+  oram_started_at_epoch=$(jq -r '.started_at_epoch' "$status_file")
+  oram_updated_at_epoch=$(jq -r '.updated_at_epoch' "$status_file")
+  oram_hard_stop_seconds=$(jq -r '.hard_stop_seconds' "$status_file")
+  oram_reason=$(jq -r '.reason' "$status_file")
+  now=$(date -u +%s)
+  if [[ "$now" =~ ^[0-9]+$ && "$now" -ge "$oram_started_at_epoch" ]]; then oram_elapsed_seconds=$((now - oram_started_at_epoch)); fi
+fi
+
+cat <<EOF
+production_status=v3
+control_plane_server_id=$server_id
+control_plane_hostname=$hostname
+control_plane_state=$state
+control_plane_virtualization=$virtualization
+control_plane_reachable=$reachable
+control_plane_running=$running
+control_plane_sev_level=$sev_level
+boot_mode=$boot_mode
+image_id=$image_id
+image_name=$image_name
+oram_status_source=$oram_status_source
+oram_stage=$oram_stage
+oram_started_at_epoch=$oram_started_at_epoch
+oram_updated_at_epoch=$oram_updated_at_epoch
+oram_elapsed_seconds=$oram_elapsed_seconds
+oram_hard_stop_seconds=$oram_hard_stop_seconds
+oram_reason=$oram_reason
+EOF

--- a/scripts/vpsbg-production-status.test.sh
+++ b/scripts/vpsbg-production-status.test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$script_dir/vpsbg-production-status.sh"
+root="$(mktemp -d "${TMPDIR:-/tmp}/bpir-vpsbg-status.XXXXXX")"
+trap 'rm -rf "$root"' EXIT
+write() { printf '%s\n' "$2" >"$1"; }
+
+write "$root/servers.json" '{"data":[{"id":25285}]}'
+write "$root/server.json" '{"id":25285,"hostname":"pir-server-vpsbg","status":"active","virtualization":"kvm","state":{"running":true,"node_reachable":true,"amd_sev_level":3,"measured_boot":{"kernel_image":{"id":229,"name":"bpir-tier3-20260812.efi","size":12345,"in_use":true,"created_at":"2026-08-12T00:00:00Z"}}}}'
+write "$root/status.json" '{"schema_version":1,"stage":"db1-build","started_at_epoch":100,"updated_at_epoch":140,"hard_stop_seconds":900,"reason":"none"}'
+actual="$($script --root "$root")"
+grep -qx 'production_status=v3' <<<"$actual"
+grep -qx 'control_plane_server_id=25285' <<<"$actual"
+grep -qx 'control_plane_hostname=pir-server-vpsbg' <<<"$actual"
+grep -qx 'control_plane_state=active' <<<"$actual"
+grep -qx 'control_plane_virtualization=kvm' <<<"$actual"
+grep -qx 'control_plane_reachable=true' <<<"$actual"
+grep -qx 'control_plane_running=true' <<<"$actual"
+grep -qx 'control_plane_sev_level=3' <<<"$actual"
+grep -qx 'boot_mode=measured' <<<"$actual"
+grep -qx 'image_id=229' <<<"$actual"
+grep -qx 'image_name=bpir-tier3-20260812.efi' <<<"$actual"
+grep -qx 'oram_status_source=offline-evidence' <<<"$actual"
+grep -qx 'oram_stage=db1-build' <<<"$actual"
+grep -qx 'oram_started_at_epoch=100' <<<"$actual"
+grep -qx 'oram_updated_at_epoch=140' <<<"$actual"
+grep -qx 'oram_hard_stop_seconds=900' <<<"$actual"
+grep -qx 'oram_reason=none' <<<"$actual"
+
+rm "$root/status.json"
+missing="$($script --root "$root")"
+grep -qx 'oram_status_source=unavailable' <<<"$missing"
+grep -qx 'oram_stage=unavailable' <<<"$missing"
+
+write "$root/servers.json" '{"data":[{"id":1},{"id":2}]}'
+if "$script" --root "$root" >/dev/null 2>&1; then echo 'ambiguous server selection unexpectedly succeeded' >&2; exit 1; fi
+
+write "$root/server.json" '{"id":2,"status":"active","virtualization":"kvm","state":{"measured_boot":null}}'
+write "$root/status.json" '{'
+if "$script" --root "$root" --server-id 2 >/dev/null 2>&1; then echo 'invalid present status unexpectedly succeeded' >&2; exit 1; fi
+echo 'vpsbg production status offline fixture: PASS'

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -111,6 +111,32 @@ esac
     /inst_multiple[^\n]*\bstat\b/,
     "Tier3 initramfs must install stat for the identity preflight",
   );
+  assert.match(
+    tier3ModuleSetupText,
+    /busybox --list \| grep -qx httpd/,
+    "Tier3 initramfs must refuse a BusyBox build without the httpd applet",
+  );
+  assert.match(
+    tier3RunText,
+    /"\$ORAM_STATUS_HTTPD" httpd -f/,
+    "status API must use BusyBox httpd",
+  );
+  assert.match(tier3RunText, /status\.json/, "status API root must contain status.json");
+  assert.match(
+    tier3RunText,
+    /start_direct_oram_status_api\nstart_total_watchdog[\s\S]*build_direct_oram mainnet/,
+    "status API must start before Direct ORAM builds",
+  );
+  assert.match(
+    tier3RunText,
+    /stop_direct_oram_status_api[\s\S]*remove_direct_oram_status_api_root[\s\S]*exec "\$UNIFIED_SERVER"/,
+    "status API must stop and remove its root before unified_server exec",
+  );
+  assert.doesNotMatch(
+    tier3RunText.match(/write_direct_oram_status_json\(\)[\s\S]*?^}/m)?.[0] ?? "",
+    /ORAM_PAGE_KEY_HEX/,
+    "status JSON must not contain the ORAM page key",
+  );
   const tier3CloudflaredText = readFileSync(tier3CloudflaredScript, "utf8");
   for (const [label, script] of [
     ["unified_server watchdog", tier3RunText],
@@ -227,6 +253,7 @@ esac
     .replace("UNIFIED_SERVER=/usr/local/bin/unified_server", `UNIFIED_SERVER=${unifiedServer}`)
     .replace("TRUSTED_INPUT_ROOT=/run/bitcoinpir-oram-inputs", `TRUSTED_INPUT_ROOT=${mismatchRoot}/trusted-inputs`)
     .replace("TRUSTED_STATE_ROOT=/run/bitcoinpir-oram-state", `TRUSTED_STATE_ROOT=${mismatchRoot}/trusted-state`)
+    .replaceAll("/run/bitcoinpir-oram-status-api", `${mismatchRoot}/status-api`)
     .replaceAll("sleep 5", ":");
   writeFileSync(fixtureRunScript, transformed);
   chmodSync(fixtureRunScript, 0o755);
@@ -254,6 +281,7 @@ esac
   const directOramctl = path.join(directRoot, "oramctl");
   const directUnifiedServer = path.join(directRoot, "unified_server");
   const directBhtmProof = path.join(directRoot, "height-940611.leaf-proof.json");
+  const directStatusApiRoot = path.join(directRoot, "status-api");
   const db0Index = "db0-index-fixture\n";
   const db0Chunks = "db0-chunks-fixture\n";
   const db1Index = "db1-index-fixture\n";
@@ -331,7 +359,7 @@ printf started >> "${unifiedStarts}"
 printf ready > "${readySignal}"
 printf 'fixture server stdout\n'
 printf 'fixture server stderr\n' >&2
-sleep 1
+sleep 2
 `,
   );
   write(
@@ -352,6 +380,12 @@ exit 1
     .replaceAll("/home/pir/data", directData)
     .replace("/usr/share/bitcoinpir/proofs/height-940611.leaf-proof.json", directBhtmProof)
     .replace("ORAMCTL=/usr/local/bin/oramctl", `ORAMCTL=${directOramctl}`)
+    .replaceAll("/run/bitcoinpir-oram-status-api", directStatusApiRoot)
+    .replace("start_direct_oram_status_api\nstart_total_watchdog", ":\nstart_total_watchdog")
+    .replace(
+      'stop_direct_oram_status_api || fatal "Direct ORAM status API did not release port 8091"\nremove_direct_oram_status_api_root || fatal "failed to remove Direct ORAM status API root"',
+      ":\nremove_direct_oram_status_api_root",
+    )
     .replace(
       "ORAM_SUPERVISOR=/usr/local/bin/direct-oram-supervisor",
       `ORAM_SUPERVISOR=${directOramSupervisor}`,
@@ -370,7 +404,7 @@ exit 1
     )
     .replace("ORAM_DB0_MAX_SECONDS=480", "ORAM_DB0_MAX_SECONDS=5")
     .replace("ORAM_DB1_MAX_SECONDS=180", "ORAM_DB1_MAX_SECONDS=5")
-    .replace("ORAM_TOTAL_MAX_SECONDS=900", "ORAM_TOTAL_MAX_SECONDS=5")
+    .replace("ORAM_TOTAL_MAX_SECONDS=900", "ORAM_TOTAL_MAX_SECONDS=8")
     .replace("ORAM_HEARTBEAT_INTERVAL_SECONDS=15", "ORAM_HEARTBEAT_INTERVAL_SECONDS=1")
     .replace("ORAM_HEARTBEAT_DEADLINE_SECONDS=90", "ORAM_HEARTBEAT_DEADLINE_SECONDS=3")
     .replace("ORAM_KILL_GRACE_SECONDS=5", "ORAM_KILL_GRACE_SECONDS=0")
@@ -466,13 +500,13 @@ exec sleep 5
   );
   chmodSync(timeoutUnifiedServer, 0o755);
   writeFileSync(bootIdFile, "33333333-3333-3333-3333-333333333333\n");
-  rmSync(readySignal);
+  rmSync(readySignal, { force: true });
   const timeoutRunScript = path.join(directRoot, "unified-server-timeout-run.sh");
   writeFileSync(
     timeoutRunScript,
     directTransformed
       .replace(`UNIFIED_SERVER=${directUnifiedServer}`, `UNIFIED_SERVER=${timeoutUnifiedServer}`)
-      .replace("ORAM_TOTAL_MAX_SECONDS=5", "ORAM_TOTAL_MAX_SECONDS=1"),
+      .replace("ORAM_TOTAL_MAX_SECONDS=8", "ORAM_TOTAL_MAX_SECONDS=1"),
   );
   chmodSync(timeoutRunScript, 0o755);
   const serverReadinessTimeout = run("sh", [timeoutRunScript], { env: directEnv });


### PR DESCRIPTION
## What changed

- expose a temporary read-only `/status.json` while Tier3 Direct ORAM rebuilds db0/db1 and publishes the result
- stop the temporary origin and release port 8091 before `unified_server` starts
- add a browserless operator command that combines VPSBG control-plane state with the temporary progress endpoint, without SSH
- add a short canonical production-operations entry point and mark older operational documents as historical evidence

## Why

The previous recovery work lacked a small, authoritative progress surface. Agents had to infer state from restarts and scattered logs. This adds stage and timing visibility without changing the ORAM algorithm or scanning its output files.

The endpoint intentionally exists only during build/switch. Once the production server owns port 8091, the command reports control-plane state and marks ORAM progress unavailable.

## Validation

- `scripts/vpsbg-production-status.test.sh`
- `node scripts/vpsbg-tier3-generation.test.mjs`
- `node scripts/payment-v1-deployment-template-gate.mjs`
- `node --test scripts/payment-v1-deployment-template-gate.test.mjs` (30/30)
- shell syntax checks and `git diff --check`
- read-only live status query confirmed server 25285 running/reachable on attached image 261; progress endpoint unavailable as expected after handoff

No UKI build, browser test, reboot, deployment, or production mutation was performed.
