### PR TITLE
Declare two bare-Cargo profiles as the production build authority

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -404,7 +404,10 @@ cargo test -p pir-sdk-wasm --lib
 
 ### Hetzner (pir-hetzner) — UKI build host
 - **SSH**: `ssh pir-hetzner` (root@65.21.91.217, key `~/.ssh/id_ed25519`)
-- **Build production binary**: use a clean checkout at the exact deploy commit, then run `cargo build --locked --release -p runtime --features cuckoo-oram --bin unified_server` and `strip --strip-debug`. Do not use the current `build_unified_server.sh` or `flake.nix` output for Tier 3; neither enables `cuckoo-oram`.
+- **Build production binaries** (bare Cargo on a clean checkout at the exact deploy commit, then `strip --strip-debug`; decided 2026-08-15 after provenance verification of the deployed binaries — see `docs/PROCESS_AUDIT_2026-08.md` Q2):
+  - **pir1** (Hetzner: DPF-0 + OnionPIR + Harmony hint — no ORAM): `cargo build --locked --release -p runtime --bin unified_server` (default features).
+  - **pir2** (VPSBG Tier 3: Direct/Circuit ORAM query path): `cargo build --locked --release -p runtime --features cuckoo-oram --bin unified_server`.
+  - Do **not** use `build_unified_server.sh` or `nix build .#unified-server` for a production binary. The flake is a development/reproducibility harness only; the deployed pir1/pir2 binaries were never Nix-built (verified via embedded source paths and cargo feature fingerprints on the build host).
 - **Build UKI** (with VPSBG kernel): `sudo env KERNEL=/boot/vmlinuz-7.0.0-15-generic BINARY=/absolute/path/to/unified_server BPIR_UNIFIED_SERVER_BIN=/absolute/path/to/unified_server ./scripts/build_uki_tier3.sh`
 - **Deploy UKI**: `scp pir-hetzner:/tmp/bpir-tier3.efi deploy/uki/bpir-tier3-vN.efi`, then portal → Upload → Save & Reboot
 - **Cross-build stack**: kernel 7.0.0-15, kmod 34.2, libkmod 2.5.1, dracut 110 (all backported from Ubuntu 25.04 plucky)

--- a/docs/PROCESS_AUDIT_2026-08.md
+++ b/docs/PROCESS_AUDIT_2026-08.md
@@ -87,6 +87,10 @@ Rule going forward: **do not copy pin values into prose documents** — link
 the owner: which path built the live pir1 binary, so the losing instructions
 can be deleted rather than merely bannered.
 
