### PR TITLE
Require reviewed service policy in Tier3 UKIs

### DIFF
--- a/.github/workflows/workflow-supply-chain.yml
+++ b/.github/workflows/workflow-supply-chain.yml
@@ -60,6 +60,8 @@ jobs:
         run: |
           node --check scripts/github-workflow-supply-chain-gate.mjs
           node --check scripts/github-workflow-supply-chain-gate.test.mjs
+          node --check scripts/tier3-uki-policy-contract.test.mjs
+          node --test scripts/tier3-uki-policy-contract.test.mjs
           node --test scripts/github-workflow-supply-chain-gate.test.mjs
           node scripts/github-workflow-supply-chain-gate.mjs
           python3 -m py_compile verification/scripts/verify_formal_lock.py verification/scripts/test_verify_formal_lock.py

--- a/docs/PRODUCTION_OPERATIONS.md
+++ b/docs/PRODUCTION_OPERATIONS.md
@@ -33,6 +33,14 @@ VPSBG release and rollback use the measured-boot procedure in the
 Use the reported attached image as the rollback reference; do not substitute a
 historical preflight for current state.
 
+Production Tier 3 builds must set `BPIR_TIER3_SERVICE_POLICY` to the exact
+currently approved signed policy. The build fails when it is missing and
+rejects anything except the reviewed digest locked in `build_uki_tier3.sh`; it
+then verifies that the initramfs contains byte-identical policy data before
+emitting an uploadable UKI. A policy-epoch rotation must update that source lock
+in a reviewed change. Never rely on the mutable-rootfs policy fallback for a
+new release.
+
 Run a manual production canary only after a deliberate web or VPSBG release,
 never as the first diagnostic step.
 

--- a/scripts/build_uki_tier3.sh
+++ b/scripts/build_uki_tier3.sh
@@ -25,7 +25,8 @@
 #
 # Operator usage (must run as root — /boot/vmlinuz-* is mode 0600):
 #   ssh vpsbg-pir 'apt install -y runit'   # one-time build dep
-#   ssh vpsbg-pir '/home/pir/BitcoinPIR/scripts/build_uki_tier3.sh'
+#   ssh vpsbg-pir 'BPIR_TIER3_SERVICE_POLICY=/absolute/service-policy.bin \
+#       /home/pir/BitcoinPIR/scripts/build_uki_tier3.sh'
 #   scp vpsbg-pir:/tmp/bpir-tier3.efi ./bpir-tier3.efi
 #
 # Recovery if Tier 3 boot fails: VPSBG portal → Measured Boot → UKI
@@ -44,6 +45,10 @@ fi
 KERNEL=${KERNEL:-}
 OUT=${OUT:-/tmp/bpir-tier3.efi}
 CUSTOM_INITRD=/tmp/bpir-tier3-initrd.img
+# The currently deployed image accepts service-policy epoch 8 with this exact
+# digest. A policy rotation is a production behavior change and must update
+# this reviewed lock in source before a new UKI can be emitted.
+TIER3_SERVICE_POLICY_SHA256=ef076d5fcb4ccc89c7ad4b883d332005ef59cfa09617e1ea66359d37f962dc14
 
 # Resolve dracut module dir relative to this script.
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
@@ -111,15 +116,26 @@ BHTM_FROM_LEAF_PROOF=${BHTM_FROM_LEAF_PROOF:-/home/pir/BitcoinPIR/web/public/pro
 }
 export BPIR_BHTM_FROM_LEAF_PROOF="$BHTM_FROM_LEAF_PROOF"
 
