### PR TITLE
Docs: process audit record, operations index, change-class test matrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -420,7 +420,15 @@ Never use `echo "$var" | grep -q` under `set -o pipefail`. `grep -q` exits on fi
 - Inspect with `lsinitrd` (handles all compression); `cpio -t <` does NOT work on zstd
 - SEV modules: ccp, sev-guest, tsm_report — validated pre/post-build in `build_uki_tier3.sh`
 
-### Attestation pins (current as of 2026-08-07)
-`web/src/attest-pin.ts` is the authoritative source — values below are a quick reference.
-- **pir1 (Hetzner)**: binary `c836e11a...` (commit `831a5ea1`, Cargo release build, default features incl. `9b7128f0` harmony response chunk fix) — no SEV, no measurement
-- **pir2 (VPSBG) Tier 3**: binary `4f51c64d...` (commit `831a5ea1`, same fix source, `--features cuckoo-oram`) baked into UKI sha256 `dcb5c867...` (measured-boot image id 229, epoch-4 policy `093f078f` embedded: harmony-query `max_response_bytes` 64→128 MiB + DPF `max_wall_time_ms` 20→120 s), measurement `1c375b26...` — pir2 serves `--serve-queries`; previous images 223/225/227 kept as rollback targets. weikeng1's policy was also re-signed to epoch 10 (same caps on pir1: harmony 128 MiB, onion 64→24 MiB request/response, DPF 120 s)
+### Attestation pins
+Do not copy pin values into this file or any prose document — copied values
+go stale and have caused operators to act on superseded release identities.
+- **Authority (client pins)**: `web/src/attest-pin.ts` — operator key, pir1/pir2
+  binary hashes, pir2 SEV measurement, and all database proof pins.
+- **Point-in-time release evidence**: `docs/data-retention/` (e.g.
+  `production-release-image-265.env`) — evidence of a past release, never a
+  statement about current live state.
+- **Current live state**: query it with `scripts/vpsbg-production-status.sh`;
+  never infer it from this file, an old preflight, or a historical record.
+- **Rotation procedure** (pins + proofs + catalog as one unit):
+  `docs/DATABASE_ROOT_ROTATION_RUNBOOK.md`.

--- a/doc/DEPLOYMENT.md
+++ b/doc/DEPLOYMENT.md
@@ -1,5 +1,16 @@
 # Bitcoin PIR Deployment Guide
 
+> **Historical / self-hosting sketch (bannered 2026-08).** This guide
+> predates the current production architecture (`unified_server`, database
+> catalogs, attested database proofs, strict frontend pins, and the Tier 3
+> measured-boot path). It does **not** describe how pir1/pir2 are released.
+> Current entry points:
+> [`docs/PRODUCTION_OPERATIONS.md`](../docs/PRODUCTION_OPERATIONS.md) for
+> operations, [`docs/DATABASE_ROOT_ROTATION_RUNBOOK.md`](../docs/DATABASE_ROOT_ROTATION_RUNBOOK.md)
+> for database rotations, and [`docs/README.md`](../docs/README.md) for the
+> full index. Use this file only as a rough starting sketch for an
+> independent self-hosted deployment.
+
 This guide explains how to deploy the Bitcoin PIR system on two servers.
 
 ## Architecture Overview

--- a/docs/OPERATOR_IDENTITY.md
+++ b/docs/OPERATOR_IDENTITY.md
@@ -5,10 +5,17 @@ exactly what a client learns when it verifies one. This covers the
 end-to-end **operator runbook** (generate → sign → deploy) and the
 **client trust model** (what each check proves, and what it does not).
 
