### PR TITLE
Pin VPSBG image 265 in Web

### DIFF
--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -24,10 +24,10 @@ describe('bundled functional-beta trusted bootstrap', () => {
       '256fb106c039f8009d3caa431a9634ff3fe5db3b9e4d9ae7282bbde66772c97a',
     );
     expect(parsed.providers[1].serverPin.measurementHex).toBe(
-      'b8b9e724b244a52a2f87dfcde3edb895cbf5eec1c9b08f964eaefc8160c8be4988c7814fe424cbbd3158ff2e7928db53',
+      'e3f6b4df452512b871dd00aa53fa1e887e8c52e8c4e258e233d6b656b1afaa69a71ead21e836c9717c0af0c012684c18',
     );
     expect(parsed.providers[1].serverPin.binarySha256Hex).toBe(
-      '8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355',
+      '4b05fc9030b63fe75ae59a9f80c9a449d620d16f56f969c0b43ff15bd98df6e2',
     );
     expect(parsed.providers[0].supportedWorkloads).toEqual([
       'dpf-query', 'harmony-hint', 'onion-session',

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -127,17 +127,17 @@ export interface ServerAttestPin {
 
 /**
  * weikeng2.bitcoinpir.org — VPSBG Tier 3 Payment V1 beta UKI, pinned
- * 2026-08-12 after separating the legacy V1 and native V2 proof slots. Image
- * 261 serves DPF, Harmony-query and TEE ORAM with the reviewed epoch-8 policy.
+ * 2026-08-12 after embedding the reviewed epoch-8 policy in the measured
+ * initramfs. Image 265 serves DPF, Harmony-query and TEE ORAM.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // Captured from image 261 after validating the AMD chain, REPORT_DATA,
+  // Captured from image 265 after validating the AMD chain, REPORT_DATA,
   // exact unified_server binary and both attested database manifest roots.
   measurementHex:
-    'b8b9e724b244a52a2f87dfcde3edb895cbf5eec1c9b08f964eaefc8160c8be4988c7814fe424cbbd3158ff2e7928db53',
+    'e3f6b4df452512b871dd00aa53fa1e887e8c52e8c4e258e233d6b656b1afaa69a71ead21e836c9717c0af0c012684c18',
   binarySha256Hex:
-    '8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355',
-  description: 'weikeng2.bitcoinpir.org (VPSBG image 261, SEV-SNP, Tier 3 DPF + Harmony + Direct ORAM, epoch-8)',
+    '4b05fc9030b63fe75ae59a9f80c9a449d620d16f56f969c0b43ff15bd98df6e2',
+  description: 'weikeng2.bitcoinpir.org (VPSBG image 265, SEV-SNP, Tier 3 DPF + Harmony + Direct ORAM, epoch-8)',
 };
 
 /**

--- a/web/src/functional-beta-trusted-bootstrap.json
+++ b/web/src/functional-beta-trusted-bootstrap.json
@@ -68,8 +68,8 @@
       "operatorSigningKeyHex": "256fb106c039f8009d3caa431a9634ff3fe5db3b9e4d9ae7282bbde66772c97a",
       "stableServerId": "pir2-vpsbg-dpf-v1",
       "serverPin": {
-        "binarySha256Hex": "8aa6928c866aaed396c8d2ffe70520ba1dd7e650c4e5bfdaea87f38eb42ea355",
-        "measurementHex": "b8b9e724b244a52a2f87dfcde3edb895cbf5eec1c9b08f964eaefc8160c8be4988c7814fe424cbbd3158ff2e7928db53"
+        "binarySha256Hex": "4b05fc9030b63fe75ae59a9f80c9a449d620d16f56f969c0b43ff15bd98df6e2",
+        "measurementHex": "e3f6b4df452512b871dd00aa53fa1e887e8c52e8c4e258e233d6b656b1afaa69a71ead21e836c9717c0af0c012684c18"
       },
       "hardwareAttestation": "required",
       "expectedArkFingerprintHex": "1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a",


### PR DESCRIPTION
## Summary

- pin the live VPSBG image 265 launch measurement and unified_server hash
- update the bundled functional-beta trusted bootstrap
- keep the browserless bootstrap regression aligned with the live pin

## Evidence

The values were re-read from image 265 after verifying the AMD ARK→ASK→VCEK chain, SNP report signature, REPORT_DATA binding, exact binary, and both database manifest roots.

## Validation

- production canary semantic contract
- focused functional-beta bootstrap Vitest (4/4)
- TypeScript build
- Vite production build and CSP verification
- git diff check

No browser test or Web deployment was run.