### PR TITLE
Add issuer-wide BAT V2 class registry

### DIFF
--- a/apps/admin/src/payment_fixture.rs
+++ b/apps/admin/src/payment_fixture.rs
@@ -2407,6 +2407,9 @@ mod tests {
                             }
                         }
                         AuthScheme::FreeV1 => {}
+                        AuthScheme::BitcoinPirCashuBatV2 => {
+                            panic!("V1 payment fixture must not emit issuer-wide BAT V2 offers")
+                        }
                     }
                 }
             }

--- a/apps/payment-issuer/src/main.rs
+++ b/apps/payment-issuer/src/main.rs
@@ -855,6 +855,15 @@ fn check_store(args: StoreCheckArgs) -> Result<(), String> {
     println!("quote_rows={}", inventory.quote_rows);
     println!("claim_rows={}", inventory.claim_rows);
     println!("retained_policy_rows={}", inventory.retained_policy_rows);
+    println!("bat_v2_class_rows={}", inventory.bat_v2_class_rows);
+    println!(
+        "bat_v2_class_head_rows={}",
+        inventory.bat_v2_class_head_rows
+    );
+    println!(
+        "bat_v2_class_member_rows={}",
+        inventory.bat_v2_class_member_rows
+    );
     println!("redemption_rows={}", inventory.redemption_rows);
     println!("payout_rows={}", inventory.payout_rows);
     Ok(())

--- a/crates/directory/nostr/src/entry.rs
+++ b/crates/directory/nostr/src/entry.rs
@@ -691,6 +691,7 @@ fn authorization_name(value: AuthScheme) -> &'static str {
         AuthScheme::CashuEcashV1 => "cashu-ecash-v1",
         AuthScheme::BitcoinPirCashuBatV1 => "bitcoinpir-cashu-bat-v1",
         AuthScheme::ArcV1Experimental => "arc-v1-experimental",
+        AuthScheme::BitcoinPirCashuBatV2 => "bitcoinpir-cashu-bat-v2",
     }
 }
 

--- a/crates/payment/issuer-core/src/lib.rs
+++ b/crates/payment/issuer-core/src/lib.rs
@@ -1172,6 +1172,11 @@ fn map_store_error(error: StoreError) -> IssuerCoreErrorV1 {
         | StoreError::ServicePolicyFork
         | StoreError::ServicePolicySigningKeyConflict
         | StoreError::BatKeyLineageConflict
+        | StoreError::BatV2ClassRollback
+        | StoreError::BatV2ClassFork
+        | StoreError::BatV2ClassTermsConflict
+        | StoreError::BatV2ClassMemberMismatch
+        | StoreError::BatV2RawKeyConflict
         | StoreError::ArcKeyLineageConflict
         | StoreError::SettlementKeyLineageConflict
         | StoreError::ProviderRegistrationRollback

--- a/crates/payment/issuer-service/src/lib.rs
+++ b/crates/payment/issuer-service/src/lib.rs
@@ -871,6 +871,7 @@ where
                 now_unix,
             )
             .map_err(|_| IssuerServiceErrorV1::Unauthorized),
+            AuthScheme::BitcoinPirCashuBatV2 => Err(IssuerServiceErrorV1::InvalidRequest),
             AuthScheme::FreeV1 | AuthScheme::CashuEcashV1 => {
                 Err(IssuerServiceErrorV1::InvalidRequest)
             }
@@ -931,6 +932,7 @@ pub fn ensure_shared_clearing_binding_material_v1(
                 &binding.claims.verification_key,
             )
         }),
+        AuthScheme::BitcoinPirCashuBatV2 => false,
         AuthScheme::Bolt11DirectReceiptV1 | AuthScheme::CashuEcashV1 => false,
     };
     if covered {
@@ -973,6 +975,9 @@ fn ensure_offer_credential_material_v1(
     if offer.acquisition != AcquisitionMethod::Bolt11V1 || &offer.issuer_id != issuer_id {
         return Ok(());
     }
+    if offer.authorization == AuthScheme::BitcoinPirCashuBatV2 {
+        return Err(IssuerServiceErrorV1::InvalidRequest);
+    }
     let binding = offer
         .credential_binding
         .as_ref()
@@ -1004,6 +1009,7 @@ fn ensure_offer_credential_material_v1(
                 &binding.claims.verification_key,
             )
         }),
