### PR TITLE
Add release-record template and generator script

### DIFF
--- a/docs/DATABASE_ROOT_ROTATION_RUNBOOK.md
+++ b/docs/DATABASE_ROOT_ROTATION_RUNBOOK.md
@@ -235,6 +235,14 @@ For each run, record that:
 - sync state is merged only after all database results verify;
 - the connection ends disconnected.
 
+After acceptance, write the release record: generate
+`docs/data-retention/production-release-image-<id>.env` with
+`scripts/generate-release-record.sh` (schema and field reference:
+`docs/data-retention/release-record.env.template`), fill any remaining
+TODO fields (measurement, served manifest hashes, acceptance tag), and
+commit it with or immediately after the pin change. Every production
+release — UKI switch, database rotation, or both — gets one record.
+
 HarmonyPIR hints may remain browser-cached. Their native blob fingerprint
 includes database height, geometry, tag seed, and master seeds; a stale blob is
 rejected and fetched again. Confirm that behavior rather than manually

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,9 @@ a browser or log search.
   incidents, and completed plans. Evidence only.
 - [`data-retention/`](data-retention/) — point-in-time inventories and
   release identity records (e.g. `production-release-image-265.env`).
+  Every production release gets one record: generate it with
+  `scripts/generate-release-record.sh` (schema:
+  [`data-retention/release-record.env.template`](data-retention/release-record.env.template)).
 - [`PROCESS_AUDIT_2026-08.md`](PROCESS_AUDIT_2026-08.md) — the audit that
   produced this index; includes the known documentation-drift list.
 - Dated plans and completed rollout records still in this directory

--- a/docs/data-retention/release-record.env.template
+++ b/docs/data-retention/release-record.env.template
@@ -1,0 +1,53 @@
+# Release record — schema v1
+#
+# One filled copy of this file is created for EVERY production release
+# (UKI upload/switch, database rotation, or both) and committed as
+# docs/data-retention/production-release-image-<IMAGE_ID>.env.
+#
+# Prefer generating it with scripts/generate-release-record.sh, which
+# fills every field it can compute and leaves TODO markers for the rest.
+# A record with TODO fields must not be treated as complete evidence.
+#
+# These records are point-in-time EVIDENCE of a past release. They are
+# never a statement about current live state (query that with
+# scripts/vpsbg-production-status.sh) and never an authority for client
+# pins (that is web/src/attest-pin.ts).
+#
+# Field reference (all values single-line, no quotes):
+#   schema_version              always 1 for this layout
+#   recorded_at                 UTC ISO-8601, when the record was written
+#   vpsbg_server_id             VPSBG control-plane server id
+#   vpsbg_image_id              VPSBG measured-boot image id made live
+#   uki_name                    filename of the uploaded UKI
+#   uki_bytes                   byte size of the UKI file
+#   uki_sha256                  sha256 of the UKI file
+#   runtime_git_revision        commit the server binary was built from
+#   web_pin_git_revision        commit whose web/src/attest-pin.ts pins
+#                               this release (the pin-update commit)
+#   unified_server_sha256       sha256 of the stripped unified_server
+#                               baked into the UKI
+#   oramctl_sha256              sha256 of the baked oramctl (if present)
+#   service_policy_sha256       sha256 of the embedded service policy
+#   measurement                 SEV-SNP launch measurement observed after
+#                               the switch (bpir-admin attest)
+#   db0_server_manifest_sha256  sha256 of the db0 server MANIFEST served
+#   db1_server_manifest_sha256  sha256 of the db1 server MANIFEST served
+#   browser_acceptance          acceptance evidence tag (e.g.
+#                               no_funds_four_backends_passed) or the
+#                               reason acceptance was skipped
+schema_version=1
+recorded_at=TODO
+vpsbg_server_id=TODO
+vpsbg_image_id=TODO
+uki_name=TODO
+uki_bytes=TODO
+uki_sha256=TODO
+runtime_git_revision=TODO
+web_pin_git_revision=TODO
+unified_server_sha256=TODO
+oramctl_sha256=TODO
+service_policy_sha256=TODO
+measurement=TODO
+db0_server_manifest_sha256=TODO
+db1_server_manifest_sha256=TODO
+browser_acceptance=TODO

