### PR TITLE
Record Hetzner secondary retirement and pir1 freeze boundary

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,12 +13,19 @@ not listed below is local-only by construction.
 | `installimage.conf` | Hetzner installimage config for the pir1 host (partitioning/RAID; no credentials) |
 | `known_hosts` | Pinned SSH public host keys for the Hetzner host (65.21.91.217) — the host-key-swap defense used by the ops runbooks |
 | `vpsbg_known_hosts` | Pinned SSH public host keys for the VPSBG host (87.120.8.198, Slice 2 only) |
-| `systemd/*.service` | The five host service units: `pir-primary` / `pir-secondary` (Hetzner), `pir-vpsbg` (VPSBG Slice 2), `cloudflared`, `dev-issuer`. Copies of what runs on the hosts; the units contain no secrets (the admin key in `pir-vpsbg.service` is the public half) |
+| `systemd/*.service` | Reviewed host-unit snapshots. `pir-primary`, `pir-vpsbg`, `cloudflared`, and `dev-issuer` describe active roles; `pir-secondary` is a retained retired snapshot and must not be installed or enabled as a fallback. The units contain no secrets (the admin key in `pir-vpsbg.service` is the public half). |
 
 These files are *facts about the deployment*, not activation levers: editing
 them here changes nothing on a host. Applying a unit change to a host is a
 production operation requiring explicit authorization
 (`docs/PRODUCTION_OPERATIONS.md`).
+
+The retired `pir-secondary.service` snapshot preserves the former single-host
+8092 configuration verbatim for historical diagnosis only; comments inside
+that snapshot describing it as warm or running are superseded by the current
+operations document. The supported pir2 recovery route is VPSBG measured boot.
+A future Hetzner replacement requires a new reviewed unit and explicit ingress
+authorization; copying or starting the old snapshot is not recovery.
 
 ## Local-only (never commit)
 

--- a/docs/PRODUCTION_OPERATIONS.md
+++ b/docs/PRODUCTION_OPERATIONS.md
@@ -44,6 +44,31 @@ new release.
 Run a manual production canary only after a deliberate web or VPSBG release,
 never as the first diagnostic step.
 
+## Active provider topology
+
+The active public provider topology is deliberately asymmetric:
+
+- `weikeng1.bitcoinpir.org` is the Hetzner `pir-primary.service` on loopback
+  port 8091. Its `c836e11a...` binary remains intentionally frozen until a
+  DPF/Harmony/Onion db1 or payment-policy change requires a coordinated pir1
+  release, or a P0/P1 defect requires an earlier fix. Direct ORAM changes on
+  pir2 alone are not a reason to rebuild pir1 for version parity.
+- `weikeng2.bitcoinpir.org` is the VPSBG measured-boot provider. Observe and
+  recover it through the status and measured-boot API routes above.
+- Hetzner `pir-secondary.service` on port 8092 was retired on 2026-08-18. It
+  is not a public provider or an approved pir2 recovery route. Its old unit,
+  binary, and database files are retained as evidence only.
+- `bitcoinpir-provider-functional-beta-2.service` is a distinct loopback-only
+  Payment functional-beta process on port 8292 on the same physical Hetzner
+  host. It is not the retired 8092 service and was outside that retirement.
+
+If a future incident requires a Hetzner replacement for pir2, do not re-enable
+the retired 8092 process. Prepare a reviewed current binary, Payment-V1 policy,
+identity, database pins, loopback-bound unit, and explicit ingress change as a
+new authorized release. Validate its public identity before any user traffic.
+The point-in-time retirement evidence and recovery boundary are recorded in
+[`history/HETZNER_SECONDARY_RETIREMENT_2026-08-18.md`](history/HETZNER_SECONDARY_RETIREMENT_2026-08-18.md).
+
 Mainnet Lightning activation is pending; source and functional-beta evidence
 are not proof of a deployed mainnet Lightning service. See
 [`docs/payment/IMPLEMENTATION_STATUS.md`](payment/IMPLEMENTATION_STATUS.md).

