### PR TITLE
Gate OnionPIR live integration tests to scheduled/manual runs

### DIFF
--- a/.github/workflows/pir-sdk-integration.yml
+++ b/.github/workflows/pir-sdk-integration.yml
@@ -232,7 +232,12 @@ jobs:
           cargo test -p runtime --bin unified_server harmony_dos_guard_tests
           cargo test -p runtime --no-default-features --bin unified_server harmony_dos_guard_tests
 
-      - name: Run ignored OnionPIR integration tests against live PIR servers
+      - name: Run ignored OnionPIR integration tests against live PIR servers (scheduled/manual only)
+        # Same policy as the DPF/Harmony live step in the `integration` job
+        # (see the header comment): PRs and main run only deterministic
+        # tests; live-production coverage belongs to the scheduled/manual
+        # canary so production availability changes cannot fail a PR.
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         # The `onion_tests` filter scopes this to the OnionPIR module
         # introduced in integration_test.rs — the DPF / Harmony tests
         # already ran in the `integration` job without the feature.


### PR DESCRIPTION
## Summary
- `pir-sdk-integration.yml` states (header comment) that PRs/main run only deterministic tests and live coverage belongs to the scheduled/manual canary. The DPF/Harmony live step honors this with `if: schedule || workflow_dispatch`, but the OnionPIR live `--ignored` step had no event filter, so PRs touching SDK paths queried production and could go red on production availability/policy changes.
- Add the identical guard to the OnionPIR live step. The step still runs on every scheduled and manually dispatched canary, where live signal is wanted.

One-line behavioral change plus comments; enforces the workflow's own stated policy (audit finding P1-B, `docs/PROCESS_AUDIT_2026-08.md`).

## Test plan
- [x] YAML parses; `scripts/github-workflow-supply-chain-gate.test.mjs` passes locally
- [x] Guard expression is byte-identical to the existing DPF/Harmony live step's

Made with [Cursor](https://cursor.com)