--- a/scripts/generate-release-record.sh
+++ b/scripts/generate-release-record.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Generate a schema-v1 production release record
+# (docs/data-retention/production-release-image-<ID>.env).
+#
+# Fills every field it can compute locally:
+#   - recorded_at from the clock
+#   - uki_name / uki_bytes / uki_sha256 from the UKI file
+#   - unified_server_sha256 / oramctl_sha256 / service_policy_sha256 from
+#     the UKI's sibling .meta file (build_uki_tier3.sh output), if present
+#   - runtime_git_revision / web_pin_git_revision from flags (or HEAD)
+# Everything else (measurement, db manifests, acceptance evidence) must be
+# supplied via flags or filled in by hand afterwards — the script writes
+# TODO markers and lists them, and a record with TODO fields is not
+# complete release evidence.
+#
+# Usage:
+#   scripts/generate-release-record.sh --uki deploy/uki/<name>.efi --image-id 265 \
+#       [--server-id 25285] \
+#       [--runtime-rev <commit>] [--web-pin-rev <commit>] \
+#       [--measurement <hex>] \
+#       [--db0-manifest-sha256 <hex>] [--db1-manifest-sha256 <hex>] \
+#       [--acceptance <tag>] \
+#       [--out <path>] [--force]
+#
+# Read-only apart from writing the record file. Field reference:
+# docs/data-retention/release-record.env.template
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+uki="" image_id="" server_id="TODO"
+runtime_rev="" web_pin_rev=""
+measurement="TODO" db0="TODO" db1="TODO" acceptance="TODO"
+out="" force=0
+
+usage() { sed -n '2,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --uki)                 uki="$2"; shift 2 ;;
+        --image-id)            image_id="$2"; shift 2 ;;
+        --server-id)           server_id="$2"; shift 2 ;;
+        --runtime-rev)         runtime_rev="$2"; shift 2 ;;
+        --web-pin-rev)         web_pin_rev="$2"; shift 2 ;;
+        --measurement)         measurement="$2"; shift 2 ;;
+        --db0-manifest-sha256) db0="$2"; shift 2 ;;
+        --db1-manifest-sha256) db1="$2"; shift 2 ;;
+        --acceptance)          acceptance="$2"; shift 2 ;;
+        --out)                 out="$2"; shift 2 ;;
+        --force)               force=1; shift ;;
+        -h|--help)             usage; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$uki" ] && [ -n "$image_id" ] \
+    || { echo "ERROR: --uki and --image-id are required" >&2; exit 2; }
+[ -f "$uki" ] || { echo "ERROR: UKI file not found: $uki" >&2; exit 2; }
+
+# sha256 across macOS (shasum) and Linux (sha256sum).
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+# Portable byte size (BSD stat vs GNU stat).
+bytes_of() {
+    if stat -f %z "$1" >/dev/null 2>&1; then stat -f %z "$1"; else stat -c %s "$1"; fi
+}
+
+# Pull a key out of the UKI's sibling .meta file; TODO when absent.
+meta="$uki.meta"
+meta_get() {
+    local val=""
+    if [ -f "$meta" ]; then
+        val="$(sed -n "s/^$1=//p" "$meta" | head -n 1)"
+    fi
+    printf '%s' "${val:-TODO}"
+}
+
+rev_or_head() {
+    if [ -n "$1" ]; then printf '%s' "$1"; else git -C "$REPO_ROOT" rev-parse HEAD; fi
+}
+
+recorded_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+uki_name="$(basename "$uki")"
+uki_bytes="$(bytes_of "$uki")"
+uki_sha256="$(sha256_of "$uki")"
+runtime_git_revision="$(rev_or_head "$runtime_rev")"
+web_pin_git_revision="$(rev_or_head "$web_pin_rev")"
+unified_server_sha256="$(meta_get binary_sha256)"
+oramctl_sha256="$(meta_get oramctl_sha256)"
+service_policy_sha256="$(meta_get service_policy_sha256)"
+
+if [ ! -f "$meta" ]; then
+    echo "NOTE: no sibling .meta file at $meta — binary/policy hashes left as TODO" >&2
+fi
+
+[ -n "$out" ] || out="$REPO_ROOT/docs/data-retention/production-release-image-$image_id.env"
+if [ -e "$out" ] && [ "$force" -ne 1 ]; then
+    echo "ERROR: $out already exists (pass --force to overwrite)" >&2
+    exit 1
+fi
+
+cat > "$out" <<EOF
+schema_version=1
+recorded_at=$recorded_at
+vpsbg_server_id=$server_id
+vpsbg_image_id=$image_id
+uki_name=$uki_name
+uki_bytes=$uki_bytes
+uki_sha256=$uki_sha256
+runtime_git_revision=$runtime_git_revision
+web_pin_git_revision=$web_pin_git_revision
+unified_server_sha256=$unified_server_sha256
+oramctl_sha256=$oramctl_sha256
+service_policy_sha256=$service_policy_sha256
+measurement=$measurement
+db0_server_manifest_sha256=$db0
+db1_server_manifest_sha256=$db1
+browser_acceptance=$acceptance
+EOF
+
+echo "wrote $out"
+todos="$(sed -n 's/^\([a-z0-9_]*\)=TODO$/\1/p' "$out")"
+if [ -n "$todos" ]; then
+    echo "incomplete — fill in these fields before treating this as release evidence:"
+    # shellcheck disable=SC2086
+    printf '  %s\n' $todos
+else
+    echo "all schema-v1 fields filled."
+fi


### PR DESCRIPTION
## Summary
- Roadmap item 3.1 (`docs/PROCESS_AUDIT_2026-08.md`): `production-release-image-265.env` was a hand-written one-off; earlier releases have no comparable record, which is why stale identity values kept living in prose documents.
- Add `docs/data-retention/release-record.env.template` (schema v1, field reference in comments) and `scripts/generate-release-record.sh`, which auto-fills recorded_at, UKI name/bytes/sha256, git revisions, and pulls `unified_server`/`oramctl`/service-policy hashes from the UKI's sibling `.meta` file (the `build_uki_tier3.sh` output); measurement, served manifest hashes, and the acceptance tag stay TODO until filled, and the script lists them.
- Wire the requirement in: rotation runbook §6 (post-deployment acceptance) and the docs index now state every production release gets one committed record.

## Test plan
- [x] Generated a record against the real image-229 UKI + `.meta`: uki_sha256 and binary hashes match the `.meta` values byte-for-byte
- [x] No-`.meta` path degrades to TODO with a warning; overwrite guard refuses without `--force`; `bash -n` clean

Made with [Cursor](https://cursor.com)