+*(Resolved 2026-08-15 — see Q2 below. Two bare-Cargo profiles are now the
+declared production authority; the flake is a development/reproducibility
+harness only. CLAUDE.md, `build_unified_server.sh`, and `flake.nix` updated.)*
+
 ### P2-F — `deploy/` is half-tracked; ops facts are not clone-recoverable
 
 *(Corrected 2026-08-14 during Step 2: the five `deploy/systemd/*.service`
@@ -183,8 +187,62 @@ No CI change, no file moves, no new gates, no pin/policy/proof changes.
 
 1. Is the local `scripts/build_full.sh` pipeline still permitted for a
    production database build, or is attested-builder the only producer?
+
+   *(Answered 2026-08-15, from the owner's session-record investigation.)*
+   **The current serving generations are of mixed provenance, and no
+   "attested-builder is the exclusive producer" decision was ever made —
+   that status cannot be claimed retroactively.** Facts:
+   - Catalog: db0 = full at height 948454; db1 = delta 940611→948454
+     (940611 is the delta base, not the serving full height).
+   - weikeng1 db0 (June 2026 generation) is a hybrid: local-pipeline
+     `utxo_set.bin` input → attested-builder rebuild of the
+     DPF/Harmony/Merkle stages → OnionPIR serving files copied from the
+     2026-05-24 local checkpoint (roots byte-equal) → manifest written by
+     this repo's `build_db_manifest.sh`.
+   - weikeng1 db1 is attested-builder from two raw Core snapshots for the
+     core stages, but `gen_2_onion`/`gen_3_onion`/`gen_4_build_merkle_onion`
+     + the manifest came from this repo's tools (2026-06-16).
+   - weikeng2 (August 2026, image 265) serves native-V2 `server-db`
+     output built end-to-end by attested-builder commit `8d9d21a6…` —
+     weikeng1 and weikeng2 no longer serve identical physical files.
+   - Last confirmed fully-local production generation: 2026-05-24
+     (manifests dated 2026-05-23). Later use of the three local wrappers:
+     no record either way.
+
+   **Agreed forward path for roadmap item 3.2:** first extend
+   attested-builder to produce the complete server-loadable output
+   (including the OnionPIR serving preprocessing and the manifest), run
+   one end-to-end consistency acceptance against the hybrid generation,
+   and only from that dated point declare "local wrappers are
+   development/regression-only; attested-builder is the sole production
+   producer". Until then the local pipeline stays bannered (not
+   forbidden), as `scripts/README.md` already states.
+
 2. How was the live pir1 binary (`c836e11a…`) actually built — cargo with
    features, the Nix flake, or `build_unified_server.sh`?
+
+   *(Answered 2026-08-15, verified on the build host.)* Bare Cargo on
+   `pir-hetzner`, worktree `/home/pir/build-831a5ea1` at commit
+   `831a5ea1`, default features (`default` + `fastprp`), **no**
+   `cuckoo-oram`, not Nix, not the wrapper script. Evidence: the deployed
+   binary embeds `/home/pir/build-831a5ea1/vendor/...` source paths
+   (the wrapper remaps those via `--remap-path-prefix`; Nix sources live
+   in the store) and the cargo feature fingerprint recorded
+   `["default","fastprp"]`; a later same-checkout `cuckoo-oram` build
+   produced a different hash (`8d892590…`, never deployed to pir1).
+   Exact flag string and an explicit `strip --strip-debug` invocation
+   are unrecorded (binary state is consistent with strip-debug). pir1's
+   roles (DPF-0 + OnionPIR + Harmony hint) do not need `cuckoo-oram`;
+   that feature gates the Direct/Circuit ORAM path only (pir2).
+
+   **Decision:** two bare-Cargo profiles are the production build
+   authority —
+   pir1: `cargo build --locked --release -p runtime --bin unified_server`;
+   pir2: `cargo build --locked --release -p runtime --features cuckoo-oram --bin unified_server`;
+   each followed by `strip --strip-debug`. The Nix flake is retained as a
+   development/reproducibility harness only and is no longer described as
+   a production authority anywhere; restoring it would require adding the
+   feature plus fresh cross-host hash and runtime acceptance.
 3. Are `explorer/` and `electrum_plugin/` still product surfaces, or
    experiments that should be demoted in the README?
    *(Answered 2026-08-14/15: owner decided to remove both —

--- a/flake.nix
+++ b/flake.nix
@@ -79,14 +79,20 @@
       # ─── packages.tier3-uki ────────────────────────────────────────
       # Production Tier 3 UKI for pir2 (weikeng2 — VPSBG, SEV-SNP).
       #
-      # ── NOT the current production recipe (2026-08) ────────────────
+      # ── NOT a production recipe (decided 2026-08-15) ───────────────
+      # This flake is a development/reproducibility harness only.
+      # Provenance verification of the deployed binaries showed neither
+      # pir1 nor pir2 was ever Nix-built (bare Cargo builds on the
+      # Hetzner build host; see docs/PROCESS_AUDIT_2026-08.md Q2), and
       # packages.unified-server builds WITHOUT `--features cuckoo-oram`
-      # (see cargoBuildFlags below), which the Direct ORAM production
-      # path requires — so this UKI is NOT what production pir2 boots.
-      # The production build procedure is CLAUDE.md "Hetzner — UKI
-      # build host" (cargo with `--features cuckoo-oram` at the exact
-      # deploy commit + scripts/build_uki_tier3.sh); release identity
-      # authority is web/src/attest-pin.ts.
+      # (see cargoBuildFlags below), which the pir2 Direct ORAM path
+      # requires — so this UKI is NOT what production pir2 boots.
+      # Production build procedure: CLAUDE.md "Hetzner — UKI build
+      # host" (two bare-Cargo profiles + scripts/build_uki_tier3.sh);
+      # release identity authority: web/src/attest-pin.ts. Restoring
+      # this flake as a hermetic production authority would require
+      # adding the cuckoo-oram feature plus fresh cross-host hash and
+      # runtime acceptance.
       #
       # Assembles the whole UKI inside Nix — VPSBG kernel + initramfs +
       # cmdline objcopy'd into systemd's EFI stub — embedding the exact
@@ -95,7 +101,8 @@
       # recipe bakes a *system-linked* binary via dracut; this one
       # bundles the full /nix/store closure via makeInitrdNG, so the
       # baked-in binary is bit-identical to `nix build .#unified-server`
-      # (hence byte-identical to what pir1 ran pre-cuckoo-oram).
+      # (a dev/repro property only — production binaries are bare-Cargo
+      # builds, see the note above).
       #
       #   nix build --impure .#tier3-uki    # on pir-hetzner, as root
       #   → ./result/bpir-tier3.efi
@@ -402,11 +409,11 @@
         echo "unified_server: ${unifiedServer}/bin/unified_server"
       '';
 
-      # Hermetic, bit-reproducible build — but WITHOUT the
-      # `cuckoo-oram` feature the current Tier 3 production binary
-      # requires (see the tier3-uki note above). Use it for
-      # reproducibility work and development; do not pin its sha256 as
-      # a production release identity.
+      # Hermetic, bit-reproducible build — development/reproducibility
+      # use only (and it lacks the `cuckoo-oram` feature the pir2
+      # production binary requires; see the tier3-uki note above).
+      # Production binaries are bare-Cargo builds per CLAUDE.md; do not
+      # pin this derivation's sha256 as a production release identity.
       unified-server = pkgs.rustPlatform.buildRustPackage {
         pname = "unified-server";
         version = "0.1.0";

--- a/scripts/build_unified_server.sh
+++ b/scripts/build_unified_server.sh
@@ -27,24 +27,29 @@
 #     pins the rustc selected via rustup; the rustup harness itself
 #     can vary)
 #
-# ── PRODUCTION AUTHORITY (2026-08) ──────────────────────────────────
-# NEITHER this script NOR the Nix flake builds the current Tier 3
-# production binary: both invoke cargo without `--features cuckoo-oram`,
-# which the Direct ORAM production path requires. For the binary that
-# gets baked into the Tier 3 UKI / pinned in web/src/attest-pin.ts,
-# follow CLAUDE.md "Hetzner — UKI build host": clean checkout at the
-# exact deploy commit, then
-#   cargo build --locked --release -p runtime --features cuckoo-oram --bin unified_server
-# and `strip --strip-debug`. Do not pin this script's (or the flake's)
-# output sha256 for a Tier 3 release.
+# ── PRODUCTION AUTHORITY (decided 2026-08-15) ───────────────────────
+# Production binaries are built with bare Cargo on a clean checkout at
+# the exact deploy commit (CLAUDE.md "Hetzner — UKI build host"):
+#   pir1 (no ORAM):  cargo build --locked --release -p runtime --bin unified_server
+#   pir2 (Tier 3):   cargo build --locked --release -p runtime --features cuckoo-oram --bin unified_server
+# followed by `strip --strip-debug`. Do not pin this script's (or the
+# flake's) output sha256 for any production release.
 #
-# Historical note (2026-05-20, pre-cuckoo-oram): the hermetic flake
-# build (`nix build .#unified-server`) was verified bit-reproducible
-# via `nix-store --realise --check` (unified-server, hexl, onionpir
-# derivations all rebuilt byte-identical), links Intel HEXL into
-# OnionPIR's C++ engine, and was what pir1/pir2 ran at that time. It
-# remains the reproducibility harness; it is just not feature-complete
-# for the current production ORAM configuration.
+# Provenance verification (2026-08, docs/PROCESS_AUDIT_2026-08.md Q2):
+# the deployed pir1 binary embeds /home/pir/build-<commit>/vendor/...
+# source paths and a default+fastprp cargo feature fingerprint — i.e. a
+# bare Cargo build. It was NOT produced by this script (which remaps
+# those paths via --remap-path-prefix and prints a build header) and
+# NOT by the Nix flake (whose source lives in the Nix store). The
+# earlier claim in this header that the flake output "is what pir1/pir2
+# actually run" was wrong for the deployed binaries.
+#
+# Historical note (2026-05-20): the hermetic flake build
+# (`nix build .#unified-server`) was verified bit-reproducible via
+# `nix-store --realise --check` (unified-server, hexl, onionpir
+# derivations all rebuilt byte-identical) and links Intel HEXL into
+# OnionPIR's C++ engine. It remains a development/reproducibility
+# harness only.
 #
 # This script is a no-Nix DEVELOPMENT convenience. By default it builds
 # OnionPIR's C++ engine with the in-crate scalar/SIMD shim


### PR DESCRIPTION
## Summary
- Closes audit questions Q1 and Q2 (`docs/PROCESS_AUDIT_2026-08.md`) with the owner's session-record and build-host verification.
- **Q2 (binary authority):** the deployed pir1 binary `c836e11a…` was a bare Cargo build at commit `831a5ea1` with default features (`default`+`fastprp`, no `cuckoo-oram`) — the embedded `/home/pir/build-831a5ea1/vendor/...` paths rule out `build_unified_server.sh` (which remaps paths) and the Nix flake (store-sourced). pir1's roles don't need `cuckoo-oram`; it gates only pir2's Direct/Circuit ORAM path. CLAUDE.md now declares the two production profiles (pir1: default features; pir2: `--features cuckoo-oram`), and `build_unified_server.sh`/`flake.nix` drop the incorrect "is what pir1/pir2 actually run" claims — the flake is a development/reproducibility harness only, with the restoration bar (add the feature + fresh cross-host hash and runtime acceptance) stated.
- **Q1 (database pipeline):** recorded verbatim in the audit — the weikeng1 June generation is a hybrid (local `utxo_set.bin` input, attested-builder core rebuild, local OnionPIR serving files, this repo's manifest tool); weikeng2 image 265 serves end-to-end attested-builder native-V2 output; **no historical exclusivity decision exists and none is claimed retroactively**. Roadmap 3.2 now has its agreed path: extend attested-builder to full server-loadable output (Onion serving preprocessing + manifest), run one end-to-end acceptance, then declare exclusivity from that date.
- Comment/documentation-only: no build behavior, pins, or production state change.

## Test plan
- [x] `bash -n scripts/build_unified_server.sh` passes
- [x] `flake.nix` diff verified comment-only

Made with [Cursor](https://cursor.com)