+        AuthScheme::BitcoinPirCashuBatV2 => false,
         AuthScheme::FreeV1 | AuthScheme::CashuEcashV1 => false,
     };
     if covered {

--- a/crates/payment/issuer-store/src/bat_v2_ops.rs
+++ b/crates/payment/issuer-store/src/bat_v2_ops.rs
@@ -1,0 +1,632 @@
+use crate::db::{
+    advance_store_generation, commit, db_u64, fixed_blob, sql_integer, verify_expected_identity,
+};
+use crate::policy_ops::{
+    project_current_bat_acceptance_member_v2, project_retained_bat_acceptance_member_v2,
+};
+use crate::rollback::mutation_digest;
+use crate::{
+    BatAcceptanceClassMemberRecordV2, BatAcceptanceClassRecordV2, CommitMarker, DurableWrite,
+    IssuerStore, StoreError, StoreResult, WriteDisposition, MAX_EXACT_BAT_V2_CLASS_BYTES,
+};
+use pir_service_protocol::{
+    bat_verification_key_fingerprint_v1, BatAcceptanceClassV2, BatAcceptanceMemberV2,
+    VerifiedBatAcceptanceMemberV2,
+};
+use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
+
+const REGISTER_BAT_V2_CLASS_MUTATION: &[u8] = b"register-bat-acceptance-class-v2";
+
+struct CandidateClassV2 {
+    exact_artifact: Vec<u8>,
+    artifact_digest: [u8; 32],
+    common_terms_digest: [u8; 32],
+    key_fingerprint: [u8; 32],
+    bat_key_id: [u8; 32],
+}
+
+struct RawArtifactRow {
+    artifact_digest: Vec<u8>,
+    common_terms_digest: Vec<u8>,
+    issuer_verifying_key: Vec<u8>,
+    raw_public_key: Vec<u8>,
+    key_fingerprint: Vec<u8>,
+    bat_key_id: Vec<u8>,
+    key_not_before: i64,
+    key_not_after: i64,
+    member_count: i64,
+    exact_artifact: Vec<u8>,
+    commit_seq: i64,
+}
+
+struct RawMemberRow {
+    member_index: i64,
+    provider_id: Vec<u8>,
+    policy_digest: Vec<u8>,
+    scope_id: Vec<u8>,
+    offer_id: i64,
+    redemption_deadline: i64,
+    commit_seq: i64,
+}
+
+impl IssuerStore {
+    /// Registers one complete issuer-signed BAT V2 class/key-epoch snapshot.
+    ///
+    /// Every member must resolve to that provider's exact current policy head
+    /// in this same `BEGIN IMMEDIATE` transaction. Older epochs remain
+    /// append-only for later redemption, while the head advances atomically
+    /// with the complete canonical member set.
+    pub fn register_bat_acceptance_class_v2(
+        &self,
+        artifact: &BatAcceptanceClassV2,
+        now_unix: u64,
+    ) -> StoreResult<DurableWrite<BatAcceptanceClassRecordV2>> {
+        if now_unix == 0 {
+            return Err(StoreError::InvalidInput(
+                "BAT V2 class registration time is zero",
+            ));
+        }
+        let candidate = build_candidate(self, artifact)?;
+        let mut connection = self.open_checked(false)?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let previous_identity = verify_expected_identity(&transaction, &self.handle)?;
+        let previous_floor = self.require_exact_rollback_floor(&previous_identity)?;
+
+        let head: Option<(i64, Vec<u8>, Vec<u8>)> = transaction
+            .query_row(
+                "SELECT highest_key_epoch, artifact_digest, common_terms_digest \
+                 FROM bat_v2_class_heads WHERE issuer_id = ?1 AND class_id = ?2",
+                params![
+                    self.handle.expected_issuer_id.as_slice(),
+                    artifact.class_id.as_slice(),
+                ],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()?;
+        if let Some((head_epoch_raw, head_digest_raw, head_terms_raw)) = head {
+            let head_epoch = db_u64(head_epoch_raw, "negative BAT V2 class head epoch")?;
+            let head_digest: [u8; 32] =
+                fixed_blob(head_digest_raw, "invalid BAT V2 class head digest")?;
+            let head_terms: [u8; 32] =
+                fixed_blob(head_terms_raw, "invalid BAT V2 class head terms digest")?;
+            let existing =
+                read_bat_acceptance_class_v2(&transaction, self, &artifact.class_id, head_epoch)?
+                    .ok_or_else(|| {
+                    StoreError::SchemaMismatch("BAT V2 class head artifact is missing".to_owned())
+                })?;
+            if artifact.key_epoch < head_epoch {
+                return Err(StoreError::BatV2ClassRollback);
+            }
+            if artifact.key_epoch == head_epoch {
+                if candidate.artifact_digest != head_digest
+                    || existing.exact_artifact != candidate.exact_artifact
+                {
+                    return Err(StoreError::BatV2ClassFork);
+                }
+                return Ok(DurableWrite {
+                    disposition: WriteDisposition::ExactReplay,
+                    commit: existing.commit,
+                    value: existing,
+                });
+            }
+            if head_terms != candidate.common_terms_digest
+                || existing.common_terms_digest != candidate.common_terms_digest
+            {
+                return Err(StoreError::BatV2ClassTermsConflict);
+            }
+        }
+
+        reject_owned_raw_key(&transaction, self, artifact, &candidate)?;
+
+        let mut verified_members = Vec::with_capacity(artifact.members.len());
+        for member in &artifact.members {
+            let (projection, _) =
+                project_current_bat_acceptance_member_v2(&transaction, self, member, now_unix)?;
+            if !projection_matches_artifact(artifact, member, &projection) {
+                return Err(if projection.common_terms != artifact.common_terms {
+                    StoreError::BatV2ClassTermsConflict
+                } else {
+                    StoreError::BatV2ClassMemberMismatch
+                });
+            }
+            verified_members.push(projection);
+        }
+
+        let member_material = encode_member_commitment_material(&verified_members);
+        let mutation = mutation_digest(
+            REGISTER_BAT_V2_CLASS_MUTATION,
+            &[
+                &candidate.exact_artifact,
+                &candidate.artifact_digest,
+                &candidate.common_terms_digest,
+                &candidate.key_fingerprint,
+                &candidate.bat_key_id,
+                &member_material,
+            ],
+        );
+        let committed_identity = advance_store_generation(
+            &transaction,
+            &previous_identity,
+            REGISTER_BAT_V2_CLASS_MUTATION,
+            &mutation,
+        )?;
+        let sequence = committed_identity.commit_seq;
+        transaction.execute(
+            "INSERT INTO bat_v2_class_artifacts (issuer_id, class_id, key_epoch, \
+             artifact_digest, common_terms_digest, issuer_verifying_key, raw_public_key, \
+             key_fingerprint, bat_key_id, key_not_before, key_not_after, member_count, \
+             exact_artifact, commit_seq) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+            params![
+                self.handle.expected_issuer_id.as_slice(),
+                artifact.class_id.as_slice(),
+                sql_integer(artifact.key_epoch, "BAT V2 key epoch exceeds SQLite range")?,
+                candidate.artifact_digest.as_slice(),
+                candidate.common_terms_digest.as_slice(),
+                artifact.issuer_verifying_key.as_slice(),
+                artifact.bat_verification_key.as_slice(),
+                candidate.key_fingerprint.as_slice(),
+                candidate.bat_key_id.as_slice(),
+                sql_integer(
+                    artifact.key_not_before,
+                    "BAT V2 not-before exceeds SQLite range"
+                )?,
+                sql_integer(
+                    artifact.key_not_after,
+                    "BAT V2 not-after exceeds SQLite range"
+                )?,
+                i64::try_from(artifact.members.len()).map_err(|_| {
+                    StoreError::InvalidInput("BAT V2 member count exceeds SQLite range")
+                })?,
+                candidate.exact_artifact.as_slice(),
+                sql_integer(sequence, "commit sequence exceeds SQLite range")?,
+            ],
+        )?;
+        for (member_index, projection) in verified_members.iter().enumerate() {
+            transaction.execute(
+                "INSERT INTO bat_v2_class_members (issuer_id, class_id, key_epoch, member_index, \
+                 provider_id, policy_digest, scope_id, offer_id, redemption_deadline, commit_seq) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                params![
+                    self.handle.expected_issuer_id.as_slice(),
+                    artifact.class_id.as_slice(),
+                    sql_integer(artifact.key_epoch, "BAT V2 key epoch exceeds SQLite range")?,
+                    i64::try_from(member_index).map_err(|_| {
+                        StoreError::InvalidInput("BAT V2 member index exceeds SQLite range")
+                    })?,
+                    projection.member.provider_id.as_slice(),
+                    projection.member.policy_digest.as_slice(),
+                    projection.member.scope_id.as_slice(),
+                    i64::from(projection.member.offer_id),
+                    sql_integer(
+                        projection.redemption_deadline,
+                        "BAT V2 redemption deadline exceeds SQLite range"
+                    )?,
+                    sql_integer(sequence, "commit sequence exceeds SQLite range")?,
+                ],
+            )?;
+        }
+        transaction.execute(
+            "INSERT INTO bat_v2_class_heads (issuer_id, class_id, highest_key_epoch, \
+             artifact_digest, common_terms_digest, commit_seq) VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+             ON CONFLICT(issuer_id, class_id) DO UPDATE SET \
+             highest_key_epoch = excluded.highest_key_epoch, \
+             artifact_digest = excluded.artifact_digest, \
+             common_terms_digest = excluded.common_terms_digest, \
+             commit_seq = excluded.commit_seq",
+            params![
+                self.handle.expected_issuer_id.as_slice(),
+                artifact.class_id.as_slice(),
+                sql_integer(artifact.key_epoch, "BAT V2 key epoch exceeds SQLite range")?,
+                candidate.artifact_digest.as_slice(),
+                candidate.common_terms_digest.as_slice(),
+                sql_integer(sequence, "commit sequence exceeds SQLite range")?,
+            ],
+        )?;
+        commit(transaction)?;
+        self.anchor_committed_identity(&previous_floor, &committed_identity)?;
+        let value = self
+            .bat_acceptance_class_v2(&artifact.class_id, artifact.key_epoch)?
+            .ok_or_else(|| {
+                StoreError::SchemaMismatch("committed BAT V2 class is missing".to_owned())
+            })?;
+        Ok(DurableWrite {
+            disposition: WriteDisposition::Committed,
+            commit: marker(self, sequence),
+            value,
+        })
+    }
+
+    /// Reads one retained class/key epoch. Historical epochs remain available
+    /// after the current head advances.
+    pub fn bat_acceptance_class_v2(
+        &self,
+        class_id: &[u8; 32],
+        key_epoch: u64,
+    ) -> StoreResult<Option<BatAcceptanceClassRecordV2>> {
+        let connection = self.open_checked(false)?;
+        let value = read_bat_acceptance_class_v2(&connection, self, class_id, key_epoch)?;
+        self.confirm_anchored_read(&connection, value)
+    }
+
+    /// Reads the issuer-authoritative current key epoch for one stable class
+    /// ID without discarding any retained older epoch.
+    pub fn current_bat_acceptance_class_v2(
+        &self,
+        class_id: &[u8; 32],
+    ) -> StoreResult<Option<BatAcceptanceClassRecordV2>> {
+        if class_id.iter().all(|byte| *byte == 0) {
+            return Err(StoreError::InvalidInput("BAT V2 class ID is all zero"));
+        }
+        let connection = self.open_checked(false)?;
+        let epoch: Option<i64> = connection
+            .query_row(
+                "SELECT highest_key_epoch FROM bat_v2_class_heads \
+                 WHERE issuer_id = ?1 AND class_id = ?2",
+                params![
+                    self.handle.expected_issuer_id.as_slice(),
+                    class_id.as_slice(),
+                ],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let value = epoch
+            .map(|epoch| {
+                let epoch = db_u64(epoch, "negative BAT V2 class head epoch")?;
+                read_bat_acceptance_class_v2(&connection, self, class_id, epoch)?.ok_or_else(|| {
+                    StoreError::SchemaMismatch("BAT V2 class head is missing".to_owned())
+                })
+            })
+            .transpose()?;
+        self.confirm_anchored_read(&connection, value)
+    }
+}
+
+fn build_candidate(
+    store: &IssuerStore,
+    artifact: &BatAcceptanceClassV2,
+) -> StoreResult<CandidateClassV2> {
+    artifact.verify().map_err(StoreError::Protocol)?;
+    if artifact.issuer_id != store.handle.expected_issuer_id {
+        return Err(StoreError::IssuerMismatch);
+    }
+    let exact_artifact = artifact.encode().map_err(StoreError::Protocol)?;
+    if exact_artifact.is_empty() || exact_artifact.len() > MAX_EXACT_BAT_V2_CLASS_BYTES {
+        return Err(StoreError::InvalidInput(
+            "BAT V2 class artifact exceeds issuer-store bound",
+        ));
+    }
+    let artifact_digest = artifact.class_digest().map_err(StoreError::Protocol)?;
+    let common_terms_digest = artifact
+        .common_terms
+        .terms_digest()
+        .map_err(StoreError::Protocol)?;
+    let key_fingerprint = bat_verification_key_fingerprint_v1(&artifact.bat_verification_key)
+        .map_err(StoreError::Protocol)?;
+    Ok(CandidateClassV2 {
+        exact_artifact,
+        artifact_digest,
+        common_terms_digest,
+        key_fingerprint,
+        bat_key_id: artifact.bat_key_id(),
+    })
+}
+
+fn reject_owned_raw_key(
+    connection: &Connection,
+    store: &IssuerStore,
+    artifact: &BatAcceptanceClassV2,
+    candidate: &CandidateClassV2,
+) -> StoreResult<()> {
+    let legacy_owner: Option<Vec<u8>> = connection
+        .query_row(
+            "SELECT key_fingerprint FROM bat_key_lineages \
+             WHERE issuer_id = ?1 AND (raw_public_key = ?2 OR key_fingerprint = ?3) LIMIT 1",
+            params![
+                store.handle.expected_issuer_id.as_slice(),
+                artifact.bat_verification_key.as_slice(),
+                candidate.key_fingerprint.as_slice(),
+            ],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let v2_owner: Option<Vec<u8>> = connection
+        .query_row(
+            "SELECT class_id FROM bat_v2_class_artifacts WHERE issuer_id = ?1 AND \
+             (raw_public_key = ?2 OR key_fingerprint = ?3 OR bat_key_id = ?4) LIMIT 1",
+            params![
+                store.handle.expected_issuer_id.as_slice(),
+                artifact.bat_verification_key.as_slice(),
+                candidate.key_fingerprint.as_slice(),
+                candidate.bat_key_id.as_slice(),
+            ],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if legacy_owner.is_some() || v2_owner.is_some() {
+        return Err(StoreError::BatV2RawKeyConflict);
+    }
+    Ok(())
+}
+
+fn projection_matches_artifact(
+    artifact: &BatAcceptanceClassV2,
+    member: &BatAcceptanceMemberV2,
+    projection: &VerifiedBatAcceptanceMemberV2,
+) -> bool {
+    if projection.issuer_id != artifact.issuer_id
+        || projection.class_id != artifact.class_id
+        || projection.member != *member
+        || projection.common_terms != artifact.common_terms
+        || artifact.key_not_before > projection.policy_issued_at
+        || artifact.key_not_after > projection.redemption_deadline
+    {
+        return false;
+    }
+    projection
+        .policy_expires_at
+        .checked_add(u64::from(projection.common_terms.invoice_expiry_seconds))
+        .and_then(|value| {
+            value.checked_add(u64::from(projection.common_terms.claim_window_seconds))
+        })
+        .and_then(|value| {
+            value.checked_add(u64::from(
+                projection.common_terms.minimum_credential_validity_seconds,
+            ))
+        })
+        .is_some_and(|minimum_not_after| artifact.key_not_after >= minimum_not_after)
+}
+
+fn encode_member_commitment_material(members: &[VerifiedBatAcceptanceMemberV2]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + members.len() * 116);
+    out.extend_from_slice(&(members.len() as u32).to_le_bytes());
+    for (index, member) in members.iter().enumerate() {
+        out.extend_from_slice(&(index as u32).to_le_bytes());
+        out.extend_from_slice(&member.member.provider_id);
+        out.extend_from_slice(&member.member.policy_digest);
+        out.extend_from_slice(&member.member.scope_id);
+        out.extend_from_slice(&member.member.offer_id.to_le_bytes());
+        out.extend_from_slice(&member.redemption_deadline.to_le_bytes());
+    }
+    out
+}
+
+pub(crate) fn read_bat_acceptance_class_v2(
+    connection: &Connection,
+    store: &IssuerStore,
+    class_id: &[u8; 32],
+    key_epoch: u64,
+) -> StoreResult<Option<BatAcceptanceClassRecordV2>> {
+    if class_id.iter().all(|byte| *byte == 0) || key_epoch == 0 {
+        return Err(StoreError::InvalidInput("invalid BAT V2 class lookup"));
+    }
+    let raw: Option<RawArtifactRow> = connection
+        .query_row(
+            "SELECT artifact_digest, common_terms_digest, issuer_verifying_key, raw_public_key, \
+             key_fingerprint, bat_key_id, key_not_before, key_not_after, member_count, \
+             exact_artifact, commit_seq FROM bat_v2_class_artifacts \
+             WHERE issuer_id = ?1 AND class_id = ?2 AND key_epoch = ?3",
+            params![
+                store.handle.expected_issuer_id.as_slice(),
+                class_id.as_slice(),
+                sql_integer(key_epoch, "BAT V2 key epoch exceeds SQLite range")?,
+            ],
+            |row| {
+                Ok(RawArtifactRow {
+                    artifact_digest: row.get(0)?,
+                    common_terms_digest: row.get(1)?,
+                    issuer_verifying_key: row.get(2)?,
+                    raw_public_key: row.get(3)?,
+                    key_fingerprint: row.get(4)?,
+                    bat_key_id: row.get(5)?,
+                    key_not_before: row.get(6)?,
+                    key_not_after: row.get(7)?,
+                    member_count: row.get(8)?,
+                    exact_artifact: row.get(9)?,
+                    commit_seq: row.get(10)?,
+                })
+            },
+        )
+        .optional()?;
+    raw.map(|raw| rebuild_record(connection, store, class_id, key_epoch, raw))
+        .transpose()
+}
+
+fn rebuild_record(
+    connection: &Connection,
+    store: &IssuerStore,
+    class_id: &[u8; 32],
+    key_epoch: u64,
+    raw: RawArtifactRow,
+) -> StoreResult<BatAcceptanceClassRecordV2> {
+    let artifact_digest = fixed_blob(raw.artifact_digest, "invalid BAT V2 artifact digest")?;
+    let common_terms_digest = fixed_blob(
+        raw.common_terms_digest,
+        "invalid BAT V2 common terms digest",
+    )?;
+    let issuer_verifying_key = fixed_blob(
+        raw.issuer_verifying_key,
+        "invalid BAT V2 issuer verifying key",
+    )?;
+    let raw_public_key = fixed_blob(raw.raw_public_key, "invalid BAT V2 raw public key")?;
+    let key_fingerprint = fixed_blob(raw.key_fingerprint, "invalid BAT V2 key fingerprint")?;
+    let bat_key_id = fixed_blob(raw.bat_key_id, "invalid BAT V2 key ID")?;
+    let key_not_before = db_u64(raw.key_not_before, "negative BAT V2 not-before")?;
+    let key_not_after = db_u64(raw.key_not_after, "negative BAT V2 not-after")?;
+    let member_count = usize::try_from(raw.member_count)
+        .map_err(|_| StoreError::SchemaMismatch("invalid BAT V2 member count".to_owned()))?;
+    let commit_seq = db_u64(raw.commit_seq, "negative BAT V2 artifact commit")?;
+    let artifact = BatAcceptanceClassV2::decode(&raw.exact_artifact)
+        .map_err(|_| StoreError::SchemaMismatch("BAT V2 artifact is not canonical".to_owned()))?;
+    if artifact.encode().map_err(StoreError::Protocol)? != raw.exact_artifact
+        || artifact
+            .verify_for(&store.handle.expected_issuer_id, class_id)
+            .is_err()
+        || artifact.key_epoch != key_epoch
+        || artifact.class_digest().map_err(StoreError::Protocol)? != artifact_digest
+        || artifact
+            .common_terms
+            .terms_digest()
+            .map_err(StoreError::Protocol)?
+            != common_terms_digest
+        || artifact.issuer_verifying_key != issuer_verifying_key
+        || artifact.bat_verification_key != raw_public_key
+        || bat_verification_key_fingerprint_v1(&artifact.bat_verification_key)
+            .map_err(StoreError::Protocol)?
+            != key_fingerprint
+        || artifact.bat_key_id() != bat_key_id
+        || artifact.key_not_before != key_not_before
+        || artifact.key_not_after != key_not_after
+        || artifact.members.len() != member_count
+    {
+        return Err(StoreError::SchemaMismatch(
+            "BAT V2 artifact metadata, digest, signature, or key identity mismatches".to_owned(),
+        ));
+    }
+
+    let mut statement = connection.prepare(
+        "SELECT member_index, provider_id, policy_digest, scope_id, offer_id, \
+         redemption_deadline, commit_seq FROM bat_v2_class_members \
+         WHERE issuer_id = ?1 AND class_id = ?2 AND key_epoch = ?3 ORDER BY member_index",
+    )?;
+    let rows = statement.query_map(
+        params![
+            store.handle.expected_issuer_id.as_slice(),
+            class_id.as_slice(),
+            sql_integer(key_epoch, "BAT V2 key epoch exceeds SQLite range")?,
+        ],
+        |row| {
+            Ok(RawMemberRow {
+                member_index: row.get(0)?,
+                provider_id: row.get(1)?,
+                policy_digest: row.get(2)?,
+                scope_id: row.get(3)?,
+                offer_id: row.get(4)?,
+                redemption_deadline: row.get(5)?,
+                commit_seq: row.get(6)?,
+            })
+        },
+    )?;
+    let raw_members = rows.collect::<Result<Vec<_>, _>>()?;
+    if raw_members.len() != member_count {
+        return Err(StoreError::SchemaMismatch(
+            "BAT V2 artifact member count mismatches retained rows".to_owned(),
+        ));
+    }
+    let mut members = Vec::with_capacity(member_count);
+    for (expected_index, (raw_member, signed_member)) in
+        raw_members.into_iter().zip(&artifact.members).enumerate()
+    {
+        let member_index = u16::try_from(raw_member.member_index)
+            .map_err(|_| StoreError::SchemaMismatch("invalid BAT V2 member index".to_owned()))?;
+        let member = BatAcceptanceMemberV2 {
+            provider_id: fixed_blob(raw_member.provider_id, "invalid BAT V2 member provider ID")?,
+            policy_digest: fixed_blob(
+                raw_member.policy_digest,
+                "invalid BAT V2 member policy digest",
+            )?,
+            scope_id: fixed_blob(raw_member.scope_id, "invalid BAT V2 member scope ID")?,
+            offer_id: u32::try_from(raw_member.offer_id)
+                .map_err(|_| StoreError::SchemaMismatch("invalid BAT V2 offer ID".to_owned()))?,
+        };
+        let redemption_deadline = db_u64(
+            raw_member.redemption_deadline,
+            "negative BAT V2 redemption deadline",
+        )?;
+        let member_commit = db_u64(raw_member.commit_seq, "negative BAT V2 member commit")?;
+        if usize::from(member_index) != expected_index
+            || member != *signed_member
+            || member_commit != commit_seq
+        {
+            return Err(StoreError::SchemaMismatch(
+                "BAT V2 member rows do not match the signed canonical set".to_owned(),
+            ));
+        }
+        let (projection, policy_record) = project_retained_bat_acceptance_member_v2(
+            connection, store, &member,
+        )
+        .map_err(|error| match error {
+            StoreError::BatV2ClassMemberMismatch => StoreError::SchemaMismatch(
+                "BAT V2 member no longer projects from its retained signed policy".to_owned(),
+            ),
+            error => error,
+        })?;
+        let later_policy_at_commit: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM issuer_service_policies WHERE provider_id = ?1 \
+             AND commit_seq <= ?2 AND policy_epoch > ?3",
+            params![
+                member.provider_id.as_slice(),
+                sql_integer(commit_seq, "BAT V2 commit exceeds SQLite range")?,
+                sql_integer(
+                    policy_record.policy_epoch,
+                    "BAT V2 member policy epoch exceeds SQLite range"
+                )?,
+            ],
+            |row| row.get(0),
+        )?;
+        if policy_record.commit.commit_seq > commit_seq
+            || later_policy_at_commit != 0
+            || projection.redemption_deadline != redemption_deadline
+            || !projection_matches_artifact(&artifact, &member, &projection)
+        {
+            return Err(StoreError::SchemaMismatch(
+                "BAT V2 member policy, validity, or historical-head linkage mismatches".to_owned(),
+            ));
+        }
+        members.push(BatAcceptanceClassMemberRecordV2 {
+            member_index,
+            provider_id: member.provider_id,
+            policy_digest: member.policy_digest,
+            scope_id: member.scope_id,
+            offer_id: member.offer_id,
+            redemption_deadline,
+        });
+    }
+    Ok(BatAcceptanceClassRecordV2 {
+        class_id: *class_id,
+        key_epoch,
+        artifact_digest,
+        common_terms_digest,
+        issuer_verifying_key,
+        raw_public_key,
+        key_fingerprint,
+        bat_key_id,
+        key_not_before,
+        key_not_after,
+        exact_artifact: raw.exact_artifact,
+        members,
+        commit: marker(store, commit_seq),
+    })
+}
+
+pub(crate) fn verify_all_bat_acceptance_classes_v2(
+    store: &IssuerStore,
+    connection: &Connection,
+) -> StoreResult<()> {
+    let mut statement = connection.prepare(
+        "SELECT class_id, key_epoch FROM bat_v2_class_artifacts \
+         WHERE issuer_id = ?1 ORDER BY class_id, key_epoch",
+    )?;
+    let rows = statement
+        .query_map([store.handle.expected_issuer_id.as_slice()], |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?))
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    for (class_id, key_epoch) in rows {
+        let class_id = fixed_blob(class_id, "invalid BAT V2 class ID")?;
+        let key_epoch = db_u64(key_epoch, "negative BAT V2 key epoch")?;
+        if read_bat_acceptance_class_v2(connection, store, &class_id, key_epoch)?.is_none() {
+            return Err(StoreError::SchemaMismatch(
+                "BAT V2 inventory row disappeared during integrity read".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn marker(store: &IssuerStore, sequence: u64) -> CommitMarker {
+    CommitMarker {
+        store_instance_id: store.handle.expected_store_instance_id,
+        commit_seq: sequence,
+    }
+}

--- a/crates/payment/issuer-store/src/db.rs
+++ b/crates/payment/issuer-store/src/db.rs
@@ -303,6 +303,9 @@ fn run_integrity_checks(connection: &Connection, handle: &StoreHandle) -> StoreR
             (SELECT COUNT(*) FROM receipt_serials WHERE issuer_id != ?1) + \
             (SELECT COUNT(*) FROM arc_key_lineages WHERE issuer_id != ?1) + \
             (SELECT COUNT(*) FROM bat_key_lineages WHERE issuer_id != ?1) + \
+            (SELECT COUNT(*) FROM bat_v2_class_artifacts WHERE issuer_id != ?1) + \
+            (SELECT COUNT(*) FROM bat_v2_class_heads WHERE issuer_id != ?1) + \
+            (SELECT COUNT(*) FROM bat_v2_class_members WHERE issuer_id != ?1) + \
             (SELECT COUNT(*) FROM settlement_key_lineages WHERE issuer_id != ?1) + \
             (SELECT COUNT(*) FROM provider_registration_history WHERE issuer_id != ?1) + \
             (SELECT COUNT(*) FROM provider_registrations WHERE issuer_id != ?1) + \
@@ -320,6 +323,56 @@ fn run_integrity_checks(connection: &Connection, handle: &StoreHandle) -> StoreR
     )?;
     if foreign_rows != 0 {
         return Err(StoreError::IssuerMismatch);
+    }
+
+    let bad_bat_v2_registry: i64 = connection.query_row(
+        "SELECT \
+            (SELECT COUNT(*) FROM bat_v2_class_heads h \
+                LEFT JOIN bat_v2_class_artifacts a \
+                  ON a.issuer_id = h.issuer_id AND a.class_id = h.class_id \
+                 AND a.key_epoch = h.highest_key_epoch \
+                WHERE a.artifact_digest IS NULL \
+                   OR a.artifact_digest != h.artifact_digest \
+                   OR a.common_terms_digest != h.common_terms_digest \
+                   OR a.commit_seq != h.commit_seq \
+                   OR h.highest_key_epoch != (SELECT MAX(prior.key_epoch) \
+                        FROM bat_v2_class_artifacts prior \
+                        WHERE prior.issuer_id = h.issuer_id AND prior.class_id = h.class_id)) + \
+            (SELECT COUNT(*) FROM bat_v2_class_artifacts a \
+                WHERE NOT EXISTS (SELECT 1 FROM bat_v2_class_heads h \
+                    WHERE h.issuer_id = a.issuer_id AND h.class_id = a.class_id) \
+                   OR EXISTS (SELECT 1 FROM bat_v2_class_heads h \
+                    WHERE h.issuer_id = a.issuer_id AND h.class_id = a.class_id \
+                      AND h.common_terms_digest != a.common_terms_digest) \
+                   OR a.member_count != (SELECT COUNT(*) FROM bat_v2_class_members m \
+                    WHERE m.issuer_id = a.issuer_id AND m.class_id = a.class_id \
+                      AND m.key_epoch = a.key_epoch) \
+                   OR 0 != (SELECT MIN(m.member_index) FROM bat_v2_class_members m \
+                    WHERE m.issuer_id = a.issuer_id AND m.class_id = a.class_id \
+                      AND m.key_epoch = a.key_epoch) \
+                   OR a.member_count - 1 != (SELECT MAX(m.member_index) \
+                        FROM bat_v2_class_members m \
+                        WHERE m.issuer_id = a.issuer_id AND m.class_id = a.class_id \
+                          AND m.key_epoch = a.key_epoch) \
+                   OR EXISTS (SELECT 1 FROM bat_v2_class_members m \
+                        WHERE m.issuer_id = a.issuer_id AND m.class_id = a.class_id \
+                          AND m.key_epoch = a.key_epoch AND m.commit_seq != a.commit_seq)) + \
+            (SELECT COUNT(*) FROM bat_v2_class_members m \
+                LEFT JOIN issuer_service_policies p \
+                  ON p.policy_digest = m.policy_digest AND p.provider_id = m.provider_id \
+                WHERE p.policy_digest IS NULL) + \
+            (SELECT COUNT(*) FROM bat_key_lineages legacy \
+                JOIN bat_v2_class_artifacts class \
+                  ON class.issuer_id = legacy.issuer_id \
+                 AND (class.raw_public_key = legacy.raw_public_key \
+                      OR class.key_fingerprint = legacy.key_fingerprint))",
+        [],
+        |row| row.get(0),
+    )?;
+    if bad_bat_v2_registry != 0 {
+        return Err(StoreError::SchemaMismatch(
+            "BAT V2 class registry linkage or raw-key ownership failed".to_owned(),
+        ));
     }
 
     let bad_provider_registration_history: i64 = connection.query_row(
@@ -435,6 +488,9 @@ fn run_integrity_checks(connection: &Connection, handle: &StoreHandle) -> StoreR
             UNION ALL SELECT commit_seq FROM quote_status_nonces \
             UNION ALL SELECT commit_seq FROM arc_key_lineages \
             UNION ALL SELECT commit_seq FROM bat_key_lineages \
+            UNION ALL SELECT commit_seq FROM bat_v2_class_artifacts \
+            UNION ALL SELECT commit_seq FROM bat_v2_class_heads \
+            UNION ALL SELECT commit_seq FROM bat_v2_class_members \
             UNION ALL SELECT commit_seq FROM settlement_key_lineages \
             UNION ALL SELECT commit_seq FROM provider_registration_history \
             UNION ALL SELECT commit_seq FROM provider_registrations \

--- a/crates/payment/issuer-store/src/error.rs
+++ b/crates/payment/issuer-store/src/error.rs
@@ -54,6 +54,11 @@ pub enum StoreError {
     ServicePolicyFork,
     ServicePolicySigningKeyConflict,
     BatKeyLineageConflict,
+    BatV2ClassRollback,
+    BatV2ClassFork,
+    BatV2ClassTermsConflict,
+    BatV2ClassMemberMismatch,
+    BatV2RawKeyConflict,
     ArcKeyLineageConflict,
     SettlementKeyLineageConflict,
     ProviderRegistrationRollback,
@@ -206,6 +211,25 @@ impl fmt::Display for StoreError {
             Self::BatKeyLineageConflict => {
                 write!(f, "Cashu BAT raw key conflicts with immutable lineage")
             }
+            Self::BatV2ClassRollback => {
+                write!(f, "BAT V2 class key epoch rollback rejected")
+            }
+            Self::BatV2ClassFork => write!(
+                f,
+                "different BAT V2 class artifact at an accepted key epoch rejected"
+            ),
+            Self::BatV2ClassTermsConflict => write!(
+                f,
+                "BAT V2 common terms changed under an existing class ID"
+            ),
+            Self::BatV2ClassMemberMismatch => write!(
+                f,
+                "BAT V2 class member does not match a current exact provider policy"
+            ),
+            Self::BatV2RawKeyConflict => write!(
+                f,
+                "BAT raw key is already owned by another V1 or V2 lineage"
+            ),
             Self::ArcKeyLineageConflict => {
                 write!(f, "experimental ARC raw key conflicts with immutable lineage")
             }

--- a/crates/payment/issuer-store/src/lib.rs
+++ b/crates/payment/issuer-store/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![forbid(unsafe_code)]
 
+mod bat_v2_ops;
 mod clearing_ops;
 mod db;
 mod error;
@@ -27,7 +28,8 @@ pub use rollback::{
 };
 pub use sqlite_rollback::SqliteIssuerRollbackFloorAuthorityV1;
 pub use types::{
-    ArcKeyLineageV1, AuthenticatedQuoteStatus, BatKeyLineage, BatKeyLineageRegistration,
+    ArcKeyLineageV1, AuthenticatedQuoteStatus, BatAcceptanceClassMemberRecordV2,
+    BatAcceptanceClassRecordV2, BatKeyLineage, BatKeyLineageRegistration,
     ClaimCryptographicVerificationInput, ClaimCryptographicVerifier, ClaimRecord, ClaimWrite,
     ClearingAuthorizationRecordV1, CommitMarker, DelegationAdvance, DelegationHead, DurableWrite,
     IssuerServicePolicyRecordV1, IssuerStoreOperationalInventoryV1, LedgerTransactionKindV1,
@@ -39,15 +41,16 @@ pub use types::{
     SettlementDepositRecordV1, SettlementKeyLineage, SettlementKeyLineageRegistration,
     SharedCredentialCryptographicVerifierV1, SharedCredentialSpendSinkV1,
     SharedCredentialVerificationInputV1, StoreIdentity, StoreOptions, VerifiedRedeemCommitV1,
-    VerifiedSharedIssuerRedeemV1, WriteDisposition, MAX_EXACT_CLAIM_REQUEST_BYTES,
-    MAX_EXACT_CLAIM_RESPONSE_BYTES, MAX_EXACT_CLEARING_APPROVAL_BYTES,
-    MAX_EXACT_CLEARING_AUTHORIZATION_BYTES, MAX_EXACT_DELEGATION_BYTES, MAX_EXACT_INTENT_BYTES,
-    MAX_EXACT_PAYOUT_INTENT_REQUEST_BYTES, MAX_EXACT_PAYOUT_INTENT_RESPONSE_BYTES,
-    MAX_EXACT_PAYOUT_REQUEST_BYTES, MAX_EXACT_PAYOUT_RESPONSE_BYTES,
-    MAX_EXACT_PAYOUT_STATUS_RESPONSE_BYTES, MAX_EXACT_REDEEM_REQUEST_BYTES,
-    MAX_EXACT_REDEEM_RESPONSE_BYTES, MAX_EXACT_SERVICE_POLICY_BYTES,
-    MAX_EXACT_SETTLEMENT_DEPOSIT_REQUEST_BYTES, MAX_EXACT_SETTLEMENT_DEPOSIT_RESPONSE_BYTES,
-    MAX_INVOICE_BYTES, MAX_RECEIPT_SERIALS_PER_CLAIM, MAX_SIGNED_QUOTE_BYTES, SCHEMA_VERSION,
+    VerifiedSharedIssuerRedeemV1, WriteDisposition, MAX_EXACT_BAT_V2_CLASS_BYTES,
+    MAX_EXACT_CLAIM_REQUEST_BYTES, MAX_EXACT_CLAIM_RESPONSE_BYTES,
+    MAX_EXACT_CLEARING_APPROVAL_BYTES, MAX_EXACT_CLEARING_AUTHORIZATION_BYTES,
+    MAX_EXACT_DELEGATION_BYTES, MAX_EXACT_INTENT_BYTES, MAX_EXACT_PAYOUT_INTENT_REQUEST_BYTES,
+    MAX_EXACT_PAYOUT_INTENT_RESPONSE_BYTES, MAX_EXACT_PAYOUT_REQUEST_BYTES,
+    MAX_EXACT_PAYOUT_RESPONSE_BYTES, MAX_EXACT_PAYOUT_STATUS_RESPONSE_BYTES,
+    MAX_EXACT_REDEEM_REQUEST_BYTES, MAX_EXACT_REDEEM_RESPONSE_BYTES,
+    MAX_EXACT_SERVICE_POLICY_BYTES, MAX_EXACT_SETTLEMENT_DEPOSIT_REQUEST_BYTES,
+    MAX_EXACT_SETTLEMENT_DEPOSIT_RESPONSE_BYTES, MAX_INVOICE_BYTES, MAX_RECEIPT_SERIALS_PER_CLAIM,
+    MAX_SIGNED_QUOTE_BYTES, SCHEMA_VERSION,
 };
 
 pub use clearing_ops::{
@@ -231,11 +234,15 @@ impl IssuerStore {
     /// material.
     pub fn operational_inventory(&self) -> StoreResult<IssuerStoreOperationalInventoryV1> {
         let connection = self.open_checked(false)?;
-        let raw: (i64, i64, i64, i64, i64, i64) = connection.query_row(
+        type RawInventory = (i64, i64, i64, i64, i64, i64, i64, i64, i64);
+        let raw: RawInventory = connection.query_row(
             "SELECT (SELECT commit_seq FROM store_identity WHERE singleton = 1), \
                     (SELECT COUNT(*) FROM quotes), \
                     (SELECT COUNT(*) FROM claims), \
                     (SELECT COUNT(*) FROM issuer_service_policies), \
+                    (SELECT COUNT(*) FROM bat_v2_class_artifacts), \
+                    (SELECT COUNT(*) FROM bat_v2_class_heads), \
+                    (SELECT COUNT(*) FROM bat_v2_class_members), \
                     (SELECT COUNT(*) FROM redemptions), \
                     (SELECT COUNT(*) FROM payouts)",
             [],
@@ -247,6 +254,9 @@ impl IssuerStore {
                     row.get(3)?,
                     row.get(4)?,
                     row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                    row.get(8)?,
                 ))
             },
         )?;
@@ -255,8 +265,11 @@ impl IssuerStore {
             quote_rows: db::db_u64(raw.1, "negative quote row count")?,
             claim_rows: db::db_u64(raw.2, "negative claim row count")?,
             retained_policy_rows: db::db_u64(raw.3, "negative retained policy row count")?,
-            redemption_rows: db::db_u64(raw.4, "negative redemption row count")?,
-            payout_rows: db::db_u64(raw.5, "negative payout row count")?,
+            bat_v2_class_rows: db::db_u64(raw.4, "negative BAT V2 class row count")?,
+            bat_v2_class_head_rows: db::db_u64(raw.5, "negative BAT V2 class head row count")?,
+            bat_v2_class_member_rows: db::db_u64(raw.6, "negative BAT V2 class member row count")?,
+            redemption_rows: db::db_u64(raw.7, "negative redemption row count")?,
+            payout_rows: db::db_u64(raw.8, "negative payout row count")?,
         };
         self.confirm_anchored_read(&connection, inventory)
     }
@@ -283,6 +296,7 @@ impl IssuerStore {
         if run_integrity_check {
             quote_ops::verify_all_quote_histories(self, &connection)?;
             clearing_ops::verify_all_provider_registration_histories(self, &connection)?;
+            bat_v2_ops::verify_all_bat_acceptance_classes_v2(self, &connection)?;
         }
         Ok(connection)
     }

--- a/crates/payment/issuer-store/src/policy_ops.rs
+++ b/crates/payment/issuer-store/src/policy_ops.rs
@@ -8,9 +8,11 @@ use crate::{
 };
 use ed25519_dalek::VerifyingKey;
 use pir_service_protocol::{
-    AuthScheme, Bolt11QuoteIntentV1, CashuManifestEpochFloorV1, CredentialKeyBindingExpectationV1,
+    bat_acceptance_member_from_verified_policy_v2, AuthScheme, BatAcceptanceMemberV2,
+    Bolt11QuoteIntentV1, CashuManifestEpochFloorV1, CredentialKeyBindingExpectationV1,
     CredentialKeyBindingV1, CredentialKeysetEpochFloorV1, PolicyRollbackGuardV1,
     ProviderClearingAuthorizationV1, ServicePolicyEpochFloorsV1, ServicePolicyV1,
+    VerifiedBatAcceptanceMemberV2,
 };
 use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 use sha2::{Digest, Sha256};
@@ -598,6 +600,11 @@ impl IssuerStore {
                         "clearing rule references a non-shared credential scheme",
                     ));
                 }
+                AuthScheme::BitcoinPirCashuBatV2 => {
+                    return Err(StoreError::InvalidInput(
+                        "BAT V2 has no V1 credential binding or clearing-rule path",
+                    ));
+                }
             }
             resolved.push(binding.clone());
         }
@@ -605,31 +612,45 @@ impl IssuerStore {
     }
 }
 
-fn read_policy_head(
+pub(crate) fn read_policy_head(
     connection: &Connection,
     store: &IssuerStore,
     provider_id: &[u8; 32],
 ) -> StoreResult<Option<IssuerServicePolicyRecordV1>> {
-    let digest: Option<Vec<u8>> = connection
+    type RawHead = (i64, Vec<u8>, Vec<u8>, i64);
+    let head: Option<RawHead> = connection
         .query_row(
-            "SELECT policy_digest FROM issuer_service_policy_heads WHERE provider_id = ?1",
+            "SELECT highest_epoch, policy_digest, policy_verifying_key, commit_seq \
+             FROM issuer_service_policy_heads WHERE provider_id = ?1",
             [provider_id.as_slice()],
-            |row| row.get(0),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )
         .optional()?;
-    digest
-        .map(|digest| {
-            let digest = fixed_blob(digest, "invalid service policy head digest")?;
+    head.map(|(highest_epoch, digest, verifying_key, commit_seq)| {
+        let highest_epoch = db_u64(highest_epoch, "negative service policy head epoch")?;
+        let digest = fixed_blob(digest, "invalid service policy head digest")?;
+        let verifying_key = fixed_blob(verifying_key, "invalid service policy head verifying key")?;
+        let commit_seq = db_u64(commit_seq, "negative service policy head commit")?;
+        let record =
             read_policy_by_digest(connection, store, provider_id, &digest)?.ok_or_else(|| {
                 StoreError::SchemaMismatch(
                     "service policy head points to a missing retained policy".to_owned(),
                 )
-            })
-        })
-        .transpose()
+            })?;
+        if record.policy_epoch != highest_epoch
+            || record.policy_verifying_key != verifying_key
+            || record.commit.commit_seq != commit_seq
+        {
+            return Err(StoreError::SchemaMismatch(
+                "service policy head metadata points to different retained rows".to_owned(),
+            ));
+        }
+        Ok(record)
+    })
+    .transpose()
 }
 
-fn read_policy_by_digest(
+pub(crate) fn read_policy_by_digest(
     connection: &Connection,
     store: &IssuerStore,
     provider_id: &[u8; 32],
@@ -692,6 +713,84 @@ fn read_policy_by_digest(
         })
     })
     .transpose()
+}
+
+/// Resolves a BAT V2 member only through the provider's currently registered
+/// policy head. This is used inside the class-registration transaction so a
+/// retained but superseded policy can never activate a new class epoch.
+pub(crate) fn project_current_bat_acceptance_member_v2(
+    connection: &Connection,
+    store: &IssuerStore,
+    member: &BatAcceptanceMemberV2,
+    now_unix: u64,
+) -> StoreResult<(VerifiedBatAcceptanceMemberV2, IssuerServicePolicyRecordV1)> {
+    let record = read_policy_head(connection, store, &member.provider_id)?
+        .ok_or(StoreError::BatV2ClassMemberMismatch)?;
+    if record.policy_digest != member.policy_digest {
+        return Err(StoreError::BatV2ClassMemberMismatch);
+    }
+    let floors = read_policy_floors(connection, &member.provider_id)?;
+    project_bat_acceptance_member_from_record_v2(record, member, now_unix, &floors)
+}
+
+/// Rebuilds the BAT V2 projection from one retained exact signed policy at its
+/// original issuance time. It is readback/integrity-only and therefore never
+/// makes an expired policy eligible for a new class registration.
+pub(crate) fn project_retained_bat_acceptance_member_v2(
+    connection: &Connection,
+    store: &IssuerStore,
+    member: &BatAcceptanceMemberV2,
+) -> StoreResult<(VerifiedBatAcceptanceMemberV2, IssuerServicePolicyRecordV1)> {
+    let record = read_policy_by_digest(
+        connection,
+        store,
+        &member.provider_id,
+        &member.policy_digest,
+    )?
+    .ok_or_else(|| StoreError::SchemaMismatch("BAT V2 member policy is not retained".to_owned()))?;
+    let policy = ServicePolicyV1::decode(&record.exact_policy).map_err(|_| {
+        StoreError::SchemaMismatch("retained BAT V2 member policy is not canonical".to_owned())
+    })?;
+    project_bat_acceptance_member_from_record_v2(
+        record,
+        member,
+        policy.issued_at,
+        &ServicePolicyEpochFloorsV1::initial(),
+    )
+}
+
+fn project_bat_acceptance_member_from_record_v2(
+    record: IssuerServicePolicyRecordV1,
+    member: &BatAcceptanceMemberV2,
+    verification_time: u64,
+    floors: &ServicePolicyEpochFloorsV1,
+) -> StoreResult<(VerifiedBatAcceptanceMemberV2, IssuerServicePolicyRecordV1)> {
+    let policy = ServicePolicyV1::decode(&record.exact_policy).map_err(|_| {
+        StoreError::SchemaMismatch("retained BAT V2 member policy is not canonical".to_owned())
+    })?;
+    let key = VerifyingKey::from_bytes(&record.policy_verifying_key).map_err(|_| {
+        StoreError::SchemaMismatch("retained BAT V2 policy key is malformed".to_owned())
+    })?;
+    let guard = PolicyRollbackGuardV1 {
+        highest_epoch: record.policy_epoch,
+        digest_at_highest_epoch: record.policy_digest,
+    };
+    let verified = policy
+        .verify_current_for_acquisition(
+            &member.provider_id,
+            verification_time,
+            &guard,
+            floors,
+            &key,
+        )
+        .map_err(|_| StoreError::BatV2ClassMemberMismatch)?;
+    let projection =
+        bat_acceptance_member_from_verified_policy_v2(&verified, &member.scope_id, member.offer_id)
+            .map_err(|_| StoreError::BatV2ClassMemberMismatch)?;
+    if projection.member != *member {
+        return Err(StoreError::BatV2ClassMemberMismatch);
+    }
+    Ok((projection, record))
 }
 
 fn read_policy_floors(

--- a/crates/payment/issuer-store/src/registry_ops.rs
+++ b/crates/payment/issuer-store/src/registry_ops.rs
@@ -146,6 +146,23 @@ impl IssuerStore {
         let previous_identity = verify_expected_identity(&transaction, &self.handle)?;
         let previous_floor = self.require_exact_rollback_floor(&previous_identity)?;
 
+        let v2_owner: Option<Vec<u8>> = transaction
+            .query_row(
+                "SELECT class_id FROM bat_v2_class_artifacts \
+                 WHERE issuer_id = ?1 AND (raw_public_key = ?2 OR key_fingerprint = ?3) \
+                 LIMIT 1",
+                params![
+                    self.handle.expected_issuer_id.as_slice(),
+                    candidate.raw_public_key.as_slice(),
+                    candidate.key_fingerprint.as_slice(),
+                ],
+                |row| row.get(0),
+            )
+            .optional()?;
+        if v2_owner.is_some() {
+            return Err(StoreError::BatV2RawKeyConflict);
+        }
+
         if let Some(existing) = read_bat_lineage(&transaction, self, &candidate.key_fingerprint)? {
             if bat_lineage_matches(&existing, &candidate) {
                 return Ok(DurableWrite {

--- a/crates/payment/issuer-store/src/schema.rs
+++ b/crates/payment/issuer-store/src/schema.rs
@@ -1,5 +1,5 @@
 use crate::{
-    MAX_EXACT_CLAIM_REQUEST_BYTES, MAX_EXACT_CLAIM_RESPONSE_BYTES,
+    MAX_EXACT_BAT_V2_CLASS_BYTES, MAX_EXACT_CLAIM_REQUEST_BYTES, MAX_EXACT_CLAIM_RESPONSE_BYTES,
     MAX_EXACT_CLEARING_APPROVAL_BYTES, MAX_EXACT_CLEARING_AUTHORIZATION_BYTES,
     MAX_EXACT_DELEGATION_BYTES, MAX_EXACT_INTENT_BYTES, MAX_EXACT_PAYOUT_INTENT_REQUEST_BYTES,
     MAX_EXACT_PAYOUT_INTENT_RESPONSE_BYTES, MAX_EXACT_PAYOUT_REQUEST_BYTES,
@@ -8,6 +8,7 @@ use crate::{
     MAX_EXACT_SERVICE_POLICY_BYTES, MAX_EXACT_SETTLEMENT_DEPOSIT_REQUEST_BYTES,
     MAX_EXACT_SETTLEMENT_DEPOSIT_RESPONSE_BYTES, MAX_INVOICE_BYTES, MAX_SIGNED_QUOTE_BYTES,
 };
+use pir_service_protocol::MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2;
 
 pub(crate) const APPLICATION_ID: i64 = 0x4250_4949;
 
@@ -340,6 +341,112 @@ pub(crate) const BAT_KEY_LINEAGES_SQL: &str = r#"CREATE TABLE bat_key_lineages (
     UNIQUE (issuer_id, lineage_digest),
     UNIQUE (issuer_id, provider_id, scope_id, offer_id, entitlement_profile, keyset_epoch)
 ) STRICT, WITHOUT ROWID"#;
+
+pub(crate) fn bat_v2_class_artifacts_sql() -> String {
+    format!(
+        r#"CREATE TABLE bat_v2_class_artifacts (
+    issuer_id             BLOB NOT NULL CHECK (
+        length(issuer_id) = 32 AND issuer_id != zeroblob(32)
+    ),
+    class_id              BLOB NOT NULL CHECK (
+        length(class_id) = 32 AND class_id != zeroblob(32)
+    ),
+    key_epoch             INTEGER NOT NULL CHECK (key_epoch > 0),
+    artifact_digest       BLOB NOT NULL CHECK (
+        length(artifact_digest) = 32 AND artifact_digest != zeroblob(32)
+    ),
+    common_terms_digest   BLOB NOT NULL CHECK (
+        length(common_terms_digest) = 32 AND common_terms_digest != zeroblob(32)
+    ),
+    issuer_verifying_key  BLOB NOT NULL CHECK (
+        length(issuer_verifying_key) = 32 AND issuer_verifying_key != zeroblob(32)
+    ),
+    raw_public_key        BLOB NOT NULL CHECK (
+        length(raw_public_key) = 33 AND raw_public_key != zeroblob(33)
+    ),
+    key_fingerprint       BLOB NOT NULL CHECK (
+        length(key_fingerprint) = 32 AND key_fingerprint != zeroblob(32)
+    ),
+    bat_key_id            BLOB NOT NULL CHECK (
+        length(bat_key_id) = 32 AND bat_key_id != zeroblob(32)
+    ),
+    key_not_before        INTEGER NOT NULL CHECK (key_not_before >= 0),
+    key_not_after         INTEGER NOT NULL CHECK (key_not_after >= key_not_before),
+    member_count          INTEGER NOT NULL CHECK (
+        member_count BETWEEN 1 AND {max_members}
+    ),
+    exact_artifact        BLOB NOT NULL CHECK (
+        length(exact_artifact) BETWEEN 1 AND {max_artifact}
+    ),
+    commit_seq            INTEGER NOT NULL CHECK (commit_seq > 0),
+    PRIMARY KEY (issuer_id, class_id, key_epoch),
+    UNIQUE (issuer_id, artifact_digest),
+    UNIQUE (issuer_id, raw_public_key),
+    UNIQUE (issuer_id, key_fingerprint),
+    UNIQUE (issuer_id, bat_key_id)
+) STRICT, WITHOUT ROWID"#,
+        max_artifact = MAX_EXACT_BAT_V2_CLASS_BYTES,
+        max_members = MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2,
+    )
+}
+
+pub(crate) const BAT_V2_CLASS_HEADS_SQL: &str = r#"CREATE TABLE bat_v2_class_heads (
+    issuer_id           BLOB NOT NULL CHECK (
+        length(issuer_id) = 32 AND issuer_id != zeroblob(32)
+    ),
+    class_id            BLOB NOT NULL CHECK (
+        length(class_id) = 32 AND class_id != zeroblob(32)
+    ),
+    highest_key_epoch   INTEGER NOT NULL CHECK (highest_key_epoch > 0),
+    artifact_digest     BLOB NOT NULL CHECK (
+        length(artifact_digest) = 32 AND artifact_digest != zeroblob(32)
+    ),
+    common_terms_digest BLOB NOT NULL CHECK (
+        length(common_terms_digest) = 32 AND common_terms_digest != zeroblob(32)
+    ),
+    commit_seq          INTEGER NOT NULL CHECK (commit_seq > 0),
+    PRIMARY KEY (issuer_id, class_id),
+    FOREIGN KEY (issuer_id, class_id, highest_key_epoch)
+        REFERENCES bat_v2_class_artifacts(issuer_id, class_id, key_epoch) ON DELETE RESTRICT,
+    FOREIGN KEY (issuer_id, artifact_digest)
+        REFERENCES bat_v2_class_artifacts(issuer_id, artifact_digest) ON DELETE RESTRICT
+) STRICT, WITHOUT ROWID"#;
+
+pub(crate) fn bat_v2_class_members_sql() -> String {
+    format!(
+        r#"CREATE TABLE bat_v2_class_members (
+    issuer_id           BLOB NOT NULL CHECK (
+        length(issuer_id) = 32 AND issuer_id != zeroblob(32)
+    ),
+    class_id            BLOB NOT NULL CHECK (
+        length(class_id) = 32 AND class_id != zeroblob(32)
+    ),
+    key_epoch           INTEGER NOT NULL CHECK (key_epoch > 0),
+    member_index        INTEGER NOT NULL CHECK (
+        member_index BETWEEN 0 AND {max_member_index}
+    ),
+    provider_id         BLOB NOT NULL CHECK (
+        length(provider_id) = 32 AND provider_id != zeroblob(32)
+    ),
+    policy_digest       BLOB NOT NULL CHECK (
+        length(policy_digest) = 32 AND policy_digest != zeroblob(32)
+    ),
+    scope_id            BLOB NOT NULL CHECK (
+        length(scope_id) = 32 AND scope_id != zeroblob(32)
+    ),
+    offer_id            INTEGER NOT NULL CHECK (offer_id > 0),
+    redemption_deadline INTEGER NOT NULL CHECK (redemption_deadline > 0),
+    commit_seq          INTEGER NOT NULL CHECK (commit_seq > 0),
+    PRIMARY KEY (issuer_id, class_id, key_epoch, member_index),
+    UNIQUE (issuer_id, class_id, key_epoch, provider_id, policy_digest, scope_id, offer_id),
+    FOREIGN KEY (issuer_id, class_id, key_epoch)
+        REFERENCES bat_v2_class_artifacts(issuer_id, class_id, key_epoch) ON DELETE RESTRICT,
+    FOREIGN KEY (policy_digest)
+        REFERENCES issuer_service_policies(policy_digest) ON DELETE RESTRICT
+) STRICT, WITHOUT ROWID"#,
+        max_member_index = MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2 - 1,
+    )
+}
 
 pub(crate) const ARC_KEY_LINEAGES_SQL: &str = r#"CREATE TABLE arc_key_lineages (
     issuer_id           BLOB NOT NULL CHECK (
@@ -816,6 +923,9 @@ pub(crate) fn schema() -> Vec<(&'static str, String)> {
     vec![
         ("arc_key_lineages", ARC_KEY_LINEAGES_SQL.to_owned()),
         ("bat_key_lineages", BAT_KEY_LINEAGES_SQL.to_owned()),
+        ("bat_v2_class_artifacts", bat_v2_class_artifacts_sql()),
+        ("bat_v2_class_heads", BAT_V2_CLASS_HEADS_SQL.to_owned()),
+        ("bat_v2_class_members", bat_v2_class_members_sql()),
         ("claims", claims_sql()),
         ("clearing_authorizations", clearing_authorizations_sql()),
         (

--- a/crates/payment/issuer-store/src/types.rs
+++ b/crates/payment/issuer-store/src/types.rs
@@ -9,7 +9,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// On-disk schema version. This crate never performs an implicit migration.
-pub const SCHEMA_VERSION: u32 = 5;
+/// Version 6 is a fresh-schema boundary for the append-only BAT V2 class
+/// registry; existing version-5 stores must be migrated by an explicit,
+/// separately reviewed operation.
+pub const SCHEMA_VERSION: u32 = 6;
 
 pub const MAX_EXACT_INTENT_BYTES: usize = 64 * 1024;
 pub const MAX_EXACT_DELEGATION_BYTES: usize = 64 * 1024;
@@ -29,6 +32,11 @@ pub const MAX_EXACT_PAYOUT_REQUEST_BYTES: usize = 16 * 1024;
 pub const MAX_EXACT_PAYOUT_RESPONSE_BYTES: usize = 16 * 1024;
 pub const MAX_EXACT_PAYOUT_STATUS_RESPONSE_BYTES: usize = 16 * 1024;
 pub const MAX_EXACT_SERVICE_POLICY_BYTES: usize = pir_service_protocol::MAX_SIGNED_POLICY_LEN;
+/// Durable upper bound for one canonical signed BAT V2 class artifact. The
+/// protocol codec has its own equal-or-smaller bound; this store never accepts
+/// an artifact that the protocol layer cannot decode and re-encode exactly.
+pub const MAX_EXACT_BAT_V2_CLASS_BYTES: usize =
+    pir_service_protocol::MAX_BAT_ACCEPTANCE_CLASS_LEN_V2;
 /// V1 protocol acquisition cap. Store limits may not exceed the wire cap.
 pub const MAX_RECEIPT_SERIALS_PER_CLAIM: usize = 256;
 
@@ -74,8 +82,44 @@ pub struct IssuerStoreOperationalInventoryV1 {
     pub quote_rows: u64,
     pub claim_rows: u64,
     pub retained_policy_rows: u64,
+    pub bat_v2_class_rows: u64,
+    pub bat_v2_class_head_rows: u64,
+    pub bat_v2_class_member_rows: u64,
     pub redemption_rows: u64,
     pub payout_rows: u64,
+}
+
+/// One exact provider-policy member retained under one signed BAT V2 class
+/// artifact. The redemption deadline is derived from the registered exact
+/// policy and signed offer at registration time; it is not caller supplied.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatAcceptanceClassMemberRecordV2 {
+    pub member_index: u16,
+    pub provider_id: [u8; 32],
+    pub policy_digest: [u8; 32],
+    pub scope_id: [u8; 32],
+    pub offer_id: u32,
+    pub redemption_deadline: u64,
+}
+
+/// Append-only issuer BAT V2 class/key-epoch snapshot. `exact_artifact`
+/// remains the canonical signed protocol object; the duplicated fixed-width
+/// columns are checked readback indexes, not a second source of truth.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BatAcceptanceClassRecordV2 {
+    pub class_id: [u8; 32],
+    pub key_epoch: u64,
+    pub artifact_digest: [u8; 32],
+    pub common_terms_digest: [u8; 32],
+    pub issuer_verifying_key: [u8; 32],
+    pub raw_public_key: [u8; 33],
+    pub key_fingerprint: [u8; 32],
+    pub bat_key_id: [u8; 32],
+    pub key_not_before: u64,
+    pub key_not_after: u64,
+    pub exact_artifact: Vec<u8>,
+    pub members: Vec<BatAcceptanceClassMemberRecordV2>,
+    pub commit: CommitMarker,
 }
 
 /// One provider policy retained by the issuer for current acquisition and

--- a/crates/payment/issuer-store/tests/issuer_store.rs
+++ b/crates/payment/issuer-store/tests/issuer_store.rs
@@ -10,11 +10,15 @@ use pir_issuer_store::{
 };
 use pir_service_protocol::{
     derive_bat_key_id_v1, derive_cashu_keyset_id_v2, derive_issuer_id, paid_receipt_key_id,
-    AuthScheme, Bolt11QuoteClaimV1, Bolt11QuoteIntentV1, Bolt11QuoteKeyDelegationV1,
-    Bolt11QuoteStatusRequestV1, Bolt11QuoteStatusV1, Bolt11QuoteV1, CashuDenominationKeyV1,
-    CredentialIssuanceRequestItemsV1, CredentialIssuanceRequestV1,
-    CredentialIssuanceResponseItemsV1, CredentialIssuanceResponseV1, LightningNetworkV1,
-    PaidReceiptBindingV1, PaidReceiptV1, BOLT11_QUOTE_SIGNATURE_DOMAIN,
+    AcquisitionMethod, AuthPaddingClassV1, AuthScheme, BackendId, BatAcceptanceClassV2,
+    BatAcceptanceMemberV2, BatAcceptanceTermsV2, Bolt11QuoteClaimV1, Bolt11QuoteIntentV1,
+    Bolt11QuoteKeyDelegationV1, Bolt11QuoteStatusRequestV1, Bolt11QuoteStatusV1, Bolt11QuoteV1,
+    CashuDenominationKeyV1, CredentialIssuanceRequestItemsV1, CredentialIssuanceRequestV1,
+    CredentialIssuanceResponseItemsV1, CredentialIssuanceResponseV1, DatasetBindingV1,
+    DeploymentStatus, EntitlementLimitsV1, FreeModeV1, LightningNetworkV1, PaidReceiptBindingV1,
+    PaidReceiptV1, PriceV1, PrivacyLeakageV1, ServiceOfferV1, ServicePolicyV1,
+    ServiceScopePolicyV1, ServiceScopeV1, VerificationMode, WorkloadId,
+    BOLT11_QUOTE_SIGNATURE_DOMAIN,
 };
 use rusqlite::Connection;
 use std::path::{Path, PathBuf};
@@ -208,6 +212,181 @@ fn point(multiplier: u64) -> [u8; 33] {
         .to_affine()
         .to_encoded_point(true);
     encoded.as_bytes().try_into().expect("compressed point")
+}
+
+fn bat_v2_limits() -> EntitlementLimitsV1 {
+    EntitlementLimitsV1 {
+        max_logical_inputs: 4,
+        max_frames: 200,
+        max_request_bytes: 1_000_000,
+        max_response_bytes: 2_000_000,
+        max_wall_time_ms: 60_000,
+        max_concurrent_sockets: 1,
+        max_hint_groups: 0,
+        max_work_units: 9_000,
+    }
+}
+
+fn bat_v2_privacy() -> PrivacyLeakageV1 {
+    PrivacyLeakageV1::from_bits(
+        PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+            | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+            | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+    )
+    .expect("BAT V2 privacy flags")
+}
+
+fn bat_v2_scope(provider_id: [u8; 32]) -> ServiceScopeV1 {
+    ServiceScopeV1 {
+        provider_id,
+        backend: BackendId::DpfPirV1,
+        workload: WorkloadId::DpfEvaluateJobV1,
+        protocol_version: 1,
+        dataset: DatasetBindingV1::Class { class_id: 1 },
+        operation_profile: 1,
+        entitlement_profile: 2,
+    }
+}
+
+fn bat_v2_offer(class_id: [u8; 32]) -> ServiceOfferV1 {
+    ServiceOfferV1 {
+        offer_id: 7,
+        acquisition: AcquisitionMethod::Bolt11V1,
+        free_mode: FreeModeV1::NotFree,
+        free_quota: 0,
+        free_window_seconds: 0,
+        free_pow_difficulty_bits: 0,
+        priority_class: 1,
+        authorization: AuthScheme::BitcoinPirCashuBatV2,
+        verification: VerificationMode::SharedIssuerOnline,
+        deployment_status: DeploymentStatus::Stable,
+        price: PriceV1::MilliSatoshi(2_000),
+        issuer_id: issuer_id(),
+        key_id: class_id.to_vec(),
+        credential_binding: None,
+        cashu_mint_manifest: None,
+        endpoint: "https://issuer.invalid".to_owned(),
+        invoice_expiry_seconds: 60,
+        claim_window_seconds: 120,
+        minimum_credential_validity_seconds: 300,
+        retired_policy_grace_seconds: 480,
+        credential_count: 2,
+        credential_presentation_limit: 1,
+        privacy_leakage: bat_v2_privacy(),
+    }
+}
+
+fn bat_v2_terms() -> BatAcceptanceTermsV2 {
+    BatAcceptanceTermsV2 {
+        auth_padding_class: AuthPaddingClassV1::Class16KiB,
+        backend: BackendId::DpfPirV1,
+        workload: WorkloadId::DpfEvaluateJobV1,
+        protocol_version: 1,
+        dataset: DatasetBindingV1::Class { class_id: 1 },
+        operation_profile: 1,
+        entitlement_profile: 2,
+        limits: bat_v2_limits(),
+        priority_class: 1,
+        deployment_status: DeploymentStatus::Stable,
+        price_msat: 2_000,
+        issuer_endpoint: "https://issuer.invalid".to_owned(),
+        invoice_expiry_seconds: 60,
+        claim_window_seconds: 120,
+        minimum_credential_validity_seconds: 300,
+        retired_policy_grace_seconds: 480,
+        credential_count: 2,
+        credential_presentation_limit: 1,
+        privacy_leakage: bat_v2_privacy(),
+    }
+}
+
+fn register_bat_v2_member_policy(
+    store: &IssuerStore,
+    provider_byte: u8,
+    signing_key_byte: u8,
+    class_id: [u8; 32],
+    policy_epoch: u64,
+) -> BatAcceptanceMemberV2 {
+    let provider_id = [provider_byte; 32];
+    let scope = bat_v2_scope(provider_id);
+    let scope_id = scope.scope_id();
+    let signing_key = SigningKey::from_bytes(&[signing_key_byte; 32]);
+    let policy = ServicePolicyV1::sign(
+        provider_id,
+        policy_epoch,
+        100,
+        1_000,
+        AuthPaddingClassV1::Class16KiB,
+        vec![ServiceScopePolicyV1 {
+            scope,
+            limits: bat_v2_limits(),
+            offers: vec![bat_v2_offer(class_id)],
+        }],
+        &signing_key,
+    )
+    .expect("sign BAT V2 member policy");
+    let policy_digest = policy.policy_digest().expect("BAT V2 policy digest");
+    let _ = store
+        .register_service_policy(&policy, &signing_key.verifying_key(), 200)
+        .expect("register BAT V2 member policy");
+    BatAcceptanceMemberV2 {
+        provider_id,
+        policy_digest,
+        scope_id,
+        offer_id: 7,
+    }
+}
+
+fn register_bat_v2_members(
+    store: &IssuerStore,
+    class_id: [u8; 32],
+    policy_epoch: u64,
+) -> Vec<BatAcceptanceMemberV2> {
+    vec![
+        register_bat_v2_member_policy(store, 0xa1, 0xb1, class_id, policy_epoch),
+        register_bat_v2_member_policy(store, 0xa2, 0xb2, class_id, policy_epoch),
+    ]
+}
+
+fn bat_v2_class(
+    class_id: [u8; 32],
+    key_epoch: u64,
+    raw_key_multiplier: u64,
+    terms: BatAcceptanceTermsV2,
+    members: Vec<BatAcceptanceMemberV2>,
+) -> BatAcceptanceClassV2 {
+    bat_v2_class_with_validity(
+        class_id,
+        key_epoch,
+        raw_key_multiplier,
+        100,
+        1_480,
+        terms,
+        members,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn bat_v2_class_with_validity(
+    class_id: [u8; 32],
+    key_epoch: u64,
+    raw_key_multiplier: u64,
+    key_not_before: u64,
+    key_not_after: u64,
+    terms: BatAcceptanceTermsV2,
+    members: Vec<BatAcceptanceMemberV2>,
+) -> BatAcceptanceClassV2 {
+    BatAcceptanceClassV2::sign(
+        class_id,
+        key_epoch,
+        key_not_before,
+        key_not_after,
+        point(raw_key_multiplier),
+        terms,
+        members,
+        &root_key(),
+    )
+    .expect("sign BAT V2 class")
 }
 
 fn xonly(multiplier: u64) -> [u8; 32] {
@@ -955,6 +1134,9 @@ fn explicit_create_open_identity_schema_and_privacy_boundary() {
     assert_eq!(inventory.quote_rows, 0);
     assert_eq!(inventory.claim_rows, 0);
     assert_eq!(inventory.retained_policy_rows, 0);
+    assert_eq!(inventory.bat_v2_class_rows, 0);
+    assert_eq!(inventory.bat_v2_class_head_rows, 0);
+    assert_eq!(inventory.bat_v2_class_member_rows, 0);
     assert_eq!(inventory.redemption_rows, 0);
     assert_eq!(inventory.payout_rows, 0);
     let floor = test_path.authority.floor().unwrap();
@@ -2319,6 +2501,198 @@ fn bat_and_settlement_key_lineages_are_immutable_and_survive_restart() {
             .manifest_digest,
         settlement.manifest_digest
     );
+}
+
+#[test]
+fn bat_v2_registry_accepts_two_provider_epochs_and_survives_restart() {
+    let test_path = TestPath::new();
+    let store = create_store(&test_path);
+    let class_id = [0x42; 32];
+    let first_members = register_bat_v2_members(&store, class_id, 1);
+    let first = bat_v2_class(class_id, 1, 40, bat_v2_terms(), first_members);
+    let installed = store.register_bat_acceptance_class_v2(&first, 200).unwrap();
+    assert_eq!(installed.disposition, WriteDisposition::Committed);
+    assert_eq!(installed.value.members.len(), 2);
+    assert_eq!(
+        store
+            .register_bat_acceptance_class_v2(&first, 200)
+            .unwrap()
+            .disposition,
+        WriteDisposition::ExactReplay
+    );
+
+    let second_members = register_bat_v2_members(&store, class_id, 2);
+    let second = bat_v2_class(class_id, 2, 41, bat_v2_terms(), second_members);
+    let _ = store
+        .register_bat_acceptance_class_v2(&second, 200)
+        .unwrap();
+    assert!(matches!(
+        store.register_bat_acceptance_class_v2(&first, 200),
+        Err(StoreError::BatV2ClassRollback)
+    ));
+    assert_eq!(
+        store
+            .current_bat_acceptance_class_v2(&class_id)
+            .unwrap()
+            .unwrap()
+            .key_epoch,
+        2
+    );
+    assert_eq!(
+        store
+            .bat_acceptance_class_v2(&class_id, 1)
+            .unwrap()
+            .unwrap()
+            .exact_artifact,
+        first.encode().unwrap()
+    );
+    let inventory = store.operational_inventory().unwrap();
+    assert_eq!(inventory.bat_v2_class_rows, 2);
+    assert_eq!(inventory.bat_v2_class_head_rows, 1);
+    assert_eq!(inventory.bat_v2_class_member_rows, 4);
+    drop(store);
+
+    let reopened = open_store(&test_path).unwrap();
+    assert_eq!(
+        reopened
+            .current_bat_acceptance_class_v2(&class_id)
+            .unwrap()
+            .unwrap()
+            .exact_artifact,
+        second.encode().unwrap()
+    );
+    assert!(reopened
+        .bat_acceptance_class_v2(&class_id, 1)
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn bat_v2_registry_rejects_member_terms_epoch_and_cross_class_conflicts() {
+    let test_path = TestPath::new();
+    let store = create_store(&test_path);
+    let class_id = [0x43; 32];
+    let members = register_bat_v2_members(&store, class_id, 1);
+
+    let mut changed_terms = bat_v2_terms();
+    changed_terms.price_msat += 1;
+    let terms_mismatch = bat_v2_class(class_id, 1, 50, changed_terms.clone(), members.clone());
+    assert!(matches!(
+        store.register_bat_acceptance_class_v2(&terms_mismatch, 200),
+        Err(StoreError::BatV2ClassTermsConflict)
+    ));
+
+    let mut wrong_members = members.clone();
+    wrong_members[0].offer_id += 1;
+    let wrong_member = bat_v2_class(class_id, 1, 50, bat_v2_terms(), wrong_members);
+    assert!(matches!(
+        store.register_bat_acceptance_class_v2(&wrong_member, 200),
+        Err(StoreError::BatV2ClassMemberMismatch)
+    ));
+
+    let late_not_before =
+        bat_v2_class_with_validity(class_id, 1, 52, 101, 1_480, bat_v2_terms(), members.clone());
+    assert!(matches!(
+        store.register_bat_acceptance_class_v2(&late_not_before, 200),
+        Err(StoreError::BatV2ClassMemberMismatch)
+    ));
+    let short_not_after =
+        bat_v2_class_with_validity(class_id, 1, 53, 100, 1_479, bat_v2_terms(), members.clone());
+    assert!(matches!(
+        store.register_bat_acceptance_class_v2(&short_not_after, 200),
+        Err(StoreError::BatV2ClassMemberMismatch)
+    ));
+    let long_not_after =
+        bat_v2_class_with_validity(class_id, 1, 54, 100, 1_481, bat_v2_terms(), members.clone());
+    assert!(matches!(
+        store.register_bat_acceptance_class_v2(&long_not_after, 200),
+        Err(StoreError::BatV2ClassMemberMismatch)
+    ));
+
+    let accepted = bat_v2_class(class_id, 1, 50, bat_v2_terms(), members.clone());
+    let _ = store
+        .register_bat_acceptance_class_v2(&accepted, 200)
+        .unwrap();
+    let same_epoch_fork = bat_v2_class(class_id, 1, 51, bat_v2_terms(), members.clone());
+    assert!(matches!(
+        store.register_bat_acceptance_class_v2(&same_epoch_fork, 200),
+        Err(StoreError::BatV2ClassFork)
+    ));
+    let changed_terms_epoch = bat_v2_class(class_id, 2, 51, changed_terms, members.clone());
+    assert!(matches!(
+        store.register_bat_acceptance_class_v2(&changed_terms_epoch, 200),
+        Err(StoreError::BatV2ClassTermsConflict)
+    ));
+    let reused_epoch_key = bat_v2_class(class_id, 2, 50, bat_v2_terms(), members);
+    assert!(matches!(
+        store.register_bat_acceptance_class_v2(&reused_epoch_key, 200),
+        Err(StoreError::BatV2RawKeyConflict)
+    ));
+
+    let other_class_id = [0x44; 32];
+    let other_members = register_bat_v2_members(&store, other_class_id, 2);
+    let cross_class_reuse = bat_v2_class(other_class_id, 1, 50, bat_v2_terms(), other_members);
+    assert!(matches!(
+        store.register_bat_acceptance_class_v2(&cross_class_reuse, 200),
+        Err(StoreError::BatV2RawKeyConflict)
+    ));
+}
+
+fn bat_v2_legacy_lineage(raw_public_key: [u8; 33]) -> BatKeyLineageRegistration {
+    let provider_id = [0xd1; 32];
+    let scope_id = [0xd2; 32];
+    BatKeyLineageRegistration {
+        raw_public_key,
+        provider_id,
+        scope_id,
+        offer_id: 9,
+        entitlement_profile: 4,
+        keyset_epoch: 3,
+        credential_key_id: derive_bat_key_id_v1(&provider_id, &scope_id, 9, 4, 3, &raw_public_key),
+    }
+}
+
+#[test]
+fn bat_v2_registry_rejects_bidirectional_legacy_raw_key_reuse() {
+    let legacy_first_path = TestPath::new();
+    let legacy_first = create_store(&legacy_first_path);
+    let class_id = [0x45; 32];
+    let members = register_bat_v2_members(&legacy_first, class_id, 1);
+    let artifact = bat_v2_class(class_id, 1, 60, bat_v2_terms(), members);
+    let lineage = bat_v2_legacy_lineage(point(60));
+    let _ = legacy_first.register_bat_key_lineage(&lineage).unwrap();
+    assert!(matches!(
+        legacy_first.register_bat_acceptance_class_v2(&artifact, 200),
+        Err(StoreError::BatV2RawKeyConflict)
+    ));
+
+    let v2_first_path = TestPath::new();
+    let v2_first = create_store(&v2_first_path);
+    let class_id = [0x46; 32];
+    let members = register_bat_v2_members(&v2_first, class_id, 1);
+    let artifact = bat_v2_class(class_id, 1, 61, bat_v2_terms(), members);
+    let _ = v2_first
+        .register_bat_acceptance_class_v2(&artifact, 200)
+        .unwrap();
+    let lineage = bat_v2_legacy_lineage(point(61));
+    assert!(matches!(
+        v2_first.register_bat_key_lineage(&lineage),
+        Err(StoreError::BatV2RawKeyConflict)
+    ));
+}
+
+#[test]
+fn bat_v2_schema_v6_rejects_implicit_v5_open() {
+    let test_path = TestPath::new();
+    let store = create_store(&test_path);
+    drop(store);
+    let connection = Connection::open(&test_path.database).unwrap();
+    connection.pragma_update(None, "user_version", 5).unwrap();
+    drop(connection);
+    assert!(matches!(
+        open_store(&test_path),
+        Err(StoreError::SchemaMismatch(_))
+    ));
 }
 
 #[test]

--- a/crates/protocol/service-store/src/offer_namespace.rs
+++ b/crates/protocol/service-store/src/offer_namespace.rs
@@ -1,8 +1,8 @@
 //! Safe derivation of provider-local durable spend namespaces.
 
 use pir_service_protocol::{
-    bat_verification_key_fingerprint_v1, derive_shared_issuer_local_grant_namespace_v1,
-    AuthScheme, CredentialKeyBindingV1, FreeModeV1, ServiceProtocolError, VerificationMode,
+    bat_verification_key_fingerprint_v1, derive_shared_issuer_local_grant_namespace_v1, AuthScheme,
+    CredentialKeyBindingV1, FreeModeV1, ServiceProtocolError, VerificationMode,
     VerifiedServiceOfferV1, SHARED_ISSUER_LOCAL_GRANT_NAMESPACE_SCHEME_V1,
 };
 use rusqlite::{params, OptionalExtension};
@@ -178,6 +178,11 @@ where
     A: ArcExclusiveKeyLineageVerifierV1 + ?Sized,
 {
     let offer = verified_offer.offer();
+    if offer.authorization == AuthScheme::BitcoinPirCashuBatV2 {
+        return Err(StoreError::InvalidInput(
+            "issuer-wide BAT V2 has no provider-store namespace",
+        ));
+    }
     match offer.verification {
         VerificationMode::SharedIssuerOnline => {
             let synthetic = derive_shared_issuer_local_grant_namespace_v1(verified_offer)?;
@@ -207,6 +212,11 @@ where
                 ))
             }
             AuthScheme::Bolt11DirectReceiptV1 | AuthScheme::BitcoinPirCashuBatV1 => {}
+            AuthScheme::BitcoinPirCashuBatV2 => {
+                return Err(StoreError::InvalidInput(
+                    "issuer-wide BAT V2 has no provider-store namespace",
+                ))
+            }
             AuthScheme::ArcV1Experimental if arc_lineage_verifier.is_some() => {}
             AuthScheme::ArcV1Experimental => {
                 return Ok(DerivedOfferNamespaceV1::UnsupportedExperimental)

--- a/crates/protocol/service-store/tests/verified_offer_namespace.rs
+++ b/crates/protocol/service-store/tests/verified_offer_namespace.rs
@@ -2,12 +2,12 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use pir_service_protocol::{
     arc_provider_global_spend_key_v1, bat_verification_key_fingerprint_v1, bind_auth_begin_v1,
     derive_bat_key_id_v1, derive_cashu_keyset_id_v2, derive_cashu_mint_id,
-    derive_shared_issuer_local_grant_namespace_v1,
-    free_anonymous_ticket_key_id, paid_receipt_key_id, AcquisitionMethod, ArcPresentationV1,
-    AuthBeginV1, AuthPaddingClassV1, AuthScheme, AuthorizationProofV1, BackendId,
-    BoundAuthAttemptV1, CashuDenominationKeyV1, CashuKeysetBindingV1, CashuRequiredNutsV1,
-    CredentialKeyBindingClaimsV1, CredentialKeyBindingV1, CredentialUnitV1, DatasetBindingV1,
-    DeploymentStatus, EntitlementLimitsV1, FreeAnonymousTicketV1, FreeModeV1, OperationStartV1,
+    derive_shared_issuer_local_grant_namespace_v1, free_anonymous_ticket_key_id,
+    paid_receipt_key_id, AcquisitionMethod, ArcPresentationV1, AuthBeginV1, AuthPaddingClassV1,
+    AuthScheme, AuthorizationProofV1, BackendId, BoundAuthAttemptV1, CashuDenominationKeyV1,
+    CashuKeysetBindingV1, CashuRequiredNutsV1, CredentialKeyBindingClaimsV1,
+    CredentialKeyBindingV1, CredentialUnitV1, DatasetBindingV1, DeploymentStatus,
+    EntitlementLimitsV1, FreeAnonymousTicketV1, FreeModeV1, OperationStartV1,
     PolicyRollbackGuardV1, PriceV1, PrivacyLeakageV1, ServiceOfferV1, ServicePolicyEpochFloorsV1,
     ServicePolicyV1, ServiceProtocolError, ServiceScopePolicyV1, ServiceScopeV1,
     StandardCashuMintManifestV1, TrustedCatalogResolutionV1, VerificationMode,
@@ -248,6 +248,9 @@ fn credential_binding(
         ),
         AuthScheme::ArcV1Experimental => (CredentialUnitV1::Auth, vec![0xa5; 99], vec![0xa6; 16]),
         AuthScheme::CashuEcashV1 => panic!("standard Cashu has no credential binding"),
+        AuthScheme::BitcoinPirCashuBatV2 => {
+            panic!("issuer-wide BAT V2 has no V1 provider-store credential binding")
+        }
     };
     let issuer_signing_key = SigningKey::from_bytes(&ISSUER_SIGNING_SEED);
     let binding = CredentialKeyBindingV1::sign(
@@ -506,6 +509,30 @@ fn expect_namespace(
         } => (*namespace, install_outcome),
         other => panic!("expected a durable namespace, got {other:?}"),
     }
+}
+
+#[test]
+fn issuer_wide_bat_v2_never_derives_a_provider_store_namespace() {
+    let path = TestPath::new();
+    let store = create_store(&path.database, 0x20);
+    let scope = scope(1);
+    let mut offer = bearer_offer(
+        &scope,
+        59,
+        AuthScheme::BitcoinPirCashuBatV1,
+        VerificationMode::SharedIssuerOnline,
+        1,
+    );
+    offer.authorization = AuthScheme::BitcoinPirCashuBatV2;
+    offer.key_id = vec![0x42; 32];
+    offer.credential_binding = None;
+
+    assert!(matches!(
+        install_offer(&store, scope, offer, 1),
+        Err(StoreError::InvalidInput(
+            "issuer-wide BAT V2 has no provider-store namespace"
+        ))
+    ));
 }
 
 #[test]

--- a/crates/protocol/service/src/bat_v2.rs
+++ b/crates/protocol/service/src/bat_v2.rs
@@ -1,0 +1,1080 @@
+//! Issuer-wide BitcoinPIR Cashu BAT acceptance classes.
+//!
+//! A class identifier is allocated before providers sign policies that refer
+//! to it. The issuer then signs the exact, canonical set of policy members and
+//! one raw BAT verification key epoch. This ordering avoids a digest cycle
+//! between provider policy signatures and the issuer class signature.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+use crate::codec::{put_bytes_u16, Decoder};
+use crate::{
+    derive_issuer_id, is_canonical_service_https_origin_v1, AuthPaddingClassV1, AuthScheme,
+    BackendId, DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1, PriceV1, PrivacyLeakageV1,
+    ProviderId, ScopeId, ServiceProtocolError, ServiceScopeV1, VerifiedCurrentPolicyV1, WorkloadId,
+    MAX_BITCOIN_MSAT_V1, MAX_BOLT11_CLAIM_WINDOW_SECONDS_V1,
+    MAX_BOLT11_CREDENTIAL_VALIDITY_SECONDS_V1, MAX_BOLT11_INVOICE_EXPIRY_SECONDS_V1,
+    MAX_CREDENTIALS_PER_ACQUISITION_V1, MAX_ENDPOINT_LEN,
+};
+
+pub const BAT_ACCEPTANCE_CLASS_CODEC_MAGIC_V2: &[u8; 8] = b"BPIRBAT2";
+pub const BAT_ACCEPTANCE_CLASS_WIRE_VERSION_V2: u8 = 2;
+pub const BAT_ACCEPTANCE_CLASS_SIGNATURE_DOMAIN_V2: &[u8] =
+    b"BitcoinPIR/bat-acceptance-class-signature/v2";
+pub const BAT_ACCEPTANCE_CLASS_DIGEST_DOMAIN_V2: &[u8] =
+    b"BitcoinPIR/bat-acceptance-class-digest/v2";
+pub const BAT_ACCEPTANCE_TERMS_DIGEST_DOMAIN_V2: &[u8] =
+    b"BitcoinPIR/bat-acceptance-terms-digest/v2";
+pub const BAT_ACCEPTANCE_KEY_ID_DOMAIN_V2: &[u8] = b"BitcoinPIR/cashu-bat-acceptance-key-id/v2";
+pub const MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2: usize = 4_096;
+pub const MAX_BAT_ACCEPTANCE_TERMS_LEN_V2: usize = 2_048;
+pub const MAX_BAT_ACCEPTANCE_CLASS_LEN_V2: usize = 512 * 1024;
+
+pub type BatAcceptanceClassIdV2 = [u8; 32];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BatAcceptanceTermsV2 {
+    pub auth_padding_class: AuthPaddingClassV1,
+    pub backend: BackendId,
+    pub workload: WorkloadId,
+    pub protocol_version: u16,
+    pub dataset: DatasetBindingV1,
+    pub operation_profile: u16,
+    pub entitlement_profile: u16,
+    pub limits: EntitlementLimitsV1,
+    pub priority_class: u16,
+    pub deployment_status: DeploymentStatus,
+    pub price_msat: u64,
+    pub issuer_endpoint: String,
+    pub invoice_expiry_seconds: u32,
+    pub claim_window_seconds: u32,
+    pub minimum_credential_validity_seconds: u32,
+    pub retired_policy_grace_seconds: u32,
+    pub credential_count: u32,
+    pub credential_presentation_limit: u32,
+    pub privacy_leakage: PrivacyLeakageV1,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BatAcceptanceMemberV2 {
+    pub provider_id: ProviderId,
+    pub policy_digest: [u8; 32],
+    pub scope_id: ScopeId,
+    pub offer_id: u32,
+}
+
+/// Owned projection of one live, verified provider policy member. Issuer-store
+/// registration can retain this after the policy typestate borrow ends.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedBatAcceptanceMemberV2 {
+    pub issuer_id: [u8; 32],
+    pub class_id: BatAcceptanceClassIdV2,
+    pub member: BatAcceptanceMemberV2,
+    pub common_terms: BatAcceptanceTermsV2,
+    pub policy_issued_at: u64,
+    pub policy_expires_at: u64,
+    pub redemption_deadline: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BatAcceptanceClassV2 {
+    pub issuer_id: [u8; 32],
+    pub issuer_verifying_key: [u8; 32],
+    pub class_id: BatAcceptanceClassIdV2,
+    pub key_epoch: u64,
+    pub key_not_before: u64,
+    pub key_not_after: u64,
+    pub bat_verification_key: [u8; 33],
+    pub common_terms: BatAcceptanceTermsV2,
+    pub members: Vec<BatAcceptanceMemberV2>,
+    pub signature: [u8; 64],
+}
+
+pub fn validate_bat_acceptance_class_id_v2(
+    class_id: &BatAcceptanceClassIdV2,
+) -> Result<(), ServiceProtocolError> {
+    if class_id.iter().all(|byte| *byte == 0) {
+        Err(ServiceProtocolError::InvalidValue {
+            field: "BatAcceptanceClassV2.class_id",
+            reason: "preallocated class ID must be non-zero",
+        })
+    } else {
+        Ok(())
+    }
+}
+
+pub fn derive_bat_acceptance_key_id_v2(
+    issuer_id: &[u8; 32],
+    class_id: &BatAcceptanceClassIdV2,
+    key_epoch: u64,
+    bat_verification_key: &[u8; 33],
+) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(BAT_ACCEPTANCE_KEY_ID_DOMAIN_V2);
+    hasher.update(issuer_id);
+    hasher.update(class_id);
+    hasher.update(key_epoch.to_le_bytes());
+    hasher.update(bat_verification_key);
+    hasher.finalize().into()
+}
+
+pub fn bat_acceptance_member_from_verified_policy_v2(
+    verified: &VerifiedCurrentPolicyV1<'_>,
+    expected_scope_id: &ScopeId,
+    offer_id: u32,
+) -> Result<VerifiedBatAcceptanceMemberV2, ServiceProtocolError> {
+    let selected = verified.offer(expected_scope_id, offer_id)?;
+    let scope = selected.scope();
+    let offer = selected.offer();
+    if offer.authorization != AuthScheme::BitcoinPirCashuBatV2
+        || offer.acquisition != crate::AcquisitionMethod::Bolt11V1
+        || offer.verification != crate::VerificationMode::SharedIssuerOnline
+        || offer.credential_binding.is_some()
+        || offer.cashu_mint_manifest.is_some()
+        || offer.credential_presentation_limit != 1
+    {
+        return Err(ServiceProtocolError::InvalidValue {
+            field: "ServiceOfferV1.bat_v2_class_binding",
+            reason: "verified member is not an issuer-wide BAT V2 offer",
+        });
+    }
+    let class_id: BatAcceptanceClassIdV2 =
+        offer
+            .key_id
+            .as_slice()
+            .try_into()
+            .map_err(|_| ServiceProtocolError::InvalidValue {
+                field: "ServiceOfferV1.key_id",
+                reason: "BAT V2 class ID must be exactly 32 bytes",
+            })?;
+    validate_bat_acceptance_class_id_v2(&class_id)?;
+    let PriceV1::MilliSatoshi(price_msat) = &offer.price else {
+        return Err(ServiceProtocolError::InvalidValue {
+            field: "ServiceOfferV1.price",
+            reason: "BAT V2 uses a millisatoshi BOLT11 price",
+        });
+    };
+    let common_terms = BatAcceptanceTermsV2 {
+        auth_padding_class: verified.policy().auth_padding_class,
+        backend: scope.backend,
+        workload: scope.workload,
+        protocol_version: scope.protocol_version,
+        dataset: scope.dataset.clone(),
+        operation_profile: scope.operation_profile,
+        entitlement_profile: scope.entitlement_profile,
+        limits: selected.limits().clone(),
+        priority_class: offer.priority_class,
+        deployment_status: offer.deployment_status,
+        price_msat: *price_msat,
+        issuer_endpoint: offer.endpoint.clone(),
+        invoice_expiry_seconds: offer.invoice_expiry_seconds,
+        claim_window_seconds: offer.claim_window_seconds,
+        minimum_credential_validity_seconds: offer.minimum_credential_validity_seconds,
+        retired_policy_grace_seconds: offer.retired_policy_grace_seconds,
+        credential_count: offer.credential_count,
+        credential_presentation_limit: offer.credential_presentation_limit,
+        privacy_leakage: offer.privacy_leakage,
+    };
+    common_terms.validate()?;
+    Ok(VerifiedBatAcceptanceMemberV2 {
+        issuer_id: offer.issuer_id,
+        class_id,
+        member: BatAcceptanceMemberV2 {
+            provider_id: scope.provider_id,
+            policy_digest: verified.policy_digest(),
+            scope_id: *expected_scope_id,
+            offer_id,
+        },
+        common_terms,
+        policy_issued_at: verified.policy().issued_at,
+        policy_expires_at: verified.policy().expires_at,
+        redemption_deadline: selected.redemption_deadline(),
+    })
+}
+
+impl BatAcceptanceTermsV2 {
+    pub fn validate(&self) -> Result<(), ServiceProtocolError> {
+        ServiceScopeV1 {
+            provider_id: [1; 32],
+            backend: self.backend,
+            workload: self.workload,
+            protocol_version: self.protocol_version,
+            dataset: self.dataset.clone(),
+            operation_profile: self.operation_profile,
+            entitlement_profile: self.entitlement_profile,
+        }
+        .validate()?;
+        self.limits.validate()?;
+        if self.priority_class == 0 {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceTermsV2.priority_class",
+                reason: "must be non-zero",
+            });
+        }
+        if self.price_msat == 0 || self.price_msat > MAX_BITCOIN_MSAT_V1 {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceTermsV2.price_msat",
+                reason: "must be non-zero and within the Bitcoin supply bound",
+            });
+        }
+        if self.issuer_endpoint.len() > MAX_ENDPOINT_LEN
+            || !is_canonical_service_https_origin_v1(&self.issuer_endpoint)
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceTermsV2.issuer_endpoint",
+                reason: "must be a bounded canonical HTTPS origin",
+            });
+        }
+        if self.invoice_expiry_seconds == 0
+            || self.invoice_expiry_seconds > MAX_BOLT11_INVOICE_EXPIRY_SECONDS_V1
+            || self.claim_window_seconds == 0
+            || self.claim_window_seconds > MAX_BOLT11_CLAIM_WINDOW_SECONDS_V1
+            || self.minimum_credential_validity_seconds == 0
+            || self.minimum_credential_validity_seconds > MAX_BOLT11_CREDENTIAL_VALIDITY_SECONDS_V1
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceTermsV2.validity_windows",
+                reason: "BOLT11 and credential windows must be non-zero and within protocol caps",
+            });
+        }
+        let required_grace = self
+            .invoice_expiry_seconds
+            .checked_add(self.claim_window_seconds)
+            .and_then(|value| value.checked_add(self.minimum_credential_validity_seconds))
+            .ok_or(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceTermsV2.retired_policy_grace_seconds",
+                reason: "validity horizon overflow",
+            })?;
+        if self.retired_policy_grace_seconds < required_grace {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceTermsV2.retired_policy_grace_seconds",
+                reason: "must cover invoice, claim, and credential horizons",
+            });
+        }
+        if self.credential_count == 0
+            || self.credential_count > MAX_CREDENTIALS_PER_ACQUISITION_V1
+            || self.credential_presentation_limit != 1
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceTermsV2.credential_shape",
+                reason: "credential count must be bounded and each BAT is single-presentation",
+            });
+        }
+        let required_privacy = PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+            | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+            | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER;
+        if !self.privacy_leakage.contains_all(required_privacy) {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceTermsV2.privacy_leakage",
+                reason: "flags understate issuer-wide BAT V2 leakage",
+            });
+        }
+        Ok(())
+    }
+
+    pub fn terms_digest(&self) -> Result<[u8; 32], ServiceProtocolError> {
+        let mut hasher = Sha256::new();
+        hasher.update(BAT_ACCEPTANCE_TERMS_DIGEST_DOMAIN_V2);
+        hasher.update(self.encode()?);
+        Ok(hasher.finalize().into())
+    }
+
+    fn encode(&self) -> Result<Vec<u8>, ServiceProtocolError> {
+        self.validate()?;
+        let mut out = Vec::with_capacity(160 + self.issuer_endpoint.len());
+        out.push(self.auth_padding_class as u8);
+        out.push(self.backend as u8);
+        out.push(self.workload as u8);
+        out.extend_from_slice(&self.protocol_version.to_le_bytes());
+        self.dataset.encode_into(&mut out);
+        out.extend_from_slice(&self.operation_profile.to_le_bytes());
+        out.extend_from_slice(&self.entitlement_profile.to_le_bytes());
+        self.limits.encode_into(&mut out)?;
+        out.extend_from_slice(&self.priority_class.to_le_bytes());
+        out.push(self.deployment_status as u8);
+        out.extend_from_slice(&self.price_msat.to_le_bytes());
+        put_bytes_u16(&mut out, self.issuer_endpoint.as_bytes());
+        out.extend_from_slice(&self.invoice_expiry_seconds.to_le_bytes());
+        out.extend_from_slice(&self.claim_window_seconds.to_le_bytes());
+        out.extend_from_slice(&self.minimum_credential_validity_seconds.to_le_bytes());
+        out.extend_from_slice(&self.retired_policy_grace_seconds.to_le_bytes());
+        out.extend_from_slice(&self.credential_count.to_le_bytes());
+        out.extend_from_slice(&self.credential_presentation_limit.to_le_bytes());
+        out.extend_from_slice(&self.privacy_leakage.bits().to_le_bytes());
+        if out.len() > MAX_BAT_ACCEPTANCE_TERMS_LEN_V2 {
+            return Err(ServiceProtocolError::FieldTooLong {
+                field: "BatAcceptanceTermsV2",
+                len: out.len(),
+                max: MAX_BAT_ACCEPTANCE_TERMS_LEN_V2,
+            });
+        }
+        Ok(out)
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, ServiceProtocolError> {
+        if bytes.len() > MAX_BAT_ACCEPTANCE_TERMS_LEN_V2 {
+            return Err(ServiceProtocolError::FieldTooLong {
+                field: "BatAcceptanceTermsV2",
+                len: bytes.len(),
+                max: MAX_BAT_ACCEPTANCE_TERMS_LEN_V2,
+            });
+        }
+        let mut decoder = Decoder::new(bytes);
+        let value = Self {
+            auth_padding_class: AuthPaddingClassV1::decode(
+                decoder.u8("BatAcceptanceTermsV2.auth_padding_class")?,
+            )?,
+            backend: BackendId::decode(decoder.u8("BatAcceptanceTermsV2.backend")?)?,
+            workload: WorkloadId::decode(decoder.u8("BatAcceptanceTermsV2.workload")?)?,
+            protocol_version: decoder.u16("BatAcceptanceTermsV2.protocol_version")?,
+            dataset: DatasetBindingV1::decode_from(&mut decoder)?,
+            operation_profile: decoder.u16("BatAcceptanceTermsV2.operation_profile")?,
+            entitlement_profile: decoder.u16("BatAcceptanceTermsV2.entitlement_profile")?,
+            limits: EntitlementLimitsV1::decode_from(&mut decoder)?,
+            priority_class: decoder.u16("BatAcceptanceTermsV2.priority_class")?,
+            deployment_status: DeploymentStatus::decode(
+                decoder.u8("BatAcceptanceTermsV2.deployment_status")?,
+            )?,
+            price_msat: decoder.u64("BatAcceptanceTermsV2.price_msat")?,
+            issuer_endpoint: decoder
+                .string_u16("BatAcceptanceTermsV2.issuer_endpoint", MAX_ENDPOINT_LEN)?,
+            invoice_expiry_seconds: decoder.u32("BatAcceptanceTermsV2.invoice_expiry_seconds")?,
+            claim_window_seconds: decoder.u32("BatAcceptanceTermsV2.claim_window_seconds")?,
+            minimum_credential_validity_seconds: decoder
+                .u32("BatAcceptanceTermsV2.minimum_credential_validity_seconds")?,
+            retired_policy_grace_seconds: decoder
+                .u32("BatAcceptanceTermsV2.retired_policy_grace_seconds")?,
+            credential_count: decoder.u32("BatAcceptanceTermsV2.credential_count")?,
+            credential_presentation_limit: decoder
+                .u32("BatAcceptanceTermsV2.credential_presentation_limit")?,
+            privacy_leakage: PrivacyLeakageV1::from_bits(
+                decoder.u16("BatAcceptanceTermsV2.privacy_leakage")?,
+            )?,
+        };
+        decoder.finish()?;
+        value.validate()?;
+        Ok(value)
+    }
+}
+
+impl BatAcceptanceClassV2 {
+    #[allow(clippy::too_many_arguments)]
+    pub fn sign(
+        class_id: BatAcceptanceClassIdV2,
+        key_epoch: u64,
+        key_not_before: u64,
+        key_not_after: u64,
+        bat_verification_key: [u8; 33],
+        common_terms: BatAcceptanceTermsV2,
+        members: Vec<BatAcceptanceMemberV2>,
+        issuer_signing_key: &SigningKey,
+    ) -> Result<Self, ServiceProtocolError> {
+        let issuer_verifying_key = issuer_signing_key.verifying_key().to_bytes();
+        let mut value = Self {
+            issuer_id: derive_issuer_id(&issuer_verifying_key),
+            issuer_verifying_key,
+            class_id,
+            key_epoch,
+            key_not_before,
+            key_not_after,
+            bat_verification_key,
+            common_terms,
+            members,
+            signature: [0; 64],
+        };
+        value.validate()?;
+        value.signature = issuer_signing_key
+            .sign(&value.signing_preimage()?)
+            .to_bytes();
+        Ok(value)
+    }
+
+    pub fn verify(&self) -> Result<(), ServiceProtocolError> {
+        self.validate()?;
+        let verifying_key = VerifyingKey::from_bytes(&self.issuer_verifying_key)
+            .map_err(|_| ServiceProtocolError::BadPublicKey)?;
+        verifying_key
+            .verify_strict(
+                &self.signing_preimage()?,
+                &Signature::from_bytes(&self.signature),
+            )
+            .map_err(|_| ServiceProtocolError::BadSignature)
+    }
+
+    pub fn verify_for(
+        &self,
+        expected_issuer_id: &[u8; 32],
+        expected_class_id: &BatAcceptanceClassIdV2,
+    ) -> Result<(), ServiceProtocolError> {
+        self.verify()?;
+        if &self.issuer_id != expected_issuer_id || &self.class_id != expected_class_id {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceClassV2.identity",
+                reason: "issuer or preallocated class ID does not match",
+            });
+        }
+        Ok(())
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, ServiceProtocolError> {
+        let mut out = self.encode_unsigned()?;
+        out.extend_from_slice(&self.signature);
+        if out.len() > MAX_BAT_ACCEPTANCE_CLASS_LEN_V2 {
+            return Err(ServiceProtocolError::FieldTooLong {
+                field: "BatAcceptanceClassV2",
+                len: out.len(),
+                max: MAX_BAT_ACCEPTANCE_CLASS_LEN_V2,
+            });
+        }
+        Ok(out)
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, ServiceProtocolError> {
+        if bytes.len() > MAX_BAT_ACCEPTANCE_CLASS_LEN_V2 {
+            return Err(ServiceProtocolError::FieldTooLong {
+                field: "BatAcceptanceClassV2",
+                len: bytes.len(),
+                max: MAX_BAT_ACCEPTANCE_CLASS_LEN_V2,
+            });
+        }
+        let mut decoder = Decoder::new(bytes);
+        let magic: [u8; 8] = decoder.fixed("BatAcceptanceClassV2.magic")?;
+        if &magic != BAT_ACCEPTANCE_CLASS_CODEC_MAGIC_V2 {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceClassV2.magic",
+                reason: "wrong BAT acceptance-class codec domain",
+            });
+        }
+        let version = decoder.u8("BatAcceptanceClassV2.version")?;
+        if version != BAT_ACCEPTANCE_CLASS_WIRE_VERSION_V2 {
+            return Err(ServiceProtocolError::UnknownVersion {
+                kind: "BatAcceptanceClassV2",
+                version,
+            });
+        }
+        let issuer_id = decoder.fixed("BatAcceptanceClassV2.issuer_id")?;
+        let issuer_verifying_key = decoder.fixed("BatAcceptanceClassV2.issuer_verifying_key")?;
+        let class_id = decoder.fixed("BatAcceptanceClassV2.class_id")?;
+        let key_epoch = decoder.u64("BatAcceptanceClassV2.key_epoch")?;
+        let key_not_before = decoder.u64("BatAcceptanceClassV2.key_not_before")?;
+        let key_not_after = decoder.u64("BatAcceptanceClassV2.key_not_after")?;
+        let bat_verification_key = decoder.fixed("BatAcceptanceClassV2.bat_verification_key")?;
+        let common_terms = BatAcceptanceTermsV2::decode(&decoder.bytes_u16(
+            "BatAcceptanceClassV2.common_terms",
+            MAX_BAT_ACCEPTANCE_TERMS_LEN_V2,
+        )?)?;
+        let member_count = decoder.u32("BatAcceptanceClassV2.member_count")? as usize;
+        if member_count > MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2 {
+            return Err(ServiceProtocolError::TooManyItems {
+                field: "BatAcceptanceClassV2.members",
+                len: member_count,
+                max: MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2,
+            });
+        }
+        let mut members = Vec::with_capacity(member_count);
+        for _ in 0..member_count {
+            members.push(BatAcceptanceMemberV2 {
+                provider_id: decoder.fixed("BatAcceptanceMemberV2.provider_id")?,
+                policy_digest: decoder.fixed("BatAcceptanceMemberV2.policy_digest")?,
+                scope_id: decoder.fixed("BatAcceptanceMemberV2.scope_id")?,
+                offer_id: decoder.u32("BatAcceptanceMemberV2.offer_id")?,
+            });
+        }
+        let signature = decoder.fixed("BatAcceptanceClassV2.signature")?;
+        decoder.finish()?;
+        let value = Self {
+            issuer_id,
+            issuer_verifying_key,
+            class_id,
+            key_epoch,
+            key_not_before,
+            key_not_after,
+            bat_verification_key,
+            common_terms,
+            members,
+            signature,
+        };
+        value.validate()?;
+        Ok(value)
+    }
+
+    pub fn class_digest(&self) -> Result<[u8; 32], ServiceProtocolError> {
+        let mut hasher = Sha256::new();
+        hasher.update(BAT_ACCEPTANCE_CLASS_DIGEST_DOMAIN_V2);
+        hasher.update(self.encode()?);
+        Ok(hasher.finalize().into())
+    }
+
+    pub fn bat_key_id(&self) -> [u8; 32] {
+        derive_bat_acceptance_key_id_v2(
+            &self.issuer_id,
+            &self.class_id,
+            self.key_epoch,
+            &self.bat_verification_key,
+        )
+    }
+
+    pub fn validate(&self) -> Result<(), ServiceProtocolError> {
+        validate_bat_acceptance_class_id_v2(&self.class_id)?;
+        if self.issuer_id != derive_issuer_id(&self.issuer_verifying_key) {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceClassV2.issuer_id",
+                reason: "does not derive from the embedded issuer verifying key",
+            });
+        }
+        VerifyingKey::from_bytes(&self.issuer_verifying_key)
+            .map_err(|_| ServiceProtocolError::BadPublicKey)?;
+        if self.key_epoch == 0 {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceClassV2.key_epoch",
+                reason: "must be non-zero",
+            });
+        }
+        if self.key_not_before > self.key_not_after {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceClassV2.key_validity",
+                reason: "not_before is after not_after",
+            });
+        }
+        if !crate::cashu_manifest::is_valid_compressed_point(&self.bat_verification_key) {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceClassV2.bat_verification_key",
+                reason: "must be a compressed secp256k1 point",
+            });
+        }
+        self.common_terms.validate()?;
+        if self.members.is_empty() || self.members.len() > MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2 {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceClassV2.members",
+                reason: "member list must be non-empty and bounded",
+            });
+        }
+        let mut previous: Option<&BatAcceptanceMemberV2> = None;
+        for member in &self.members {
+            if member.provider_id.iter().all(|byte| *byte == 0)
+                || member.policy_digest.iter().all(|byte| *byte == 0)
+                || member.scope_id.iter().all(|byte| *byte == 0)
+                || member.offer_id == 0
+            {
+                return Err(ServiceProtocolError::InvalidValue {
+                    field: "BatAcceptanceClassV2.members",
+                    reason: "member identifiers and policy digest must be non-zero",
+                });
+            }
+            if previous.is_some_and(|prior| prior >= member) {
+                return Err(ServiceProtocolError::InvalidValue {
+                    field: "BatAcceptanceClassV2.members",
+                    reason: "members must be strictly canonical-sorted without duplicates",
+                });
+            }
+            previous = Some(member);
+        }
+        Ok(())
+    }
+
+    fn signing_preimage(&self) -> Result<Vec<u8>, ServiceProtocolError> {
+        let unsigned = self.encode_unsigned()?;
+        let mut preimage =
+            Vec::with_capacity(BAT_ACCEPTANCE_CLASS_SIGNATURE_DOMAIN_V2.len() + unsigned.len());
+        preimage.extend_from_slice(BAT_ACCEPTANCE_CLASS_SIGNATURE_DOMAIN_V2);
+        preimage.extend_from_slice(&unsigned);
+        Ok(preimage)
+    }
+
+    fn encode_unsigned(&self) -> Result<Vec<u8>, ServiceProtocolError> {
+        self.validate()?;
+        let terms = self.common_terms.encode()?;
+        let mut out = Vec::with_capacity(256 + terms.len() + self.members.len() * 100);
+        out.extend_from_slice(BAT_ACCEPTANCE_CLASS_CODEC_MAGIC_V2);
+        out.push(BAT_ACCEPTANCE_CLASS_WIRE_VERSION_V2);
+        out.extend_from_slice(&self.issuer_id);
+        out.extend_from_slice(&self.issuer_verifying_key);
+        out.extend_from_slice(&self.class_id);
+        out.extend_from_slice(&self.key_epoch.to_le_bytes());
+        out.extend_from_slice(&self.key_not_before.to_le_bytes());
+        out.extend_from_slice(&self.key_not_after.to_le_bytes());
+        out.extend_from_slice(&self.bat_verification_key);
+        put_bytes_u16(&mut out, &terms);
+        out.extend_from_slice(&(self.members.len() as u32).to_le_bytes());
+        for member in &self.members {
+            out.extend_from_slice(&member.provider_id);
+            out.extend_from_slice(&member.policy_digest);
+            out.extend_from_slice(&member.scope_id);
+            out.extend_from_slice(&member.offer_id.to_le_bytes());
+        }
+        if out.len() + 64 > MAX_BAT_ACCEPTANCE_CLASS_LEN_V2 {
+            return Err(ServiceProtocolError::FieldTooLong {
+                field: "BatAcceptanceClassV2",
+                len: out.len() + 64,
+                max: MAX_BAT_ACCEPTANCE_CLASS_LEN_V2,
+            });
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        derive_bat_key_id_v1, AcquisitionMethod, CredentialKeyBindingClaimsV1,
+        CredentialKeyBindingV1, CredentialUnitV1, FreeModeV1, PolicyRollbackGuardV1,
+        ServiceOfferV1, ServicePolicyEpochFloorsV1, ServicePolicyV1, ServiceScopePolicyV1,
+        VerificationMode,
+    };
+    use k256::elliptic_curve::sec1::ToEncodedPoint;
+    use k256::{ProjectivePoint, Scalar};
+
+    fn point(multiplier: u64) -> [u8; 33] {
+        (ProjectivePoint::GENERATOR * Scalar::from(multiplier))
+            .to_affine()
+            .to_encoded_point(true)
+            .as_bytes()
+            .try_into()
+            .unwrap()
+    }
+
+    fn limits() -> EntitlementLimitsV1 {
+        EntitlementLimitsV1 {
+            max_logical_inputs: 4,
+            max_frames: 200,
+            max_request_bytes: 1_000_000,
+            max_response_bytes: 2_000_000,
+            max_wall_time_ms: 60_000,
+            max_concurrent_sockets: 1,
+            max_hint_groups: 0,
+            max_work_units: 9_000,
+        }
+    }
+
+    fn scope(provider_id: ProviderId) -> ServiceScopeV1 {
+        ServiceScopeV1 {
+            provider_id,
+            backend: BackendId::DpfPirV1,
+            workload: WorkloadId::DpfEvaluateJobV1,
+            protocol_version: 1,
+            dataset: DatasetBindingV1::Class { class_id: 1 },
+            operation_profile: 1,
+            entitlement_profile: 2,
+        }
+    }
+
+    fn v2_offer(_provider_scope: &ServiceScopeV1) -> ServiceOfferV1 {
+        let issuer_key = SigningKey::from_bytes(&[8; 32]);
+        ServiceOfferV1 {
+            offer_id: 7,
+            acquisition: AcquisitionMethod::Bolt11V1,
+            free_mode: FreeModeV1::NotFree,
+            free_quota: 0,
+            free_window_seconds: 0,
+            free_pow_difficulty_bits: 0,
+            priority_class: 1,
+            authorization: AuthScheme::BitcoinPirCashuBatV2,
+            verification: VerificationMode::SharedIssuerOnline,
+            deployment_status: DeploymentStatus::Stable,
+            price: PriceV1::MilliSatoshi(2_000),
+            issuer_id: derive_issuer_id(&issuer_key.verifying_key().to_bytes()),
+            key_id: vec![0x42; 32],
+            credential_binding: None,
+            cashu_mint_manifest: None,
+            endpoint: "https://issuer.invalid".into(),
+            invoice_expiry_seconds: 60,
+            claim_window_seconds: 120,
+            minimum_credential_validity_seconds: 300,
+            retired_policy_grace_seconds: 480,
+            credential_count: 2,
+            credential_presentation_limit: 1,
+            privacy_leakage: PrivacyLeakageV1::from_bits(
+                PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                    | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                    | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+            )
+            .unwrap(),
+        }
+    }
+
+    fn sign_policy_with_offer(
+        provider_scope: ServiceScopeV1,
+        offer: ServiceOfferV1,
+    ) -> Result<ServicePolicyV1, ServiceProtocolError> {
+        ServicePolicyV1::sign(
+            provider_scope.provider_id,
+            8,
+            100,
+            1_000,
+            AuthPaddingClassV1::Class16KiB,
+            vec![ServiceScopePolicyV1 {
+                scope: provider_scope,
+                limits: limits(),
+                offers: vec![offer],
+            }],
+            &SigningKey::from_bytes(&[3; 32]),
+        )
+    }
+
+    fn terms() -> BatAcceptanceTermsV2 {
+        let provider_scope = scope([9; 32]);
+        let offer = v2_offer(&provider_scope);
+        BatAcceptanceTermsV2 {
+            auth_padding_class: AuthPaddingClassV1::Class16KiB,
+            backend: provider_scope.backend,
+            workload: provider_scope.workload,
+            protocol_version: provider_scope.protocol_version,
+            dataset: provider_scope.dataset,
+            operation_profile: provider_scope.operation_profile,
+            entitlement_profile: provider_scope.entitlement_profile,
+            limits: limits(),
+            priority_class: offer.priority_class,
+            deployment_status: offer.deployment_status,
+            price_msat: 2_000,
+            issuer_endpoint: offer.endpoint,
+            invoice_expiry_seconds: offer.invoice_expiry_seconds,
+            claim_window_seconds: offer.claim_window_seconds,
+            minimum_credential_validity_seconds: offer.minimum_credential_validity_seconds,
+            retired_policy_grace_seconds: offer.retired_policy_grace_seconds,
+            credential_count: offer.credential_count,
+            credential_presentation_limit: offer.credential_presentation_limit,
+            privacy_leakage: offer.privacy_leakage,
+        }
+    }
+
+    fn members() -> Vec<BatAcceptanceMemberV2> {
+        vec![
+            BatAcceptanceMemberV2 {
+                provider_id: [2; 32],
+                policy_digest: [3; 32],
+                scope_id: [4; 32],
+                offer_id: 5,
+            },
+            BatAcceptanceMemberV2 {
+                provider_id: [6; 32],
+                policy_digest: [7; 32],
+                scope_id: [8; 32],
+                offer_id: 9,
+            },
+        ]
+    }
+
+    fn signed_class() -> BatAcceptanceClassV2 {
+        BatAcceptanceClassV2::sign(
+            [0x42; 32],
+            3,
+            100,
+            2_000,
+            point(11),
+            terms(),
+            members(),
+            &SigningKey::from_bytes(&[8; 32]),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn bat_v2_class_codec_signature_digest_and_key_id() {
+        let value = signed_class();
+        value.verify().unwrap();
+        value.verify_for(&value.issuer_id, &value.class_id).unwrap();
+        let encoded = value.encode().unwrap();
+        let decoded = BatAcceptanceClassV2::decode(&encoded).unwrap();
+        assert_eq!(decoded, value);
+        decoded.verify().unwrap();
+        assert_eq!(
+            decoded.class_digest().unwrap(),
+            value.class_digest().unwrap()
+        );
+        assert_eq!(
+            decoded.bat_key_id(),
+            derive_bat_acceptance_key_id_v2(
+                &decoded.issuer_id,
+                &decoded.class_id,
+                decoded.key_epoch,
+                &decoded.bat_verification_key,
+            )
+        );
+        assert_ne!(decoded.bat_key_id(), [0; 32]);
+        assert_ne!(decoded.common_terms.terms_digest().unwrap(), [0; 32]);
+
+        let mut excessive_members = encoded;
+        let terms_len_offset = 8 + 1 + 32 + 32 + 32 + (8 * 3) + 33;
+        let terms_len = u16::from_le_bytes(
+            excessive_members[terms_len_offset..terms_len_offset + 2]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let member_count_offset = terms_len_offset + 2 + terms_len;
+        excessive_members[member_count_offset..member_count_offset + 4]
+            .copy_from_slice(&u32::MAX.to_le_bytes());
+        assert!(matches!(
+            BatAcceptanceClassV2::decode(&excessive_members),
+            Err(ServiceProtocolError::TooManyItems {
+                field: "BatAcceptanceClassV2.members",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn bat_v2_rejects_noncanonical_members_and_tampering() {
+        let mut unsorted = members();
+        unsorted.reverse();
+        assert!(BatAcceptanceClassV2::sign(
+            [0x42; 32],
+            3,
+            100,
+            2_000,
+            point(11),
+            terms(),
+            unsorted,
+            &SigningKey::from_bytes(&[8; 32]),
+        )
+        .is_err());
+
+        let mut duplicate = members();
+        duplicate.push(duplicate[1].clone());
+        assert!(BatAcceptanceClassV2::sign(
+            [0x42; 32],
+            3,
+            100,
+            2_000,
+            point(11),
+            terms(),
+            duplicate,
+            &SigningKey::from_bytes(&[8; 32]),
+        )
+        .is_err());
+
+        let mut tampered = signed_class();
+        tampered.common_terms.price_msat += 1;
+        assert_eq!(tampered.verify(), Err(ServiceProtocolError::BadSignature));
+
+        let mut wrong_identity = signed_class();
+        wrong_identity.issuer_id[0] ^= 1;
+        assert!(matches!(
+            wrong_identity.verify(),
+            Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceClassV2.issuer_id",
+                ..
+            })
+        ));
+
+        assert!(BatAcceptanceClassV2::sign(
+            [0; 32],
+            3,
+            100,
+            2_000,
+            point(11),
+            terms(),
+            members(),
+            &SigningKey::from_bytes(&[8; 32]),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn bat_v2_offer_and_verified_member_projection_are_exact() {
+        let provider_scope = scope([9; 32]);
+        let scope_id = provider_scope.scope_id();
+        let policy =
+            sign_policy_with_offer(provider_scope.clone(), v2_offer(&provider_scope)).unwrap();
+        let provider_key = SigningKey::from_bytes(&[3; 32]);
+        let verified = policy
+            .verify_current_for_acquisition(
+                &provider_scope.provider_id,
+                150,
+                &PolicyRollbackGuardV1::initial(),
+                &ServicePolicyEpochFloorsV1::initial(),
+                &provider_key.verifying_key(),
+            )
+            .unwrap();
+        let projected =
+            bat_acceptance_member_from_verified_policy_v2(&verified, &scope_id, 7).unwrap();
+        assert_eq!(projected.issuer_id, policy.scopes[0].offers[0].issuer_id);
+        assert_eq!(projected.class_id, [0x42; 32]);
+        assert_eq!(projected.member.provider_id, [9; 32]);
+        assert_eq!(
+            projected.member.policy_digest,
+            policy.policy_digest().unwrap()
+        );
+        assert_eq!(projected.member.scope_id, scope_id);
+        assert_eq!(projected.member.offer_id, 7);
+        assert_eq!(projected.common_terms, terms());
+        assert_eq!(projected.policy_issued_at, 100);
+        assert_eq!(projected.policy_expires_at, 1_000);
+        assert_eq!(projected.redemption_deadline, 1_480);
+    }
+
+    #[test]
+    fn bat_v2_offer_rejects_v1_delegation_and_wrong_shape() {
+        let provider_scope = scope([9; 32]);
+
+        let mut wrong_verification = v2_offer(&provider_scope);
+        wrong_verification.verification = VerificationMode::ProviderLocal;
+        assert!(sign_policy_with_offer(provider_scope.clone(), wrong_verification).is_err());
+
+        let mut wrong_class_id = v2_offer(&provider_scope);
+        wrong_class_id.key_id.pop();
+        assert!(sign_policy_with_offer(provider_scope.clone(), wrong_class_id).is_err());
+
+        let mut multi_presentation = v2_offer(&provider_scope);
+        multi_presentation.credential_presentation_limit = 2;
+        assert!(sign_policy_with_offer(provider_scope.clone(), multi_presentation).is_err());
+
+        let v1_key = point(11);
+        let v1_key_id = derive_bat_key_id_v1(
+            &provider_scope.provider_id,
+            &provider_scope.scope_id(),
+            7,
+            provider_scope.entitlement_profile,
+            1,
+            &v1_key,
+        );
+        let v1_binding = CredentialKeyBindingV1::sign(
+            CredentialKeyBindingClaimsV1 {
+                provider_id: provider_scope.provider_id,
+                scope_id: provider_scope.scope_id(),
+                offer_id: 7,
+                scheme: AuthScheme::BitcoinPirCashuBatV1,
+                keyset_epoch: 1,
+                entitlement_profile: provider_scope.entitlement_profile,
+                unit: CredentialUnitV1::Auth,
+                amount: 1,
+                presentation_limit: 1,
+                not_before: 50,
+                not_after: 1_480,
+                credential_key_id: v1_key_id.to_vec(),
+                verification_key: v1_key.to_vec(),
+            },
+            &SigningKey::from_bytes(&[8; 32]),
+        )
+        .unwrap();
+        let mut v1_delegated = v2_offer(&provider_scope);
+        v1_delegated.credential_binding = Some(v1_binding);
+        assert!(sign_policy_with_offer(provider_scope, v1_delegated).is_err());
+
+        let rejected_v2_binding = CredentialKeyBindingV1::sign(
+            CredentialKeyBindingClaimsV1 {
+                provider_id: [9; 32],
+                scope_id: [10; 32],
+                offer_id: 7,
+                scheme: AuthScheme::BitcoinPirCashuBatV2,
+                keyset_epoch: 1,
+                entitlement_profile: 2,
+                unit: CredentialUnitV1::Auth,
+                amount: 1,
+                presentation_limit: 1,
+                not_before: 50,
+                not_after: 1_480,
+                credential_key_id: vec![0x42; 32],
+                verification_key: point(11).to_vec(),
+            },
+            &SigningKey::from_bytes(&[8; 32]),
+        );
+        assert!(matches!(
+            rejected_v2_binding,
+            Err(ServiceProtocolError::InvalidValue {
+                field: "CredentialKeyBindingV1.scheme",
+                ..
+            })
+        ));
+    }
+
+    fn v1_golden_policy() -> ServicePolicyV1 {
+        let provider_scope = scope([9; 32]);
+        let verification_key = point(11);
+        let credential_key_id = derive_bat_key_id_v1(
+            &provider_scope.provider_id,
+            &provider_scope.scope_id(),
+            7,
+            provider_scope.entitlement_profile,
+            1,
+            &verification_key,
+        )
+        .to_vec();
+        let binding = CredentialKeyBindingV1::sign(
+            CredentialKeyBindingClaimsV1 {
+                provider_id: provider_scope.provider_id,
+                scope_id: provider_scope.scope_id(),
+                offer_id: 7,
+                scheme: AuthScheme::BitcoinPirCashuBatV1,
+                keyset_epoch: 1,
+                entitlement_profile: provider_scope.entitlement_profile,
+                unit: CredentialUnitV1::Auth,
+                amount: 1,
+                presentation_limit: 1,
+                not_before: 50,
+                not_after: 173_600,
+                credential_key_id: credential_key_id.clone(),
+                verification_key: verification_key.to_vec(),
+            },
+            &SigningKey::from_bytes(&[8; 32]),
+        )
+        .unwrap();
+        let offer = ServiceOfferV1 {
+            offer_id: 7,
+            acquisition: AcquisitionMethod::Bolt11V1,
+            free_mode: FreeModeV1::NotFree,
+            free_quota: 0,
+            free_window_seconds: 0,
+            free_pow_difficulty_bits: 0,
+            priority_class: 1,
+            authorization: AuthScheme::BitcoinPirCashuBatV1,
+            verification: VerificationMode::SharedIssuerOnline,
+            deployment_status: DeploymentStatus::Stable,
+            price: PriceV1::MilliSatoshi(2_000),
+            issuer_id: binding.issuer_id,
+            key_id: credential_key_id,
+            credential_binding: Some(binding),
+            cashu_mint_manifest: None,
+            endpoint: "https://issuer.invalid".into(),
+            invoice_expiry_seconds: 600,
+            claim_window_seconds: 86_400,
+            minimum_credential_validity_seconds: 86_400,
+            retired_policy_grace_seconds: 173_400,
+            credential_count: 10,
+            credential_presentation_limit: 1,
+            privacy_leakage: PrivacyLeakageV1::from_bits(
+                PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                    | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                    | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+            )
+            .unwrap(),
+        };
+        ServicePolicyV1::sign(
+            provider_scope.provider_id,
+            8,
+            100,
+            200,
+            AuthPaddingClassV1::Class16KiB,
+            vec![ServiceScopePolicyV1 {
+                scope: provider_scope,
+                limits: limits(),
+                offers: vec![offer],
+            }],
+            &SigningKey::from_bytes(&[3; 32]),
+        )
+        .unwrap()
+    }
+
+    fn hex_lower(bytes: &[u8]) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut encoded = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            encoded.push(HEX[(byte >> 4) as usize] as char);
+            encoded.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+        encoded
+    }
+
+    #[test]
+    fn bat_v2_v1_signed_policy_bytes_and_digest_golden() {
+        const EXPECTED_POLICY_HEX: &str = "01090909090909090909090909090909090909090909090909090909090909090908000000000000006400000000000000c80000000000000001012c0001090909090909090909090909090909090909090909090909090909090909090901010100010100010002000400c800000040420f000000000080841e000000000060ea0000010000282300000000000001c501070000000200000000000000000000010004020102d0070000000000003aab74cb18daa3a6c0f76b81213f9e3f80aa19b5a39dcfda63b2832f9906fb7a20159ce3e88cead7043d67c1392dba945e7d3733735a66e8cc364191bd61ebeff6013101013aab74cb18daa3a6c0f76b81213f9e3f80aa19b5a39dcfda63b2832f9906fb7a1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca0909090909090909090909090909090909090909090909090909090909090909a7a70edebede938c46c4e867a8850308401981d5035dfc04ab8dbcb27f0e02a707000000040100000000000000020002010000000000000001000000320000000000000020a602000000000020159ce3e88cead7043d67c1392dba945e7d3733735a66e8cc364191bd61ebeff6210003774ae7f858a9411e5ef4246b70c65aac5649980be5c17891bbec17895da008cb1d7dbd76a08307b7d95b7fd7196e87d39c76165e1089f7b1c3dbcafd86457fb41dab56dc96293bfaea8db36481c5f76c18a18d4bbd51bebbe39ba87adc3dd00500160068747470733a2f2f6973737565722e696e76616c696458020000805101008051010058a502000a000000010000001c00d9b115c08cdf9b332b91ca2b6a951913ccdf7a90a968e681cf54e717aff0bc9bdf9c12fb9dedcc1fe535452602a5ade2de38a29b262cd62ad932cffdc1394fbff84ceb729fe2b39b8789f8846418300e";
+        const EXPECTED_DIGEST_HEX: &str =
+            "b14880fc4fedc792914693a4eb36f00a789c4b18b849cffec0539044a54ff54d";
+        let policy = v1_golden_policy();
+        let encoded = policy.encode().unwrap();
+        let digest = policy.policy_digest().unwrap();
+        assert_eq!(hex_lower(&encoded), EXPECTED_POLICY_HEX);
+        assert_eq!(hex_lower(&digest), EXPECTED_DIGEST_HEX);
+    }
+}

--- a/crates/protocol/service/src/binding.rs
+++ b/crates/protocol/service/src/binding.rs
@@ -312,6 +312,13 @@ impl CredentialKeyBindingV1 {
             }
             AuthScheme::BitcoinPirCashuBatV1 => (CredentialUnitV1::Auth, 33usize, true),
             AuthScheme::ArcV1Experimental => (CredentialUnitV1::Auth, 99usize, false),
+            AuthScheme::BitcoinPirCashuBatV2 => {
+                return Err(ServiceProtocolError::InvalidValue {
+                    field: "CredentialKeyBindingV1.scheme",
+                    reason:
+                        "BAT V2 uses an issuer-wide acceptance class, not a V1 provider binding",
+                })
+            }
             AuthScheme::CashuEcashV1 => {
                 return Err(ServiceProtocolError::InvalidValue {
                     field: "CredentialKeyBindingV1.scheme",

--- a/crates/protocol/service/src/issuance.rs
+++ b/crates/protocol/service/src/issuance.rs
@@ -405,10 +405,12 @@ impl CredentialIssuanceRequestV1 {
                 }
                 CredentialIssuanceRequestItemsV1::ArcExperimental(values)
             }
-            AuthScheme::FreeV1 | AuthScheme::CashuEcashV1 => {
+            AuthScheme::FreeV1
+            | AuthScheme::CashuEcashV1
+            | AuthScheme::BitcoinPirCashuBatV2 => {
                 return Err(ServiceProtocolError::InvalidValue {
                     field: "CredentialIssuanceRequestV1.authorization",
-                    reason: "custom BOLT11 claims support only direct receipt, BAT, or experimental ARC; standard Cashu uses NUT-04",
+                    reason: "the V1 issuance envelope supports only direct receipt, provider-bound BAT V1, or experimental ARC",
                 })
             }
         };
@@ -734,10 +736,12 @@ impl CredentialIssuanceResponseV1 {
                 }
                 CredentialIssuanceResponseItemsV1::ArcExperimental(values)
             }
-            AuthScheme::FreeV1 | AuthScheme::CashuEcashV1 => {
+            AuthScheme::FreeV1
+            | AuthScheme::CashuEcashV1
+            | AuthScheme::BitcoinPirCashuBatV2 => {
                 return Err(ServiceProtocolError::InvalidValue {
                     field: "CredentialIssuanceResponseV1.authorization",
-                    reason: "custom BOLT11 claims support only direct receipt, BAT, or experimental ARC; standard Cashu uses NUT-04",
+                    reason: "the V1 issuance envelope supports only direct receipt, provider-bound BAT V1, or experimental ARC",
                 })
             }
         };

--- a/crates/protocol/service/src/lib.rs
+++ b/crates/protocol/service/src/lib.rs
@@ -7,6 +7,7 @@
 mod attach;
 mod auth;
 mod auth_verify;
+mod bat_v2;
 mod binding;
 mod cashu_manifest;
 mod challenge;
@@ -38,6 +39,16 @@ pub use auth::{
 };
 pub use auth_verify::{
     bind_auth_begin_v1, BoundAuthAttemptV1, TrustedCatalogResolutionV1, TrustedServiceCatalogV1,
+};
+pub use bat_v2::{
+    bat_acceptance_member_from_verified_policy_v2, derive_bat_acceptance_key_id_v2,
+    validate_bat_acceptance_class_id_v2, BatAcceptanceClassIdV2, BatAcceptanceClassV2,
+    BatAcceptanceMemberV2, BatAcceptanceTermsV2, VerifiedBatAcceptanceMemberV2,
+    BAT_ACCEPTANCE_CLASS_CODEC_MAGIC_V2, BAT_ACCEPTANCE_CLASS_DIGEST_DOMAIN_V2,
+    BAT_ACCEPTANCE_CLASS_SIGNATURE_DOMAIN_V2, BAT_ACCEPTANCE_CLASS_WIRE_VERSION_V2,
+    BAT_ACCEPTANCE_KEY_ID_DOMAIN_V2, BAT_ACCEPTANCE_TERMS_DIGEST_DOMAIN_V2,
+    MAX_BAT_ACCEPTANCE_CLASS_LEN_V2, MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2,
+    MAX_BAT_ACCEPTANCE_TERMS_LEN_V2,
 };
 pub use binding::{
     derive_bat_key_id_v1, derive_issuer_id, CredentialKeyBindingClaimsV1,

--- a/crates/protocol/service/src/policy.rs
+++ b/crates/protocol/service/src/policy.rs
@@ -76,7 +76,7 @@ impl AuthPaddingClassV1 {
         }
     }
 
-    fn decode(value: u8) -> Result<Self, ServiceProtocolError> {
+    pub(crate) fn decode(value: u8) -> Result<Self, ServiceProtocolError> {
         match value {
             1 => Ok(Self::Class16KiB),
             value => Err(ServiceProtocolError::UnknownDiscriminant {
@@ -147,7 +147,7 @@ pub enum DeploymentStatus {
 }
 
 impl DeploymentStatus {
-    fn decode(value: u8) -> Result<Self, ServiceProtocolError> {
+    pub(crate) fn decode(value: u8) -> Result<Self, ServiceProtocolError> {
         match value {
             1 => Ok(Self::Stable),
             2 => Ok(Self::Experimental),
@@ -295,7 +295,7 @@ pub struct EntitlementLimitsV1 {
 }
 
 impl EntitlementLimitsV1 {
-    fn validate(&self) -> Result<(), ServiceProtocolError> {
+    pub(crate) fn validate(&self) -> Result<(), ServiceProtocolError> {
         if self.max_frames == 0 || self.max_wall_time_ms == 0 || self.max_concurrent_sockets == 0 {
             return Err(ServiceProtocolError::InvalidValue {
                 field: "EntitlementLimitsV1",
@@ -305,7 +305,7 @@ impl EntitlementLimitsV1 {
         Ok(())
     }
 
-    fn encode_into(&self, out: &mut Vec<u8>) -> Result<(), ServiceProtocolError> {
+    pub(crate) fn encode_into(&self, out: &mut Vec<u8>) -> Result<(), ServiceProtocolError> {
         self.validate()?;
         out.extend_from_slice(&self.max_logical_inputs.to_le_bytes());
         out.extend_from_slice(&self.max_frames.to_le_bytes());
@@ -318,7 +318,7 @@ impl EntitlementLimitsV1 {
         Ok(())
     }
 
-    fn decode_from(decoder: &mut Decoder<'_>) -> Result<Self, ServiceProtocolError> {
+    pub(crate) fn decode_from(decoder: &mut Decoder<'_>) -> Result<Self, ServiceProtocolError> {
         let value = Self {
             max_logical_inputs: decoder.u16("EntitlementLimitsV1.max_logical_inputs")?,
             max_frames: decoder.u32("EntitlementLimitsV1.max_frames")?,
@@ -483,6 +483,7 @@ impl ServiceOfferV1 {
                     AcquisitionMethod::Bolt11V1,
                     AuthScheme::Bolt11DirectReceiptV1
                         | AuthScheme::BitcoinPirCashuBatV1
+                        | AuthScheme::BitcoinPirCashuBatV2
                         | AuthScheme::ArcV1Experimental
                 )
                 | (AcquisitionMethod::CashuEcashV1, AuthScheme::CashuEcashV1)
@@ -523,6 +524,9 @@ impl ServiceOfferV1 {
                 self.verification,
                 VerificationMode::ProviderLocal | VerificationMode::SharedIssuerOnline
             ),
+            AuthScheme::BitcoinPirCashuBatV2 => {
+                self.verification == VerificationMode::SharedIssuerOnline
+            }
             AuthScheme::ArcV1Experimental => matches!(
                 self.verification,
                 VerificationMode::ProviderLocal | VerificationMode::SharedIssuerOnline
@@ -565,10 +569,25 @@ impl ServiceOfferV1 {
                 reason: "non-issued Free grants and standard Cashu spends authorize one operation",
             });
         }
-        let credential_backed = self.authorization != AuthScheme::FreeV1
+        let class_backed = self.authorization == AuthScheme::BitcoinPirCashuBatV2;
+        let credential_backed = !class_backed
+            && self.authorization != AuthScheme::FreeV1
             && self.authorization != AuthScheme::CashuEcashV1
             || self.free_mode == FreeModeV1::AnonymousTicket;
-        if credential_backed {
+        if class_backed {
+            if self.issuer_id.iter().all(|byte| *byte == 0)
+                || self.key_id.len() != 32
+                || self.key_id.iter().all(|byte| *byte == 0)
+                || self.endpoint.is_empty()
+                || self.credential_binding.is_some()
+                || self.cashu_mint_manifest.is_some()
+            {
+                return Err(ServiceProtocolError::InvalidValue {
+                    field: "ServiceOfferV1.bat_v2_class_binding",
+                    reason: "BAT V2 requires issuer, non-zero 32-byte class ID, endpoint, and no V1 delegation",
+                });
+            }
+        } else if credential_backed {
             if self.issuer_id.iter().all(|byte| *byte == 0)
                 || self.key_id.is_empty()
                 || self.endpoint.is_empty()
@@ -635,7 +654,9 @@ impl ServiceOfferV1 {
                 PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
                     | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER
             }
-            AuthScheme::BitcoinPirCashuBatV1 | AuthScheme::ArcV1Experimental => {
+            AuthScheme::BitcoinPirCashuBatV1
+            | AuthScheme::BitcoinPirCashuBatV2
+            | AuthScheme::ArcV1Experimental => {
                 if self.verification == VerificationMode::SharedIssuerOnline {
                     PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
                         | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER

--- a/crates/protocol/service/src/scope.rs
+++ b/crates/protocol/service/src/scope.rs
@@ -69,6 +69,7 @@ pub enum AuthScheme {
     CashuEcashV1 = 3,
     BitcoinPirCashuBatV1 = 4,
     ArcV1Experimental = 5,
+    BitcoinPirCashuBatV2 = 6,
 }
 
 impl AuthScheme {
@@ -79,6 +80,7 @@ impl AuthScheme {
             3 => Ok(Self::CashuEcashV1),
             4 => Ok(Self::BitcoinPirCashuBatV1),
             5 => Ok(Self::ArcV1Experimental),
+            6 => Ok(Self::BitcoinPirCashuBatV2),
             value => Err(ServiceProtocolError::UnknownDiscriminant {
                 kind: "AuthScheme",
                 value,
@@ -95,7 +97,7 @@ pub enum DatasetBindingV1 {
 }
 
 impl DatasetBindingV1 {
-    fn encode_into(&self, out: &mut Vec<u8>) {
+    pub(crate) fn encode_into(&self, out: &mut Vec<u8>) {
         match self {
             Self::Class { class_id } => {
                 out.push(1);
@@ -112,7 +114,7 @@ impl DatasetBindingV1 {
         }
     }
 
-    fn decode_from(decoder: &mut Decoder<'_>) -> Result<Self, ServiceProtocolError> {
+    pub(crate) fn decode_from(decoder: &mut Decoder<'_>) -> Result<Self, ServiceProtocolError> {
         match decoder.u8("DatasetBindingV1.type")? {
             1 => Ok(Self::Class {
                 class_id: decoder.u16("DatasetBindingV1.class_id")?,

--- a/crates/protocol/service/tests/payment_v1_adversarial.rs
+++ b/crates/protocol/service/tests/payment_v1_adversarial.rs
@@ -76,6 +76,9 @@ fn public_v1_decoders() -> Vec<(&'static str, DecoderV1)> {
         ("CredentialKeyBindingV1", |bytes| {
             CredentialKeyBindingV1::decode(bytes).is_ok()
         }),
+        ("BatAcceptanceClassV2", |bytes| {
+            BatAcceptanceClassV2::decode(bytes).is_ok()
+        }),
         ("CashuKeysetBindingV1", |bytes| {
             CashuKeysetBindingV1::decode(bytes).is_ok()
         }),
@@ -350,7 +353,7 @@ fn payment_v1_public_decoders_are_total_for_bounded_adversarial_corpus() {
     );
     assert_eq!(
         decoders.len(),
-        53,
+        54,
         "the explicit public-decoder inventory must not shrink silently"
     );
     assert!(

--- a/crates/sdk/wasm/src/service.rs
+++ b/crates/sdk/wasm/src/service.rs
@@ -821,6 +821,7 @@ const fn auth_scheme_label(value: AuthScheme) -> &'static str {
         AuthScheme::CashuEcashV1 => "cashu-ecash",
         AuthScheme::BitcoinPirCashuBatV1 => "cashu-bat",
         AuthScheme::ArcV1Experimental => "arc-experimental",
+        AuthScheme::BitcoinPirCashuBatV2 => "cashu-bat-v2",
     }
 }
 

--- a/docs/payment/ARCHITECTURE.md
+++ b/docs/payment/ARCHITECTURE.md
@@ -429,18 +429,29 @@ guidance and is therefore named as a BitcoinPIR protocol rather than claimed
 as an unmodified NUT-22 implementation.
 
 Provider-specific public keysets allow private-key verification by a provider's
-own issuer sidecar. A shared issuer is shared infrastructure only: v1 still requires a
-distinct raw DHKE key for every `(provider_id, scope_id, offer_id,
-entitlement_profile, epoch)`.
-One signing keyset MUST NOT span provider audiences; doing so would make a blind
-BAT transferable across providers or require an issuance-to-proof mapping that
-destroys blind issuance.
+own issuer sidecar. A shared issuer is shared infrastructure only: v1 still
+requires a distinct raw DHKE key for every `(provider_id, scope_id, offer_id,
+entitlement_profile, epoch)`. One V1 signing keyset MUST NOT span provider
+audiences; doing so would make a V1 blind BAT transferable across providers or
+require an issuance-to-proof mapping that destroys blind issuance.
 
 The durable BAT spend key uses the raw DHKE public-key fingerprint and token
 secret, not the audience-derived key ID. Both the provider store and shared
 issuer retain a permanent raw-key lineage registry so policy/key-ID rebinding
 cannot reset the spent namespace. This does not replace the requirement that
 the two independent PIR providers use different raw keys.
+
+Issuer-wide BAT V2 does not weaken or reinterpret that V1 rule. It uses a new
+scheme value and a separate issuer-signed acceptance-class artifact. Provider
+policies commit only a stable class ID; the later artifact commits one fresh
+raw-key epoch, identical commercial/entitlement terms, and the canonical exact
+provider-policy members allowed to receive that credential. The raw key may be
+shared only inside that signed member set. A member or policy rotation uses a
+fresh raw key/epoch and retains the old artifact; different terms use a new
+class ID. The class codec/policy shape and issuer-store v6 registry are the only
+implemented V2 components at this stage. They prevent V1/V2 raw-key rebinding
+and class rollback, but do not yet expose V2 acquisition, redemption or
+provider admission.
 
 V1 does not send Cashu DLEQ blinding material to a provider for public-key-only
 offline verification and later batch redemption. Although such a receiver can

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -18,14 +18,26 @@ activated the path with real money.
       db0/db1 pool bindings, exact-db admission/reservation/dispatch and
       cross-database V2Half continuation isolation. The focused process test
       starts one complete two-database policy with two distinct pool markers.
-- [ ] **Issuer-wide V2 protocol pending.** Current policy bindings, issuer
-      lineage rules, SDK/Web selection and render gates remain provider-bound
-      and deliberately reject a shared raw BAT key across providers. Current
-      `main` also retains the old Direct Mainnet issuer unit and a stateful
-      single-pool provider profile. An unmerged draft's fixed
-      2-policy/12-key/2-clearing shape is superseded rather than ready to merge.
-      The current focused Mainnet script checks Direct V1; the draft CI checked
-      2/12/2. Neither is V2 readiness evidence.
+- [x] **Issuer-wide V2 class registry implemented.** Scheme 6 policies carry a
+      stable, preallocated 32-byte class ID and no V1 provider binding. A
+      separately signed issuer artifact fixes one immutable key epoch, common
+      commercial/entitlement terms and a canonical set of exact provider
+      policy members. Issuer-store schema v6 registers the complete artifact
+      atomically, retains old epochs, rejects class forks/terms changes and
+      prevents a raw BAT key from crossing either V2 classes or the legacy V1
+      lineage namespace. Focused protocol and store tests cover canonical
+      bytes, two-provider membership, epoch rotation/restart, validity bounds
+      and bidirectional V1/V2 key isolation. Version 5 stores are not migrated
+      implicitly.
+- [ ] **Issuer-wide V2 acquisition and redemption pending.** V1 quote, claim,
+      issuance, redeem and ProviderStore paths deliberately reject scheme 6;
+      no old replayable V1 success is reinterpreted. The class-bound quote/
+      wallet record, issuer-global first-spend transaction, non-grantable
+      replay response, storeless provider commit, SDK/Web selection and render
+      gates remain to implement. Current `main` also retains the old Direct
+      Mainnet issuer unit and stateful V1 provider profiles. An old draft's
+      fixed 2-policy/12-key/2-clearing shape remains superseded and is not V2
+      readiness evidence.
 - [ ] **Payment-storeless provider mode pending.** The current shared-BAT
       committer still uses ProviderStore for a local delivery claim and the
       existing storeless mode accepts only Free-PoW. The V2 path must make the

--- a/docs/payment/MAINNET_SHARED_BAT_PRODUCTION_PLAN.md
+++ b/docs/payment/MAINNET_SHARED_BAT_PRODUCTION_PLAN.md
@@ -474,6 +474,17 @@ grant success. Freeze the V2 public attempt-ID/removal wire and signature
 contract without a provider HMAC root. Keep V1 parsing and history isolated for
 compatibility/recovery.
 
+Source checkpoint (2026-08-19): the first Phase-B slice implements the stable
+class ID, scheme-6 policy shape, canonical issuer-signed class/key-epoch
+artifact and rollback-protected issuer-store v6 registry. Complete artifacts
+are registered atomically against exact current provider policy heads; older
+epochs remain retained, common terms cannot change under one class ID, and raw
+BAT keys cannot cross V1/V2 ownership. Existing V1 acquisition, issuance,
+redeem and ProviderStore paths still reject scheme 6. This checkpoint is not a
+usable V2 purchase or redemption path; the remaining Phase-B work below is
+unchanged. Version-5 issuer stores require a separately reviewed explicit
+migration or isolated legacy retention and are never upgraded at startup.
+
 Acceptance:
 
 - one BAT acquired through a class member can redeem at another compatible

--- a/docs/payment/PROTOCOL.md
+++ b/docs/payment/PROTOCOL.md
@@ -225,6 +225,38 @@ pub enum PriceV1 {
 The server derives all limits from its loaded signed policy. Wire values only
 select an existing scope/offer.
 
+### Issuer-wide BAT V2 class registry
+
+`AuthScheme::BitcoinPirCashuBatV2` is wire value `6`. Its policy offer remains
+inside the unchanged canonical `ServicePolicyV1` encoding, but it uses a new
+shape: BOLT11 acquisition, `SharedIssuerOnline` verification, a nonzero
+issuer ID, and an exact nonzero 32-byte preallocated acceptance-class ID in
+`key_id`. It carries neither `CredentialKeyBindingV1` nor a standard-Cashu
+manifest. V1 binding, issuance, proof/redeem and ProviderStore paths reject
+scheme 6 instead of treating it as provider-bound BAT V1.
+
+After all provider policies are signed, the credential issuer signs a
+separate canonical `BatAcceptanceClassV2` artifact. It binds the issuer root,
+stable class ID, key epoch and absolute key validity, one raw BAT verification
+key, one common-terms projection, and a strictly sorted set of exact
+`(provider_id, policy_digest, scope_id, offer_id)` members. The class ID is not
+derived from that artifact, so provider policy digests and the issuer artifact
+do not form a digest cycle. The class artifact and terms use independent V2
+signature/digest domains; the raw-key ID additionally commits issuer, class,
+key epoch and raw key.
+
+Issuer-store schema v6 atomically installs a complete class epoch against each
+provider's current exact signed policy head. A class ID keeps the same common
+terms across epochs; a changed exact member set requires a fresh epoch and raw
+key, while the old signed artifact remains available through its promised
+retired-policy horizon. The store rejects epoch rollback/forks, incomplete or
+incompatible members, and raw-key reuse across V2 classes or legacy BAT V1.
+Schema v6 has no implicit migration from v5.
+
+This registry is only the first V2 source slice. Class-bound quote/claim
+records, issuer-global first-spend redemption, non-grantable replay results,
+storeless provider admission and SDK/Web wallet handling are still pending.
+
 ## PIR wire messages
 
 Four opcode values are reserved after a repository-wide collision check:

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -1245,6 +1245,17 @@ accept a changing artifact.
 
 ## Shared clearing and settlement tests
 
+The issuer-wide BAT V2 class-registry slice has two intentionally narrow test
+groups. Protocol tests lock the scheme-6 offer shape, canonical class codec,
+issuer signature, terms/member ordering, key-ID derivation and a complete BAT
+V1 signed-policy bytes/digest golden. Issuer-store tests install one class
+across two exact provider policies, advance to a fresh key epoch, retain and
+reopen the old epoch, and reject member/terms mismatches, epoch rollback/fork,
+invalid key-validity horizons, cross-class raw-key reuse and both V1-to-V2 and
+V2-to-V1 raw-key reuse. A v5 store is rejected rather than implicitly
+migrated. These tests do not claim that V2 quote, redeem, provider, SDK or Web
+paths exist.
+
 - identified redeem credits only the authenticated provider;
 - blind redeem also requires provider authentication and signs exactly the
   fixed settlement denomination;


### PR DESCRIPTION
## Summary

- add scheme 6 and a canonical issuer-signed BAT V2 acceptance-class artifact
- add issuer-store schema v6 with atomic class epoch/member registration, retained history, rollback/fork checks, and V1/V2 raw-key isolation
- keep V2 fail-closed in every legacy V1 issuance, redemption, and ProviderStore path
- document the exact partial implementation boundary

## Boundary

This PR does not add V2 acquisition, issuer-global redemption, provider admission, SDK/Web wallet handling, deployment, or an implicit v5 store migration. Those remain separate follow-up slices.

## Verification

- cargo test --locked --offline -p pir-service-protocol bat_v2_ (5 passed)
- cargo test --locked --offline -p pir-issuer-store bat_v2_ -- --nocapture (4 passed)
- cargo test --locked --offline -p pir-service-store verified_offer_namespace_tests::issuer_wide_bat_v2_never_derives_a_provider_store_namespace -- --exact (1 passed)
- cargo check --locked --offline --workspace --all-targets --exclude bitcoinpir-cln-rpc-guard
- scoped rustfmt --check and git diff --check

The excluded cln-rpc-guard target has an existing unrelated macOS st_dev type error.