### PR TITLE
Add advisory CI summary workflow aggregating all triggered PR checks

### DIFF
--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -1,0 +1,41 @@
+name: CI summary (advisory)
+
+# Single-signal aggregate for pull requests (process-audit Q5, decided
+# 2026-08-15: "aggregate signal first, not required").
+#
+# GitHub applies each workflow's own path filters when it creates runs
+# for a PR head SHA, so instead of duplicating any path mapping here,
+# this job simply waits for every OTHER workflow run that GitHub
+# created for this exact head SHA and reports one green/red status.
+# Zero path-config drift by construction.
+#
+# Deliberately NOT a required check: merges stay manual. If a red check
+# ever slips through a manual merge, upgrading this to a required
+# branch-protection check is the recorded escalation path.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  summary:
+    name: All triggered workflows green
+    runs-on: ubuntu-24.04
+    timeout-minutes: 75
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Wait for sibling workflow runs on this head SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SELF_NAME: CI summary (advisory)
+        run: bash scripts/ci-summary-wait.sh

--- a/docs/PROCESS_AUDIT_2026-08.md
+++ b/docs/PROCESS_AUDIT_2026-08.md
@@ -251,5 +251,23 @@ No CI change, no file moves, no new gates, no pin/policy/proof changes.
    future wallet path instead. Both removed.)*
 4. Should the three builder identities (v1 DPF/Harmony, Onion v2 re-attest,
    ORAM native) be collapsed to one at the next root rotation?
+
+   *(Answered 2026-08-15 — actually four pinned builder commits:
+   `01e8db91` delta v1, `b692aec1` ORAM source, `d49a199e` Onion v2
+   strict, `8d9d21a6` native V2 producer.)* **Yes, but deferred to the
+   next root rotation** — a from-scratch rebuild of every proof family is
+   too heavy to run as a standalone exercise. When the next rotation
+   happens (after the 3.2 attested-builder extension), one builder commit
+   should produce all proof families in a single run, collapsing the pins
+   to one `builderGitCommit`.
 5. Is an aggregate required-check for `main` wanted, or is manual merge
    inspection the deliberate long-term state?
+
+   *(Answered 2026-08-15: aggregate signal first, not required.)* The
+   "CI summary (advisory)" workflow (`.github/workflows/ci-summary.yml` +
+   `scripts/ci-summary-wait.sh`) runs on every PR and waits for all
+   sibling workflow runs GitHub created for the head SHA — no duplicated
+   path mapping, so no filter drift. Merges stay manual and the check is
+   deliberately not required; the recorded escalation path is to upgrade
+   it to a required branch-protection check only if a red check ever
+   slips through a manual merge.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Do not copy those values into prose documents; link them.
 
 | Operation | Entry point | Notes |
 |---|---|---|
-| Ordinary development | [`TESTING.md`](TESTING.md) change-class matrix → PR → manual merge after inspecting the path-filtered Actions results | No aggregate required check exists; see `PROJECT_CLOSEOUT_TODO.md:124-126` |
+| Ordinary development | [`TESTING.md`](TESTING.md) change-class matrix → PR → manual merge once the advisory "CI summary" check is green | The summary check aggregates all triggered workflows but is deliberately not required; see `TESTING.md` |
 | Database / root rotation | [`DATABASE_ROOT_ROTATION_RUNBOOK.md`](DATABASE_ROOT_ROTATION_RUNBOOK.md), with [`DATABASE_ARTIFACT_RETENTION.md`](DATABASE_ARTIFACT_RETENTION.md) read first | The legacy refresh flow in `scripts/README.md` is **not** the production path |
 | Web release | Manual `deploy-web.yml` dispatch from `main` with the production confirmation ([`PRODUCTION_OPERATIONS.md`](PRODUCTION_OPERATIONS.md)) | The workflow deployment record is the release evidence |
 | Tier 3 UKI / VPSBG release | [VPSBG measured-boot skill](../.agents/skills/vpsbg-measured-boot/SKILL.md) + `scripts/build_uki_tier3.sh` (policy digest is locked in the script) | Upload/switch/reboot require explicit authorization |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -26,9 +26,13 @@ and passing it says nothing about non-Payment changes.
 | UKI scripts, `.github/workflows/**` | `node --test scripts/github-workflow-supply-chain-gate.test.mjs scripts/tier3-uki-policy-contract.test.mjs` | `workflow-supply-chain.yml` (every PR, unfiltered) | UKI builds themselves are operator actions on the build host, not CI |
 | Documentation only | none | `formal-proof.yml` + `workflow-supply-chain.yml` still run (unfiltered PR events) | CI does not check documentation truth; identity values (hashes, image IDs) must be pointers to `web/src/attest-pin.ts` / `docs/data-retention/`, not copies |
 
-Merges are manual: there is no aggregate required check on `main`, so inspect
-every applicable Actions result before merging
-(`PROJECT_CLOSEOUT_TODO.md:124-126`).
+Merges are manual: there is no aggregate **required** check on `main`
+(`PROJECT_CLOSEOUT_TODO.md:124-126`, reaffirmed 2026-08-15). The advisory
+"CI summary (advisory)" workflow runs on every PR and waits for all sibling
+workflow runs on the head SHA, so its single green/red status is the one
+signal to inspect before merging; it does not block a merge. If a red check
+ever slips through a manual merge, upgrading it to a required check is the
+recorded escalation path.
 
 ## Payment V1 profiles
 