-# Optional public, signed policy to bind to this measured image.  It is not a
-# credential key or issuer secret; the provider still verifies its signature
-# at runtime.  Leaving it unset preserves the established mutable-rootfs
-# policy fallback.
-if [ -n "${BPIR_TIER3_SERVICE_POLICY:-}" ]; then
-    [ -r "$BPIR_TIER3_SERVICE_POLICY" ] || {
-        echo "error: BPIR_TIER3_SERVICE_POLICY is not readable: $BPIR_TIER3_SERVICE_POLICY" >&2
-        exit 1
-    }
+# The public signed policy is part of the measured production identity.  It is
+# not a credential key or issuer secret.  Requiring an explicit input prevents
+# a release from silently falling back to an older mutable-rootfs policy whose
+# epoch has already been superseded by the rollback authority.
+[ -n "${BPIR_TIER3_SERVICE_POLICY:-}" ] || {
+    echo "error: BPIR_TIER3_SERVICE_POLICY is required for a production Tier 3 UKI" >&2
+    exit 1
+}
+[ -f "$BPIR_TIER3_SERVICE_POLICY" ] \
+    && [ -r "$BPIR_TIER3_SERVICE_POLICY" ] \
+    && [ -s "$BPIR_TIER3_SERVICE_POLICY" ] || {
+    echo "error: BPIR_TIER3_SERVICE_POLICY is not a readable non-empty file: $BPIR_TIER3_SERVICE_POLICY" >&2
+    exit 1
+}
+SERVICE_POLICY_HASH=$(sha256sum "$BPIR_TIER3_SERVICE_POLICY" | awk '{print $1}')
+if [ "$SERVICE_POLICY_HASH" != "$TIER3_SERVICE_POLICY_SHA256" ]; then
+    echo "error: BPIR_TIER3_SERVICE_POLICY is not the reviewed production policy" >&2
+    echo "  expected sha256: $TIER3_SERVICE_POLICY_SHA256" >&2
+    echo "  actual sha256:   $SERVICE_POLICY_HASH" >&2
+    exit 1
 fi
 
 # ─── Kernel auto-detection ──────────────────────────────────────────────────
@@ -230,11 +246,8 @@ echo "BHTM from-leaf proof:     $BHTM_FROM_LEAF_PROOF"
 echo "binary sha256:            $BIN_HASH"
 echo "oramctl sha256:           $ORAMCTL_HASH"
 echo "BHTM proof sha256:        $BHTM_PROOF_HASH"
-if [ -n "${BPIR_TIER3_SERVICE_POLICY:-}" ]; then
-    SERVICE_POLICY_HASH=$(sha256sum "$BPIR_TIER3_SERVICE_POLICY" | awk '{print $1}')
-    echo "service policy:          $BPIR_TIER3_SERVICE_POLICY"
-    echo "service policy sha256:   $SERVICE_POLICY_HASH"
-fi
+echo "service policy:          $BPIR_TIER3_SERVICE_POLICY"
+echo "service policy sha256:   $SERVICE_POLICY_HASH"
 
 # ─── Generate initramfs ────────────────────────────────────────────────────
 # --add network            : pulls in dracut's network plumbing (mostly
