### PR TITLE
Support Harmony pools for db0 and db1

### DIFF
--- a/apps/server/src/bin/unified_server.rs
+++ b/apps/server/src/bin/unified_server.rs
@@ -209,6 +209,12 @@ enum ServerRole {
     Secondary,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct HarmonyPoolBinding {
+    db_id: u8,
+    pool_dir: Option<PathBuf>,
+}
+
 struct CliArgs {
     /// IP address to bind. The production-compatible default remains the
     /// dual-stack wildcard; local integration harnesses can explicitly bind
@@ -244,13 +250,12 @@ struct CliArgs {
     /// changes (kernel update, microcode update) — see
     /// docs/PHASE3_ROADMAP.md.
     vcek_dir: Option<PathBuf>,
-    /// HarmonyPIR V2 hint pool size (0 = pool disabled, use V1 on-demand).
+    /// HarmonyPIR V2 hint pool size per configured database (0 = disabled).
     pool_size: usize,
-    /// Database ID whose immutable tables back this process's single V2 hint
-    /// pool. One process deliberately owns one pool/database binding.
-    pool_db_id: u8,
-    /// Directory for pool file persistence.
-    pool_dir: Option<PathBuf>,
+    /// Exact immutable database/directory bindings for the V2 hint pools.
+    /// Legacy `--pool-db-id`/`--pool-dir` normalizes to one entry; repeated
+    /// `--harmony-pool-db <db_id>=<dir>` entries enable explicit multi-pool.
+    harmony_pool_bindings: Vec<HarmonyPoolBinding>,
     /// Require ARC credential presentation before serving PIR queries.
     require_arc: bool,
     /// Path to the 128-byte ARC private key (`arc_key.bin`) shared with the
@@ -445,6 +450,67 @@ fn parse_cuckoo_oram_db_arg(spec: &str) -> Result<(u8, PathBuf), String> {
     Ok((db_id, PathBuf::from(dir_raw)))
 }
 
+fn parse_harmony_pool_db_arg(spec: &str) -> Result<(u8, PathBuf), String> {
+    let Some((db_id_raw, dir_raw)) = spec.split_once('=') else {
+        return Err("--harmony-pool-db expects <db_id>=<dir>".into());
+    };
+    let db_id = db_id_raw
+        .parse::<u8>()
+        .map_err(|e| format!("invalid --harmony-pool-db db_id `{db_id_raw}`: {e}"))?;
+    if dir_raw.is_empty() {
+        return Err("--harmony-pool-db requires a non-empty directory".into());
+    }
+    Ok((db_id, PathBuf::from(dir_raw)))
+}
+
+fn normalize_harmony_pool_bindings(
+    pool_size: usize,
+    legacy_db_id: u8,
+    legacy_db_id_explicit: bool,
+    legacy_pool_dir: Option<PathBuf>,
+    explicit: Vec<(u8, PathBuf)>,
+) -> Result<Vec<HarmonyPoolBinding>, String> {
+    if explicit.is_empty() {
+        return Ok((pool_size > 0)
+            .then_some(HarmonyPoolBinding {
+                db_id: legacy_db_id,
+                pool_dir: legacy_pool_dir,
+            })
+            .into_iter()
+            .collect());
+    }
+    if pool_size == 0 {
+        return Err("--harmony-pool-db requires --pool-size greater than zero".into());
+    }
+    if legacy_db_id_explicit || legacy_pool_dir.is_some() {
+        return Err("--harmony-pool-db cannot be combined with --pool-db-id or --pool-dir".into());
+    }
+
+    let mut by_database = BTreeMap::new();
+    let mut directories = BTreeSet::new();
+    for (db_id, pool_dir) in explicit {
+        if by_database.contains_key(&db_id) {
+            return Err(format!(
+                "--harmony-pool-db configures database {db_id} more than once"
+            ));
+        }
+        if !directories.insert(pool_dir.clone()) {
+            return Err(format!(
+                "--harmony-pool-db reuses pool directory {}",
+                pool_dir.display()
+            ));
+        }
+        by_database.insert(
+            db_id,
+            HarmonyPoolBinding {
+                db_id,
+                pool_dir: Some(pool_dir),
+            },
+        );
+    }
+    Ok(by_database.into_values().collect())
+}
+
 fn parse_direct_oram_db_arg(spec: &str) -> Result<(u8, PathBuf), String> {
     let Some((db_id_raw, dir_raw)) = spec.split_once('=') else {
         return Err("--direct-oram-db expects <db_id>=<dir>".into());
@@ -534,7 +600,9 @@ fn parse_args_from(args: Vec<String>) -> CliArgs {
     let mut vcek_dir: Option<PathBuf> = None;
     let mut pool_size: usize = 0; // 0 = pool disabled
     let mut pool_db_id: u8 = 0;
+    let mut pool_db_id_explicit = false;
     let mut pool_dir: Option<PathBuf> = None;
+    let mut harmony_pool_dbs: Vec<(u8, PathBuf)> = Vec::new();
     let mut require_arc = false;
     let mut arc_key_path: Option<PathBuf> = None;
     let mut require_cashu = false;
@@ -689,12 +757,21 @@ fn parse_args_from(args: Vec<String>) -> CliArgs {
                         "--pool-db-id must be a u8 database ID, got {value}"
                     ))
                 });
+                pool_db_id_explicit = true;
                 i += 1;
             }
             "--pool-dir" => {
                 if let Some(dir) = args.get(i + 1) {
                     pool_dir = Some(PathBuf::from(dir));
                 }
+                i += 1;
+            }
+            "--harmony-pool-db" => {
+                let spec = args
+                    .get(i + 1)
+                    .unwrap_or_else(|| fatal_cli("--harmony-pool-db requires <db_id>=<dir>"));
+                harmony_pool_dbs
+                    .push(parse_harmony_pool_db_arg(spec).unwrap_or_else(|error| fatal_cli(error)));
                 i += 1;
             }
             "--require-arc" => {
@@ -1091,6 +1168,14 @@ fn parse_args_from(args: Vec<String>) -> CliArgs {
     if !(10_000..=600_000).contains(&service_pre_auth_timeout_ms) {
         fatal_cli("--service-pre-auth-timeout-ms must be in 10000..=600000");
     }
+    let harmony_pool_bindings = normalize_harmony_pool_bindings(
+        pool_size,
+        pool_db_id,
+        pool_db_id_explicit,
+        pool_dir,
+        harmony_pool_dbs,
+    )
+    .unwrap_or_else(|error| fatal_cli(error));
 
     CliArgs {
         bind_address,
@@ -1104,8 +1189,7 @@ fn parse_args_from(args: Vec<String>) -> CliArgs {
         disable_onion,
         vcek_dir,
         pool_size,
-        pool_db_id,
-        pool_dir,
+        harmony_pool_bindings,
         require_arc,
         arc_key_path,
         require_cashu,
@@ -3666,13 +3750,12 @@ fn validate_harmony_hints_request(
     Ok(())
 }
 
-/// A V2 hint pool is precomputed against exactly one immutable database.
-/// Never serve those hints for another catalog entry, even when that db_id is
-/// otherwise valid and loaded by the server.
-fn validate_harmony_v2_pool_database(bound_db_id: u8, requested_db_id: u8) -> Result<(), String> {
+/// A pending V2Half session is bound to the database that supplied its first
+/// half. The same client token must never splice halves from different pools.
+fn validate_harmony_v2_half_database(bound_db_id: u8, requested_db_id: u8) -> Result<(), String> {
     if requested_db_id != bound_db_id {
         return Err(format!(
-            "HarmonyPIR V2 hint pool is bound to db {}, not requested db {}",
+            "HarmonyPIR V2 half token is bound to db {}, not requested db {}",
             bound_db_id, requested_db_id
         ));
     }
@@ -3932,6 +4015,8 @@ fn harmony_batch_response_from_table<T: CuckooTableAccess>(
 /// only reads from it; once both halves have been served, the entry is
 /// simply dropped (the pool refills lazily).
 struct V2HalfPending {
+    /// Exact pool/database selected by the first half using this token.
+    db_id: u8,
     /// The pool entry feeding both halves of this session. Shared so
     /// the second half's serve loop can read its frames without
     /// having to coordinate with the first half's lifetime.
@@ -3990,8 +4075,9 @@ struct UnifiedServerData {
     /// `channel_keypair.new_handshake()` in the dispatch loop's
     /// REQ_HANDSHAKE branch.
     channel_keypair: pir_runtime_core::channel::ChannelKeypair,
-    /// Pre-computed HarmonyPIR V2 hint pool (None if pool_size=0).
-    hint_pool: Option<hint_pool::HintPool>,
+    /// Pre-computed HarmonyPIR V2 hint pools indexed by exact database ID.
+    /// Empty when `--pool-size=0`.
+    hint_pools: BTreeMap<u8, hint_pool::HintPool>,
     /// Optional legacy ORAM-backed INDEX/CHUNK cuckoo-table access indexed by
     /// db_id. This is kept only as a compatibility fallback for
     /// REQ_ORAM_LOOKUP; HarmonyPIR queries stay mmap-backed so ORAM state
@@ -4406,11 +4492,7 @@ impl UnifiedServerData {
                 self.serve_queries
             }
             OperationStartV1::HarmonyHint { .. } => {
-                self.serve_hints
-                    && self
-                        .hint_pool
-                        .as_ref()
-                        .is_some_and(|pool| pool.database_id() == db_id)
+                self.serve_hints && self.hint_pools.contains_key(&db_id)
             }
             OperationStartV1::OnionSession { .. } => {
                 self.serve_queries && self.onionpir_tx_for(db_id).is_some()
@@ -8595,7 +8677,7 @@ async fn main() {
     if !args.serve_hints && !args.serve_queries {
         eprintln!(
             "ERROR: must enable at least one of --serve-hints / --serve-queries.\n  \
-             Hint-only deployment (HarmonyPIR V2 pool):  --serve-hints --pool-size N [--pool-db-id ID]\n  \
+             Hint-only deployment (HarmonyPIR V2 pool):  --serve-hints --pool-size N [--pool-db-id ID | --harmony-pool-db ID=DIR ...]\n  \
              Query-only deployment (DPF / OnionPIR / HarmonyPIR query): --serve-queries\n  \
              Both (legacy single-host or pir1 Hetzner topology):       --serve-hints --serve-queries"
         );
@@ -9987,19 +10069,19 @@ async fn main() {
         (None, false)
     };
 
-    let hint_pool = if args.pool_size > 0 {
+    let mut hint_pools = BTreeMap::new();
+    for binding in &args.harmony_pool_bindings {
         let pool_config = hint_pool::HintPoolConfig {
             pool_size: args.pool_size,
             // Advertise exactly the backend compiled into this runtime:
             // FastPRP with the feature, HMR12 otherwise.
             prp_backend: hint_pool::default_prp_backend(),
-            pool_dir: args.pool_dir.clone(),
+            pool_dir: binding.pool_dir.clone(),
         };
-        let pool_db_id = args.pool_db_id;
-        let pool_db = state.get_db(pool_db_id).unwrap_or_else(|| {
+        let pool_db = state.get_db(binding.db_id).unwrap_or_else(|| {
             panic!(
                 "HarmonyPIR hint pool database db_id {} must be loaded",
-                pool_db_id
+                binding.db_id
             )
         });
         let backend_name = match pool_config.prp_backend {
@@ -10009,7 +10091,7 @@ async fn main() {
         };
         println!(
             "  HarmonyPIR V2 hint pool: db_id={}, size={}, backend={}, dir={}",
-            pool_db_id,
+            binding.db_id,
             pool_config.pool_size,
             backend_name,
             pool_config
@@ -10018,18 +10100,27 @@ async fn main() {
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|| "memory-only".into())
         );
+        let pool =
+            hint_pool::HintPool::new(pool_config, binding.db_id, pool_db).unwrap_or_else(|e| {
+                panic!(
+                    "HarmonyPIR hint pool init failed for db {}: {e}",
+                    binding.db_id
+                )
+            });
+        let previous = hint_pools.insert(binding.db_id, pool);
+        debug_assert!(
+            previous.is_none(),
+            "pool bindings were normalized as unique"
+        );
+    }
+    if hint_pools.is_empty() {
+        println!("  HarmonyPIR V2 hint pool: disabled (use --pool-size to enable)");
+    } else {
         println!(
             "  HarmonyPIR V2 online-authority AUTH limit: {} (provider-local headroom reserved)",
             online_v2full_auth_limit
         );
-        Some(
-            hint_pool::HintPool::new(pool_config, pool_db_id, pool_db)
-                .unwrap_or_else(|e| panic!("HarmonyPIR hint pool init failed: {}", e)),
-        )
-    } else {
-        println!("  HarmonyPIR V2 hint pool: disabled (use --pool-size to enable)");
-        None
-    };
+    }
 
     let server = Arc::new(UnifiedServerData {
         state,
@@ -10040,7 +10131,7 @@ async fn main() {
         admin_config,
         data_root,
         channel_keypair,
-        hint_pool,
+        hint_pools,
         #[cfg(feature = "cuckoo-oram")]
         cuckoo_oram,
         #[cfg(feature = "cuckoo-oram")]
@@ -11046,11 +11137,8 @@ async fn main() {
                                             } else {
                                                 v2_full_reservation_db_id.and_then(|db_id| {
                                                     server
-                                                        .hint_pool
-                                                        .as_ref()
-                                                        .filter(|pool| {
-                                                            pool.database_id() == db_id
-                                                        })
+                                                        .hint_pools
+                                                        .get(&db_id)
                                                         .and_then(|pool| {
                                                             if requires_online_v2full_authority {
                                                                 pool.try_reserve_preserving_ready_floor(1)
@@ -12189,29 +12277,16 @@ async fn main() {
                             continue;
                         }
 
-                        let pool = match &server.hint_pool {
-                            Some(p) => p,
+                        let pool = match server.hint_pools.get(&db_id) {
+                            Some(pool) => pool,
                             None => {
                                 let resp = Response::Error(
-                                    "V2 hints not available: start server with --pool-size to enable".into()
+                                    format!("V2 hints not available for db_id {db_id}")
                                 );
                                 let _ = send_resp(&mut sink, channel_session.as_mut(), resp.encode()).await;
                                 continue;
                             }
                         };
-                        if let Err(message) = validate_harmony_v2_pool_database(
-                            pool.database_id(),
-                            db_id,
-                        ) {
-                            let resp = Response::Error(message);
-                            let _ = send_resp(
-                                &mut sink,
-                                channel_session.as_mut(),
-                                resp.encode(),
-                            )
-                            .await;
-                            continue;
-                        }
 
                         let entry = if server.service_admission_enforcement
                             == AdmissionEnforcementV1::Enforced
@@ -12381,30 +12456,16 @@ async fn main() {
                             continue;
                         }
 
-                        let pool = match &server.hint_pool {
-                            Some(p) => p,
+                        let pool = match server.hint_pools.get(&db_id) {
+                            Some(pool) => pool,
                             None => {
                                 let resp = Response::Error(
-                                    "V2 half hints not available: start server with --pool-size to enable"
-                                        .into(),
+                                    format!("V2 half hints not available for db_id {db_id}"),
                                 );
                                 let _ = send_resp(&mut sink, channel_session.as_mut(), resp.encode()).await;
                                 continue;
                             }
                         };
-                        if let Err(message) = validate_harmony_v2_pool_database(
-                            pool.database_id(),
-                            db_id,
-                        ) {
-                            let resp = Response::Error(message);
-                            let _ = send_resp(
-                                &mut sink,
-                                channel_session.as_mut(),
-                                resp.encode(),
-                            )
-                            .await;
-                            continue;
-                        }
 
                         let token = v2half_req.session_token;
                         let side = v2half_req.side;
@@ -12418,6 +12479,19 @@ async fn main() {
                             let mut map = server.v2_half_pending.lock().await;
                             match map.get_mut(&token) {
                                 Some(pend) => {
+                                    if let Err(message) =
+                                        validate_harmony_v2_half_database(pend.db_id, db_id)
+                                    {
+                                        drop(map);
+                                        let resp = Response::Error(message);
+                                        let _ = send_resp(
+                                            &mut sink,
+                                            channel_session.as_mut(),
+                                            resp.encode(),
+                                        )
+                                        .await;
+                                        continue;
+                                    }
                                     if pend.sides_served & side_bit != 0 {
                                         // Same side already served on
                                         // this token — protocol error.
@@ -12471,6 +12545,7 @@ async fn main() {
                                     map.insert(
                                         token,
                                         V2HalfPending {
+                                            db_id,
                                             entry: Arc::clone(&arc),
                                             sides_served: side_bit,
                                             created_at: Instant::now(),
@@ -13935,6 +14010,94 @@ mod service_admission_dispatch_tests {
         assert_eq!(online_v2full_auth_limit_v1(4, 8, Some(2)).unwrap(), 2);
         assert!(online_v2full_auth_limit_v1(4, 8, Some(4)).is_err());
         assert!(online_v2full_auth_limit_v1(8, 4, Some(4)).is_err());
+    }
+
+    #[test]
+    fn harmony_pool_cli_preserves_legacy_single_pool_binding() {
+        let args = parse_args_from(vec![
+            "unified_server".to_owned(),
+            "--pool-size".to_owned(),
+            "8".to_owned(),
+            "--pool-db-id".to_owned(),
+            "7".to_owned(),
+            "--pool-dir".to_owned(),
+            "/private/pool-7".to_owned(),
+        ]);
+        assert_eq!(
+            args.harmony_pool_bindings,
+            vec![HarmonyPoolBinding {
+                db_id: 7,
+                pool_dir: Some(PathBuf::from("/private/pool-7")),
+            }]
+        );
+
+        let defaults = normalize_harmony_pool_bindings(8, 0, false, None, Vec::new()).unwrap();
+        assert_eq!(
+            defaults,
+            vec![HarmonyPoolBinding {
+                db_id: 0,
+                pool_dir: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn harmony_pool_cli_accepts_distinct_repeatable_database_bindings() {
+        let args = parse_args_from(vec![
+            "unified_server".to_owned(),
+            "--pool-size".to_owned(),
+            "8".to_owned(),
+            "--harmony-pool-db".to_owned(),
+            "1=/private/pool-1".to_owned(),
+            "--harmony-pool-db".to_owned(),
+            "0=/private/pool-0".to_owned(),
+        ]);
+        assert_eq!(
+            args.harmony_pool_bindings,
+            vec![
+                HarmonyPoolBinding {
+                    db_id: 0,
+                    pool_dir: Some(PathBuf::from("/private/pool-0")),
+                },
+                HarmonyPoolBinding {
+                    db_id: 1,
+                    pool_dir: Some(PathBuf::from("/private/pool-1")),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn harmony_pool_cli_rejects_ambiguous_or_aliased_multi_pool_bindings() {
+        let one = vec![(0, PathBuf::from("/private/pool-0"))];
+        assert!(normalize_harmony_pool_bindings(0, 0, false, None, one.clone()).is_err());
+        assert!(normalize_harmony_pool_bindings(8, 0, true, None, one.clone(),).is_err());
+        assert!(
+            normalize_harmony_pool_bindings(8, 0, false, Some(PathBuf::from("/legacy")), one,)
+                .is_err()
+        );
+        assert!(normalize_harmony_pool_bindings(
+            8,
+            0,
+            false,
+            None,
+            vec![
+                (0, PathBuf::from("/private/pool-a")),
+                (0, PathBuf::from("/private/pool-b")),
+            ],
+        )
+        .is_err());
+        assert!(normalize_harmony_pool_bindings(
+            8,
+            0,
+            false,
+            None,
+            vec![
+                (0, PathBuf::from("/private/shared")),
+                (1, PathBuf::from("/private/shared")),
+            ],
+        )
+        .is_err());
     }
 
     #[test]
@@ -15696,10 +15859,10 @@ mod harmony_dos_guard_tests {
     }
 
     #[test]
-    fn v2_hint_pool_rejects_a_different_database_id() {
-        assert!(validate_harmony_v2_pool_database(0, 0).is_ok());
-        assert!(validate_harmony_v2_pool_database(7, 7).is_ok());
-        let error = validate_harmony_v2_pool_database(0, 1).unwrap_err();
+    fn v2_half_pending_token_rejects_a_different_database_id() {
+        assert!(validate_harmony_v2_half_database(0, 0).is_ok());
+        assert!(validate_harmony_v2_half_database(7, 7).is_ok());
+        let error = validate_harmony_v2_half_database(0, 1).unwrap_err();
         assert!(error.contains("bound to db 0"));
         assert!(error.contains("requested db 1"));
     }

--- a/apps/server/src/hint_pool.rs
+++ b/apps/server/src/hint_pool.rs
@@ -307,9 +307,9 @@ pub struct HintPool {
 impl HintPool {
     /// Create a new pool and start the background generator.
     ///
-    /// `db` is the exact database selected by `bound_db_id`. Payment V1 keeps
-    /// one pool/database binding per provider process; the default remains the
-    /// main UTXO snapshot at db_id=0.
+    /// `db` is the exact database selected by `bound_db_id`. Every pool instance
+    /// remains a single immutable database binding even when one provider
+    /// process owns several explicitly configured pools.
     pub fn new(
         mut config: HintPoolConfig,
         bound_db_id: u8,

--- a/apps/server/tests/payment_v1_harmony_pool_process_e2e.rs
+++ b/apps/server/tests/payment_v1_harmony_pool_process_e2e.rs
@@ -122,10 +122,6 @@ impl ServerProcess {
         port: u16,
         generation: u8,
     ) -> Self {
-        let stdout_path = root.join(format!("harmony-pool-generation-{generation}-stdout.log"));
-        let stderr_path = root.join(format!("harmony-pool-generation-{generation}-stderr.log"));
-        let stdout = File::create(&stdout_path).expect("create server stdout log");
-        let stderr = File::create(&stderr_path).expect("create server stderr log");
         // The method matrix includes Standard Cashu (online authority). Keep
         // one pool entry reserved for provider-local methods while the online
         // authorization limiter owns the other; the receipt-only baseline
@@ -178,8 +174,16 @@ impl ServerProcess {
         if let Some(matrix) = &fixture.method_matrix {
             matrix.extend_server_args(&mut args);
         }
+        Self::spawn_with_args(root, port, generation, args)
+    }
+
+    fn spawn_with_args(root: &Path, port: u16, generation: u8, args: Vec<String>) -> Self {
+        let stdout_path = root.join(format!("harmony-pool-generation-{generation}-stdout.log"));
+        let stderr_path = root.join(format!("harmony-pool-generation-{generation}-stderr.log"));
+        let stdout = File::create(&stdout_path).expect("create server stdout log");
+        let stderr = File::create(&stderr_path).expect("create server stderr log");
         let child = Command::new(env!("CARGO_BIN_EXE_unified_server"))
-            .args(args)
+            .args(&args)
             .stdin(Stdio::null())
             .stdout(Stdio::from(stdout))
             .stderr(Stdio::from(stderr))
@@ -245,6 +249,90 @@ impl Drop for ServerProcess {
             );
         }
     }
+}
+
+#[test]
+fn complete_two_database_policy_starts_with_two_exact_hint_pools() {
+    let root = tempfile::tempdir().expect("test root");
+    chmod(root.path(), 0o700);
+    let (db0_path, db0_root) = write_merkle_database_named(root.path(), "tiny-merkle-db0", 0);
+    let (db1_path, db1_root) = write_merkle_database_named(root.path(), "tiny-merkle-db1", 1);
+    let config_path = root.path().join("databases.toml");
+    fs::write(
+        &config_path,
+        format!(
+            "[[database]]\nname = \"db0\"\ntype = \"full\"\npath = \"{}\"\nbase_height = 0\nheight = 1\n\n[[database]]\nname = \"db1\"\ntype = \"delta\"\npath = \"{}\"\nbase_height = 1\nheight = 2\n",
+            db0_path.display(),
+            db1_path.display(),
+        ),
+    )
+    .unwrap();
+
+    let mut fixture = build_provider(root.path(), db0_root, unix_now(), None);
+    install_two_database_free_pow_policy(&mut fixture, [db0_root, db1_root], unix_now());
+    let pool0 = root.path().join("harmony-pool-db0");
+    let pool1 = root.path().join("harmony-pool-db1");
+    for pool in [&pool0, &pool1] {
+        fs::create_dir(pool).unwrap();
+        chmod(pool, 0o700);
+    }
+
+    let port = unused_loopback_port();
+    let args = vec![
+        "--bind-address".to_owned(),
+        "127.0.0.1".to_owned(),
+        "--port".to_owned(),
+        port.to_string(),
+        "--config".to_owned(),
+        config_path.display().to_string(),
+        "--role".to_owned(),
+        "secondary".to_owned(),
+        "--disable-onion".to_owned(),
+        "--serve-hints".to_owned(),
+        "--pool-size".to_owned(),
+        "1".to_owned(),
+        "--harmony-pool-db".to_owned(),
+        format!("0={}", pool0.display()),
+        "--harmony-pool-db".to_owned(),
+        format!("1={}", pool1.display()),
+        "--require-service-auth-v1".to_owned(),
+        "--service-policy".to_owned(),
+        fixture.policy_path.display().to_string(),
+        "--service-provider-id-hex".to_owned(),
+        hex::encode(fixture.provider_id),
+        "--service-policy-key-hex".to_owned(),
+        hex::encode(fixture.policy_signing_key.verifying_key().to_bytes()),
+        "--service-store".to_owned(),
+        fixture.store_path.display().to_string(),
+        "--service-rollback-authority".to_owned(),
+        fixture.rollback_path.display().to_string(),
+        "--allow-local-service-rollback-authority-dev".to_owned(),
+        "--max-connections".to_owned(),
+        "16".to_owned(),
+        "--service-max-concurrent-auth".to_owned(),
+        "4".to_owned(),
+        "--websocket-handshake-timeout-ms".to_owned(),
+        "1000".to_owned(),
+        "--connection-idle-timeout-ms".to_owned(),
+        "30000".to_owned(),
+        "--service-pre-auth-timeout-ms".to_owned(),
+        "30000".to_owned(),
+    ];
+    let mut server = ServerProcess::spawn_with_args(root.path(), port, 9, args);
+    wait_for_path(
+        &mut server,
+        &pool0.join(BINDING_MARKER),
+        "db0 pool binding marker",
+    );
+    wait_for_path(
+        &mut server,
+        &pool1.join(BINDING_MARKER),
+        "db1 pool binding marker",
+    );
+    let (stdout, stderr) = server.stop();
+    assert_server_log(&stdout, &stderr, port);
+    assert!(stdout.contains("HarmonyPIR V2 hint pool: db_id=0"));
+    assert!(stdout.contains("HarmonyPIR V2 hint pool: db_id=1"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -970,6 +1058,76 @@ fn build_provider(
     }
 }
 
+fn install_two_database_free_pow_policy(
+    fixture: &mut ProviderFixture,
+    manifest_roots: [[u8; 32]; 2],
+    now: u64,
+) {
+    let total_groups = u16::try_from(INDEX_PARAMS.k + CHUNK_PARAMS.k).unwrap();
+    let scopes = manifest_roots
+        .into_iter()
+        .enumerate()
+        .map(|(db_id, root)| ServiceScopePolicyV1 {
+            scope: ServiceScopeV1 {
+                provider_id: fixture.provider_id,
+                backend: BackendId::HarmonyPirV2,
+                workload: WorkloadId::HarmonyHintBundleV1,
+                protocol_version: 2,
+                dataset: DatasetBindingV1::ManifestRoot { root },
+                operation_profile: OPERATION_PROFILE,
+                entitlement_profile: ENTITLEMENT_PROFILE,
+            },
+            limits: EntitlementLimitsV1 {
+                max_logical_inputs: 0,
+                max_frames: 1,
+                max_request_bytes: 1_024,
+                max_response_bytes: 64 * 1024 * 1024,
+                max_wall_time_ms: 30_000,
+                max_concurrent_sockets: 1,
+                max_hint_groups: total_groups,
+                max_work_units: u64::from(total_groups),
+            },
+            offers: vec![ServiceOfferV1 {
+                offer_id: 70 + u32::try_from(db_id).unwrap(),
+                acquisition: AcquisitionMethod::FreeV1,
+                free_mode: FreeModeV1::ProofOfWork,
+                free_quota: 0,
+                free_window_seconds: 0,
+                free_pow_difficulty_bits: 1,
+                priority_class: 1,
+                authorization: AuthScheme::FreeV1,
+                verification: VerificationMode::ProviderLocal,
+                deployment_status: DeploymentStatus::Stable,
+                price: PriceV1::Free,
+                issuer_id: [0; 32],
+                key_id: Vec::new(),
+                credential_binding: None,
+                cashu_mint_manifest: None,
+                endpoint: String::new(),
+                invoice_expiry_seconds: 0,
+                claim_window_seconds: 0,
+                minimum_credential_validity_seconds: 60,
+                retired_policy_grace_seconds: 0,
+                credential_count: 1,
+                credential_presentation_limit: 1,
+                privacy_leakage: PrivacyLeakageV1::NONE,
+            }],
+        })
+        .collect();
+    let policy = ServicePolicyV1::sign(
+        fixture.provider_id,
+        1,
+        now.saturating_sub(60),
+        now.checked_add(3_600).unwrap(),
+        AuthPaddingClassV1::Class16KiB,
+        scopes,
+        &fixture.policy_signing_key,
+    )
+    .unwrap();
+    fixture.policy_digest = policy.policy_digest().unwrap();
+    fs::write(&fixture.policy_path, policy.encode().unwrap()).unwrap();
+}
+
 struct BucketMerkleArtifacts {
     super_root: [u8; 32],
     tree_tops: Vec<u8>,
@@ -977,12 +1135,20 @@ struct BucketMerkleArtifacts {
 }
 
 fn write_merkle_database(root: &Path) -> (PathBuf, [u8; 32]) {
-    let db = root.join("tiny-merkle-db");
+    write_merkle_database_named(root, "tiny-merkle-db", 0)
+}
+
+fn write_merkle_database_named(
+    root: &Path,
+    name: &str,
+    database_variant: u64,
+) -> (PathBuf, [u8; 32]) {
+    let db = root.join(name);
     fs::create_dir(&db).unwrap();
     let mut index = write_header_with_anchor(
-        &INDEX_PARAMS.with_master_seed(0x1111_2222_3333_4444),
+        &INDEX_PARAMS.with_master_seed(0x1111_2222_3333_4444 ^ database_variant),
         TINY_BINS_PER_TABLE,
-        0x9999_aaaa_bbbb_cccc,
+        0x9999_aaaa_bbbb_cccc ^ database_variant,
         None,
     );
     index.resize(
@@ -990,9 +1156,9 @@ fn write_merkle_database(root: &Path) -> (PathBuf, [u8; 32]) {
         0,
     );
     let mut chunk = write_header_with_anchor(
-        &CHUNK_PARAMS.with_master_seed(0x5555_6666_7777_8888),
+        &CHUNK_PARAMS.with_master_seed(0x5555_6666_7777_8888 ^ database_variant),
         TINY_BINS_PER_TABLE,
-        0,
+        database_variant,
         None,
     );
     chunk.resize(

--- a/docs/DB1_FREE_POW_BAT_IMPLEMENTATION_PLAN.md
+++ b/docs/DB1_FREE_POW_BAT_IMPLEMENTATION_PLAN.md
@@ -1,10 +1,10 @@
 # db1 Free-PoW + BAT implementation plan
 
 Status: the db1 policy-template, retained-proof and Web-selection source slice
-was completed on 2026-08-18. Same-process pir1 Harmony db0/db1 pool routing is
-not present on `main` and remains a production source blocker. The
-provider-specific BAT production contract was superseded later that day and
-requires the issuer-wide V2 work in
+was completed on 2026-08-18. Same-process pir1 Harmony db0/db1 pool routing was
+then independently re-landed with exact-db isolation and focused tests. The
+provider-specific BAT production contract was superseded and still requires
+the issuer-wide V2 work in
 [`payment/MAINNET_SHARED_BAT_PRODUCTION_PLAN.md`](payment/MAINNET_SHARED_BAT_PRODUCTION_PLAN.md).
 This document is not production deployment, policy rotation, database rebuild,
 public Web publication, or funds authorization.
@@ -92,8 +92,8 @@ The steps below record the completed db1 policy/proof/UI source slice. Any
 assertion that a BAT key, vault record or spent namespace must remain
 provider-specific is superseded by the issuer-wide plan. Dataset roots,
 generic admission isolation, Free-PoW policy shape and Direct-proof work remain
-valid. Runtime reachability for pir1 Harmony db0 and db1 in one process is not
-complete and is carried into the issuer-wide plan.
+valid. Runtime reachability for pir1 Harmony db0 and db1 in one process is now
+implemented independently of the superseded payment profile.
 
 ## Implementation sequence
 
@@ -124,8 +124,8 @@ backend grant DFA to accept db1 operations after authorization.
 Historical acceptance target:
 
 - one focused matrix gate validates both Free-PoW and BAT policy entries for
-  every db1 workload; this static policy result does not prove that the current
-  single-pool pir1 process can serve both Harmony databases;
+  every db1 workload; this static policy result did not by itself prove Harmony
+  runtime reachability, which the later two-pool process test now covers;
 - a db0 authorization cannot admit db1 work, and a db1 authorization cannot
   admit db0 work;
 - the historical V1 gate keeps its provider/scope/offer isolation until it is
@@ -134,10 +134,11 @@ Historical acceptance target:
 
 Implementation result: no admission/client payment code change was necessary
 for the db1 policy/proof/UI slice. The old source gate checked all six policy
-rows and the provider-specific bindings that existed at that time. It did not
-add same-process pir1 Harmony db0/db1 pools; that runtime work remains pending.
-The issuer-wide V2 work must replace the old binding assertions, while the
-existing generic arbitrary-db authorization isolation can be reused.
+rows and the provider-specific bindings that existed at that time. The later
+independent Harmony slice adds same-process pir1 db0/db1 pools and exact-db
+dispatch without changing that old payment wire. The issuer-wide V2 work must
+replace the old binding assertions, while the existing generic arbitrary-db
+authorization isolation can be reused.
 
 Superseding V2 acceptance remains pending: one BAT may target any compatible
 acceptance-class member, but the issuer's first successful commit must make

--- a/docs/payment/ARCHITECTURE.md
+++ b/docs/payment/ARCHITECTURE.md
@@ -224,13 +224,14 @@ integration bound, not a quoted commercial price; production policies must be
 derived from the deployed database's sibling depths and response sizes.
 
 V2Full is not restricted by the wire protocol to the main database: its
-canonical request carries an optional non-zero `db_id`. The first release keeps
-the operational boundary smaller: each hint-provider process has one pool,
-bound by `--pool-db-id` (default `0`) to one loaded immutable database and one
-pool directory. A provider that sells cold hints for several deltas runs
-separate instances/ports and advertises a distinct exact dataset scope for each.
-The authorized client must use V2Full for the granted database and must not
-downgrade a committed grant to V1 if the pool becomes unavailable.
+canonical request carries an optional non-zero `db_id`. Each pool remains bound
+to one loaded immutable database and one private pool directory. The legacy
+single-pool form uses `--pool-db-id` (default `0`); a complete provider may
+instead repeat `--harmony-pool-db <db_id>=<pool-dir>` to install an explicit
+in-process map. Admission and dispatch look up the authenticated database ID,
+and a V2Half token retains the database selected by its first half. The
+authorized client must use V2Full for the granted database and must not
+downgrade a committed grant to V1 if that exact pool becomes unavailable.
 
 V2Full capacity is connection-bound before spend. After the untrusted request
 is structurally bound to the current signed offer and local database, the

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -13,10 +13,11 @@ activated the path with real money.
       issuer's first successful commit consumes that credential globally. One
       paid two-provider query uses two BATs. Providers do not keep a durable BAT
       spent set or delivery claim. See `MAINNET_SHARED_BAT_PRODUCTION_PLAN.md`.
-- [ ] **pir1 Harmony multi-pool routing pending on `main`.** An unmerged draft
-      implements exact-db multi-pool routing and cross-db continuation
-      isolation with narrow tests. That useful slice must be re-landed and
-      reviewed independently of the superseded BAT-profile work.
+- [x] **pir1 Harmony multi-pool routing implemented independently.** The server
+      preserves the legacy single-pool CLI and adds explicit repeatable
+      db0/db1 pool bindings, exact-db admission/reservation/dispatch and
+      cross-database V2Half continuation isolation. The focused process test
+      starts one complete two-database policy with two distinct pool markers.
 - [ ] **Issuer-wide V2 protocol pending.** Current policy bindings, issuer
       lineage rules, SDK/Web selection and render gates remain provider-bound
       and deliberately reject a shared raw BAT key across providers. Current
@@ -238,12 +239,12 @@ activated the path with real money.
       bind response opcode/level/round and reject malformed canonical errors,
       truncation and trailing bytes. V2Full now has canonical two/three-byte
       request bodies;
-      `main` currently exposes only the legacy single-pool
-      `--pool-db-id` binding. Same-process db0/db1 pools, exact-db dispatch and
-      cross-database V2Half token isolation remain pending; the unmerged draft
-      contains a candidate implementation and narrow tests that must be
-      reviewed and re-landed independently. Within the current single-pool
-      path, V2Full now reserves one entry atomically after exact structural
+      `--pool-db-id` preserves the legacy single-pool binding, while repeatable
+      `--harmony-pool-db ID=DIR` entries let one process own an explicit map of
+      independently bound snapshot/delta pools. Auth, reservation and dispatch
+      select the exact database, V2Half tokens reject cross-database pairing,
+      and a granted client forces V2Full for that database without paid V1
+      fallback. V2Full now reserves one entry atomically after exact structural
       binding but before credential commit by locking the unchanged ready inode;
       rejection/pre-use disconnect returns it without a filesystem mutation,
       while first main dispatch unlinks and directory-fsyncs only the

--- a/docs/payment/MAINNET_SHARED_BAT_PRODUCTION_PLAN.md
+++ b/docs/payment/MAINNET_SHARED_BAT_PRODUCTION_PLAN.md
@@ -6,9 +6,8 @@ source-ready; no production activation is authorized**. The
 earlier unmerged draft implemented a shared issuer with provider-specific BATs,
 twelve raw BAT key lineages and provider-side payment stores. That shape is
 superseded by this plan and must not be rendered or activated. The independent
-unmerged draft's pir1 Harmony db0/db1 multi-pool work remains a useful
-candidate, but it is not present on `main` and must be reviewed and re-landed
-independently.
+pir1 Harmony db0/db1 multi-pool slice has been reviewed and re-landed without
+the superseded payment profile.
 
 This is the ordered source-to-production plan. It does not authorize rendering
 private inputs, installing files on a host, building or switching a VPSBG UKI,
@@ -290,10 +289,10 @@ as another provider payment store.
 
 ## Disposition of the current source draft
 
-The unmerged source draft contains two different kinds of work:
+The superseded source draft contained two different kinds of work:
 
-- **review and re-land independently:** pir1 exact-db Harmony multi-pool
-  routing, cross-db V2Half token isolation and their narrow tests;
+- **independently re-landed:** pir1 exact-db Harmony multi-pool routing,
+  cross-db V2Half token isolation and their narrow tests;
 - **replace:** provider-specific BAT policy bindings, the fixed
   2-policy/12-BAT/2-clearing issuer shape, provider-side
   ProviderStore/idempotency/rollback requirements, and client checks that
@@ -460,8 +459,8 @@ Acceptance:
   payment store are unambiguous;
 - the one-BAT/one-winning-provider rule is explicit;
 - V1 is not silently reinterpreted;
-- the unmerged Harmony multi-pool candidate is separated from superseded
-  payment work and remains explicitly pending on `main`;
+- Harmony multi-pool routing is separated from and re-landed without the
+  superseded payment work;
 - pir2's distinct long-lived authentication roles and the measurement-bound
   sealed-envelope decision are explicit, while implementation and the VPSBG
   capability canary remain P1 work; and
@@ -515,9 +514,8 @@ Acceptance:
 ### Phase D — update policies, clients, profiles and focused tests
 
 Replace the provider-specific templates, issuer unit, render gates and wallet
-selection model. Preserve the already-correct db0/db1 roots; independently
-review and re-land the unmerged Harmony multi-pool candidate before claiming
-db0/db1 Harmony runtime reachability.
+selection model. Preserve the already-correct db0/db1 roots and the
+independently re-landed Harmony multi-pool routing.
 
 The meaningful minimum checks are:
 

--- a/docs/payment/OPERATOR_RUNBOOK.md
+++ b/docs/payment/OPERATOR_RUNBOOK.md
@@ -55,13 +55,14 @@ Harmony hint and Harmony query must be separate scopes/offers. A hint provider
 may charge more than a query provider. Do not reuse one capability across those
 roles.
 
-For Harmony V2Full, one `unified_server` process serves one cold-cache database
-binding. Start its pool with `--pool-size N --pool-db-id ID`; omitted
-`--pool-db-id` means the existing `db_id=0` behavior. The ID must exist in the
-loaded catalog or startup fails. Use a distinct process/port and a distinct
-`--pool-dir` for each additional delta database, and publish only the scope
-whose exact dataset binding that process can serve. First-version deployment
-does not share or multiplex one hint pool across database IDs.
+For Harmony V2Full, every pool serves one cold-cache database binding. The
+legacy single-pool form is `--pool-size N --pool-db-id ID --pool-dir DIR`;
+omitted `--pool-db-id` means `db_id=0`. A provider serving several catalog
+entries in one process uses the common per-pool target `--pool-size N` and one
+repeatable `--harmony-pool-db ID=DIR` per database. Do not combine that form
+with `--pool-db-id` or `--pool-dir`, repeat an ID, or reuse a directory. Every
+ID must exist in the loaded catalog or startup fails, and the signed policy may
+publish only exact dataset scopes backed by configured pools.
 
 ### Harmony V2Full pool filesystem and upgrade contract
 

--- a/docs/payment/PROTOCOL.md
+++ b/docs/payment/PROTOCOL.md
@@ -486,12 +486,14 @@ inherits this V2Full continuation rule.
 The V2Full request body has one canonical encoding: `[0xff, 0x00]` for
 `db_id=0`, or those two bytes followed by one non-zero `db_id`. A non-zero
 reserved byte, redundant zero database suffix, or any trailing byte is invalid.
-One hint-provider process owns exactly one immutable pool/database binding,
-selected with `--pool-db-id` (default `0`). Its service policy may authorize a
-V2Full hint scope only for that loaded binding. Serving several snapshot/delta
-databases in V1 therefore uses separate provider processes/ports and separate
-pool directories; it does not introduce a shared in-process multi-database
-pool or cross-provider state.
+Every hint pool owns exactly one immutable pool/database binding. The legacy
+single-pool CLI selects it with `--pool-db-id` (default `0`) and optional
+`--pool-dir`. A provider that intentionally serves several loaded databases in
+one process instead repeats `--harmony-pool-db <db_id>=<pool-dir>`; this form is
+mutually exclusive with the legacy locator flags, uses the common `--pool-size`
+as the target for each pool, and requires a distinct private directory per
+database. Admission, reservation and dispatch select the pool by the exact
+authenticated `db_id`; there is no cross-database pool or cross-provider state.
 
 For an exact, structurally bound V2Full authorization attempt, the provider
 atomically removes one entry from that database's pool before method-specific

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -648,9 +648,11 @@ Cashu-specific:
 - cold cache consumes once, serves the V2Full main INDEX/CHUNK bundle, then
   accepts the same-db full-group legacy level-10+/20+ sibling-hint sequence on
   the same socket without marking the grant complete after the main request;
-- a provider process bound with `--pool-db-id N` accepts canonical V2Full only
-  for that loaded database, including non-zero delta IDs, and rejects another
-  database before any hint frame is served;
+- the legacy provider form bound with `--pool-db-id N` accepts canonical V2Full
+  only for that loaded database; the repeatable `--harmony-pool-db ID=DIR` form
+  starts one signed two-database policy with distinct db0/db1 pool bindings,
+  selects the authenticated database exactly, and rejects a cross-database
+  V2Half token before any hint frame is served;
 - after a Payment V1 V2Full grant, the SDK sends V2Full for that exact database
   even when `db_id != 0`; pool-unavailable never falls back to V1 and losing
   local main-hint state never retries the already-consumed main bundle;

--- a/docs/payment/render-plan-skeletons/README.md
+++ b/docs/payment/render-plan-skeletons/README.md
@@ -47,10 +47,11 @@ The three checked-in provider skeletons are separate V1 profiles, not
 optional-field variants. `provider-v1` retains its complete Standard Cashu
 inputs unchanged. `provider-no-standard-cashu-v1` is the older stateful,
 single-Harmony-pool profile with provider-local BAT and shared-issuer inputs.
-An unmerged draft's exact-db two-pool routing remains useful source reference,
-but its payment profile is superseded. The checked-in profile is not the V2
-payment-storeless pir1 profile, cannot be materialized for Mainnet, and must not
-be described as the current production skeleton.
+The server's independently re-landed exact-db multi-pool routing is available
+as a source foundation, but the checked-in profile still configures one pool
+and its payment shape is superseded. It is not the V2 payment-storeless pir1
+profile, cannot be materialized for Mainnet, and must not be described as the
+current production skeleton.
 `provider-direct-v1` has another distinct unit, identity, state/configuration
 root and sentinel. Its nine payloads contain only the unified-server binary and
 manifest, database config, provider identity key/certificate, signed policy,
@@ -130,7 +131,7 @@ separately reviewed owner-only record; a skeleton cannot establish it.
 | `issuer-lightning-signet-v1.plan.json.example` | `issuer-lightning-signet-v1` | Default-Signet CLN, RPC guard, preflight and payment issuer. |
 | `issuer-lightning-mainnet-v1.plan.json.example` | `issuer-lightning-mainnet-v1` | Deliberately empty, gate-rejected legacy V1 placeholder. It implements neither the unmerged 2/12/2 draft nor the approved V2 contract, cannot render or deploy, and must not be completed. A future V2 issuer-wide skeleton is not yet checked in. |
 | `provider-v1.plan.json.example` | `provider-v1` | One provider process and its complete Payment V1 material. |
-| `provider-no-standard-cashu-v1.plan.json.example` | `provider-no-standard-cashu-v1` | Older stateful, single-pool V1 profile with local-BAT/shared-issuer inputs. An unmerged draft's db0/db1 two-pool work may inform V2, but neither payment shape is the issuer-wide production skeleton and this checked-in profile must not be materialized for it. |
+| `provider-no-standard-cashu-v1.plan.json.example` | `provider-no-standard-cashu-v1` | Older stateful, single-pool V1 profile with local-BAT/shared-issuer inputs. The server now has independently re-landed db0/db1 multi-pool routing, but this checked-in payment profile is not the issuer-wide production skeleton and must not be materialized for it. |
 | `provider-direct-v1.plan.json.example` | `provider-direct-v1` | Built-in Free subset and direct BOLT11 receipt, without optional payment-adapter material. |
 | `rollback-authority-v1.plan.json.example` | `rollback-authority-v1` | One independent monotonic rollback authority. |
 


### PR DESCRIPTION
## Summary

- preserve the legacy single Harmony pool CLI while adding repeatable exact-db pool bindings
- route policy locality, admission reservation, V2Full dispatch, and V2Half continuation by authenticated db_id
- reject mixed legacy/new locators, duplicate databases, reused directories, and cross-database V2Half token pairing
- add one focused two-database process startup test and update the corresponding protocol/operator docs

## Validation

- `cargo test --locked --offline -p runtime --bin unified_server` — 75 passed
- `cargo test --locked --offline -p runtime --test payment_v1_harmony_pool_process_e2e complete_two_database_policy_starts_with_two_exact_hint_pools -- --exact` — 1 passed
- `git diff --check`
- two independent P0/P1 reviews of the final 11-file diff

## Scope boundary

This PR re-lands only the Harmony multi-pool slice from the superseded draft. It does not merge the old provider-specific BAT profile, fixed 2/12/2 issuer shape, ProviderStore assumptions, sealed credentials, deployment, or funds operations.