--- a/scripts/ci-summary-wait.sh
+++ b/scripts/ci-summary-wait.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Advisory CI summary: wait for every other workflow run GitHub created
+# for $HEAD_SHA (event=pull_request) and report one green/red result.
+#
+# Driven by .github/workflows/ci-summary.yml. Because GitHub has already
+# applied each workflow's own path filters when creating runs, the set of
+# sibling runs for the head SHA IS the set of applicable lanes — no path
+# mapping is duplicated here.
+#
+# Environment:
+#   GH_TOKEN   token for gh api (actions: read)
+#   REPO       owner/name
+#   HEAD_SHA   PR head commit SHA
+#   SELF_NAME  this workflow's name, excluded from the wait set
+# Tunables: SETTLE_SECONDS (60), POLL_SECONDS (30), DEADLINE_SECONDS (4200).
+#
+# Exit 0: every sibling run completed with success/skipped/neutral.
+# Exit 1: any run failed/cancelled/timed out, or the deadline passed.
+set -euo pipefail
+
+: "${GH_TOKEN:?}" "${REPO:?}" "${HEAD_SHA:?}" "${SELF_NAME:?}"
+SETTLE_SECONDS="${SETTLE_SECONDS:-60}"
+POLL_SECONDS="${POLL_SECONDS:-30}"
+DEADLINE_SECONDS="${DEADLINE_SECONDS:-4200}"
+
+# Give GitHub time to create all runs for the head SHA before the first
+# poll, so a lane that starts slowly is not missed entirely.
+sleep "$SETTLE_SECONDS"
+
+start_epoch="$(date +%s)"
+
+fetch_siblings() {
+    gh api "repos/$REPO/actions/runs?event=pull_request&head_sha=$HEAD_SHA&per_page=100" \
+        --jq '[.workflow_runs[] | {name, status, conclusion, html_url}]' \
+      | jq --arg self "$SELF_NAME" '[ .[] | select(.name != $self) ]'
+}
+
+print_table() {
+    jq -r '.[] | "\(.conclusion // .status)\t\(.name)\t\(.html_url)"' <<< "$1" \
+      | sort
+}
+
+while :; do
+    siblings="$(fetch_siblings)"
+
+    failed="$(jq '[ .[] | select(.status == "completed"
+        and (.conclusion | IN("success", "skipped", "neutral") | not)) ]' <<< "$siblings")"
+    pending="$(jq '[ .[] | select(.status != "completed") ]' <<< "$siblings")"
+    failed_count="$(jq 'length' <<< "$failed")"
+    pending_count="$(jq 'length' <<< "$pending")"
+    total_count="$(jq 'length' <<< "$siblings")"
+
+    if [ "$failed_count" -gt 0 ]; then
+        echo "FAILED — $failed_count of $total_count sibling workflow run(s) did not succeed:"
+        print_table "$failed"
+        echo
+        echo "Full set:"
+        print_table "$siblings"
+        [ -n "${GITHUB_STEP_SUMMARY:-}" ] && {
+            echo "## CI summary: FAILED"
+            echo '```'
+            print_table "$siblings"
+            echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+        exit 1
+    fi
+
+    if [ "$pending_count" -eq 0 ]; then
+        echo "GREEN — all $total_count sibling workflow run(s) completed successfully:"
+        print_table "$siblings"
+        [ -n "${GITHUB_STEP_SUMMARY:-}" ] && {
+            echo "## CI summary: all $total_count triggered workflows green"
+            echo '```'
+            print_table "$siblings"
+            echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+        exit 0
+    fi
+
+    now_epoch="$(date +%s)"
+    if [ $(( now_epoch - start_epoch )) -ge "$DEADLINE_SECONDS" ]; then
+        echo "TIMED OUT — $pending_count of $total_count sibling run(s) still pending after ${DEADLINE_SECONDS}s:"
+        print_table "$pending"
+        exit 1
+    fi
+
+    echo "waiting: $pending_count of $total_count sibling run(s) still pending ($(( now_epoch - start_epoch ))s elapsed)"
+    sleep "$POLL_SECONDS"
+done


### PR DESCRIPTION
## Summary
- Audit question Q5 (`docs/PROCESS_AUDIT_2026-08.md`), owner decision: "aggregate signal first, not required". New `.github/workflows/ci-summary.yml` + `scripts/ci-summary-wait.sh`: on every PR, the job lists every other workflow run GitHub created for the exact head SHA (`event=pull_request`), polls until all complete, and reports a single green/red status with a table in the step summary. GitHub already applied each workflow's own `paths:` filters when creating those runs, so the set of sibling runs *is* the set of applicable lanes — no duplicated path mapping, no filter drift by construction.
- Deliberately **not** a required branch-protection check: merges stay manual, and the recorded escalation path (in `docs/TESTING.md` and the audit) is to flip it to required only if a red check ever slips through a manual merge. Fails fast on the first failed sibling; 70-minute internal deadline under a 75-minute job timeout.
- Also records the Q4 decision in the audit: the four pinned builder commits (`01e8db91` delta v1, `b692aec1` ORAM source, `d49a199e` Onion v2 strict, `8d9d21a6` native V2) collapse to one at the **next** root rotation — deferred because a from-scratch rebuild of every proof family is too heavy to run standalone.

## Test plan
- [x] Live-tested the wait script against PR #203's head SHA: found both sibling runs, reported GREEN, exit 0
- [x] Failure-filter logic verified against crafted JSON (failure caught; skipped/pending not misclassified)
- [x] Supply-chain gate passes with the new workflow (13 workflows, exact checkout pin, persist-credentials: false); `node --test` gate suite green; `bash -n` clean

Made with [Cursor](https://cursor.com)