@@ -341,13 +354,23 @@ if [ -n "${BPIR_TIER3_IDENTITY_KEY:-}" ] || [ -n "${BPIR_TIER3_IDENTITY_CERT:-}"
     echo "measured identity confirmed in initramfs (private parent + key + cert)"
 fi
 
-if [ -n "${BPIR_TIER3_SERVICE_POLICY:-}" ]; then
-    if ! grep -Eq -- '-rw-r--r--[[:space:]]+.*etc/bitcoinpir/payment/service-policy\.bin$' <<< "$INITRD_LISTING"; then
-        echo "ERROR: measured service policy missing or has an unsafe mode" >&2
-        exit 1
-    fi
-    echo "measured service policy confirmed in initramfs"
+if ! grep -Eq -- '-rw-r--r--[[:space:]]+.*etc/bitcoinpir/payment/service-policy\.bin$' <<< "$INITRD_LISTING"; then
+    echo "ERROR: measured service policy missing or has an unsafe mode" >&2
+    exit 1
 fi
+EMBEDDED_SERVICE_POLICY_HASH=$(
+    /usr/bin/lsinitrd -f /etc/bitcoinpir/payment/service-policy.bin \
+        "$CUSTOM_INITRD" 2>/dev/null \
+        | sha256sum \
+        | awk '{print $1}'
+)
+if [ "$EMBEDDED_SERVICE_POLICY_HASH" != "$SERVICE_POLICY_HASH" ]; then
+    echo "ERROR: measured service policy bytes do not match BPIR_TIER3_SERVICE_POLICY" >&2
+    echo "  input sha256:    $SERVICE_POLICY_HASH" >&2
+    echo "  embedded sha256: $EMBEDDED_SERVICE_POLICY_HASH" >&2
+    exit 1
+fi
+echo "measured service policy confirmed in initramfs: $SERVICE_POLICY_HASH"
 
 # ─── Build the cmdline ─────────────────────────────────────────────────────
 # rdinit=/sbin/bpir-tier3-init  : kernel exec's OUR script as PID 1
@@ -387,7 +410,8 @@ echo "tier3 uki sha256:         $UKI_SHA"
     "unified_server=$BINARY" \
     "binary_sha256=$BIN_HASH" \
     "oramctl_sha256=$ORAMCTL_HASH" \
-    "bhtm_from_leaf_sha256=$BHTM_PROOF_HASH"
+    "bhtm_from_leaf_sha256=$BHTM_PROOF_HASH" \
+    "service_policy_sha256=$SERVICE_POLICY_HASH"
 echo
 echo "Next steps (Phase 3.2 acceptance):"
 echo "  0. (One-time, before first deploy of this Tier 3 variant) provision"
@@ -407,8 +431,8 @@ echo "       UKI_ARCHIVE_REMOTE=pir-hetzner:/home/pir/uki-archive/tier3"
 echo "     Download $OUT only as an operator convenience:"
 echo "       scp vpsbg-pir:$OUT ./bpir-tier3.efi"
 echo
-echo "  2. VPSBG dashboard → Confidentiality & Protection →"
-echo "     Advanced: Measured Boot → UKI → Upload → Save & Reboot."
+echo "  2. Upload and attach the UKI through the reviewed VPSBG measured-boot"
+echo "     API procedure in .agents/skills/vpsbg-measured-boot/SKILL.md."
 echo
 echo "  3. Verify the binary and AMD signature on the same attestation response:"
 echo "       bpir-admin attest wss://weikeng2.bitcoinpir.org \\"

--- a/scripts/dracut/96bpir-unified-server/module-setup.sh
+++ b/scripts/dracut/96bpir-unified-server/module-setup.sh
@@ -101,18 +101,17 @@ install() {
         chmod 0644 "$initdir/etc/bitcoinpir/identity/server.cert"
     fi
 
-    # A Tier 3 release can bind a public, signed admission policy to the
-    # measured image without putting issuer, payment, or identity secrets in
-    # it.  The runner keeps its historical rootfs policy fallback for existing
-    # deployments; this optional copy is for releases that must atomically
-    # change the attested runtime and its advertised Free scopes.
-    if [ -n "$service_policy" ]; then
-        if [ ! -r "$service_policy" ]; then
-            derror "bpir-unified-server: BPIR_TIER3_SERVICE_POLICY is not readable"
-            return 1
-        fi
-        inst_dir /etc/bitcoinpir/payment
-        inst_simple "$service_policy" /etc/bitcoinpir/payment/service-policy.bin
-        chmod 0644 "$initdir/etc/bitcoinpir/payment/service-policy.bin"
+    # The public signed admission policy must change atomically with the
+    # measured runtime.  A missing input must fail the build instead of
+    # allowing the guest to select a stale mutable-rootfs policy at boot.
+    if [ -z "$service_policy" ] \
+        || [ ! -f "$service_policy" ] \
+        || [ ! -r "$service_policy" ] \
+        || [ ! -s "$service_policy" ]; then
+        derror "bpir-unified-server: BPIR_TIER3_SERVICE_POLICY must name a readable non-empty file"
+        return 1
     fi
+    inst_dir /etc/bitcoinpir/payment
+    inst_simple "$service_policy" /etc/bitcoinpir/payment/service-policy.bin
+    chmod 0644 "$initdir/etc/bitcoinpir/payment/service-policy.bin"
 }

--- a/scripts/tier3-uki-policy-contract.test.mjs
+++ b/scripts/tier3-uki-policy-contract.test.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const buildPath = resolve(repository, "scripts/build_uki_tier3.sh");
+const modulePath = resolve(
+  repository,
+  "scripts/dracut/96bpir-unified-server/module-setup.sh",
+);
+const reviewedPolicySha256 =
+  "ef076d5fcb4ccc89c7ad4b883d332005ef59cfa09617e1ea66359d37f962dc14";
+
+function validateBuildContract(source) {
+  const policyRequirement = source.indexOf(
+    '[ -n "${BPIR_TIER3_SERVICE_POLICY:-}" ] || {',
+  );
+  const dracutBuild = source.indexOf("SOURCE_DATE_EPOCH=0 dracut");
+  assert.ok(policyRequirement >= 0, "Tier3 build must require an explicit policy");
+  assert.ok(
+    policyRequirement < dracutBuild,
+    "Tier3 build must reject a missing policy before invoking dracut",
+  );
+  assert.match(
+    source,
+    new RegExp(`TIER3_SERVICE_POLICY_SHA256=${reviewedPolicySha256}`),
+  );
+  assert.match(
+    source,
+    /\[ "\$SERVICE_POLICY_HASH" != "\$TIER3_SERVICE_POLICY_SHA256" \]/,
+  );
+  assert.match(
+    source,
+    /lsinitrd -f \/etc\/bitcoinpir\/payment\/service-policy\.bin/,
+  );
+  assert.match(
+    source,
+    /\[ "\$EMBEDDED_SERVICE_POLICY_HASH" != "\$SERVICE_POLICY_HASH" \]/,
+  );
+  assert.match(source, /"service_policy_sha256=\$SERVICE_POLICY_HASH"/);
+}
+
+function validateDracutModuleContract(source) {
+  assert.match(source, /\[ -z "\$service_policy" \]/);
+  assert.match(source, /\[ ! -f "\$service_policy" \]/);
+  assert.match(source, /\[ ! -r "\$service_policy" \]/);
+  assert.match(source, /\[ ! -s "\$service_policy" \]/);
+  assert.match(
+    source,
+    /inst_simple "\$service_policy" \/etc\/bitcoinpir\/payment\/service-policy\.bin/,
+  );
+}
+
+test("production Tier3 build requires and byte-verifies reviewed policy", () => {
+  validateBuildContract(readFileSync(buildPath, "utf8"));
+});
+
+test("production Tier3 build rejects policy lock or embedded-byte regressions", () => {
+  const source = readFileSync(buildPath, "utf8");
+  assert.throws(() =>
+    validateBuildContract(
+      source.replace(reviewedPolicySha256, "0".repeat(64)),
+    ),
+  );
+  assert.throws(() =>
+    validateBuildContract(
+      source.replace(
+        '[ "$EMBEDDED_SERVICE_POLICY_HASH" != "$SERVICE_POLICY_HASH" ]',
+        '[ "$EMBEDDED_SERVICE_POLICY_HASH" = "$SERVICE_POLICY_HASH" ]',
+      ),
+    ),
+  );
+});
+
+test("dracut module refuses to omit the measured policy", () => {
+  validateDracutModuleContract(readFileSync(modulePath, "utf8"));
+});
+
+test("dracut module rejects an optional-policy regression", () => {
+  const source = readFileSync(modulePath, "utf8");
+  assert.throws(() =>
+    validateDracutModuleContract(
+      source.replace('[ -z "$service_policy" ]', '[ -n "$service_policy" ]'),
+    ),
+  );
+});


### PR DESCRIPTION
## Summary

- require an explicit, non-empty service policy for production Tier3 UKI builds
- lock the currently accepted epoch-8 policy digest and compare the extracted initramfs bytes before emitting the UKI
- make the dracut module fail when the policy input is absent and record the policy digest in release metadata
- add a lightweight regression contract to the existing required workflow gate

## Incident evidence

Image 263 contained no measured service policy, fell back to the mutable rootfs policy, and exited after Direct ORAM/database loading with `invalid ServicePolicyV1.policy_epoch: policy epoch rollback`. Image 261 accepted policy epoch 8.

## Verification

- shell syntax checks for both changed shell files
- Tier3 policy contract: 4/4 pass
- workflow supply-chain tests: 69/69 pass; full gate pass
- formal lock mutation tests: 5/5 pass
- Hetzner no-build behavior checks: missing and wrong policy rejected before dracut; accepted epoch-8 policy passed the gate and stopped at a deliberately missing kernel
- no UKI build, upload, server switch, or browser canary run