-> **Status (2026-05-28).** **LIVE.** Deployed and live-verified end-to-end
-> on both production servers: pir1 + pir2 serve REQ_ANNOUNCE on the
-> announce-enabled binary (v22 `f7df82d0…` → current v23 `57ac525b…`). The
-> pinned operator pubkey in `web/src/attest-pin.ts` is the **real**
+> **Status (2026-05-28, historical).** The rollout below completed and the
+> mechanism remains deployed, but every concrete identity value in this
+> document (binary versions/hashes such as v22 `f7df82d0…` / v23
+> `57ac525b…`) is a point-in-time record that has since rotated. The only
+> authority for the currently pinned operator key and server
+> binary/measurement pins is [`web/src/attest-pin.ts`](../web/src/attest-pin.ts);
+> release-time evidence lives in [`data-retention/`](data-retention/). Do
+> not copy values from this document into code or operations.
+>
+> Original record: deployed and live-verified end-to-end on both production
+> servers; the pinned operator pubkey in `web/src/attest-pin.ts` is the
 > published key (`256fb106…`), and the "verified operator" badge is wired
 > into the www client (DPF + HarmonyPIR cards) and the playground, gated on
 > `state === 'verified'`. See [Current status](#current-status).

--- a/docs/PROCESS_AUDIT_2026-08.md
+++ b/docs/PROCESS_AUDIT_2026-08.md
@@ -1,0 +1,188 @@
+# Engineering-process and repository-architecture audit (2026-08-14)
+
+Status: point-in-time audit record and improvement plan, produced from a
+read-only review of `main` at `137056d2`. It changes no production behavior.
+The follow-up documentation work it prescribes is tracked as "Step 1" below.
+
+Scope: development/testing entry points, CI coverage, the database production
+lifecycle, release-identity sources of truth, documentation layering, and
+repository-split evaluation. Production live state was deliberately **not**
+queried; nothing here is a claim about what is currently serving.
+
+## Findings
+
+Severity uses the repository rule: only P0/P1 may block delivery. There are
+no P0 findings. None of the P1 findings are protocol or correctness defects;
+they are operational-safety and process-clarity defects.
+
+### P1-A — "Which tests do I run?" has no trustworthy answer
+
+- `AGENTS.md` names `docs/TESTING.md` as the default entry, but that file
+  only documented the Payment V1 profiles (`--quick` runs a single
+  `pir-runtime-core` service-admission test; see
+  `scripts/payment-v1-local-check.sh`).
+- `--pr` calls itself "CI-equivalent" but covers none of: `pir-core`,
+  `tools/db-builder`, `explorer/`, `electrum_plugin/`, UKI contracts.
+- The real change→check mapping only existed implicitly in the `paths:`
+  filters of nine workflows.
+
+Resolution: `docs/TESTING.md` now carries a change-class matrix and
+`docs/README.md` is the operations/documentation index.
+
+### P1-B — CI contradicts its own stated policy and has blind spots
+
+- `.github/workflows/pir-sdk-integration.yml` states (header, lines 15–21)
+  that PRs run only deterministic tests and live coverage belongs to the
+  scheduled canary — but the OnionPIR live `--ignored` step (line 235) has no
+  event filter, so every PR touching SDK paths hits production and can fail
+  on production availability changes. The sibling DPF step (line 114–116)
+  and both canary steps are correctly filtered.
+- No workflow covers `crates/sdk/server`, `tools/db-builder`, `explorer/`,
+  `electrum_plugin/`, `apps/dev-issuer`, or the `scripts/build_*.sh` data
+  pipeline scripts. `tools/db-builder` has no `tests/` directory at all.
+- `main` has no aggregate required check; merges are manual inspection of
+  path-filtered Actions results (`docs/PROJECT_CLOSEOUT_TODO.md:124-126`).
+  This is a known, deliberate state — recorded here, not re-litigated.
+
+Planned fix (separate one-line PR, not this documentation change): add the
+same `if: schedule || workflow_dispatch` guard to the OnionPIR live step.
+
+### P1-C — Two contradictory database-production narratives
+
+- Legacy narrative: `scripts/README.md` ("Regular database refresh
+  runbook") and `doc/DEPLOYMENT.md` describe local `build_full.sh` → rsync →
+  SSH → `systemctl restart`, ending with **deleting** the previous
+  checkpoint.
+- Current contract: `docs/DATABASE_ROOT_ROTATION_RUNBOOK.md` +
+  `docs/DATABASE_ARTIFACT_RETENTION.md` — attested-builder producer,
+  independent `db-proof verify`, dual-host staging without activation,
+  maintenance-window atomic switch, and retention of the prior generation;
+  the two raw Core snapshots are irreplaceable (a delta cannot reconstruct
+  the earlier snapshot's spent Coin fields).
+- Neither side referenced the other. Following the legacy text can cause
+  irreversible data loss. Resolution: banners on the legacy documents.
+
+### P1-D — Stale release-identity copies in high-authority locations
+
+Old values written in present tense where agents/operators read first:
+
+| Location | Said | Actual authority |
+|---|---|---|
+| `CLAUDE.md` attestation-pins section | image 229, binary `4f51c64d…`, measurement `1c375b26…` | `web/src/attest-pin.ts` (image 265, `4b05fc90…`, `e3f6b4df…`) + `docs/data-retention/production-release-image-265.env` |
+| `.claude/skills/hetzner-pir/SKILL.md` | pir1/pir2 = one Hetzner box, two ports | Hetzner hint + VPSBG Tier 3 query split (`pir-sdk-integration.yml:71-79`) |
+| `docs/ORAM_LIVE_IMAGE_BINDING_PLAN.md:6` | "Production VPSBG image 261" | design record; live state must be queried |
+| `docs/OPERATOR_IDENTITY.md:8-14` | "LIVE" + v22/v23 binary hashes | `attest-pin.ts` |
+
+Resolution: replace copied values with pointers; banner the stale documents.
+Rule going forward: **do not copy pin values into prose documents** — link
+`web/src/attest-pin.ts`, `docs/data-retention/`, and the status script.
+
+### P2-E — Split build authority for the pir2 production binary
+
+`scripts/build_unified_server.sh:30-40` and `flake.nix` present
+`nix build .#unified-server` as the canonical pinned-hash build, while
+`CLAUDE.md` forbids both for Tier 3 (neither enables `cuckoo-oram`) and
+`scripts/build_uki_tier3.sh:94` requires
+`cargo build --release -p runtime --features cuckoo-oram`. Open question for
+the owner: which path built the live pir1 binary, so the losing instructions
+can be deleted rather than merely bannered.
+
+### P2-F — `deploy/` is half-tracked; ops facts are not clone-recoverable
+
+`git ls-files deploy` returns only `deploy/payment-v1/**`, but the working
+tree also contains untracked `installimage.conf`, `known_hosts`,
+`vpsbg_known_hosts`, `systemd/`, `uki/`, `logs/`, and a sensitive
+`cloudflared_tunnel.env`. Consequences:
+
+- the Hetzner skill's "source of truth" links point at files a fresh clone
+  does not have;
+- the SSH host-key pinning defense depends on an untracked `known_hosts`,
+  so the defense itself is not reproducible from the repository;
+- `deploy/uki/` (where CLAUDE.md says release UKIs are archived) is
+  local-only state.
+
+Suggested follow-up (separate PR, owner decision): track the non-secret
+fixed values (`known_hosts`, `vpsbg_known_hosts`, `installimage.conf`,
+systemd units); document the locations and backup story of the secret and
+artifact entries in a `deploy/README.md`.
+
+### P2-G — Documentation layering
+
+Two documentation roots (`doc/` and `docs/`); dated plans, completed
+rollouts, and a stale whitepaper checklist in the `docs/` root;
+`docs/history/README.md` indexes only part of the historical set; there was
+no `docs/README.md`. Resolution: the new index classifies documents and
+names the single current entry point per operation.
+
+### P3-H — Miscellaneous drift
+
+- `scripts/build_uki_tier3.sh:1-24` header still self-describes as the
+  "Phase 3.1" minimal UKI though it now enforces the policy digest and
+  bakes the full server.
+- `docs/PROJECT_CLOSEOUT_TODO.md:128-130` ("no remaining backlog") vs
+  `docs/PR_CLEANUP_TRACKER.md` P1-2 (paid TEE-ORAM BLOCKED).
+- `scripts/start_pir_servers.sh` is a local two-port topology; fine, but
+  should be labeled dev-only.
+
+## Repository-split evaluation (summary)
+
+No new repository should be split now. Payment V1, the production Web app,
+trust/verification consumers, deployment integration, and `vendor/` must
+stay (they need atomic commits with the runtime and hold the production
+trust policy). `explorer/`, `electrum_plugin/`, and a reusable web-client
+package remain "split only after the `docs/REPOSITORY_BOUNDARIES.md` gates
+are met" — none currently are. Already-external repositories
+(protocol-proofs, proof-registry, attested-builder, harmonypir, oram,
+whitepaper) stay external behind their exact-commit locks.
+
+## Improvement plan
+
+### Step 1 (documentation only — implemented alongside this record)
+
+1. `docs/README.md` — operations and documentation index (new).
+2. `docs/TESTING.md` — change-class → required-checks matrix; `--quick`
+   demoted to the Payment/agent default rather than a whole-repo test.
+3. Banners: `scripts/README.md` (legacy DB refresh + deletion advice),
+   `doc/DEPLOYMENT.md` (historical self-hosting sketch),
+   `docs/OPERATOR_IDENTITY.md` (status section historical).
+4. `CLAUDE.md` attestation-pins section → pointers only, no copied values.
+5. `.claude/skills/hetzner-pir/SKILL.md` — topology correction and
+   untracked-`deploy/` warning.
+
+No CI change, no file moves, no new gates, no pin/policy/proof changes.
+
+### Step 2 (1–2 weeks, three independent small PRs)
+
+1. OnionPIR live-test event filter in `pir-sdk-integration.yml` (enforces
+   the workflow's own stated policy).
+2. `deploy/` tracking boundary (P2-F above).
+3. Build-authority declaration or deletion in `build_unified_server.sh` /
+   `flake.nix`, after the owner answers which path is canonical.
+
+### Step 3 (1–3 months, as needed)
+
+- A release-record template generalizing
+  `docs/data-retention/production-release-image-265.env` (one filled per
+  release; evidence, never a substitute for querying live state).
+- Converge `tools/db-builder` scripts with the external attested-builder:
+  either wrap the locked producer or label the local pipeline
+  research/dev-only.
+- Design an internal `packages/web-client` (the prerequisite for any future
+  explorer/electrum extraction). Do **not** move `web/` → `apps/web` as a
+  standalone rename.
+- Automate identity-consistency checks only (extending the existing
+  `web/src/__tests__/proof-registry-lock.test.ts` pattern), not builds or
+  deployments.
+
+## Open questions for the owner
+
+1. Is the local `scripts/build_full.sh` pipeline still permitted for a
+   production database build, or is attested-builder the only producer?
+2. How was the live pir1 binary (`c836e11a…`) actually built — cargo with
+   features, the Nix flake, or `build_unified_server.sh`?
+3. Are `explorer/` and `electrum_plugin/` still product surfaces, or
+   experiments that should be demoted in the README?
+4. Should the three builder identities (v1 DPF/Harmony, Onion v2 re-attest,
+   ORAM native) be collapsed to one at the next root rotation?
+5. Is an aggregate required-check for `main` wanted, or is manual merge
+   inspection the deliberate long-term state?

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,93 @@
+# Documentation and operations index
+
+Start here. This index answers two questions: *which document is the current
+entry point for each operation*, and *which class a given document belongs
+to*. When two documents disagree, the one listed under "Current norms and
+runbooks" wins; dated records never override it.
+
+## Live state is queried, never inferred
+
+The repository contains no document that describes the current production
+state. Point-in-time records (retention inventory, release `.env` files,
+preflights) are evidence of what *was* true when written.
+
+```bash
+scripts/vpsbg-production-status.sh   # read-only control-plane + status.json
+```
+
+Client-side release identity (binary hashes, SEV measurement, database proof
+pins) has exactly one authority: [`web/src/attest-pin.ts`](../web/src/attest-pin.ts).
+Do not copy those values into prose documents; link them.
+
+## The five routine operations
+
+| Operation | Entry point | Notes |
+|---|---|---|
+| Ordinary development | [`TESTING.md`](TESTING.md) change-class matrix → PR → manual merge after inspecting the path-filtered Actions results | No aggregate required check exists; see `PROJECT_CLOSEOUT_TODO.md:124-126` |
+| Database / root rotation | [`DATABASE_ROOT_ROTATION_RUNBOOK.md`](DATABASE_ROOT_ROTATION_RUNBOOK.md), with [`DATABASE_ARTIFACT_RETENTION.md`](DATABASE_ARTIFACT_RETENTION.md) read first | The legacy refresh flow in `scripts/README.md` is **not** the production path |
+| Web release | Manual `deploy-web.yml` dispatch from `main` with the production confirmation ([`PRODUCTION_OPERATIONS.md`](PRODUCTION_OPERATIONS.md)) | The workflow deployment record is the release evidence |
+| Tier 3 UKI / VPSBG release | [VPSBG measured-boot skill](../.agents/skills/vpsbg-measured-boot/SKILL.md) + `scripts/build_uki_tier3.sh` (policy digest is locked in the script) | Upload/switch/reboot require explicit authorization |
+| Rollback | Same unit as the forward release: Web = prior Pages artifact/commit; database = prior complete generation + catalog + pins; UKI = the retained previous VPSBG image | [`DATABASE_ROOT_ROTATION_RUNBOOK.md`](DATABASE_ROOT_ROTATION_RUNBOOK.md) §7 for data; the measured-boot skill for images |
+
+Production diagnosis always starts at
+[`PRODUCTION_OPERATIONS.md`](PRODUCTION_OPERATIONS.md) — status first, never
+a browser or log search.
+
+## Current norms and runbooks
+
+- [`../AGENTS.md`](../AGENTS.md) — agent working rules (delivery priority,
+  bounded investigation, testing defaults, git hygiene).
+- [`TESTING.md`](TESTING.md) — change-class → required checks matrix, plus
+  the Payment V1 profiles.
+- [`PRODUCTION_OPERATIONS.md`](PRODUCTION_OPERATIONS.md) — operator/agent
+  entry point for status, release routing, and canary policy.
+- [`DATABASE_ROOT_ROTATION_RUNBOOK.md`](DATABASE_ROOT_ROTATION_RUNBOOK.md)
+  — the only supported database/proof/pin rotation procedure.
+- [`DATABASE_ARTIFACT_RETENTION.md`](DATABASE_ARTIFACT_RETENTION.md) — what
+  may never be deleted and where retained artifacts live; read before any
+  rebuild or cleanup.
+- [`ORAM_DIRECT_TEE_DEBUG_RUNBOOK.md`](ORAM_DIRECT_TEE_DEBUG_RUNBOOK.md) —
+  bounded Direct ORAM debug workflow (time limits are part of acceptance).
+- [`ATTESTED_BUILDER_TIER3_UKI.md`](ATTESTED_BUILDER_TIER3_UKI.md) — the
+  temporary builder UKI runbook.
+- [`REPOSITORY_BOUNDARIES.md`](REPOSITORY_BOUNDARIES.md) — normative for
+  repository moves and split gates.
+- [`payment/IMPLEMENTATION_STATUS.md`](payment/IMPLEMENTATION_STATUS.md) —
+  exact Payment V1 method/test/activation status. Source-ready ≠ deployed.
+- [`payment/OPERATOR_RUNBOOK.md`](payment/OPERATOR_RUNBOOK.md) — Payment
+  deployment phases and approval scopes.
+
+## Verification and trust inputs
+
+- [`../verification/locks/`](../verification/locks/) — exact external proof
+  pins (formal proofs, generated proof bundles, rootbundle, whitepaper).
+  The locks are the trust inputs; default-branch links are navigational.
+- [`VERIFICATION_OVERVIEW.md`](VERIFICATION_OVERVIEW.md) — consolidated
+  verification final state.
+- [`../web/src/attest-pin.ts`](../web/src/attest-pin.ts) — client pin
+  authority (operator key, server binaries/measurement, database proofs).
+
+## Historical evidence, plans, and status snapshots
+
+- [`history/README.md`](history/README.md) — indexed historical preflights,
+  incidents, and completed plans. Evidence only.
+- [`data-retention/`](data-retention/) — point-in-time inventories and
+  release identity records (e.g. `production-release-image-265.env`).
+- [`PROCESS_AUDIT_2026-08.md`](PROCESS_AUDIT_2026-08.md) — the audit that
+  produced this index; includes the known documentation-drift list.
+- Dated plans and completed rollout records still in this directory
+  (`PHASE3_*`, `ORAM_LIVE_IMAGE_BINDING_PLAN.md`, `STRICT_VERIFICATION_PROGRESS.md`,
+  `PROJECT_CLOSEOUT_TODO.md`, `PR_CLEANUP_TRACKER.md`, `CODE_REVIEW_2026-06.md`,
+  `release_checklist.md`, …) are records of past work. They are not
+  operating instructions, and identity values inside them (image IDs,
+  binary hashes, measurements) are stale by construction.
+
+## Legacy documents
+
+- [`../doc/`](../doc/) (singular) predates this directory.
+  `doc/DEPLOYMENT.md` is a historical self-hosting sketch, not the pir1/pir2
+  release path; `doc/WEB.md` partially describes legacy opcodes (tracked as
+  P2-5 in `PR_CLEANUP_TRACKER.md`).
+- The database build/refresh sections of
+  [`../scripts/README.md`](../scripts/README.md) describe the pre-attested
+  local pipeline. Production rotations use the runbook above.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,40 @@
 # Testing entry points
 
-Use the repository-owned payment check as the default local and agent entry:
+Pick your checks by *change class*, not by a single default command. The
+matrix below maps what you touched to the minimum local checks and to the CI
+that will actually run on your PR (most workflows are path-filtered; two run
+on every PR regardless).
+
+The Payment V1 profiles further down remain the default entry **for agents
+and for Payment work** (`AGENTS.md` points here for that purpose). `--quick`
+runs one focused service-admission test; it is not a whole-repository test
+and passing it says nothing about non-Payment changes.
+
+## Change-class → required checks
+
+| You changed | Minimum local checks | CI triggered on the PR | Known gaps |
+|---|---|---|---|
+| `crates/protocol/core` (cuckoo, Merkle, anchors) | `cargo test --locked --offline -p pir-core --test cross_build_determinism`; `cargo test --locked --offline -p pir-core`; `cargo clippy --locked --offline -p pir-core --tests -- -D warnings` | `build-determinism.yml` | A determinism break means operators can no longer reproduce the database byte-for-byte — treat failures as release blockers |
+| `crates/sdk/{core,client}` | `cargo test -p pir-sdk-client` (add `--features onion` if you touched the Onion path) | `pir-sdk-integration.yml` (deterministic jobs; live tests belong to the scheduled canary) | The OnionPIR job currently also runs live `--ignored` tests on PRs (workflow line ~235, missing an event filter) — a red there may be production availability, not your change |
+| `crates/sdk/wasm` or the WASM↔TS boundary | `wasm-pack build crates/sdk/wasm --target web --out-dir pkg -- --locked --offline`, then `cd web && npm run build && npm test` | `web-build.yml` | — |
+| `crates/sdk/server` | `cargo test --locked --offline -p pir-sdk-server`; `cargo build -p pir-sdk-server` | **None** — no workflow watches this path | Crate has ~0 lib tests; CI stays green if you break it |
+| `apps/server` / `crates/protocol/runtime` | `cargo test --locked --offline -p runtime --lib hint_pool`; `cargo test --locked --offline -p runtime --bin unified_server`; for admission/process behavior run `scripts/payment-v1-local-check.sh --pr` or the matching `scripts/payment-v1-ci-lane.sh --lane runtime-*` | `payment-platform.yml` (via `apps/server/**`); `pir-sdk-integration.yml` only if you touched `hint_pool.rs`, `unified_server.rs`, or the crate manifest | A deployed binary/UKI is a separate authorized release, never implied by green CI |
+| `web/` (TypeScript, pins, tests) | `cd web && npm run build && npm test && npm run build-web` | `web-build.yml`; `deploy-web.yml` adds Playwright gates only at the manual release dispatch | Pin edits: keep `web/src/attest-pin.ts`, the `verification/locks` files, and the duplicate pins in `crates/sdk/client/tests/integration_test.rs` consistent (rotation runbook §3) |
+| Payment V1 (crates/payment, issuer apps, deploy templates) | Profiles below (`--quick` / `--pr`; `--deploy-template-audit` only for template work) | `payment-platform.yml`, sometimes `directory-relay-artifact.yml` | Source-ready ≠ deployed; see `payment/IMPLEMENTATION_STATUS.md` |
+| `verification/locks`, contracts, verifier scripts | `cargo test --locked --offline -p pir-sdk --features serde --test wire_shape_contract`; `python3 -m unittest verification/scripts/test_verify_formal_lock.py`; `cd web && npm test` (lock↔pin tests) | `formal-proof.yml` (every PR, unfiltered); `generated-proof-lock.yml` (lock paths) | Protocol framing / round-shape / padding changes must update the contract and proof lock (`REPOSITORY_BOUNDARIES.md`) |
+| `tools/db-builder`, `scripts/build_*.sh` | `cargo build -p build`; there is no test suite | **None** | Production databases come from the locked attested-builder, not these scripts; see `DATABASE_ARTIFACT_RETENTION.md` before any rebuild |
+| `explorer/`, `electrum_plugin/` | `cd explorer && npm run build`; `python electrum_plugin/test_pir_client.py` (local only) | **None** | Both can drift from the SDK silently; the Electrum plugin reimplements the protocol in Python |
+| UKI scripts, `.github/workflows/**` | `node --test scripts/github-workflow-supply-chain-gate.test.mjs scripts/tier3-uki-policy-contract.test.mjs` | `workflow-supply-chain.yml` (every PR, unfiltered) | UKI builds themselves are operator actions on the build host, not CI |
+| Documentation only | none | `formal-proof.yml` + `workflow-supply-chain.yml` still run (unfiltered PR events) | CI does not check documentation truth; identity values (hashes, image IDs) must be pointers to `web/src/attest-pin.ts` / `docs/data-retention/`, not copies |
+
+Merges are manual: there is no aggregate required check on `main`, so inspect
+every applicable Actions result before merging
+(`PROJECT_CLOSEOUT_TODO.md:124-126`).
+
+## Payment V1 profiles
+
+Use the repository-owned payment check as the default local and agent entry
+for Payment work:
 
 ```sh
 scripts/payment-v1-local-check.sh
@@ -20,6 +54,10 @@ profile agents should run by default.
 --browser  Explicit opt-in: --pr plus local headless Chromium payment checks.
 --full     Explicit compatibility alias for --browser.
 ```
+
+`--pr` approximates the Payment-platform CI lanes plus the Web gates. It does
+**not** cover `pir-core`, `tools/db-builder`, `explorer/`, `electrum_plugin/`,
+or UKI contracts — use the matrix above for those.
 
 Run `--deploy-template-audit` only while changing or preparing a Payment
 deployment template. Run `--browser` or `--full` only when browser coverage is explicitly requested.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,15 @@
 
 Helper scripts for running and testing the PIR system.
 
+> **Scope note (2026-08).** The database build and refresh sections below
+> describe the local development pipeline. They are **not** the production
+> database release path: production rotations use the locked
+> `Bitcoin-PIR/attested-builder` producer and
+> [`docs/DATABASE_ROOT_ROTATION_RUNBOOK.md`](../docs/DATABASE_ROOT_ROTATION_RUNBOOK.md),
+> and every retention/cleanup decision is governed by
+> [`docs/DATABASE_ARTIFACT_RETENTION.md`](../docs/DATABASE_ARTIFACT_RETENTION.md).
+> Where this file and those documents disagree, those documents win.
+
 ## Production status
 
 For production diagnosis, run this read-only command first:
@@ -113,7 +122,13 @@ web client's OnionPIR tab can query `db_id=1`.
 
 ---
 
-## Regular database refresh runbook
+## Regular database refresh runbook (LEGACY — not the production path)
+
+> **Superseded.** This flow (local build → rsync → SSH → restart) predates
+> the attested-builder proof chain, dual-host staging, frontend proof pins,
+> and the fail-closed activation window. For any production rotation use
+> [`docs/DATABASE_ROOT_ROTATION_RUNBOOK.md`](../docs/DATABASE_ROOT_ROTATION_RUNBOOK.md).
+> It is retained only as a sketch of the local/dev pipeline stages.
 
 Refresh production with a new full snapshot at height `B` plus a delta
 from the previous full-snapshot height `A` to `B`. Keep the existing
@@ -156,7 +171,16 @@ ssh pir-hetzner "systemctl restart pir-primary pir-secondary"
 ssh pir-hetzner 'journalctl -u pir-primary -n 50 --no-pager | grep -E "Loaded|height"'
 ```
 
-After verifying live queries against `wss://weikeng1.bitcoinpir.org`, you
-can clean up the previous checkpoint dir on the host
+> **Do not follow this cleanup advice for production data.**
+> [`docs/DATABASE_ARTIFACT_RETENTION.md`](../docs/DATABASE_ARTIFACT_RETENTION.md)
+> requires keeping the prior complete generation until the rollback window
+> closes, both raw Core snapshots permanently (a delta cannot reconstruct
+> the earlier snapshot's spent Coin fields), and the Direct ORAM inputs and
+> exact manifests. Only purely local, non-retained intermediates may be
+> deleted after checking that map.
+
+After verifying live queries against `wss://weikeng1.bitcoinpir.org`, the
+old flow deleted the previous checkpoint dir on the host
 (`/home/pir/data/checkpoints/<A>/`) and the local intermediate dir
-(`/Volumes/Bitcoin/data/intermediate/full_<B>/`).
+(`/Volumes/Bitcoin/data/intermediate/full_<B>/`) — see the retention
+warning above before deleting anything.


### PR DESCRIPTION
## Summary
- Save the 2026-08 engineering-process audit record (`docs/PROCESS_AUDIT_2026-08.md`) and add `docs/README.md` as the operations/documentation index: one entry point per routine operation (dev, DB rotation, web release, UKI release, rollback) and a document taxonomy separating current norms from historical evidence.
- Expand `docs/TESTING.md` into a change-class -> required-checks matrix (local minimum, CI actually triggered, known gaps); `--quick` is scoped as the Payment/agent default rather than a whole-repo test.
- Banner the legacy database refresh flow in `scripts/README.md` (including a retention warning before its checkpoint-deletion advice) and the historical self-hosting guide `doc/DEPLOYMENT.md`; mark the identity values in `docs/OPERATOR_IDENTITY.md` as historical.
- Replace the stale copied pin values in `CLAUDE.md` (image 229 era) with pointers to the authoritative sources (`web/src/attest-pin.ts`, `docs/data-retention/`, `scripts/vpsbg-production-status.sh`, rotation runbook).

Documentation-only: no code, CI, pin, policy, or production changes.

## Test plan
- [x] All script/test paths referenced by the new TESTING.md matrix verified to exist
- [x] Docs-only change; no build or runtime impact

Made with [Cursor](https://cursor.com)