--- a/docs/history/HETZNER_SECONDARY_RETIREMENT_2026-08-18.md
+++ b/docs/history/HETZNER_SECONDARY_RETIREMENT_2026-08-18.md
@@ -1,0 +1,93 @@
+# Hetzner secondary retirement — 2026-08-18
+
+Status: **completed and read back**.
+
+This is point-in-time operational evidence. Current operations start at
+[`../PRODUCTION_OPERATIONS.md`](../PRODUCTION_OPERATIONS.md).
+
+## Decision
+
+The operator selected these two boundaries:
+
+1. Retire the legacy Hetzner `pir-secondary.service` on port 8092. Preserve
+   its unit, binary, databases, and logs as evidence; do not treat it as a
+   warm public fallback.
+2. Keep the active Hetzner pir1 `c836e11a...` binary intentionally frozen.
+   Revisit it when a DPF/Harmony/Onion db1 or payment-policy change requires a
+   coordinated host release, or when a P0/P1 defect requires an earlier fix.
+   A Direct ORAM-only change on pir2 does not trigger a pir1 rebuild.
+
+## Pre-retirement evidence
+
+Read-only checks immediately before the operation established:
+
+- Host `pir` ran `pir-primary.service` on `127.0.0.1:8091`; the service was
+  active and enabled.
+- The same host ran `pir-secondary.service` on `*:8092` from
+  `/home/pir/BitcoinPIR/target/release/unified_server`; its binary SHA-256 was
+  `cc4ec24b9ecf54c962d20843a374a8235d9b71954adf05bdb4d6bb3155e16b1e`.
+  The service was active but already disabled, so stopping it would not remove
+  a boot-time dependency or allow it to return at reboot.
+- `cloudflared.service` ordered itself after the secondary but did not require
+  or want it. The reverse dependency query contained no dependent service.
+- A direct external TCP probe could not reach the Hetzner host on port 8092.
+- Public attestation identified `weikeng1.bitcoinpir.org` as the pinned
+  `c836e11a...` Hetzner process and `weikeng2.bitcoinpir.org` as the pinned
+  `4b05fc90...` measured VPSBG process. Neither public identity matched the
+  legacy 8092 binary.
+- The VPSBG control plane reported server 25285 active in measured boot with
+  attached image 265.
+- The host also ran a distinct loopback-only
+  `bitcoinpir-provider-functional-beta-2.service` on port 8292. That process is
+  part of the Payment functional-beta topology, is not `pir-secondary.service`,
+  and was explicitly outside this retirement.
+
+These checks establish that 8092 was neither a public provider nor required by
+the active ingress process. They do not turn the old process into an approved
+recovery artifact.
+
+## Recovery replacement
+
+For a pir2 incident:
+
+1. Run `scripts/vpsbg-production-status.sh`.
+2. Use the repository VPSBG measured-boot API procedure for an authorized
+   rollback or release. Do not SSH to VPSBG and do not route traffic to the
+   retired Hetzner process.
+3. If a future topology decision requires a Hetzner replacement, create a new
+   reviewed deployment with the then-current binary, Payment-V1 policy,
+   identity, database pins, and a loopback-only origin. Changing public ingress
+   and running the post-release canary each require explicit authorization.
+
+The old 8092 unit, binary, database inputs, and logs remain retained for
+forensics. Re-enabling the old unit is not a rollback procedure.
+
+## Host operation
+
+Authorized operation:
+
+```text
+systemctl disable --now pir-secondary.service
+```
+
+Post-operation state is recorded below after readback.
+
+## Post-retirement readback
+
+The command completed at 2026-08-18 00:55:53 UTC. Readback established:
+
+- `pir-secondary.service`: `inactive`, `dead`, `disabled`, `MainPID=0`, and
+  systemd `Result=success`. Its terminated main process reported status 15,
+  the expected SIGTERM from the authorized stop.
+- No process listened on port 8092. The retained old binary and data were not
+  deleted.
+- `pir-primary.service` and `cloudflared.service` remained active; the only
+  listener in the 8091/8092 check was `127.0.0.1:8091`.
+- Fresh public identity checks after the stop still matched the pinned
+  `c836e11a...` Hetzner binary and the `4b05fc90...` VPSBG binary. VPSBG also
+  returned the pinned image-265 launch measurement with matching REPORT_DATA.
+- The VPSBG control plane remained active, reachable, running, and in measured
+  boot on image 265.
+
+No public ingress, pir1 binary, Payment functional-beta service, database,
+policy, identity, VPSBG image, or retained artifact was changed.

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -27,3 +27,6 @@ index. Use the maintained
 
 - [Git cleanup record (2026-08-13)](GIT_CLEANUP_2026-08-13.md)
   — records what was removed and why dirty/unmerged worktrees were preserved.
+- [Hetzner secondary retirement (2026-08-18)](HETZNER_SECONDARY_RETIREMENT_2026-08-18.md)
+  — records the authorized retirement of the unrouted 8092 legacy process,
+  its replacement recovery route, and the intentional pir1 freeze boundary.


### PR DESCRIPTION
## Summary

- record the authorized retirement of the unrouted Hetzner `pir-secondary.service` on port 8092
- make VPSBG measured boot, rather than the legacy process, the supported pir2 recovery route
- document the pir1 `c836e11a...` intentional-freeze rule: revisit it with a coordinated DPF/Harmony/Onion db1 or payment-policy release, or earlier for a P0/P1 defect
- distinguish the separate loopback-only Payment functional-beta service on port 8292 from the retired 8092 service

## Production readback

The operator authorized `systemctl disable --now pir-secondary.service`.

After the operation:

- `pir-secondary.service` is inactive, dead, disabled, and has no main PID
- no process listens on port 8092
- `pir-primary.service` and `cloudflared.service` remain active
- public weikeng1 identity still matches the pinned `c836e11a...` Hetzner binary
- public weikeng2 identity and launch measurement still match VPSBG image 265
- no binary, database, policy, identity, ingress, VPSBG image, or retained artifact was changed or deleted

## Recovery boundary

The old unit, binary, database inputs, and logs are retained as evidence only. A future Hetzner replacement requires a new reviewed current binary, Payment-V1 policy, identity, database pins, loopback-only unit, explicit ingress authorization, and post-release validation.

## Validation

- `git diff --check`
- verified all linked documentation paths exist
- performed pre/post systemd and socket readback
- performed pinned public identity checks for both providers
- queried the VPSBG control plane read-only

This is a documentation/evidence PR; no test matrix or CI gate was added.
