### PR TITLE
Mark flake and build script as non-authoritative for Tier 3 production

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,15 @@
       # ─── packages.tier3-uki ────────────────────────────────────────
       # Production Tier 3 UKI for pir2 (weikeng2 — VPSBG, SEV-SNP).
       #
+      # ── NOT the current production recipe (2026-08) ────────────────
+      # packages.unified-server builds WITHOUT `--features cuckoo-oram`
+      # (see cargoBuildFlags below), which the Direct ORAM production
+      # path requires — so this UKI is NOT what production pir2 boots.
+      # The production build procedure is CLAUDE.md "Hetzner — UKI
+      # build host" (cargo with `--features cuckoo-oram` at the exact
+      # deploy commit + scripts/build_uki_tier3.sh); release identity
+      # authority is web/src/attest-pin.ts.
+      #
       # Assembles the whole UKI inside Nix — VPSBG kernel + initramfs +
       # cmdline objcopy'd into systemd's EFI stub — embedding the exact
       # reproducible `unified_server` from packages.unified-server. This
@@ -86,7 +95,7 @@
       # recipe bakes a *system-linked* binary via dracut; this one
       # bundles the full /nix/store closure via makeInitrdNG, so the
       # baked-in binary is bit-identical to `nix build .#unified-server`
-      # (hence byte-identical to what pir1 runs).
+      # (hence byte-identical to what pir1 ran pre-cuckoo-oram).
       #
       #   nix build --impure .#tier3-uki    # on pir-hetzner, as root
       #   → ./result/bpir-tier3.efi
@@ -393,6 +402,11 @@
         echo "unified_server: ${unifiedServer}/bin/unified_server"
       '';
 
+      # Hermetic, bit-reproducible build — but WITHOUT the
+      # `cuckoo-oram` feature the current Tier 3 production binary
+      # requires (see the tier3-uki note above). Use it for
+      # reproducibility work and development; do not pin its sha256 as
+      # a production release identity.
       unified-server = pkgs.rustPlatform.buildRustPackage {
         pname = "unified-server";
         version = "0.1.0";

--- a/scripts/build_unified_server.sh
+++ b/scripts/build_unified_server.sh
@@ -27,17 +27,24 @@
 #     pins the rustc selected via rustup; the rustup harness itself
 #     can vary)
 #
-# Note (2026-05-20): for any binary whose sha256 you intend to PUBLISH
-# or PIN — including the one baked into the Tier 3 UKI and the one
-# pinned in web/src/attest-pin.ts — use the hermetic Nix flake:
+# ── PRODUCTION AUTHORITY (2026-08) ──────────────────────────────────
+# NEITHER this script NOR the Nix flake builds the current Tier 3
+# production binary: both invoke cargo without `--features cuckoo-oram`,
+# which the Direct ORAM production path requires. For the binary that
+# gets baked into the Tier 3 UKI / pinned in web/src/attest-pin.ts,
+# follow CLAUDE.md "Hetzner — UKI build host": clean checkout at the
+# exact deploy commit, then
+#   cargo build --locked --release -p runtime --features cuckoo-oram --bin unified_server
+# and `strip --strip-debug`. Do not pin this script's (or the flake's)
+# output sha256 for a Tier 3 release.
 #
-#   nix build .#unified-server
-#
-# Empirically bit-reproducible (verified 2026-05-20 via
-# `nix-store --realise --check` on the unified-server, hexl, and onionpir
-# derivations — all three rebuilt byte-identical to existing store
-# outputs), links Intel HEXL into OnionPIR's C++ engine, and is what
-# pir1/pir2 actually run.
+# Historical note (2026-05-20, pre-cuckoo-oram): the hermetic flake
+# build (`nix build .#unified-server`) was verified bit-reproducible
+# via `nix-store --realise --check` (unified-server, hexl, onionpir
+# derivations all rebuilt byte-identical), links Intel HEXL into
+# OnionPIR's C++ engine, and was what pir1/pir2 ran at that time. It
+# remains the reproducibility harness; it is just not feature-complete
+# for the current production ORAM configuration.
 #
 # This script is a no-Nix DEVELOPMENT convenience. By default it builds
 # OnionPIR's C++ engine with the in-crate scalar/SIMD shim


### PR DESCRIPTION
## Summary
- Audit finding P2-E (`docs/PROCESS_AUDIT_2026-08.md`): two contradictory build authorities existed for the production `unified_server`. `scripts/build_unified_server.sh` said to use `nix build .#unified-server` for any pinned/published binary and that the flake output "is what pir1/pir2 actually run"; `flake.nix` said its UKI is "byte-identical to what pir1 runs". Meanwhile `CLAUDE.md` forbids both for Tier 3 because neither passes `--features cuckoo-oram` (required by the Direct ORAM production path) — verified: the script's cargo invocation and the flake's `cargoBuildFlags` both lack the feature.
- Comment-only fix: both files now state up front that they do **not** produce the current Tier 3 production binary, point to the CLAUDE.md build procedure (`cargo build --locked --release -p runtime --features cuckoo-oram --bin unified_server` at the exact deploy commit) and to `web/src/attest-pin.ts` as identity authority, and keep the 2026-05-20 bit-reproducibility verification as a dated historical note.
- Deliberately conservative: nothing is deleted and no build behavior changes. Whether to make one path canonical (e.g. add the feature to the flake, or retire it) stays an open owner question (audit Q2).

## Test plan
- [x] `bash -n scripts/build_unified_server.sh` passes
- [x] `flake.nix` changes are comments only (no evaluated expressions touched)

Made with [Cursor](https://cursor.com)