### PR TITLE
Add issuer-wide BAT V2 acquisition

### DIFF
--- a/.github/workflows/pir-sdk-integration.yml
+++ b/.github/workflows/pir-sdk-integration.yml
@@ -168,15 +168,21 @@ jobs:
       - name: Install pinned Rust toolchain
         run: rustup toolchain install --profile minimal
 
-      - name: Install C++ toolchain
-        # ubuntu-latest already ships with gcc/g++/cmake, but we pin the
-        # install step explicitly so the workflow stays reproducible if
-        # GitHub's image ever trims them. libgomp is linked dynamically
-        # by libonionpir for OpenMP.
+      - name: Verify preinstalled C++ toolchain
+        # The pinned ubuntu-22.04 image supplies GCC 11, CMake and libgomp.
+        # Fail fast if that image contract changes instead of making every
+        # run depend on the Ubuntu package mirrors before testing repo code.
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake libgomp1
+          command -v gcc
+          command -v g++
+          command -v cmake
+          command -v make
+          ldconfig -p | grep -F 'libgomp.so.1'
+          test "$(gcc -dumpversion | cut -d. -f1)" = "11"
+          test "$(g++ -dumpversion | cut -d. -f1)" = "11"
+          gcc --version
+          g++ --version
+          cmake --version
 
       - name: Rewrite SSH GitHub URLs to HTTPS (for SEAL submodule)
         # The `onionpir` crate we depend on has a SEAL submodule whose
@@ -265,11 +271,20 @@ jobs:
       - name: Install pinned Rust toolchain
         run: rustup toolchain install --profile minimal
 
-      - name: Install C++ toolchain
+      - name: Verify preinstalled C++ toolchain
+        # Keep the scheduled leakage job on the same network-free toolchain
+        # preflight as the deterministic OnionPIR integration job above.
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential cmake libgomp1
+          command -v gcc
+          command -v g++
+          command -v cmake
+          command -v make
+          ldconfig -p | grep -F 'libgomp.so.1'
+          test "$(gcc -dumpversion | cut -d. -f1)" = "11"
+          test "$(g++ -dumpversion | cut -d. -f1)" = "11"
+          gcc --version
+          g++ --version
+          cmake --version
 
       - name: Rewrite SSH GitHub URLs to HTTPS (for SEAL submodule)
         run: |

--- a/apps/payment-issuer/src/main.rs
+++ b/apps/payment-issuer/src/main.rs
@@ -34,9 +34,10 @@ use pir_issuer_credentials::IssuerCredentialDerivationKeyV1;
 #[cfg(test)]
 use pir_issuer_service::SettlementPayoutPolicyV1;
 use pir_issuer_service::{
-    ensure_shared_clearing_binding_material_v1, IssuerAcquisitionServiceV1, IssuerServiceErrorV1,
-    QuoteSigningMaterialV1, ReceiptSigningMaterialV1, SharedIssuerClearingServiceV1,
-    TrustedClearingProviderV1, LEDGER_ONLY_DISABLED_PAYOUT_TARGET_ID_V1,
+    ensure_shared_clearing_binding_material_v1, IssuerAcquisitionServiceV1,
+    IssuerReconciliationBatchV1, IssuerServiceErrorV1, QuoteSigningMaterialV1,
+    ReceiptSigningMaterialV1, SharedIssuerClearingServiceV1, TrustedClearingProviderV1,
+    LEDGER_ONLY_DISABLED_PAYOUT_TARGET_ID_V1,
 };
 use pir_issuer_store::{
     BatKeyLineageRegistration, IssuerRollbackFloorAuthorityV1, IssuerStore,
@@ -58,9 +59,12 @@ use pir_lightning_backend::{
 use pir_payment_crypto::K256CashuMintKeyringV1;
 use pir_rollback_authority_client::load_remote_rollback_authority_deployment_for_business_domain_v1;
 use pir_service_protocol::{
-    AuthScheme, Bolt11QuoteClaimEnvelopeV1, Bolt11QuoteIntentV1, Bolt11QuoteKeyDelegationV1,
+    AuthScheme, BatAcceptanceClassV2, Bolt11BatV2ClaimEnvelopeV2, Bolt11BatV2QuoteIntentV2,
+    Bolt11QuoteClaimEnvelopeV1, Bolt11QuoteIntentV1, Bolt11QuoteKeyDelegationV1,
     IssuerClearingApprovalV1, LightningNetworkV1, ProviderClearingAuthorizationV1,
     ProviderRedeemEnvelopeV1, ServicePolicyV1, SettlementModesV1, SettlementUnitV1,
+    MAX_BAT_ACCEPTANCE_CLASS_LEN_V2, MAX_BAT_V2_CLAIM_ENVELOPE_LEN,
+    MAX_BAT_V2_ISSUANCE_RESPONSE_LEN, MAX_BAT_V2_QUOTE_INTENT_LEN,
     MAX_BOLT11_QUOTE_CLAIM_ENVELOPE_LEN_V1, MAX_BOLT11_QUOTE_INTENT_LEN,
     MAX_BOLT11_QUOTE_KEY_DELEGATION_LEN, MAX_BOLT11_QUOTE_STATUS_REQUEST_LEN,
     MAX_CREDENTIAL_ISSUANCE_RESPONSE_LEN_V1, MAX_EXECUTABLE_SETTLEMENT_HTTP_ENVELOPE_LEN_V1,
@@ -76,10 +80,20 @@ const MAX_HEADER_BYTES: usize = 16 * 1024;
 // The only 320 KiB settlement envelope is the 64-note deposit model, which
 // this executable does not serve. Keep the public listener capped by the
 // larger of the acquisition claim and production redeem/balance surfaces.
-const MAX_HTTP_BODY_BYTES: usize = MAX_BOLT11_QUOTE_CLAIM_ENVELOPE_LEN_V1;
+const MAX_HTTP_BODY_BYTES: usize =
+    if MAX_BAT_V2_CLAIM_ENVELOPE_LEN > MAX_BOLT11_QUOTE_CLAIM_ENVELOPE_LEN_V1 {
+        MAX_BAT_V2_CLAIM_ENVELOPE_LEN
+    } else {
+        MAX_BOLT11_QUOTE_CLAIM_ENVELOPE_LEN_V1
+    };
 const _: () = assert!(MAX_PROVIDER_REDEEM_ENVELOPE_LEN_V1 <= MAX_HTTP_BODY_BYTES);
 const _: () = assert!(MAX_EXECUTABLE_SETTLEMENT_HTTP_ENVELOPE_LEN_V1 <= MAX_HTTP_BODY_BYTES);
-const MAX_HTTP_RESPONSE_BYTES: usize = MAX_CREDENTIAL_ISSUANCE_RESPONSE_LEN_V1;
+const MAX_HTTP_RESPONSE_BYTES: usize =
+    if MAX_BAT_V2_ISSUANCE_RESPONSE_LEN > MAX_CREDENTIAL_ISSUANCE_RESPONSE_LEN_V1 {
+        MAX_BAT_V2_ISSUANCE_RESPONSE_LEN
+    } else {
+        MAX_CREDENTIAL_ISSUANCE_RESPONSE_LEN_V1
+    };
 const DEFAULT_MAX_CONNECTIONS: usize = 64;
 const DEFAULT_MAX_OUTSTANDING_QUOTES: u64 = 256;
 const DEFAULT_MAX_TOTAL_QUOTES: u64 = 100_000;
@@ -94,11 +108,15 @@ const MAX_CONFIGURED_RATE_PER_MINUTE: u32 = 60_000;
 const IO_TIMEOUT: Duration = Duration::from_secs(10);
 
 const CT_QUOTE_INTENT: &str = "application/vnd.bitcoinpir.bolt11-quote-intent-v1";
+const CT_BAT_V2_QUOTE_INTENT: &str = "application/vnd.bitcoinpir.bat-v2-bolt11-quote-intent-v2";
 const CT_QUOTE: &str = "application/vnd.bitcoinpir.bolt11-quote-v1";
 const CT_QUOTE_KEY_DELEGATION: &str = "application/vnd.bitcoinpir.bolt11-quote-key-delegation-v1";
 const CT_STATUS_REQUEST: &str = "application/vnd.bitcoinpir.bolt11-quote-status-request-v1";
 const CT_CLAIM_ENVELOPE: &str = "application/vnd.bitcoinpir.bolt11-quote-claim-envelope-v1";
+const CT_BAT_V2_CLAIM_ENVELOPE: &str =
+    "application/vnd.bitcoinpir.bat-v2-bolt11-quote-claim-envelope-v2";
 const CT_ISSUANCE_RESPONSE: &str = "application/vnd.bitcoinpir.credential-issuance-response-v1";
+const CT_BAT_V2_ISSUANCE_RESPONSE: &str = "application/vnd.bitcoinpir.bat-v2-issuance-response-v2";
 const CT_REDEEM: &str = "application/vnd.bitcoinpir.redeem-v1";
 const CT_REDEEM_RESULT: &str = "application/vnd.bitcoinpir.redeem-result-v1";
 #[cfg(any(test, feature = "test-only-fake-lightning"))]
@@ -291,6 +309,11 @@ struct ServeCommonArgs {
     /// Repeat `<signed-policy-path>=<ed25519-policy-public-key-hex>`.
     #[arg(long = "service-policy")]
     service_policies: Vec<String>,
+    /// Repeat one canonical issuer-signed BAT V2 acceptance-class artifact.
+    /// Member policies are registered first so the store can verify the exact
+    /// current policy heads atomically with each class epoch.
+    #[arg(long = "bat-v2-class")]
+    bat_v2_classes: Vec<PathBuf>,
     /// Repeat for every retained direct-receipt Ed25519 signing key.
     #[arg(long = "receipt-signing-key")]
     receipt_signing_keys: Vec<PathBuf>,
@@ -512,17 +535,35 @@ struct ReconciliationTickTotalsV1 {
     service_failures: u32,
 }
 
+impl ReconciliationTickTotalsV1 {
+    fn include(&mut self, report: &IssuerReconciliationBatchV1) {
+        self.examined = self.examined.saturating_add(report.examined);
+        self.transitioned = self.transitioned.saturating_add(report.transitioned);
+        self.unchanged = self.unchanged.saturating_add(report.unchanged);
+        self.retryable_failures = self
+            .retryable_failures
+            .saturating_add(report.retryable_failures);
+        self.permanent_failures = self
+            .permanent_failures
+            .saturating_add(report.permanent_failures);
+    }
+}
+
 fn spawn_reconciliation_worker(
     state: Arc<ServerState>,
     config: ReconciliationWorkerConfigV1,
 ) -> Result<(), String> {
     thread::Builder::new()
-        .name("issuer-reconciliation-v1".to_owned())
+        .name("issuer-reconciliation".to_owned())
         .spawn(move || {
-            let mut cursor = None;
+            let mut v1_cursor = None;
+            let mut bat_v2_cursor = None;
+            let mut bat_v2_next = false;
             loop {
                 let tick_started = Instant::now();
                 let mut totals = ReconciliationTickTotalsV1::default();
+                let mut v1_empty = false;
+                let mut bat_v2_empty = false;
                 while totals.examined < config.batch_size
                     && tick_started.elapsed() < config.tick_budget
                     && config.rate.try_acquire(Instant::now())
@@ -534,26 +575,48 @@ fn spawn_reconciliation_worker(
                             break;
                         }
                     };
-                    match state
-                        .acquisition
-                        .reconcile_quote_batch(cursor.as_ref(), 1, now_unix)
-                    {
+                    let use_bat_v2 = if v1_empty {
+                        true
+                    } else if bat_v2_empty {
+                        false
+                    } else {
+                        let selected = bat_v2_next;
+                        bat_v2_next = !bat_v2_next;
+                        selected
+                    };
+                    let result = if use_bat_v2 {
+                        state.acquisition.reconcile_bat_v2_quote_batch(
+                            bat_v2_cursor.as_ref(),
+                            1,
+                            now_unix,
+                        )
+                    } else {
+                        state
+                            .acquisition
+                            .reconcile_quote_batch(v1_cursor.as_ref(), 1, now_unix)
+                    };
+                    match result {
                         Ok(report) if report.examined == 0 => {
-                            cursor = None;
-                            break;
+                            if use_bat_v2 {
+                                bat_v2_cursor = None;
+                                bat_v2_empty = true;
+                            } else {
+                                v1_cursor = None;
+                                v1_empty = true;
+                            }
+                            if v1_empty && bat_v2_empty {
+                                break;
+                            }
                         }
                         Ok(report) => {
-                            cursor = report.next_cursor();
-                            totals.examined = totals.examined.saturating_add(report.examined);
-                            totals.transitioned =
-                                totals.transitioned.saturating_add(report.transitioned);
-                            totals.unchanged = totals.unchanged.saturating_add(report.unchanged);
-                            totals.retryable_failures = totals
-                                .retryable_failures
-                                .saturating_add(report.retryable_failures);
-                            totals.permanent_failures = totals
-                                .permanent_failures
-                                .saturating_add(report.permanent_failures);
+                            if use_bat_v2 {
+                                bat_v2_cursor = report.next_cursor();
+                                bat_v2_empty = false;
+                            } else {
+                                v1_cursor = report.next_cursor();
+                                v1_empty = false;
+                            }
+                            totals.include(&report);
                         }
                         Err(_) => {
                             totals.service_failures = totals.service_failures.saturating_add(1);
@@ -652,6 +715,37 @@ fn is_exact_claim_replay(
         return false;
     }
     let Ok(Some(existing)) = store.claim_by_idempotency_key(&envelope.claim.idempotency_key) else {
+        return false;
+    };
+    let Ok(claim_digest) = envelope.claim.claim_request_digest() else {
+        return false;
+    };
+    let Ok(exact_credential_request) = envelope.credential_request.encode() else {
+        return false;
+    };
+    existing.quote_id == envelope.claim.quote_id
+        && existing.claim_request_digest == claim_digest
+        && existing.exact_credential_request == exact_credential_request
+}
+
+/// BAT V2 exact replay uses its own protocol-discriminated claim namespace.
+/// This transport precheck only exempts an already durable exact request from
+/// rate limiting; the service/store still authenticate it before release.
+fn is_exact_bat_v2_claim_replay(
+    store: &IssuerStore,
+    route_quote_id: &[u8; 32],
+    canonical_envelope: &[u8],
+) -> bool {
+    let Ok(envelope) = Bolt11BatV2ClaimEnvelopeV2::decode(canonical_envelope) else {
+        return false;
+    };
+    if &envelope.claim.quote_id != route_quote_id
+        || envelope.encode().ok().as_deref() != Some(canonical_envelope)
+    {
+        return false;
+    }
+    let Ok(Some(existing)) = store.bat_v2_claim_by_idempotency_key(&envelope.claim.idempotency_key)
+    else {
         return false;
     };
     let Ok(claim_digest) = envelope.claim.claim_request_digest() else {
@@ -1482,6 +1576,37 @@ fn serve_with_backend(
         register_policy_key_lineages(&store, &policy, now_unix)?;
         policies.push(policy);
     }
+    for path in &args.bat_v2_classes {
+        let bytes = read_public_file(
+            path,
+            MAX_BAT_ACCEPTANCE_CLASS_LEN_V2,
+            "BAT V2 acceptance class",
+        )?;
+        let class = BatAcceptanceClassV2::decode(&bytes).map_err(|_| {
+            format!(
+                "BAT V2 acceptance class {} is not canonical V2",
+                path.display()
+            )
+        })?;
+        if class
+            .encode()
+            .map_err(|_| "BAT V2 acceptance class encode failed".to_owned())?
+            != bytes
+        {
+            return Err(format!(
+                "BAT V2 acceptance class {} is non-canonical",
+                path.display()
+            ));
+        }
+        let _registration = store
+            .register_bat_acceptance_class_v2(&class, now_unix)
+            .map_err(|error| {
+                format!(
+                    "register BAT V2 acceptance class {} failed: {error}",
+                    path.display()
+                )
+            })?;
+    }
 
     let mut receipt_keys = Vec::with_capacity(args.receipt_signing_keys.len());
     for path in &args.receipt_signing_keys {
@@ -2212,6 +2337,35 @@ fn route_request(
                 .create_quote(&request.body, now_unix)
                 .map(|body| (CT_QUOTE, body))
         }
+        "/v2/quotes/bolt11" => {
+            require_content_type(request, CT_BAT_V2_QUOTE_INTENT)?;
+            if request.body.len() > MAX_BAT_V2_QUOTE_INTENT_LEN {
+                return Err(IssuerServiceErrorV1::InvalidRequest);
+            }
+            let intent = Bolt11BatV2QuoteIntentV2::decode(&request.body)
+                .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?;
+            if intent.encode().ok().as_deref() != Some(request.body.as_slice()) {
+                return Err(IssuerServiceErrorV1::InvalidRequest);
+            }
+            let request_digest = intent
+                .request_digest()
+                .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?;
+            let stored = state
+                .store
+                .bat_v2_quote_by_creation_idempotency_key(&intent.idempotency_key)
+                .map_err(|_| IssuerServiceErrorV1::RetryableUnavailable)?;
+            let exact_replay = exact_intent_replay(
+                stored.as_ref().map(|quote| quote.intent_digest),
+                request_digest,
+            );
+            if !exact_replay && !state.quote_rate.try_acquire(Instant::now()) {
+                return Err(IssuerServiceErrorV1::RetryableUnavailable);
+            }
+            state
+                .acquisition
+                .create_bat_v2_quote(&request.body, now_unix)
+                .map(|body| (CT_QUOTE, body))
+        }
         "/v1/redeems" => {
             require_content_type(request, CT_REDEEM)?;
             if request.body.len() > MAX_PROVIDER_REDEEM_ENVELOPE_LEN_V1 {
@@ -2308,21 +2462,34 @@ fn route_request(
                     .try_into()
                     .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?,
             );
-            let quote = state
+            let quote = match state
                 .store
                 .quote(&quote_id)
                 .map_err(|_| IssuerServiceErrorV1::Internal)?
-                .ok_or(IssuerServiceErrorV1::NotFound)?;
+            {
+                Some(quote) => quote,
+                None => state
+                    .store
+                    .bat_v2_quote(&quote_id)
+                    .map_err(|_| IssuerServiceErrorV1::Internal)?
+                    .ok_or(IssuerServiceErrorV1::NotFound)?,
+            };
             fake_lightning
                 .observe_settlement(&quote.backend_label, amount, settled_at)
                 .map_err(|_| IssuerServiceErrorV1::Conflict)?;
             Ok(("application/octet-stream", Vec::new()))
         }
         path => {
-            let (quote_id, action) =
-                parse_quote_action_path(path).ok_or(IssuerServiceErrorV1::NotFound)?;
-            match action {
-                "status" => {
+            let (quote_id, action, bat_v2) =
+                if let Some((quote_id, action)) = parse_quote_action_path(path) {
+                    (quote_id, action, false)
+                } else if let Some((quote_id, action)) = parse_bat_v2_quote_action_path(path) {
+                    (quote_id, action, true)
+                } else {
+                    return Err(IssuerServiceErrorV1::NotFound);
+                };
+            match (bat_v2, action) {
+                (false, "status") => {
                     require_content_type(request, CT_STATUS_REQUEST)?;
                     if request.body.len() > MAX_BOLT11_QUOTE_STATUS_REQUEST_LEN {
                         return Err(IssuerServiceErrorV1::InvalidRequest);
@@ -2335,7 +2502,20 @@ fn route_request(
                         .quote_status(&quote_id, &request.body, now_unix)
                         .map(|body| (CT_QUOTE, body))
                 }
-                "claim" => {
+                (true, "status") => {
+                    require_content_type(request, CT_STATUS_REQUEST)?;
+                    if request.body.len() > MAX_BOLT11_QUOTE_STATUS_REQUEST_LEN {
+                        return Err(IssuerServiceErrorV1::InvalidRequest);
+                    }
+                    if !state.status_rate.try_acquire(Instant::now()) {
+                        return Err(IssuerServiceErrorV1::RetryableUnavailable);
+                    }
+                    state
+                        .acquisition
+                        .bat_v2_quote_status(&quote_id, &request.body, now_unix)
+                        .map(|body| (CT_QUOTE, body))
+                }
+                (false, "claim") => {
                     require_content_type(request, CT_CLAIM_ENVELOPE)?;
                     if request.body.len() > MAX_BOLT11_QUOTE_CLAIM_ENVELOPE_LEN_V1 {
                         return Err(IssuerServiceErrorV1::InvalidRequest);
@@ -2349,6 +2529,21 @@ fn route_request(
                         .acquisition
                         .claim_quote(&quote_id, &request.body, now_unix)
                         .map(|body| (CT_ISSUANCE_RESPONSE, body))
+                }
+                (true, "claim") => {
+                    require_content_type(request, CT_BAT_V2_CLAIM_ENVELOPE)?;
+                    if request.body.len() > MAX_BAT_V2_CLAIM_ENVELOPE_LEN {
+                        return Err(IssuerServiceErrorV1::InvalidRequest);
+                    }
+                    if !is_exact_bat_v2_claim_replay(&state.store, &quote_id, &request.body)
+                        && !state.mutation_rate.try_acquire(Instant::now())
+                    {
+                        return Err(IssuerServiceErrorV1::RetryableUnavailable);
+                    }
+                    state
+                        .acquisition
+                        .claim_bat_v2_quote(&quote_id, &request.body, now_unix)
+                        .map(|body| (CT_BAT_V2_ISSUANCE_RESPONSE, body))
                 }
                 _ => Err(IssuerServiceErrorV1::NotFound),
             }
@@ -2386,7 +2581,18 @@ fn require_executable_settlement_request(
 }
 
 fn parse_quote_action_path(path: &str) -> Option<([u8; 32], &str)> {
-    let rest = path.strip_prefix("/v1/quotes/")?;
+    parse_quote_action_path_for_prefix(path, "/v1/quotes/")
+}
+
+fn parse_bat_v2_quote_action_path(path: &str) -> Option<([u8; 32], &str)> {
+    parse_quote_action_path_for_prefix(path, "/v2/quotes/")
+}
+
+fn parse_quote_action_path_for_prefix<'a>(
+    path: &'a str,
+    prefix: &str,
+) -> Option<([u8; 32], &'a str)> {
+    let rest = path.strip_prefix(prefix)?;
     let (quote_hex, action) = rest.split_once('/')?;
     if quote_hex.len() != 64
         || !quote_hex
@@ -3782,6 +3988,17 @@ mod tests {
             parse_quote_action_path(&format!("/v1/quotes/{}/status", id.to_uppercase())).is_none()
         );
         assert!(parse_quote_action_path(&format!("/v1/quotes/{id}/status?x=1")).is_none());
+        assert_eq!(
+            parse_bat_v2_quote_action_path(&format!("/v2/quotes/{id}/claim"))
+                .unwrap()
+                .1,
+            "claim"
+        );
+        assert!(
+            parse_bat_v2_quote_action_path(&format!("/v2/quotes/{}/claim", id.to_uppercase()))
+                .is_none()
+        );
+        assert!(parse_bat_v2_quote_action_path(&format!("/v1/quotes/{id}/claim")).is_none());
     }
 
     #[test]

--- a/crates/payment/issuer-core/src/lib.rs
+++ b/crates/payment/issuer-core/src/lib.rs
@@ -8,17 +8,19 @@
 
 use ed25519_dalek::{Signer as _, SigningKey};
 use pir_issuer_store::{
-    IssuerStore, QuoteCapacityV1, QuoteExpiry, QuoteFinalization, QuoteRecord, QuoteReservation,
-    QuoteSettlement, QuoteState, StoreError, WriteDisposition,
+    BatV2QuoteReservation, IssuerStore, QuoteCapacityV1, QuoteExpiry, QuoteFinalization,
+    QuoteRecord, QuoteReservation, QuoteSettlement, QuoteState, StoreError, WriteDisposition,
 };
 use pir_lightning_backend::{
     anonymous_invoice_description_hash_v1, CreateInvoiceRequestV1, InvoiceObservationStateV1,
     LightningBackendErrorV1, LightningInvoiceBackendV1,
 };
 use pir_service_protocol::{
-    bolt11_invoice_text_digest_v1, Bolt11QuoteIntentV1, Bolt11QuoteKeyDelegationV1,
-    Bolt11QuoteStatusV1, Bolt11QuoteV1, ParsedBolt11InvoiceV1, PersistedBolt11QuoteExpectationV1,
-    VerifiedBolt11QuoteIntentV1, BOLT11_QUOTE_SIGNATURE_DOMAIN,
+    bolt11_invoice_text_digest_v1, BatAcceptanceClassV2, Bolt11BatV2QuoteIntentV2,
+    Bolt11QuoteIntentV1, Bolt11QuoteKeyDelegationV1, Bolt11QuoteKeyRollbackGuardV1,
+    Bolt11QuoteStatusV1, Bolt11QuoteV1, ParsedBolt11InvoiceV1,
+    PersistedBolt11BatV2QuoteExpectationV2, PersistedBolt11QuoteExpectationV1,
+    VerifiedBolt11BatV2QuoteIntentV2, VerifiedBolt11QuoteIntentV1, BOLT11_QUOTE_SIGNATURE_DOMAIN,
 };
 use std::fmt;
 use std::sync::Arc;
@@ -160,6 +162,12 @@ pub struct Bolt11IssuerCoreV1<B, Q> {
     backend: Arc<B>,
     quote_ids: Arc<Q>,
     quote_capacity: QuoteCapacityV1,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum QuoteAcquisitionProtocolV1 {
+    ProviderBoundV1,
+    BatV2,
 }
 
 impl<B, Q> fmt::Debug for Bolt11IssuerCoreV1<B, Q> {
@@ -308,6 +316,92 @@ where
         )
     }
 
+    /// Reserve before Lightning, then create or recover one issuer-wide BAT
+    /// V2 quote. Every durable lookup and write uses the V2 store namespace;
+    /// a V1 quote with the same raw idempotency key is never an exact replay.
+    pub fn create_or_recover_bat_v2_quote(
+        &self,
+        verified_intent: &VerifiedBolt11BatV2QuoteIntentV2<'_>,
+        quote_signing_key: &SigningKey,
+        now_unix: u64,
+    ) -> Result<QuoteCreateResultV1, IssuerCoreErrorV1> {
+        validate_now(now_unix)?;
+        validate_signer(verified_intent.delegation(), quote_signing_key)?;
+        let intent = verified_intent.intent();
+
+        if let Some(record) = self
+            .store
+            .bat_v2_quote_by_creation_idempotency_key(&intent.idempotency_key)
+            .map_err(map_store_error)?
+        {
+            return self.recover_bat_v2_record(
+                record,
+                verified_intent,
+                quote_signing_key,
+                now_unix,
+                false,
+            );
+        }
+
+        let quote_id = self
+            .quote_ids
+            .next_quote_id()
+            .map_err(|error| match error {
+                QuoteIdSourceErrorV1::Unavailable => IssuerCoreErrorV1::RetryableUnavailable,
+                QuoteIdSourceErrorV1::Exhausted => IssuerCoreErrorV1::PermanentMismatch,
+            })?;
+        if quote_id.iter().all(|byte| *byte == 0) {
+            return Err(IssuerCoreErrorV1::PermanentMismatch);
+        }
+        let invoice_created_not_before = now_unix
+            .checked_sub(INVOICE_CREATION_CLOCK_SKEW_SECONDS_V1)
+            .ok_or(IssuerCoreErrorV1::InvalidInput)?;
+        let invoice_created_not_after = now_unix
+            .checked_add(INVOICE_CREATION_CLOCK_SKEW_SECONDS_V1)
+            .ok_or(IssuerCoreErrorV1::InvalidInput)?;
+        if invoice_created_not_before == 0 {
+            return Err(IssuerCoreErrorV1::InvalidInput);
+        }
+        let reservation = BatV2QuoteReservation {
+            quote_id,
+            exact_intent: intent
+                .encode()
+                .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?,
+            exact_delegation: verified_intent
+                .delegation()
+                .encode()
+                .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?,
+            invoice_created_not_before,
+            invoice_created_not_after,
+            now_unix,
+        };
+        let (record, newly_reserved) = match self
+            .store
+            .reserve_bat_v2_quote_with_capacity(&reservation, self.quote_capacity)
+        {
+            Ok(write) => (
+                write.value,
+                write.disposition == WriteDisposition::Committed,
+            ),
+            Err(StoreError::CreationIdempotencyConflict) => {
+                let existing = self
+                    .store
+                    .bat_v2_quote_by_creation_idempotency_key(&intent.idempotency_key)
+                    .map_err(map_store_error)?
+                    .ok_or(IssuerCoreErrorV1::OutcomeUnknown)?;
+                (existing, false)
+            }
+            Err(error) => return Err(map_store_error(error)),
+        };
+        self.recover_bat_v2_record(
+            record,
+            verified_intent,
+            quote_signing_key,
+            now_unix,
+            newly_reserved,
+        )
+    }
+
     /// Reconcile one issuer-confidential backend label against durable quote
     /// state. Callers must never place this label in PIR protocol messages.
     pub fn reconcile_by_backend_label(
@@ -316,29 +410,85 @@ where
         quote_signing_key: &SigningKey,
         now_unix: u64,
     ) -> Result<QuoteReconcileResultV1, IssuerCoreErrorV1> {
+        self.reconcile_by_backend_label_for_protocol(
+            backend_label,
+            quote_signing_key,
+            now_unix,
+            QuoteAcquisitionProtocolV1::ProviderBoundV1,
+        )
+    }
+
+    /// Reconcile one BAT V2 quote without allowing a V1 row to satisfy the
+    /// backend-label lookup or receive a V2 lifecycle transition.
+    pub fn reconcile_bat_v2_by_backend_label(
+        &self,
+        backend_label: &str,
+        quote_signing_key: &SigningKey,
+        now_unix: u64,
+    ) -> Result<QuoteReconcileResultV1, IssuerCoreErrorV1> {
+        self.reconcile_by_backend_label_for_protocol(
+            backend_label,
+            quote_signing_key,
+            now_unix,
+            QuoteAcquisitionProtocolV1::BatV2,
+        )
+    }
+
+    fn reconcile_by_backend_label_for_protocol(
+        &self,
+        backend_label: &str,
+        quote_signing_key: &SigningKey,
+        now_unix: u64,
+        protocol: QuoteAcquisitionProtocolV1,
+    ) -> Result<QuoteReconcileResultV1, IssuerCoreErrorV1> {
         validate_now(now_unix)?;
         if backend_label.is_empty() {
             return Err(IssuerCoreErrorV1::InvalidInput);
         }
-        let record = self
-            .store
-            .quote_by_backend_label(backend_label)
-            .map_err(map_store_error)?
-            .ok_or(IssuerCoreErrorV1::NotFound)?;
+        let record = match protocol {
+            QuoteAcquisitionProtocolV1::ProviderBoundV1 => {
+                self.store.quote_by_backend_label(backend_label)
+            }
+            QuoteAcquisitionProtocolV1::BatV2 => {
+                self.store.bat_v2_quote_by_backend_label(backend_label)
+            }
+        }
+        .map_err(map_store_error)?
+        .ok_or(IssuerCoreErrorV1::NotFound)?;
         if record.backend_label != backend_label {
             return Err(IssuerCoreErrorV1::PermanentMismatch);
         }
         if record.state == QuoteState::Reserved {
-            return self.recover_reserved_for_reconciliation(record, quote_signing_key, now_unix);
+            return match protocol {
+                QuoteAcquisitionProtocolV1::ProviderBoundV1 => {
+                    self.recover_reserved_for_reconciliation(record, quote_signing_key, now_unix)
+                }
+                QuoteAcquisitionProtocolV1::BatV2 => self
+                    .recover_bat_v2_reserved_for_reconciliation(
+                        record,
+                        quote_signing_key,
+                        now_unix,
+                    ),
+            };
         }
         let current_exact = current_snapshot_bytes(&record)?.to_vec();
-        verify_persisted_snapshot(
-            &record,
-            &current_exact,
-            quote_signing_key,
-            now_unix,
-            expected_status_for_state(record.state)?,
-        )?;
+        match protocol {
+            QuoteAcquisitionProtocolV1::ProviderBoundV1 => verify_persisted_snapshot(
+                &record,
+                &current_exact,
+                quote_signing_key,
+                now_unix,
+                expected_status_for_state(record.state)?,
+            ),
+            QuoteAcquisitionProtocolV1::BatV2 => verify_persisted_bat_v2_snapshot(
+                &self.store,
+                &record,
+                &current_exact,
+                quote_signing_key,
+                now_unix,
+                expected_status_for_state(record.state)?,
+            ),
+        }?;
 
         let observation = self
             .backend
@@ -366,6 +516,7 @@ where
                 current_exact,
                 quote_signing_key,
                 observation.observed_at,
+                protocol,
             ),
             InvoiceObservationStateV1::Settled {
                 settled_at,
@@ -379,6 +530,7 @@ where
                 settled_at,
                 amount_received_msat,
                 settlement_evidence_digest,
+                protocol,
             ),
         }
     }
@@ -500,6 +652,150 @@ where
         ))
     }
 
+    fn recover_bat_v2_reserved_for_reconciliation(
+        &self,
+        record: QuoteRecord,
+        quote_signing_key: &SigningKey,
+        now_unix: u64,
+    ) -> Result<QuoteReconcileResultV1, IssuerCoreErrorV1> {
+        let intent = Bolt11BatV2QuoteIntentV2::decode(&record.intent_replay_image)
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+        if intent
+            .encode()
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?
+            != record.intent_replay_image
+            || intent.idempotency_key != record.creation_idempotency_digest
+            || intent.expected_payee_pubkey != record.payee_pubkey
+            || intent.minimum_quote_key_epoch != record.delegation_epoch
+            || intent.quote_delegation_digest != record.delegation_digest
+            || intent.exact_amount_msat != record.exact_amount_msat
+        {
+            return Err(IssuerCoreErrorV1::PermanentMismatch);
+        }
+        let identity = self.store.identity().map_err(map_store_error)?;
+        if intent.issuer_id != identity.issuer_id || intent.network != identity.network {
+            return Err(IssuerCoreErrorV1::PermanentMismatch);
+        }
+        let delegation = Bolt11QuoteKeyDelegationV1::decode(&record.exact_delegation)
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+        if delegation
+            .encode()
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?
+            != record.exact_delegation
+            || delegation.delegation_digest().ok() != Some(record.delegation_digest)
+            || delegation.issuer_id != identity.issuer_id
+            || delegation.network != identity.network
+            || delegation.expected_payee_pubkey != record.payee_pubkey
+            || delegation.key_epoch != record.delegation_epoch
+        {
+            return Err(IssuerCoreErrorV1::PermanentMismatch);
+        }
+        validate_signer(&delegation, quote_signing_key)?;
+        let class_record = self
+            .store
+            .bat_acceptance_class_v2(&intent.class_id, intent.class_key_epoch)
+            .map_err(map_store_error)?
+            .ok_or(IssuerCoreErrorV1::PermanentMismatch)?;
+        let class = BatAcceptanceClassV2::decode(&class_record.exact_artifact)
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+        if class
+            .encode()
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?
+            != class_record.exact_artifact
+            || class_record.artifact_digest != intent.class_digest
+            || class_record.bat_key_id != intent.bat_key_id
+        {
+            return Err(IssuerCoreErrorV1::PermanentMismatch);
+        }
+        let reservation_time = reservation_time(&record)?;
+        let guard = Bolt11QuoteKeyRollbackGuardV1::from_persisted(
+            intent.issuer_id,
+            intent.network,
+            intent.expected_payee_pubkey,
+            record.delegation_epoch,
+            record.delegation_digest,
+        )
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+        intent
+            .verify_for_class_guarded(&class, &delegation, &guard, reservation_time)
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+        let request = CreateInvoiceRequestV1 {
+            backend_label: record.backend_label.clone(),
+            network: intent.network,
+            expected_payee_pubkey: record.payee_pubkey,
+            amount_msat: record.exact_amount_msat,
+            expiry_seconds: intent.invoice_expiry_seconds,
+            description_hash: anonymous_invoice_description_hash_v1(),
+        };
+        let created = match self
+            .backend
+            .existing_invoice(&record.backend_label)
+            .map_err(map_backend_error)?
+        {
+            Some(created) => created,
+            None if now_unix <= record.invoice_created_not_after => self
+                .backend
+                .create_or_get_invoice(&request)
+                .map_err(map_backend_error)?,
+            None => return Err(IssuerCoreErrorV1::InvalidState),
+        };
+        let created = created
+            .verify_for_request(&request)
+            .map_err(map_backend_error)?
+            .created();
+        if created.created_at < record.invoice_created_not_before
+            || created.created_at > record.invoice_created_not_after
+            || created.created_at > now_unix.saturating_add(INVOICE_CREATION_CLOCK_SKEW_SECONDS_V1)
+        {
+            return Err(IssuerCoreErrorV1::PermanentMismatch);
+        }
+        let parsed = ParsedBolt11InvoiceV1::parse(&created.invoice)
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+        let exact = sign_recovered_initial_bat_v2_quote(
+            &record,
+            &intent,
+            &class,
+            &delegation,
+            &created.invoice,
+            &parsed,
+            quote_signing_key,
+        )?;
+        let horizons = intent
+            .derived_horizons(created.created_at)
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+        let write = self
+            .store
+            .finalize_bat_v2_quote(&QuoteFinalization {
+                quote_id: record.quote_id,
+                invoice: created.invoice.clone(),
+                payment_hash: created.payment_hash,
+                invoice_created_at: created.created_at,
+                invoice_expires_at: horizons.invoice_expires_at,
+                claim_deadline: horizons.claim_deadline,
+                credential_not_after: horizons.credential_not_after,
+                exact_signed_quote_response: exact,
+            })
+            .map_err(map_store_error)?;
+        let persisted = write
+            .value
+            .initial_signed_quote_response
+            .clone()
+            .ok_or(IssuerCoreErrorV1::PermanentMismatch)?;
+        verify_persisted_bat_v2_snapshot(
+            &self.store,
+            &write.value,
+            &persisted,
+            quote_signing_key,
+            now_unix,
+            Bolt11QuoteStatusV1::InvoiceOpen,
+        )?;
+        Ok(reconcile_result(
+            &write.value,
+            QuoteReconcileDispositionV1::Transitioned,
+            persisted,
+        ))
+    }
+
     fn recover_record(
         &self,
         record: QuoteRecord,
@@ -608,12 +904,123 @@ where
         })
     }
 
+    fn recover_bat_v2_record(
+        &self,
+        record: QuoteRecord,
+        verified_intent: &VerifiedBolt11BatV2QuoteIntentV2<'_>,
+        quote_signing_key: &SigningKey,
+        now_unix: u64,
+        newly_reserved: bool,
+    ) -> Result<QuoteCreateResultV1, IssuerCoreErrorV1> {
+        validate_bat_v2_record_for_intent(&record, verified_intent)?;
+        if record.state != QuoteState::Reserved {
+            let exact = record
+                .initial_signed_quote_response
+                .as_deref()
+                .ok_or(IssuerCoreErrorV1::PermanentMismatch)?;
+            verify_persisted_bat_v2_snapshot(
+                &self.store,
+                &record,
+                exact,
+                quote_signing_key,
+                now_unix,
+                Bolt11QuoteStatusV1::InvoiceOpen,
+            )?;
+            return Ok(QuoteCreateResultV1 {
+                disposition: QuoteCreateDispositionV1::ExactReplay,
+                exact_signed_quote_response: exact.to_vec(),
+            });
+        }
+
+        let intent = verified_intent.intent();
+        let request = CreateInvoiceRequestV1 {
+            backend_label: record.backend_label.clone(),
+            network: intent.network,
+            expected_payee_pubkey: record.payee_pubkey,
+            amount_msat: record.exact_amount_msat,
+            expiry_seconds: intent.invoice_expiry_seconds,
+            description_hash: anonymous_invoice_description_hash_v1(),
+        };
+        let created = match self
+            .backend
+            .existing_invoice(&record.backend_label)
+            .map_err(map_backend_error)?
+        {
+            Some(created) => created,
+            None if now_unix <= record.invoice_created_not_after => self
+                .backend
+                .create_or_get_invoice(&request)
+                .map_err(map_backend_error)?,
+            None => return Err(IssuerCoreErrorV1::InvalidState),
+        };
+        let verified_created = created
+            .verify_for_request(&request)
+            .map_err(map_backend_error)?;
+        let created = verified_created.created();
+        if created.created_at < record.invoice_created_not_before
+            || created.created_at > record.invoice_created_not_after
+            || created.created_at > now_unix.saturating_add(INVOICE_CREATION_CLOCK_SKEW_SECONDS_V1)
+        {
+            return Err(IssuerCoreErrorV1::PermanentMismatch);
+        }
+        let parsed = ParsedBolt11InvoiceV1::parse(&created.invoice)
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+        let quote = Bolt11QuoteV1::sign_for_verified_bat_v2_intent(
+            verified_intent,
+            record.quote_id,
+            created.invoice.clone(),
+            &parsed,
+            Bolt11QuoteStatusV1::InvoiceOpen,
+            created.created_at,
+            quote_signing_key,
+        )
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+        let exact = quote
+            .encode()
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+        let write = self
+            .store
+            .finalize_bat_v2_quote(&QuoteFinalization {
+                quote_id: record.quote_id,
+                invoice: created.invoice.clone(),
+                payment_hash: created.payment_hash,
+                invoice_created_at: quote.invoice_created_at,
+                invoice_expires_at: quote.invoice_expires_at,
+                claim_deadline: quote.claim_deadline,
+                credential_not_after: quote.credential_not_after,
+                exact_signed_quote_response: exact,
+            })
+            .map_err(map_store_error)?;
+        let persisted = write
+            .value
+            .initial_signed_quote_response
+            .clone()
+            .ok_or(IssuerCoreErrorV1::PermanentMismatch)?;
+        verify_persisted_bat_v2_snapshot(
+            &self.store,
+            &write.value,
+            &persisted,
+            quote_signing_key,
+            now_unix,
+            Bolt11QuoteStatusV1::InvoiceOpen,
+        )?;
+        Ok(QuoteCreateResultV1 {
+            disposition: if newly_reserved {
+                QuoteCreateDispositionV1::Created
+            } else {
+                QuoteCreateDispositionV1::RecoveredReserved
+            },
+            exact_signed_quote_response: persisted,
+        })
+    }
+
     fn reconcile_expired(
         &self,
         record: QuoteRecord,
         current_exact: Vec<u8>,
         quote_signing_key: &SigningKey,
         observed_at: u64,
+        protocol: QuoteAcquisitionProtocolV1,
     ) -> Result<QuoteReconcileResultV1, IssuerCoreErrorV1> {
         let expires_at = required_time(record.invoice_expires_at)?;
         if observed_at < expires_at {
@@ -626,22 +1033,29 @@ where
                 // at `expires_at` keeps restart recovery possible after a long
                 // issuer outage without extending the delegated quote key's
                 // validity or manufacturing a later lifecycle timestamp.
-                let next = sign_persisted_transition(
+                let next = self.sign_persisted_transition_for_protocol(
                     &record,
                     &current_exact,
                     quote_signing_key,
                     observed_at,
                     Bolt11QuoteStatusV1::InvoiceExpiredPendingReconcile,
                     expires_at,
+                    protocol,
                 )?;
-                let write = self
-                    .store
-                    .mark_invoice_expired(&QuoteExpiry {
-                        quote_id: record.quote_id,
-                        observed_at: expires_at,
-                        exact_signed_quote_response: next,
-                    })
-                    .map_err(map_store_error)?;
+                let expiry = QuoteExpiry {
+                    quote_id: record.quote_id,
+                    observed_at: expires_at,
+                    exact_signed_quote_response: next,
+                };
+                let write = match protocol {
+                    QuoteAcquisitionProtocolV1::ProviderBoundV1 => {
+                        self.store.mark_invoice_expired(&expiry)
+                    }
+                    QuoteAcquisitionProtocolV1::BatV2 => {
+                        self.store.mark_bat_v2_invoice_expired(&expiry)
+                    }
+                }
+                .map_err(map_store_error)?;
                 let exact = write
                     .value
                     .expired_signed_quote_response
@@ -677,6 +1091,7 @@ where
         settled_at: u64,
         amount_received_msat: u64,
         settlement_evidence_digest: [u8; 32],
+        protocol: QuoteAcquisitionProtocolV1,
     ) -> Result<QuoteReconcileResultV1, IssuerCoreErrorV1> {
         let created_at = required_time(record.invoice_created_at)?;
         let expires_at = required_time(record.invoice_expires_at)?;
@@ -698,24 +1113,32 @@ where
                 amount_received_msat,
                 settlement_evidence_digest,
                 Bolt11QuoteStatusV1::PaymentSettled,
+                protocol,
             ),
             QuoteState::InvoiceOpen => {
-                let expired_exact = sign_persisted_transition(
+                let expired_exact = self.sign_persisted_transition_for_protocol(
                     &record,
                     &current_exact,
                     quote_signing_key,
                     observed_at,
                     Bolt11QuoteStatusV1::InvoiceExpiredPendingReconcile,
                     expires_at,
+                    protocol,
                 )?;
-                let expired_write = self
-                    .store
-                    .mark_invoice_expired(&QuoteExpiry {
-                        quote_id: record.quote_id,
-                        observed_at: expires_at,
-                        exact_signed_quote_response: expired_exact,
-                    })
-                    .map_err(map_store_error)?;
+                let expiry = QuoteExpiry {
+                    quote_id: record.quote_id,
+                    observed_at: expires_at,
+                    exact_signed_quote_response: expired_exact,
+                };
+                let expired_write = match protocol {
+                    QuoteAcquisitionProtocolV1::ProviderBoundV1 => {
+                        self.store.mark_invoice_expired(&expiry)
+                    }
+                    QuoteAcquisitionProtocolV1::BatV2 => {
+                        self.store.mark_bat_v2_invoice_expired(&expiry)
+                    }
+                }
+                .map_err(map_store_error)?;
                 let expired_record = expired_write.value;
                 let expired_snapshot = expired_record
                     .expired_signed_quote_response
@@ -730,6 +1153,7 @@ where
                     amount_received_msat,
                     settlement_evidence_digest,
                     Bolt11QuoteStatusV1::LateSettledReconcile,
+                    protocol,
                 )
             }
             QuoteState::InvoiceExpiredPendingReconcile => {
@@ -746,6 +1170,7 @@ where
                     amount_received_msat,
                     settlement_evidence_digest,
                     Bolt11QuoteStatusV1::LateSettledReconcile,
+                    protocol,
                 )
             }
             QuoteState::PaymentSettled | QuoteState::LateSettledReconcile => {
@@ -778,6 +1203,7 @@ where
         amount_received_msat: u64,
         settlement_evidence_digest: [u8; 32],
         next_status: Bolt11QuoteStatusV1,
+        protocol: QuoteAcquisitionProtocolV1,
     ) -> Result<QuoteReconcileResultV1, IssuerCoreErrorV1> {
         let current = Bolt11QuoteV1::decode(&current_exact)
             .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
@@ -796,25 +1222,30 @@ where
         if transition_time > observed_at {
             return Err(IssuerCoreErrorV1::RetryableUnavailable);
         }
-        let next = sign_persisted_transition(
+        let next = self.sign_persisted_transition_for_protocol(
             &record,
             &current_exact,
             quote_signing_key,
             observed_at,
             next_status,
             transition_time,
+            protocol,
         )?;
-        let write = self
-            .store
-            .record_settlement(&QuoteSettlement {
-                quote_id: record.quote_id,
-                settled_at,
-                observed_at: transition_time,
-                settled_amount_msat: amount_received_msat,
-                settlement_evidence_digest,
-                exact_signed_quote_response: next,
-            })
-            .map_err(map_store_error)?;
+        let settlement = QuoteSettlement {
+            quote_id: record.quote_id,
+            settled_at,
+            observed_at: transition_time,
+            settled_amount_msat: amount_received_msat,
+            settlement_evidence_digest,
+            exact_signed_quote_response: next,
+        };
+        let write = match protocol {
+            QuoteAcquisitionProtocolV1::ProviderBoundV1 => {
+                self.store.record_settlement(&settlement)
+            }
+            QuoteAcquisitionProtocolV1::BatV2 => self.store.record_bat_v2_settlement(&settlement),
+        }
+        .map_err(map_store_error)?;
         let exact = write
             .value
             .settled_signed_quote_response
@@ -825,6 +1256,38 @@ where
             QuoteReconcileDispositionV1::Transitioned,
             exact,
         ))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn sign_persisted_transition_for_protocol(
+        &self,
+        record: &QuoteRecord,
+        current_exact: &[u8],
+        quote_signing_key: &SigningKey,
+        verification_time: u64,
+        next_status: Bolt11QuoteStatusV1,
+        transition_time: u64,
+        protocol: QuoteAcquisitionProtocolV1,
+    ) -> Result<Vec<u8>, IssuerCoreErrorV1> {
+        match protocol {
+            QuoteAcquisitionProtocolV1::ProviderBoundV1 => sign_persisted_transition(
+                record,
+                current_exact,
+                quote_signing_key,
+                verification_time,
+                next_status,
+                transition_time,
+            ),
+            QuoteAcquisitionProtocolV1::BatV2 => sign_persisted_bat_v2_transition(
+                &self.store,
+                record,
+                current_exact,
+                quote_signing_key,
+                verification_time,
+                next_status,
+                transition_time,
+            ),
+        }
     }
 }
 
@@ -872,6 +1335,45 @@ fn validate_record_for_intent(
     Ok(())
 }
 
+fn validate_bat_v2_record_for_intent(
+    record: &QuoteRecord,
+    verified_intent: &VerifiedBolt11BatV2QuoteIntentV2<'_>,
+) -> Result<(), IssuerCoreErrorV1> {
+    let intent = verified_intent.intent();
+    let exact_delegation = verified_intent
+        .delegation()
+        .encode()
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+    if record.intent_digest
+        != intent
+            .request_digest()
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?
+        || record.payee_pubkey != intent.expected_payee_pubkey
+        || record.delegation_epoch != verified_intent.delegation().key_epoch
+        || record.delegation_digest != intent.quote_delegation_digest
+        || record.exact_delegation != exact_delegation
+        || record.exact_amount_msat != intent.exact_amount_msat
+        || record.invoice_created_not_before == 0
+        || record.invoice_created_not_after < record.invoice_created_not_before
+    {
+        return Err(IssuerCoreErrorV1::PermanentMismatch);
+    }
+    Ok(())
+}
+
+fn reservation_time(record: &QuoteRecord) -> Result<u64, IssuerCoreErrorV1> {
+    let value = record
+        .invoice_created_not_before
+        .checked_add(INVOICE_CREATION_CLOCK_SKEW_SECONDS_V1)
+        .ok_or(IssuerCoreErrorV1::PermanentMismatch)?;
+    if value.checked_add(INVOICE_CREATION_CLOCK_SKEW_SECONDS_V1)
+        != Some(record.invoice_created_not_after)
+    {
+        return Err(IssuerCoreErrorV1::PermanentMismatch);
+    }
+    Ok(value)
+}
+
 fn sign_recovered_initial_quote(
     record: &QuoteRecord,
     sanitized_intent: &Bolt11QuoteIntentV1,
@@ -892,6 +1394,88 @@ fn sign_recovered_initial_quote(
             .expires_at()
             .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?
             != horizons.invoice_expires_at
+    {
+        return Err(IssuerCoreErrorV1::PermanentMismatch);
+    }
+    delegation
+        .verify_for(
+            &sanitized_intent.issuer_id,
+            sanitized_intent.network,
+            &record.payee_pubkey,
+            record.delegation_epoch,
+            parsed_invoice.created_at(),
+        )
+        .and_then(|_| {
+            delegation.verify_for(
+                &sanitized_intent.issuer_id,
+                sanitized_intent.network,
+                &record.payee_pubkey,
+                record.delegation_epoch,
+                horizons.claim_deadline,
+            )
+        })
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+    validate_signer(delegation, quote_signing_key)?;
+    let mut quote = Bolt11QuoteV1 {
+        request_digest: record.intent_digest,
+        quote_id: record.quote_id,
+        quote_key_id: delegation.quote_key_id,
+        invoice: invoice.to_owned(),
+        network: sanitized_intent.network,
+        payee_pubkey: record.payee_pubkey,
+        amount_msat: record.exact_amount_msat,
+        invoice_created_at: parsed_invoice.created_at(),
+        invoice_expires_at: horizons.invoice_expires_at,
+        claim_deadline: horizons.claim_deadline,
+        credential_not_after: horizons.credential_not_after,
+        status: Bolt11QuoteStatusV1::InvoiceOpen,
+        state_version: 1,
+        status_updated_at: parsed_invoice.created_at(),
+        signature: [0; 64],
+    };
+    let unsigned_with_placeholder = quote
+        .encode()
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+    let unsigned_len = unsigned_with_placeholder
+        .len()
+        .checked_sub(quote.signature.len())
+        .ok_or(IssuerCoreErrorV1::PermanentMismatch)?;
+    let mut signing_preimage =
+        Vec::with_capacity(BOLT11_QUOTE_SIGNATURE_DOMAIN.len() + unsigned_len);
+    signing_preimage.extend_from_slice(BOLT11_QUOTE_SIGNATURE_DOMAIN);
+    signing_preimage.extend_from_slice(&unsigned_with_placeholder[..unsigned_len]);
+    quote.signature = quote_signing_key.sign(&signing_preimage).to_bytes();
+    quote
+        .encode()
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sign_recovered_initial_bat_v2_quote(
+    record: &QuoteRecord,
+    sanitized_intent: &Bolt11BatV2QuoteIntentV2,
+    class: &BatAcceptanceClassV2,
+    delegation: &Bolt11QuoteKeyDelegationV1,
+    invoice: &str,
+    parsed_invoice: &ParsedBolt11InvoiceV1,
+    quote_signing_key: &SigningKey,
+) -> Result<Vec<u8>, IssuerCoreErrorV1> {
+    let horizons = sanitized_intent
+        .derived_horizons(parsed_invoice.created_at())
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+    if parsed_invoice.invoice_text_digest() != bolt11_invoice_text_digest_v1(invoice)
+        || parsed_invoice.network() != sanitized_intent.network
+        || parsed_invoice.payee_pubkey() != record.payee_pubkey
+        || parsed_invoice.amount_msat() != record.exact_amount_msat
+        || parsed_invoice.expiry_seconds() != sanitized_intent.invoice_expiry_seconds
+        || parsed_invoice
+            .expires_at()
+            .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?
+            != horizons.invoice_expires_at
+        || class.class_digest().ok() != Some(sanitized_intent.class_digest)
+        || class.bat_key_id() != sanitized_intent.bat_key_id
+        || parsed_invoice.created_at() < class.key_not_before
+        || horizons.credential_not_after > class.key_not_after
     {
         return Err(IssuerCoreErrorV1::PermanentMismatch);
     }
@@ -980,6 +1564,155 @@ fn expected_status_for_state(state: QuoteState) -> Result<Bolt11QuoteStatusV1, I
             Err(IssuerCoreErrorV1::InvalidState)
         }
     }
+}
+
+fn decode_persisted_bat_v2_material(
+    store: &IssuerStore,
+    record: &QuoteRecord,
+    exact: &[u8],
+    quote_signing_key: &SigningKey,
+    expected_status: Bolt11QuoteStatusV1,
+) -> Result<
+    (
+        Bolt11QuoteV1,
+        Bolt11QuoteKeyDelegationV1,
+        Bolt11BatV2QuoteIntentV2,
+        BatAcceptanceClassV2,
+    ),
+    IssuerCoreErrorV1,
+> {
+    let quote = Bolt11QuoteV1::decode(exact).map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+    if quote
+        .encode()
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?
+        != exact
+        || quote.status != expected_status
+    {
+        return Err(IssuerCoreErrorV1::PermanentMismatch);
+    }
+    let delegation = Bolt11QuoteKeyDelegationV1::decode(&record.exact_delegation)
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+    if delegation
+        .encode()
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?
+        != record.exact_delegation
+        || delegation.delegation_digest().ok() != Some(record.delegation_digest)
+    {
+        return Err(IssuerCoreErrorV1::PermanentMismatch);
+    }
+    validate_signer(&delegation, quote_signing_key)?;
+    let intent = Bolt11BatV2QuoteIntentV2::decode(&record.intent_replay_image)
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+    if intent
+        .encode()
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?
+        != record.intent_replay_image
+        || intent.idempotency_key != record.creation_idempotency_digest
+        || intent.issuer_id != delegation.issuer_id
+        || intent.network != delegation.network
+        || intent.expected_payee_pubkey != record.payee_pubkey
+        || intent.minimum_quote_key_epoch != record.delegation_epoch
+        || intent.quote_delegation_digest != record.delegation_digest
+        || intent.exact_amount_msat != record.exact_amount_msat
+    {
+        return Err(IssuerCoreErrorV1::PermanentMismatch);
+    }
+    let class_record = store
+        .bat_acceptance_class_v2(&intent.class_id, intent.class_key_epoch)
+        .map_err(map_store_error)?
+        .ok_or(IssuerCoreErrorV1::PermanentMismatch)?;
+    let class = BatAcceptanceClassV2::decode(&class_record.exact_artifact)
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+    if class
+        .encode()
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?
+        != class_record.exact_artifact
+        || class_record.artifact_digest != intent.class_digest
+        || class_record.bat_key_id != intent.bat_key_id
+        || class_record.raw_public_key != class.bat_verification_key
+    {
+        return Err(IssuerCoreErrorV1::PermanentMismatch);
+    }
+    Ok((quote, delegation, intent, class))
+}
+
+fn persisted_bat_v2_expectation<'a>(
+    record: &'a QuoteRecord,
+    intent: &'a Bolt11BatV2QuoteIntentV2,
+    class: &'a BatAcceptanceClassV2,
+) -> Result<PersistedBolt11BatV2QuoteExpectationV2<'a>, IssuerCoreErrorV1> {
+    Ok(PersistedBolt11BatV2QuoteExpectationV2 {
+        original_request_digest: &record.intent_digest,
+        replay_intent: intent,
+        class,
+        quote_id: &record.quote_id,
+        invoice: record
+            .invoice
+            .as_deref()
+            .ok_or(IssuerCoreErrorV1::PermanentMismatch)?,
+        invoice_created_at: required_time(record.invoice_created_at)?,
+        invoice_expires_at: required_time(record.invoice_expires_at)?,
+        claim_deadline: required_time(record.claim_deadline)?,
+        credential_not_after: required_time(record.credential_not_after)?,
+    })
+}
+
+fn verify_persisted_bat_v2_snapshot(
+    store: &IssuerStore,
+    record: &QuoteRecord,
+    exact: &[u8],
+    quote_signing_key: &SigningKey,
+    now_unix: u64,
+    expected_status: Bolt11QuoteStatusV1,
+) -> Result<(), IssuerCoreErrorV1> {
+    let (quote, delegation, intent, class) =
+        decode_persisted_bat_v2_material(store, record, exact, quote_signing_key, expected_status)?;
+    let latest_signed_time = quote.invoice_created_at.max(quote.status_updated_at);
+    if latest_signed_time > now_unix.saturating_add(INVOICE_CREATION_CLOCK_SKEW_SECONDS_V1) {
+        return Err(IssuerCoreErrorV1::PermanentMismatch);
+    }
+    let verification_time = now_unix.max(latest_signed_time);
+    let expected = persisted_bat_v2_expectation(record, &intent, &class)?;
+    quote
+        .verify_persisted_bat_v2_quote_for_store(expected, &delegation, verification_time)
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sign_persisted_bat_v2_transition(
+    store: &IssuerStore,
+    record: &QuoteRecord,
+    current_exact: &[u8],
+    quote_signing_key: &SigningKey,
+    verification_time: u64,
+    next_status: Bolt11QuoteStatusV1,
+    transition_time: u64,
+) -> Result<Vec<u8>, IssuerCoreErrorV1> {
+    let (quote, delegation, intent, class) = decode_persisted_bat_v2_material(
+        store,
+        record,
+        current_exact,
+        quote_signing_key,
+        expected_status_for_state(record.state)?,
+    )?;
+    if transition_time <= quote.status_updated_at {
+        return Err(IssuerCoreErrorV1::RetryableUnavailable);
+    }
+    let expected = persisted_bat_v2_expectation(record, &intent, &class)?;
+    let verified = quote
+        .verify_persisted_bat_v2_quote_for_store(expected, &delegation, verification_time)
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+    let next = Bolt11QuoteV1::with_status_from_verified_bat_v2_snapshot(
+        &verified,
+        next_status,
+        transition_time,
+        &delegation,
+        quote_signing_key,
+    )
+    .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)?;
+    next.encode()
+        .map_err(|_| IssuerCoreErrorV1::PermanentMismatch)
 }
 
 fn decode_persisted_material(
@@ -1148,6 +1881,7 @@ fn map_store_error(error: StoreError) -> IssuerCoreErrorV1 {
         | StoreError::IssuerMismatch
         | StoreError::NetworkMismatch
         | StoreError::InvalidInput(_)
+        | StoreError::QuoteProtocolMismatch
         | StoreError::QuoteConflict
         | StoreError::CreationIdempotencyConflict
         | StoreError::InvoiceConflict

--- a/crates/payment/issuer-credentials/src/lib.rs
+++ b/crates/payment/issuer-credentials/src/lib.rs
@@ -18,11 +18,12 @@ use pir_payment_crypto::{
     VerifiedBip340ClaimV1,
 };
 use pir_service_protocol::{
-    AuthScheme, BitcoinPirCashuBatIssuanceResponseItemV1, Bolt11QuoteClaimV1, Bolt11QuoteStatusV1,
+    AuthScheme, BatV2IssuanceRequestV2, BatV2IssuanceResponseV2,
+    BitcoinPirCashuBatIssuanceResponseItemV1, Bolt11QuoteClaimV1, Bolt11QuoteStatusV1,
     CheckedCredentialIssuanceResponseV1, CredentialIssuanceRequestItemsV1,
     CredentialIssuanceRequestV1, CredentialIssuanceResponseItemsV1, CredentialIssuanceResponseV1,
     CredentialKeyBindingExpectationV1, CredentialKeyBindingV1, PaidReceiptBindingV1, PaidReceiptV1,
-    ServiceProtocolError, VerifiedBolt11QuoteV1,
+    ServiceProtocolError, VerifiedBolt11BatV2QuoteV2, VerifiedBolt11QuoteV1,
 };
 use rand_chacha::{rand_core::SeedableRng, ChaCha20Rng};
 use sha2::{Digest, Sha256};
@@ -31,6 +32,8 @@ use zeroize::{Zeroize, Zeroizing};
 const DIRECT_SERIAL_DERIVATION_DOMAIN_V1: &[u8] = b"BitcoinPIR/issuer-credential/direct-serial/v1";
 const BAT_DLEQ_NONCE_DERIVATION_DOMAIN_V1: &[u8] =
     b"BitcoinPIR/issuer-credential/bat-dleq-nonce/v1";
+const BAT_V2_DLEQ_NONCE_DERIVATION_DOMAIN_V2: &[u8] =
+    b"BitcoinPIR/issuer-credential/bat-v2-dleq-nonce/v2";
 const ARC_RESPONSE_RNG_DERIVATION_DOMAIN_V1: &[u8] =
     b"BitcoinPIR/issuer-credential/arc-response-rng/v1";
 const MAX_DERIVATION_ATTEMPTS_V1: u32 = 128;
@@ -182,6 +185,37 @@ impl fmt::Debug for PreparedCredentialIssuanceV1 {
     }
 }
 
+/// Prepared issuer-wide BAT V2 response whose BIP340 claim and every NUT-12
+/// transcript have been checked. The exact bytes still must not be released
+/// until the issuer store durably commits the matching V2 claim envelope.
+pub struct PreparedBatV2IssuanceV2 {
+    response: BatV2IssuanceResponseV2,
+    verified_claim: VerifiedCredentialClaimV1,
+}
+
+impl PreparedBatV2IssuanceV2 {
+    pub const fn response(&self) -> &BatV2IssuanceResponseV2 {
+        &self.response
+    }
+
+    pub const fn verified_claim(&self) -> &VerifiedCredentialClaimV1 {
+        &self.verified_claim
+    }
+
+    pub fn encode_response(&self) -> Result<Vec<u8>, IssuerCredentialErrorV1> {
+        Ok(self.response.encode()?)
+    }
+}
+
+impl fmt::Debug for PreparedBatV2IssuanceV2 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedBatV2IssuanceV2")
+            .field("item_count", &self.response.items.len())
+            .finish_non_exhaustive()
+    }
+}
+
 /// Prepare linkable single-use receipts for a settled direct-BOLT11 quote.
 /// No response bytes may be released until the caller commits them durably.
 pub fn prepare_direct_receipt_issuance_v1(
@@ -292,6 +326,7 @@ pub fn prepare_cashu_bat_issuance_v1(
         let response = derive_and_blind_sign_v1(
             keyring,
             derivation_key,
+            BAT_DLEQ_NONCE_DERIVATION_DOMAIN_V1,
             &issuer_public_key,
             &verified_quote.quote().quote_id,
             &request_digest,
@@ -323,6 +358,67 @@ pub fn prepare_cashu_bat_issuance_v1(
         return Err(IssuerCredentialErrorV1::WrongPreparedResponseVariant);
     }
     Ok(PreparedCredentialIssuanceV1 {
+        response,
+        verified_claim,
+    })
+}
+
+/// Prepare class-bound blind BAT signatures and NUT-12 proofs for a settled
+/// BAT V2 quote. The issuer selects the signing scalar only through the exact
+/// retained class artifact; no provider-bound V1 credential binding is
+/// accepted by this path.
+pub fn prepare_cashu_bat_v2_issuance_v2(
+    request: &BatV2IssuanceRequestV2,
+    claim: &Bolt11QuoteClaimV1,
+    verified_quote: &VerifiedBolt11BatV2QuoteV2<'_>,
+    keyring: &K256CashuMintKeyringV1,
+    derivation_key: &IssuerCredentialDerivationKeyV1,
+    now_unix: u64,
+) -> Result<PreparedBatV2IssuanceV2, IssuerCredentialErrorV1> {
+    let unverified_claim = request.verify_for_verified_quote(claim, verified_quote, now_unix)?;
+    let bip340 = verify_quote_claim_v1(&unverified_claim)?;
+    let request_digest = request.request_digest()?;
+    let issuer_public_key = verified_quote.class().bat_verification_key;
+    let mut used_nonce_fingerprints = HashSet::with_capacity(request.items.len());
+    let mut items = Vec::with_capacity(request.items.len());
+    for (index, item) in request.items.iter().enumerate() {
+        let index =
+            u32::try_from(index).map_err(|_| IssuerCredentialErrorV1::DerivationExhausted)?;
+        let signed = derive_and_blind_sign_v1(
+            keyring,
+            derivation_key,
+            BAT_V2_DLEQ_NONCE_DERIVATION_DOMAIN_V2,
+            &issuer_public_key,
+            &verified_quote.quote().quote_id,
+            &request_digest,
+            index,
+            &item.blinded_message,
+            &mut used_nonce_fingerprints,
+        )?;
+        items.push(BitcoinPirCashuBatIssuanceResponseItemV1 {
+            blinded_message: item.blinded_message,
+            blinded_signature: *signed.blinded_signature(),
+            dleq_e: *signed.dleq_e(),
+            dleq_s: *signed.dleq_s(),
+        });
+    }
+    let response = BatV2IssuanceResponseV2 {
+        issuer_id: request.issuer_id,
+        quote_id: request.quote_id,
+        quote_request_digest: request.quote_request_digest,
+        credential_request_digest: request_digest,
+        class_id: request.class_id,
+        class_digest: request.class_digest,
+        class_key_epoch: request.class_key_epoch,
+        bat_key_id: request.bat_key_id,
+        items,
+    };
+    let verified_claim =
+        verify_prepared_bat_v2_response_v2(claim, request, &response, verified_quote, now_unix)?;
+    if verified_claim.bip340_message_digest() != bip340.message_digest() {
+        return Err(IssuerCredentialErrorV1::WrongPreparedResponseVariant);
+    }
+    Ok(PreparedBatV2IssuanceV2 {
         response,
         verified_claim,
     })
@@ -438,6 +534,32 @@ pub fn verify_prepared_response_v1(
     Ok(VerifiedCredentialClaimV1 { bip340 })
 }
 
+/// Verify a prepared BAT V2 response without issuer secret material. This
+/// repeats the exact quote/request binding, BIP340 ownership proof, and every
+/// NUT-12 equation before a store callback may authorize the durable write.
+pub fn verify_prepared_bat_v2_response_v2(
+    claim: &Bolt11QuoteClaimV1,
+    request: &BatV2IssuanceRequestV2,
+    response: &BatV2IssuanceResponseV2,
+    verified_quote: &VerifiedBolt11BatV2QuoteV2<'_>,
+    now_unix: u64,
+) -> Result<VerifiedCredentialClaimV1, IssuerCredentialErrorV1> {
+    let unverified_claim = request.verify_for_verified_quote(claim, verified_quote, now_unix)?;
+    let bip340 = verify_quote_claim_v1(&unverified_claim)?;
+    let checked = response.verify_for_verified_quote(request, verified_quote)?;
+    let verifier = K256CashuDleqVerifierV1;
+    for tuple in checked.unverified_dleq() {
+        verifier.verify(
+            &tuple.issuer_public_key,
+            &tuple.blinded_message,
+            &tuple.blinded_signature,
+            &tuple.dleq_e,
+            &tuple.dleq_s,
+        )?;
+    }
+    Ok(VerifiedCredentialClaimV1 { bip340 })
+}
+
 fn verify_request_claim_v1(
     request: &CredentialIssuanceRequestV1,
     claim: &Bolt11QuoteClaimV1,
@@ -476,6 +598,7 @@ fn response_envelope_v1(
 fn derive_and_blind_sign_v1(
     keyring: &K256CashuMintKeyringV1,
     derivation_key: &IssuerCredentialDerivationKeyV1,
+    nonce_domain: &[u8],
     issuer_public_key: &[u8; 33],
     quote_id: &[u8; 32],
     request_digest: &[u8; 32],
@@ -485,7 +608,7 @@ fn derive_and_blind_sign_v1(
 ) -> Result<pir_payment_crypto::CashuBlindSignatureWithDleqV1, IssuerCredentialErrorV1> {
     for attempt in 0..MAX_DERIVATION_ATTEMPTS_V1 {
         let mut nonce = derivation_key.derive(
-            BAT_DLEQ_NONCE_DERIVATION_DOMAIN_V1,
+            nonce_domain,
             quote_id,
             request_digest,
             index,

--- a/crates/payment/issuer-service/src/lib.rs
+++ b/crates/payment/issuer-service/src/lib.rs
@@ -21,10 +21,12 @@ use pir_issuer_core::{
     INVOICE_CREATION_CLOCK_SKEW_SECONDS_V1,
 };
 use pir_issuer_credentials::{
-    prepare_arc_issuance_v1, prepare_cashu_bat_issuance_v1, prepare_direct_receipt_issuance_v1,
-    IssuerCredentialDerivationKeyV1, PreparedCredentialIssuanceV1,
+    prepare_arc_issuance_v1, prepare_cashu_bat_issuance_v1, prepare_cashu_bat_v2_issuance_v2,
+    prepare_direct_receipt_issuance_v1, IssuerCredentialDerivationKeyV1, PreparedBatV2IssuanceV2,
+    PreparedCredentialIssuanceV1,
 };
 use pir_issuer_store::{
+    BatAcceptanceClassRecordV2, BatV2ClaimCryptographicVerificationInputV2, BatV2ClaimWrite,
     ClaimCryptographicVerificationInput, ClaimWrite, IssuerStore,
     ProviderSettlementRegistrationRecordV1, QuoteCapacityV1, QuoteState, QuoteStatusBip340Input,
     StoreError, VerifiedRedeemCommitV1,
@@ -39,7 +41,8 @@ use pir_service_protocol::{
     verify_new_balance_request_for, verify_new_payout_request_for,
     verify_new_payout_status_request_for, verify_payout_initial_response_for_exact_request,
     verify_persisted_payout_snapshot_for_store_v1, verify_redeem_response_for_exact_request,
-    AcquisitionMethod, AuthScheme, Bolt11QuoteClaimEnvelopeV1, Bolt11QuoteIntentV1,
+    AcquisitionMethod, AuthScheme, BatAcceptanceClassV2, Bolt11BatV2ClaimEnvelopeV2,
+    Bolt11BatV2QuoteIntentV2, Bolt11QuoteClaimEnvelopeV1, Bolt11QuoteIntentV1,
     Bolt11QuoteKeyDelegationV1, Bolt11QuoteKeyRollbackGuardV1, Bolt11QuoteStatusRequestV1,
     Bolt11QuoteStatusV1, Bolt11QuoteV1, CashuKeysetBindingV1, CommittedRedeemReplayExpectationV1,
     IssuerBalanceResponseV1, IssuerClearingApprovalV1, IssuerPayoutIntentResponseV1,
@@ -335,6 +338,18 @@ where
                 arc_keyring_experimental.as_deref(),
             )?;
         }
+        for requirement in store
+            .bat_v2_credential_material_requirements(now_unix)
+            .map_err(map_store_error)?
+        {
+            let covered = bat_keyring.as_ref().is_some_and(|keys| {
+                keys.denomination_public_keys()
+                    .contains(&requirement.raw_public_key)
+            });
+            if !covered {
+                return Err(IssuerServiceErrorV1::InvalidRequest);
+            }
+        }
         Ok(Self {
             core: Bolt11IssuerCoreV1::new_with_quote_capacity(
                 store.clone(),
@@ -500,6 +515,128 @@ where
             .map_err(map_core_error)
     }
 
+    /// `POST /v2/quotes/bolt11` body handler for issuer-wide BAT V2.
+    /// The intent is class-only: no provider policy, scope, offer, or V1
+    /// credential binding is accepted on this path.
+    pub fn create_bat_v2_quote(
+        &self,
+        canonical_intent: &[u8],
+        now_unix: u64,
+    ) -> Result<Vec<u8>, IssuerServiceErrorV1> {
+        let intent = Bolt11BatV2QuoteIntentV2::decode(canonical_intent)
+            .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?;
+        if intent
+            .encode()
+            .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?
+            .as_slice()
+            != canonical_intent
+        {
+            return Err(IssuerServiceErrorV1::InvalidRequest);
+        }
+        if let Some(existing) = self
+            .store
+            .bat_v2_quote_by_creation_idempotency_key(&intent.idempotency_key)
+            .map_err(map_store_error)?
+        {
+            if existing.intent_digest
+                != intent
+                    .request_digest()
+                    .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?
+            {
+                return Err(IssuerServiceErrorV1::Conflict);
+            }
+            let class_record = self
+                .store
+                .bat_acceptance_class_v2(&intent.class_id, intent.class_key_epoch)
+                .map_err(map_store_error)?
+                .ok_or(IssuerServiceErrorV1::Internal)?;
+            let class = decode_bat_v2_class(&class_record)?;
+            let delegation = Bolt11QuoteKeyDelegationV1::decode(&existing.exact_delegation)
+                .map_err(|_| IssuerServiceErrorV1::Internal)?;
+            let quote_material = self
+                .quote_material(&existing.delegation_digest)
+                .ok_or(IssuerServiceErrorV1::Internal)?;
+            let reservation_time = existing
+                .invoice_created_not_before
+                .checked_add(INVOICE_CREATION_CLOCK_SKEW_SECONDS_V1)
+                .ok_or(IssuerServiceErrorV1::Internal)?;
+            if reservation_time.checked_add(INVOICE_CREATION_CLOCK_SKEW_SECONDS_V1)
+                != Some(existing.invoice_created_not_after)
+            {
+                return Err(IssuerServiceErrorV1::Internal);
+            }
+            let guard = Bolt11QuoteKeyRollbackGuardV1::from_persisted(
+                intent.issuer_id,
+                intent.network,
+                intent.expected_payee_pubkey,
+                existing.delegation_epoch,
+                existing.delegation_digest,
+            )
+            .map_err(|_| IssuerServiceErrorV1::Internal)?;
+            let verified_intent = intent
+                .verify_for_class_guarded(&class, &delegation, &guard, reservation_time)
+                .map_err(|_| IssuerServiceErrorV1::Unauthorized)?;
+            if existing.state == QuoteState::Reserved {
+                self.ensure_bat_v2_class_credential_material(&class_record)?;
+            }
+            return self
+                .core
+                .create_or_recover_bat_v2_quote(
+                    &verified_intent,
+                    &quote_material.signing_key,
+                    now_unix,
+                )
+                .map(|result| result.into_exact_signed_quote_response())
+                .map_err(map_core_error);
+        }
+
+        let class_record = self
+            .store
+            .current_bat_acceptance_class_v2(&intent.class_id)
+            .map_err(map_store_error)?
+            .ok_or(IssuerServiceErrorV1::Unauthorized)?;
+        if class_record.key_epoch != intent.class_key_epoch
+            || class_record.artifact_digest != intent.class_digest
+            || class_record.bat_key_id != intent.bat_key_id
+        {
+            return Err(IssuerServiceErrorV1::Unauthorized);
+        }
+        self.ensure_bat_v2_class_credential_material(&class_record)?;
+        if intent.quote_delegation_digest != self.current_quote_key.delegation_digest {
+            return Err(IssuerServiceErrorV1::Unauthorized);
+        }
+        let quote_material = self
+            .quote_material(&intent.quote_delegation_digest)
+            .ok_or(IssuerServiceErrorV1::Unauthorized)?;
+        let guard = match self
+            .store
+            .delegation_head(&intent.expected_payee_pubkey)
+            .map_err(map_store_error)?
+        {
+            Some(head) => Bolt11QuoteKeyRollbackGuardV1::from_persisted(
+                intent.issuer_id,
+                intent.network,
+                intent.expected_payee_pubkey,
+                head.highest_epoch,
+                head.delegation_digest,
+            ),
+            None => Bolt11QuoteKeyRollbackGuardV1::initial(
+                intent.issuer_id,
+                intent.network,
+                intent.expected_payee_pubkey,
+            ),
+        }
+        .map_err(|_| IssuerServiceErrorV1::Unauthorized)?;
+        let class = decode_bat_v2_class(&class_record)?;
+        let verified_intent = intent
+            .verify_for_class_guarded(&class, &quote_material.delegation, &guard, now_unix)
+            .map_err(|_| IssuerServiceErrorV1::Unauthorized)?;
+        self.core
+            .create_or_recover_bat_v2_quote(&verified_intent, &quote_material.signing_key, now_unix)
+            .map(|result| result.into_exact_signed_quote_response())
+            .map_err(map_core_error)
+    }
+
     /// Reconcile one bounded cursor page without any browser status nonce.
     /// Individual backend failures are reduced to aggregate counters so no
     /// invoice, label, payment hash, or quote ID can reach logs.
@@ -531,6 +668,63 @@ where
                 continue;
             };
             match self.core.reconcile_by_backend_label(
+                candidate.backend_label(),
+                &material.signing_key,
+                now_unix,
+            ) {
+                Ok(result) => match result.disposition() {
+                    QuoteReconcileDispositionV1::Transitioned => {
+                        report.transitioned = report.transitioned.saturating_add(1)
+                    }
+                    QuoteReconcileDispositionV1::Unchanged => {
+                        report.unchanged = report.unchanged.saturating_add(1)
+                    }
+                },
+                Err(
+                    IssuerCoreErrorV1::RetryableUnavailable
+                    | IssuerCoreErrorV1::OutcomeUnknown
+                    | IssuerCoreErrorV1::StoreUnanchored,
+                ) => report.retryable_failures = report.retryable_failures.saturating_add(1),
+                Err(_) => report.permanent_failures = report.permanent_failures.saturating_add(1),
+            }
+        }
+        if candidates.len() == limit as usize {
+            report.next_cursor = candidates.last().map(|candidate| *candidate.quote_id());
+        }
+        Ok(report)
+    }
+
+    /// Reconcile one bounded BAT V2 cursor page. Store queries and core
+    /// transitions are protocol-discriminated, so a V1 row can never enter
+    /// this batch even if a caller reuses a quote ID or backend label.
+    pub fn reconcile_bat_v2_quote_batch(
+        &self,
+        after_quote_id: Option<&[u8; 32]>,
+        limit: u32,
+        now_unix: u64,
+    ) -> Result<IssuerReconciliationBatchV1, IssuerServiceErrorV1> {
+        if now_unix == 0 {
+            return Err(IssuerServiceErrorV1::InvalidRequest);
+        }
+        let candidates = self
+            .store
+            .bat_v2_quote_reconciliation_candidates_after(after_quote_id, limit, now_unix)
+            .map_err(map_store_error)?;
+        let mut report = IssuerReconciliationBatchV1 {
+            next_cursor: None,
+            examined: 0,
+            transitioned: 0,
+            unchanged: 0,
+            retryable_failures: 0,
+            permanent_failures: 0,
+        };
+        for candidate in &candidates {
+            report.examined = report.examined.saturating_add(1);
+            let Some(material) = self.quote_material(candidate.delegation_digest()) else {
+                report.permanent_failures = report.permanent_failures.saturating_add(1);
+                continue;
+            };
+            match self.core.reconcile_bat_v2_by_backend_label(
                 candidate.backend_label(),
                 &material.signing_key,
                 now_unix,
@@ -605,6 +799,65 @@ where
             .ok_or(IssuerServiceErrorV1::Internal)?;
         self.core
             .reconcile_by_backend_label(
+                &record.backend_label,
+                &quote_material.signing_key,
+                now_unix,
+            )
+            .map(|result| result.into_exact_signed_quote_response())
+            .map_err(map_core_error)
+    }
+
+    /// `POST /v2/quotes/{quote_id}/status` body handler. Although the status
+    /// request wire type is shared, the store lookup and persisted typestate
+    /// reconstruction are strictly BAT V2.
+    pub fn bat_v2_quote_status(
+        &self,
+        route_quote_id: &[u8; 32],
+        canonical_request: &[u8],
+        now_unix: u64,
+    ) -> Result<Vec<u8>, IssuerServiceErrorV1> {
+        let request = Bolt11QuoteStatusRequestV1::decode(canonical_request)
+            .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?;
+        if &request.quote_id != route_quote_id
+            || request
+                .encode()
+                .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?
+                .as_slice()
+                != canonical_request
+        {
+            return Err(IssuerServiceErrorV1::InvalidRequest);
+        }
+        let bip340 = K256Bip340PrehashVerifierV1;
+        let authenticated = self
+            .store
+            .consume_bat_v2_quote_status_request(
+                &request,
+                now_unix,
+                &|input: QuoteStatusBip340Input<'_>| {
+                    bip340
+                        .verify(
+                            input.claim_pubkey_xonly,
+                            input.message_digest,
+                            input.signature,
+                        )
+                        .is_ok()
+                },
+            )
+            .map_err(map_store_error)?
+            .value;
+        if authenticated.state == QuoteState::CredentialClaimed {
+            return Ok(authenticated.exact_signed_quote_response);
+        }
+        let record = self
+            .store
+            .bat_v2_quote(route_quote_id)
+            .map_err(map_store_error)?
+            .ok_or(IssuerServiceErrorV1::NotFound)?;
+        let quote_material = self
+            .quote_material(&record.delegation_digest)
+            .ok_or(IssuerServiceErrorV1::Internal)?;
+        self.core
+            .reconcile_bat_v2_by_backend_label(
                 &record.backend_label,
                 &quote_material.signing_key,
                 now_unix,
@@ -816,6 +1069,156 @@ where
         Ok(write.value.exact_claim_response)
     }
 
+    /// `POST /v2/quotes/{quote_id}/claim` body handler. Exact committed
+    /// recovery precedes time, class-key, quote-key, and Lightning checks so a
+    /// lost successful response remains recoverable after restart or expiry.
+    pub fn claim_bat_v2_quote(
+        &self,
+        route_quote_id: &[u8; 32],
+        canonical_envelope: &[u8],
+        now_unix: u64,
+    ) -> Result<Vec<u8>, IssuerServiceErrorV1> {
+        let envelope = Bolt11BatV2ClaimEnvelopeV2::decode(canonical_envelope)
+            .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?;
+        if &envelope.claim.quote_id != route_quote_id
+            || envelope
+                .encode()
+                .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?
+                .as_slice()
+                != canonical_envelope
+        {
+            return Err(IssuerServiceErrorV1::InvalidRequest);
+        }
+
+        if let Some(existing) = self
+            .store
+            .bat_v2_claim_by_idempotency_key(&envelope.claim.idempotency_key)
+            .map_err(map_store_error)?
+        {
+            let replay = self
+                .store
+                .record_bat_v2_claim(
+                    &BatV2ClaimWrite {
+                        exact_claim_envelope: canonical_envelope.to_vec(),
+                        exact_claim_response: existing.exact_claim_response.clone(),
+                        exact_signed_quote_response: existing.exact_signed_quote_response.clone(),
+                        now_unix,
+                    },
+                    &|_: BatV2ClaimCryptographicVerificationInputV2<'_>| false,
+                )
+                .map_err(map_store_error)?;
+            return Ok(replay.value.exact_claim_response);
+        }
+
+        let quote_record = self
+            .store
+            .bat_v2_quote(route_quote_id)
+            .map_err(map_store_error)?
+            .ok_or(IssuerServiceErrorV1::NotFound)?;
+        if envelope
+            .quote_intent
+            .request_digest()
+            .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?
+            != quote_record.intent_digest
+        {
+            return Err(IssuerServiceErrorV1::Unauthorized);
+        }
+        let class_record = self
+            .store
+            .bat_acceptance_class_v2(
+                &envelope.quote_intent.class_id,
+                envelope.quote_intent.class_key_epoch,
+            )
+            .map_err(map_store_error)?
+            .ok_or(IssuerServiceErrorV1::Unauthorized)?;
+        let class = decode_bat_v2_class(&class_record)?;
+        self.ensure_bat_v2_class_credential_material(&class_record)?;
+        let delegation = Bolt11QuoteKeyDelegationV1::decode(&quote_record.exact_delegation)
+            .map_err(|_| IssuerServiceErrorV1::Internal)?;
+        let quote_material = self
+            .quote_material(&quote_record.delegation_digest)
+            .ok_or(IssuerServiceErrorV1::Internal)?;
+        let invoice = quote_record
+            .invoice
+            .as_deref()
+            .ok_or(IssuerServiceErrorV1::Internal)?;
+        let parsed_invoice =
+            ParsedBolt11InvoiceV1::parse(invoice).map_err(|_| IssuerServiceErrorV1::Internal)?;
+        let exact_settled = quote_record
+            .settled_signed_quote_response
+            .as_deref()
+            .ok_or(IssuerServiceErrorV1::Conflict)?;
+        let quote =
+            Bolt11QuoteV1::decode(exact_settled).map_err(|_| IssuerServiceErrorV1::Internal)?;
+        if !matches!(
+            quote.status,
+            Bolt11QuoteStatusV1::PaymentSettled | Bolt11QuoteStatusV1::LateSettledReconcile
+        ) {
+            return Err(IssuerServiceErrorV1::Conflict);
+        }
+        if now_unix <= quote.status_updated_at {
+            return Err(IssuerServiceErrorV1::RetryableUnavailable);
+        }
+        let verified_quote = quote
+            .verify_bat_v2_for_claim_submission(
+                &envelope.quote_intent,
+                &class,
+                &delegation,
+                &parsed_invoice,
+                now_unix,
+            )
+            .map_err(|_| IssuerServiceErrorV1::Unauthorized)?;
+        let prepared: PreparedBatV2IssuanceV2 = prepare_cashu_bat_v2_issuance_v2(
+            &envelope.credential_request,
+            &envelope.claim,
+            &verified_quote,
+            self.bat_keyring
+                .as_ref()
+                .ok_or(IssuerServiceErrorV1::Internal)?,
+            &self.credential_derivation_key,
+            now_unix,
+        )
+        .map_err(|_| IssuerServiceErrorV1::Unauthorized)?;
+        let exact_response = prepared
+            .encode_response()
+            .map_err(|_| IssuerServiceErrorV1::Internal)?;
+        let expected_checked = prepared
+            .response()
+            .verify_for_verified_quote(&envelope.credential_request, &verified_quote)
+            .map_err(|_| IssuerServiceErrorV1::Internal)?;
+        let claimed_quote = Bolt11QuoteV1::with_status_from_verified_bat_v2_snapshot(
+            &verified_quote,
+            Bolt11QuoteStatusV1::CredentialClaimed,
+            now_unix,
+            &delegation,
+            &quote_material.signing_key,
+        )
+        .map_err(|_| IssuerServiceErrorV1::Internal)?
+        .encode()
+        .map_err(|_| IssuerServiceErrorV1::Internal)?;
+        let expected_bip340_digest = *prepared.verified_claim().bip340_message_digest();
+        let expected_response = prepared.response().clone();
+        let verifier = |input: BatV2ClaimCryptographicVerificationInputV2<'_>| {
+            input.bip340_message_digest == &expected_bip340_digest
+                && input.claim_envelope == &envelope
+                && input.issuance_response == &expected_response
+                && input.checked_response == &expected_checked
+        };
+        let write = self
+            .store
+            .record_bat_v2_claim(
+                &BatV2ClaimWrite {
+                    exact_claim_envelope: canonical_envelope.to_vec(),
+                    exact_claim_response: exact_response,
+                    exact_signed_quote_response: claimed_quote,
+                    now_unix,
+                },
+                &verifier,
+            )
+            .map_err(map_store_error)?;
+        Ok(write.value.exact_claim_response)
+    }
+
     fn prepare_credential(
         &self,
         envelope: &Bolt11QuoteClaimEnvelopeV1,
@@ -884,6 +1287,20 @@ where
             .find(|material| &material.delegation_digest == digest)
     }
 
+    fn ensure_bat_v2_class_credential_material(
+        &self,
+        class: &BatAcceptanceClassRecordV2,
+    ) -> Result<(), IssuerServiceErrorV1> {
+        if self.bat_keyring.as_ref().is_some_and(|keys| {
+            keys.denomination_public_keys()
+                .contains(&class.raw_public_key)
+        }) {
+            Ok(())
+        } else {
+            Err(IssuerServiceErrorV1::Internal)
+        }
+    }
+
     fn ensure_offer_credential_material(
         &self,
         offer: &pir_service_protocol::ServiceOfferV1,
@@ -897,6 +1314,23 @@ where
             self.arc_keyring_experimental.as_deref(),
         )
     }
+}
+
+fn decode_bat_v2_class(
+    record: &BatAcceptanceClassRecordV2,
+) -> Result<BatAcceptanceClassV2, IssuerServiceErrorV1> {
+    let class = BatAcceptanceClassV2::decode(&record.exact_artifact)
+        .map_err(|_| IssuerServiceErrorV1::Internal)?;
+    if class.encode().map_err(|_| IssuerServiceErrorV1::Internal)? != record.exact_artifact
+        || class.class_id != record.class_id
+        || class.key_epoch != record.key_epoch
+        || class.class_digest().ok() != Some(record.artifact_digest)
+        || class.bat_key_id() != record.bat_key_id
+        || class.bat_verification_key != record.raw_public_key
+    {
+        return Err(IssuerServiceErrorV1::Internal);
+    }
+    Ok(class)
 }
 
 /// Verifies that an exact issuer-retained shared-clearing binding still has
@@ -975,8 +1409,12 @@ fn ensure_offer_credential_material_v1(
     if offer.acquisition != AcquisitionMethod::Bolt11V1 || &offer.issuer_id != issuer_id {
         return Ok(());
     }
+    // Scheme 6 is configured and checked through the issuer-wide class
+    // registry and the separate V2 acquisition handlers. The V1 policy scan
+    // must neither reinterpret it as a provider binding nor prevent a mixed
+    // V1/V2 issuer process from starting.
     if offer.authorization == AuthScheme::BitcoinPirCashuBatV2 {
-        return Err(IssuerServiceErrorV1::InvalidRequest);
+        return Ok(());
     }
     let binding = offer
         .credential_binding

--- a/crates/payment/issuer-service/tests/acquisition.rs
+++ b/crates/payment/issuer-service/tests/acquisition.rs
@@ -15,19 +15,23 @@ use pir_issuer_store::{
     StoreOptions,
 };
 use pir_lightning_backend::FakeLightningNodeV1;
-use pir_payment_crypto::{blind_cashu_message_v1, sign_bip340_prehash_v1, K256CashuMintKeyringV1};
+use pir_payment_crypto::{
+    blind_cashu_message_v1, sign_bip340_prehash_v1, K256CashuDleqVerifierV1, K256CashuMintKeyringV1,
+};
 use pir_service_protocol::{
-    derive_bat_key_id_v1, derive_issuer_id, AcquisitionMethod, AuthPaddingClassV1, AuthScheme,
-    BackendId, BitcoinPirCashuBatIssuanceRequestItemV1, Bolt11QuoteClaimEnvelopeV1,
-    Bolt11QuoteClaimV1, Bolt11QuoteIntentV1, Bolt11QuoteKeyDelegationV1,
-    Bolt11QuoteKeyRollbackGuardV1, Bolt11QuoteStatusV1, Bolt11QuoteV1,
-    CredentialIssuanceRequestItemsV1, CredentialIssuanceRequestV1, CredentialKeyBindingClaimsV1,
-    CredentialKeyBindingV1, CredentialUnitV1, DatasetBindingV1, DeploymentStatus,
-    EntitlementLimitsV1, FreeModeV1, LightningNetworkV1, PolicyRollbackGuardV1, PriceV1,
-    PrivacyLeakageV1, ProviderClearingAuthorizationClaimsV1, ProviderClearingAuthorizationV1,
-    ServiceOfferV1, ServicePolicyEpochFloorsV1, ServicePolicyV1, ServiceScopePolicyV1,
-    ServiceScopeV1, SettlementModesV1, SettlementRuleV1, SettlementUnitV1, VerificationMode,
-    WorkloadId,
+    bat_acceptance_member_from_verified_policy_v2, derive_bat_key_id_v1, derive_issuer_id,
+    AcquisitionMethod, AuthPaddingClassV1, AuthScheme, BackendId, BatAcceptanceClassV2,
+    BatAcceptanceTermsV2, BatV2IssuanceRequestV2, BatV2IssuanceResponseV2,
+    BitcoinPirCashuBatIssuanceRequestItemV1, Bolt11BatV2ClaimEnvelopeV2, Bolt11BatV2QuoteIntentV2,
+    Bolt11QuoteClaimEnvelopeV1, Bolt11QuoteClaimV1, Bolt11QuoteIntentV1,
+    Bolt11QuoteKeyDelegationV1, Bolt11QuoteKeyRollbackGuardV1, Bolt11QuoteStatusRequestV1,
+    Bolt11QuoteStatusV1, Bolt11QuoteV1, CredentialIssuanceRequestItemsV1,
+    CredentialIssuanceRequestV1, CredentialKeyBindingClaimsV1, CredentialKeyBindingV1,
+    CredentialUnitV1, DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1, FreeModeV1,
+    LightningNetworkV1, ParsedBolt11InvoiceV1, PolicyRollbackGuardV1, PriceV1, PrivacyLeakageV1,
+    ProviderClearingAuthorizationClaimsV1, ProviderClearingAuthorizationV1, ServiceOfferV1,
+    ServicePolicyEpochFloorsV1, ServicePolicyV1, ServiceScopePolicyV1, ServiceScopeV1,
+    SettlementModesV1, SettlementRuleV1, SettlementUnitV1, VerificationMode, WorkloadId,
 };
 use tempfile::{Builder, TempDir};
 
@@ -887,6 +891,362 @@ fn same_second_settlement_claim_retries_without_write_then_replays_exactly() {
         .claim_quote(&settled.quote_id, &canonical_envelope, settled_at + 2)
         .expect("exact claim replay succeeds");
     assert_eq!(replay, issued);
+}
+
+#[test]
+fn bat_v2_lifecycle_is_class_bound_dleq_checked_and_restart_replay_exact() {
+    let directory = private_tempdir("bitcoinpir-issuer-bat-v2-lifecycle-test-");
+    let authority = Arc::new(
+        SqliteIssuerRollbackFloorAuthorityV1::create(
+            directory.path().join("floor.sqlite3"),
+            StoreOptions::default().busy_timeout,
+        )
+        .expect("rollback authority"),
+    );
+    let lightning = Arc::new(
+        FakeLightningNodeV1::new(LightningNetworkV1::Regtest, [3; 32], [7; 32], NOW)
+            .expect("fake Lightning"),
+    );
+    let issuer_root = SigningKey::from_bytes(&[0x41; 32]);
+    let issuer_id = derive_issuer_id(&issuer_root.verifying_key().to_bytes());
+    let provider_id = [0x81; 32];
+    let class_id = [0x82; 32];
+    let scope = ServiceScopeV1 {
+        provider_id,
+        backend: BackendId::DpfPirV1,
+        workload: WorkloadId::DpfEvaluateJobV1,
+        protocol_version: 1,
+        dataset: DatasetBindingV1::Class { class_id: 1 },
+        operation_profile: 2,
+        entitlement_profile: 3,
+    };
+    let scope_id = scope.scope_id();
+    let limits = EntitlementLimitsV1 {
+        max_logical_inputs: 4,
+        max_frames: 200,
+        max_request_bytes: 1_000_000,
+        max_response_bytes: 2_000_000,
+        max_wall_time_ms: 60_000,
+        max_concurrent_sockets: 1,
+        max_hint_groups: 0,
+        max_work_units: 9_000,
+    };
+    let privacy_leakage = PrivacyLeakageV1::from_bits(
+        PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+            | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+            | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+    )
+    .expect("BAT V2 privacy flags");
+    let offer = ServiceOfferV1 {
+        offer_id: 7,
+        acquisition: AcquisitionMethod::Bolt11V1,
+        free_mode: FreeModeV1::NotFree,
+        free_quota: 0,
+        free_window_seconds: 0,
+        free_pow_difficulty_bits: 0,
+        priority_class: 1,
+        authorization: AuthScheme::BitcoinPirCashuBatV2,
+        verification: VerificationMode::SharedIssuerOnline,
+        deployment_status: DeploymentStatus::Stable,
+        price: PriceV1::MilliSatoshi(100_000),
+        issuer_id,
+        key_id: class_id.to_vec(),
+        credential_binding: None,
+        cashu_mint_manifest: None,
+        endpoint: "https://issuer.invalid".to_owned(),
+        invoice_expiry_seconds: 60,
+        claim_window_seconds: 120,
+        minimum_credential_validity_seconds: 300,
+        retired_policy_grace_seconds: 480,
+        credential_count: 2,
+        credential_presentation_limit: 1,
+        privacy_leakage,
+    };
+    let policy_key = SigningKey::from_bytes(&[0x83; 32]);
+    let policy = ServicePolicyV1::sign(
+        provider_id,
+        1,
+        NOW - 100,
+        NOW + 1_500,
+        AuthPaddingClassV1::Class16KiB,
+        vec![ServiceScopePolicyV1 {
+            scope: scope.clone(),
+            limits: limits.clone(),
+            offers: vec![offer],
+        }],
+        &policy_key,
+    )
+    .expect("sign BAT V2 member policy");
+    let verified_policy = policy
+        .verify_current_for_acquisition(
+            &provider_id,
+            NOW,
+            &PolicyRollbackGuardV1::initial(),
+            &ServicePolicyEpochFloorsV1::initial(),
+            &policy_key.verifying_key(),
+        )
+        .expect("verify BAT V2 member policy");
+    let member = bat_acceptance_member_from_verified_policy_v2(&verified_policy, &scope_id, 7)
+        .expect("project BAT V2 member");
+    let common_terms = BatAcceptanceTermsV2 {
+        auth_padding_class: AuthPaddingClassV1::Class16KiB,
+        backend: scope.backend,
+        workload: scope.workload,
+        protocol_version: scope.protocol_version,
+        dataset: scope.dataset.clone(),
+        operation_profile: scope.operation_profile,
+        entitlement_profile: scope.entitlement_profile,
+        limits,
+        priority_class: 1,
+        deployment_status: DeploymentStatus::Stable,
+        price_msat: 100_000,
+        issuer_endpoint: "https://issuer.invalid".to_owned(),
+        invoice_expiry_seconds: 60,
+        claim_window_seconds: 120,
+        minimum_credential_validity_seconds: 300,
+        retired_policy_grace_seconds: 480,
+        credential_count: 2,
+        credential_presentation_limit: 1,
+        privacy_leakage,
+    };
+    assert_eq!(member.common_terms, common_terms);
+    let class = BatAcceptanceClassV2::sign(
+        class_id,
+        1,
+        NOW - 100,
+        NOW + 1_980,
+        point(13),
+        common_terms,
+        vec![member.member.clone()],
+        &issuer_root,
+    )
+    .expect("sign BAT V2 class");
+    let quote_key = SigningKey::from_bytes(&[0x84; 32]);
+    let delegation = Bolt11QuoteKeyDelegationV1::sign(
+        LightningNetworkV1::Regtest,
+        lightning.payee_pubkey(),
+        4,
+        NOW - 100,
+        NOW + 3_000,
+        quote_key.verifying_key().to_bytes(),
+        &issuer_root,
+    )
+    .expect("quote delegation");
+    let guard = Bolt11QuoteKeyRollbackGuardV1::initial(
+        issuer_id,
+        LightningNetworkV1::Regtest,
+        lightning.payee_pubkey(),
+    )
+    .expect("delegation guard");
+    let (intent, _) = Bolt11BatV2QuoteIntentV2::from_verified_class_member_guarded(
+        &member,
+        &class,
+        &delegation,
+        &guard,
+        NOW,
+        xonly(5),
+        [0x85; 32],
+    )
+    .expect("BAT V2 quote intent");
+
+    let store = IssuerStore::create(
+        directory.path().join("issuer.sqlite3"),
+        [0x39; 16],
+        issuer_id,
+        LightningNetworkV1::Regtest,
+        StoreOptions::default(),
+        authority,
+    )
+    .expect("issuer store");
+    let _ = store
+        .register_service_policy(&policy, &policy_key.verifying_key(), NOW)
+        .expect("register BAT V2 member policy");
+    let _ = store
+        .register_bat_acceptance_class_v2(&class, NOW)
+        .expect("register BAT V2 class");
+    assert_eq!(
+        IssuerAcquisitionServiceV1::new(
+            store.clone(),
+            Arc::clone(&lightning),
+            Arc::new(SequentialIds(AtomicU8::new(0x8c))),
+            QuoteSigningMaterialV1::new(delegation.clone(), quote_key.clone())
+                .expect("quote material without BAT V2 scalar"),
+            Vec::new(),
+            Vec::new(),
+            None,
+            None,
+            IssuerCredentialDerivationKeyV1::from_bytes([9; 32]).expect("derivation key"),
+            NOW,
+        )
+        .unwrap_err(),
+        IssuerServiceErrorV1::InvalidRequest,
+        "a live current BAT V2 class must pin its issuance scalar at startup"
+    );
+    let build_service = |observed_at: u64, first_quote_id: u8| {
+        IssuerAcquisitionServiceV1::new(
+            store.clone(),
+            Arc::clone(&lightning),
+            Arc::new(SequentialIds(AtomicU8::new(first_quote_id))),
+            QuoteSigningMaterialV1::new(delegation.clone(), quote_key.clone())
+                .expect("quote material"),
+            Vec::new(),
+            Vec::new(),
+            Some(bat_keyring(&[13])),
+            None,
+            IssuerCredentialDerivationKeyV1::from_bytes([9; 32]).expect("derivation key"),
+            observed_at,
+        )
+        .expect("BAT V2 acquisition service")
+    };
+    let service = build_service(NOW, 0x86);
+    let intent_bytes = intent.encode().expect("encode BAT V2 intent");
+    assert_eq!(
+        service.create_quote(&intent_bytes, NOW),
+        Err(IssuerServiceErrorV1::InvalidRequest),
+        "the V1 acquisition path must reject V2 wire"
+    );
+    let initial = Bolt11QuoteV1::decode(
+        &service
+            .create_bat_v2_quote(&intent_bytes, NOW)
+            .expect("create BAT V2 quote"),
+    )
+    .expect("decode initial BAT V2 quote");
+    let open_record = store
+        .bat_v2_quote(&initial.quote_id)
+        .expect("read open BAT V2 quote")
+        .expect("open BAT V2 quote");
+
+    let settled_at = NOW + 1;
+    lightning
+        .set_time(settled_at)
+        .expect("advance fake Lightning clock");
+    lightning
+        .observe_settlement(&open_record.backend_label, initial.amount_msat, settled_at)
+        .expect("observe BAT V2 settlement");
+    let mut status_request = Bolt11QuoteStatusRequestV1 {
+        issuer_id,
+        quote_id: initial.quote_id,
+        quote_request_digest: initial.request_digest,
+        claim_pubkey_xonly: intent.claim_pubkey_xonly,
+        requested_at: settled_at,
+        request_nonce: [0x87; 32],
+        signature: [1; 64],
+    };
+    let status_digest = status_request
+        .bip340_signing_digest()
+        .expect("status signing digest");
+    let (status_pubkey, status_signature) =
+        sign_bip340_prehash_v1(&scalar_bytes(5), &status_digest, &[0x88; 32])
+            .expect("sign BAT V2 status request");
+    assert_eq!(status_pubkey, intent.claim_pubkey_xonly);
+    status_request.signature = status_signature;
+    let settled = Bolt11QuoteV1::decode(
+        &service
+            .bat_v2_quote_status(
+                &initial.quote_id,
+                &status_request.encode().expect("encode status request"),
+                settled_at,
+            )
+            .expect("reconcile through BAT V2 status"),
+    )
+    .expect("decode settled BAT V2 quote");
+    assert_eq!(settled.status, Bolt11QuoteStatusV1::PaymentSettled);
+
+    // An unfinished V2 quote must survive process restart without entering
+    // the provider-bound V1 policy/material replay path.
+    drop(service);
+    let service = build_service(settled_at, 0x8b);
+
+    let items = (0..intent.credential_count)
+        .map(|index| {
+            let byte = u8::try_from(index + 1).expect("small BAT V2 credential count");
+            BitcoinPirCashuBatIssuanceRequestItemV1 {
+                blinded_message: blind_cashu_message_v1(&[byte; 32], &scalar_bytes(byte + 16))
+                    .expect("blind BAT V2 request"),
+            }
+        })
+        .collect();
+    let credential_request = BatV2IssuanceRequestV2 {
+        issuer_id,
+        quote_id: settled.quote_id,
+        quote_request_digest: settled.request_digest,
+        class_id: intent.class_id,
+        class_digest: intent.class_digest,
+        class_key_epoch: intent.class_key_epoch,
+        bat_key_id: intent.bat_key_id,
+        items,
+    };
+    let mut claim = Bolt11QuoteClaimV1 {
+        issuer_id,
+        quote_id: settled.quote_id,
+        quote_request_digest: settled.request_digest,
+        credential_request_digest: credential_request
+            .request_digest()
+            .expect("BAT V2 request digest"),
+        claim_pubkey_xonly: intent.claim_pubkey_xonly,
+        idempotency_key: [0x89; 32],
+        signature: [1; 64],
+    };
+    let claim_digest = claim.bip340_signing_digest().expect("claim signing digest");
+    let (claim_pubkey, claim_signature) =
+        sign_bip340_prehash_v1(&scalar_bytes(5), &claim_digest, &[0x8a; 32])
+            .expect("sign BAT V2 claim");
+    assert_eq!(claim_pubkey, intent.claim_pubkey_xonly);
+    claim.signature = claim_signature;
+    let envelope = Bolt11BatV2ClaimEnvelopeV2 {
+        quote_intent: intent.clone(),
+        claim,
+        credential_request: credential_request.clone(),
+    };
+    let envelope_bytes = envelope.encode().expect("encode BAT V2 claim envelope");
+    let claim_time = settled_at + 1;
+    let issued = service
+        .claim_bat_v2_quote(&settled.quote_id, &envelope_bytes, claim_time)
+        .expect("claim BAT V2 credentials");
+    let response = BatV2IssuanceResponseV2::decode(&issued).expect("decode BAT V2 response");
+    let parsed_invoice =
+        ParsedBolt11InvoiceV1::parse(&settled.invoice).expect("parse settled invoice");
+    let verified_quote = settled
+        .verify_bat_v2_for_claim_submission(
+            &intent,
+            &class,
+            &delegation,
+            &parsed_invoice,
+            claim_time,
+        )
+        .expect("verify settled BAT V2 quote");
+    let checked = response
+        .verify_for_verified_quote(&credential_request, &verified_quote)
+        .expect("check BAT V2 response binding");
+    let dleq = K256CashuDleqVerifierV1;
+    for tuple in checked.unverified_dleq() {
+        dleq.verify(
+            &tuple.issuer_public_key,
+            &tuple.blinded_message,
+            &tuple.blinded_signature,
+            &tuple.dleq_e,
+            &tuple.dleq_s,
+        )
+        .expect("verify BAT V2 DLEQ transcript");
+    }
+    assert_eq!(
+        store
+            .bat_v2_quote(&settled.quote_id)
+            .expect("read claimed BAT V2 quote")
+            .expect("claimed BAT V2 quote")
+            .state,
+        QuoteState::CredentialClaimed
+    );
+
+    drop(service);
+    let after_deadline = settled.claim_deadline + 1;
+    let restarted = build_service(after_deadline, 0x90);
+    assert_eq!(
+        restarted
+            .claim_bat_v2_quote(&settled.quote_id, &envelope_bytes, after_deadline)
+            .expect("recover exact BAT V2 response after restart and deadline"),
+        issued
+    );
 }
 
 #[test]

--- a/crates/payment/issuer-store/src/db.rs
+++ b/crates/payment/issuer-store/src/db.rs
@@ -419,6 +419,18 @@ fn run_integrity_checks(connection: &Connection, handle: &StoreHandle) -> StoreR
         ));
     }
 
+    let bat_v2_receipt_serials: i64 = connection.query_row(
+        "SELECT COUNT(*) FROM receipt_serials r \
+         JOIN quotes q ON q.quote_id = r.quote_id WHERE q.quote_protocol = 2",
+        [],
+        |row| row.get(0),
+    )?;
+    if bat_v2_receipt_serials != 0 {
+        return Err(StoreError::SchemaMismatch(
+            "BAT V2 claims must not allocate paid-receipt serials".to_owned(),
+        ));
+    }
+
     let bad_ledger: i64 = connection.query_row(
         "SELECT \
             (SELECT COUNT(*) FROM ledger_transactions t WHERE \

--- a/crates/payment/issuer-store/src/error.rs
+++ b/crates/payment/issuer-store/src/error.rs
@@ -26,6 +26,7 @@ pub enum StoreError {
         authority_error: String,
     },
     QuoteMissing,
+    QuoteProtocolMismatch,
     QuoteConflict,
     QuoteCapacityExceeded,
     CreationIdempotencyConflict,
@@ -137,6 +138,9 @@ impl fmt::Display for StoreError {
                 "issuer-store generation {store_generation} committed but is not externally anchored: {authority_error}"
             ),
             Self::QuoteMissing => write!(f, "quote is missing"),
+            Self::QuoteProtocolMismatch => {
+                write!(f, "quote or claim belongs to a different acquisition protocol")
+            }
             Self::QuoteConflict => write!(f, "quote id conflicts with durable state"),
             Self::QuoteCapacityExceeded => {
                 write!(f, "issuer quote capacity is exhausted")

--- a/crates/payment/issuer-store/src/lib.rs
+++ b/crates/payment/issuer-store/src/lib.rs
@@ -30,6 +30,8 @@ pub use sqlite_rollback::SqliteIssuerRollbackFloorAuthorityV1;
 pub use types::{
     ArcKeyLineageV1, AuthenticatedQuoteStatus, BatAcceptanceClassMemberRecordV2,
     BatAcceptanceClassRecordV2, BatKeyLineage, BatKeyLineageRegistration,
+    BatV2ClaimCryptographicVerificationInputV2, BatV2ClaimCryptographicVerifierV2, BatV2ClaimWrite,
+    BatV2CredentialMaterialRequirementV2, BatV2QuoteReservation,
     ClaimCryptographicVerificationInput, ClaimCryptographicVerifier, ClaimRecord, ClaimWrite,
     ClearingAuthorizationRecordV1, CommitMarker, DelegationAdvance, DelegationHead, DurableWrite,
     IssuerServicePolicyRecordV1, IssuerStoreOperationalInventoryV1, LedgerTransactionKindV1,

--- a/crates/payment/issuer-store/src/policy_ops.rs
+++ b/crates/payment/issuer-store/src/policy_ops.rs
@@ -9,10 +9,10 @@ use crate::{
 use ed25519_dalek::VerifyingKey;
 use pir_service_protocol::{
     bat_acceptance_member_from_verified_policy_v2, AuthScheme, BatAcceptanceMemberV2,
-    Bolt11QuoteIntentV1, CashuManifestEpochFloorV1, CredentialKeyBindingExpectationV1,
-    CredentialKeyBindingV1, CredentialKeysetEpochFloorV1, PolicyRollbackGuardV1,
-    ProviderClearingAuthorizationV1, ServicePolicyEpochFloorsV1, ServicePolicyV1,
-    VerifiedBatAcceptanceMemberV2,
+    Bolt11BatV2QuoteIntentV2, Bolt11QuoteIntentV1, CashuManifestEpochFloorV1,
+    CredentialKeyBindingExpectationV1, CredentialKeyBindingV1, CredentialKeysetEpochFloorV1,
+    PolicyRollbackGuardV1, ProviderClearingAuthorizationV1, ServicePolicyEpochFloorsV1,
+    ServicePolicyV1, VerifiedBatAcceptanceMemberV2,
 };
 use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 use sha2::{Digest, Sha256};
@@ -243,8 +243,10 @@ impl IssuerStore {
         let mut quote_statement = connection.prepare(
             "SELECT state, intent_replay_image, invoice_created_not_after, claim_deadline
              FROM quotes
-             WHERE (state = 0 AND reservation_recovery_deadline >= ?1)
-                OR (state IN (1, 2, 4, 5) AND claim_deadline >= ?1)
+             WHERE quote_protocol = 1 AND (
+                    (state = 0 AND reservation_recovery_deadline >= ?1)
+                    OR (state IN (1, 2, 4, 5) AND claim_deadline >= ?1)
+             )
              ORDER BY quote_id",
         )?;
         let quotes = quote_statement
@@ -341,7 +343,7 @@ impl IssuerStore {
         }
         let connection = self.open_checked(false)?;
         let mut statement = connection.prepare(
-            "SELECT state, delegation_digest, intent_replay_image, \
+            "SELECT quote_protocol, state, delegation_digest, intent_replay_image, \
                     invoice_created_not_after, claim_deadline
              FROM quotes
              WHERE (state = 0 AND reservation_recovery_deadline >= ?1)
@@ -357,27 +359,79 @@ impl IssuerStore {
                 |row| {
                     Ok((
                         row.get::<_, i64>(0)?,
-                        row.get::<_, Vec<u8>>(1)?,
+                        row.get::<_, i64>(1)?,
                         row.get::<_, Vec<u8>>(2)?,
-                        row.get::<_, i64>(3)?,
-                        row.get::<_, Option<i64>>(4)?,
+                        row.get::<_, Vec<u8>>(3)?,
+                        row.get::<_, i64>(4)?,
+                        row.get::<_, Option<i64>>(5)?,
                     ))
                 },
             )?
             .collect::<Result<Vec<_>, _>>()?;
         let mut required = BTreeSet::new();
-        for (state, delegation_digest, exact_intent, create_deadline, claim_deadline) in rows {
+        for (
+            quote_protocol,
+            state,
+            delegation_digest,
+            exact_intent,
+            create_deadline,
+            claim_deadline,
+        ) in rows
+        {
             let state = crate::QuoteState::from_db(state)
                 .ok_or_else(|| StoreError::SchemaMismatch("quote has invalid state".to_owned()))?;
             let delegation_digest =
                 fixed_blob(delegation_digest, "invalid quote delegation digest")?;
-            let intent = Bolt11QuoteIntentV1::decode(&exact_intent).map_err(|_| {
-                StoreError::SchemaMismatch("quote intent replay image is not canonical".to_owned())
-            })?;
-            if intent.encode()? != exact_intent
-                || intent.issuer_id != self.handle.expected_issuer_id
-                || intent.network != self.handle.expected_network
-                || intent.quote_delegation_digest != delegation_digest
+            let (intent_issuer_id, intent_network, intent_delegation_digest, expiry, claim) =
+                match quote_protocol {
+                    1 => {
+                        let intent = Bolt11QuoteIntentV1::decode(&exact_intent).map_err(|_| {
+                            StoreError::SchemaMismatch(
+                                "V1 quote intent replay image is not canonical".to_owned(),
+                            )
+                        })?;
+                        if intent.encode()? != exact_intent {
+                            return Err(StoreError::SchemaMismatch(
+                                "V1 quote intent replay image is non-canonical".to_owned(),
+                            ));
+                        }
+                        (
+                            intent.issuer_id,
+                            intent.network,
+                            intent.quote_delegation_digest,
+                            intent.invoice_expiry_seconds,
+                            intent.claim_window_seconds,
+                        )
+                    }
+                    2 => {
+                        let intent =
+                            Bolt11BatV2QuoteIntentV2::decode(&exact_intent).map_err(|_| {
+                                StoreError::SchemaMismatch(
+                                    "BAT V2 quote intent replay image is not canonical".to_owned(),
+                                )
+                            })?;
+                        if intent.encode()? != exact_intent {
+                            return Err(StoreError::SchemaMismatch(
+                                "BAT V2 quote intent replay image is non-canonical".to_owned(),
+                            ));
+                        }
+                        (
+                            intent.issuer_id,
+                            intent.network,
+                            intent.quote_delegation_digest,
+                            intent.invoice_expiry_seconds,
+                            intent.claim_window_seconds,
+                        )
+                    }
+                    _ => {
+                        return Err(StoreError::SchemaMismatch(
+                            "quote has an unknown acquisition protocol".to_owned(),
+                        ))
+                    }
+                };
+            if intent_issuer_id != self.handle.expected_issuer_id
+                || intent_network != self.handle.expected_network
+                || intent_delegation_digest != delegation_digest
             {
                 return Err(StoreError::SchemaMismatch(
                     "quote intent does not match its durable delegation".to_owned(),
@@ -386,8 +440,8 @@ impl IssuerStore {
             let still_required = match state {
                 crate::QuoteState::Reserved => {
                     let deadline = db_u64(create_deadline, "negative invoice creation deadline")?
-                        .checked_add(u64::from(intent.invoice_expiry_seconds))
-                        .and_then(|value| value.checked_add(u64::from(intent.claim_window_seconds)))
+                        .checked_add(u64::from(expiry))
+                        .and_then(|value| value.checked_add(u64::from(claim)))
                         .ok_or_else(|| {
                             StoreError::SchemaMismatch(
                                 "reserved quote recovery horizon overflows Unix time".to_owned(),

--- a/crates/payment/issuer-store/src/quote_ops.rs
+++ b/crates/payment/issuer-store/src/quote_ops.rs
@@ -1,10 +1,13 @@
+use crate::bat_v2_ops::read_bat_acceptance_class_v2;
 use crate::db::{
     advance_store_generation, commit, db_u64, fixed_blob, is_zero, network_code,
     optional_fixed_blob, sql_integer, verify_expected_identity,
 };
 use crate::rollback::mutation_digest;
 use crate::{
-    AuthenticatedQuoteStatus, ClaimCryptographicVerificationInput, ClaimCryptographicVerifier,
+    AuthenticatedQuoteStatus, BatV2ClaimCryptographicVerificationInputV2,
+    BatV2ClaimCryptographicVerifierV2, BatV2ClaimWrite, BatV2CredentialMaterialRequirementV2,
+    BatV2QuoteReservation, ClaimCryptographicVerificationInput, ClaimCryptographicVerifier,
     ClaimRecord, ClaimWrite, CommitMarker, DelegationAdvance, DelegationHead, DurableWrite,
     IssuerStore, QuoteCapacityV1, QuoteExpiry, QuoteFinalization, QuoteReconciliationCandidateV1,
     QuoteRecord, QuoteReservation, QuoteSettlement, QuoteState, QuoteStatusBip340Input,
@@ -15,14 +18,17 @@ use crate::{
 };
 use ed25519_dalek::Signature;
 use pir_service_protocol::{
-    ArcIssuanceCanonicalizerV1, Bolt11QuoteClaimV1, Bolt11QuoteIntentV1,
-    Bolt11QuoteKeyDelegationV1, Bolt11QuoteStatusRequestV1, Bolt11QuoteStatusV1, Bolt11QuoteV1,
-    CredentialIssuanceRequestItemsV1, CredentialIssuanceRequestV1,
-    CredentialIssuanceResponseItemsV1, CredentialIssuanceResponseV1, BOLT11_QUOTE_SIGNATURE_DOMAIN,
+    ArcIssuanceCanonicalizerV1, BatAcceptanceClassV2, BatV2IssuanceResponseV2,
+    Bolt11BatV2ClaimEnvelopeV2, Bolt11BatV2QuoteIntentV2, Bolt11QuoteClaimV1, Bolt11QuoteIntentV1,
+    Bolt11QuoteKeyDelegationV1, Bolt11QuoteKeyRollbackGuardV1, Bolt11QuoteStatusRequestV1,
+    Bolt11QuoteStatusV1, Bolt11QuoteV1, CredentialIssuanceRequestItemsV1,
+    CredentialIssuanceRequestV1, CredentialIssuanceResponseItemsV1, CredentialIssuanceResponseV1,
+    PersistedBolt11BatV2QuoteExpectationV2, BOLT11_QUOTE_SIGNATURE_DOMAIN,
     MAX_BOLT11_QUOTE_STATUS_REQUEST_AGE_SECONDS_V1,
 };
 use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
 use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
 
 const QUOTE_CREATE_IDEMPOTENCY_DIGEST_DOMAIN_V1: &[u8] =
     b"BitcoinPIR/issuer-store/POST-/v1/quotes/idempotency-digest/v1";
@@ -30,6 +36,8 @@ const QUOTE_CLAIM_IDEMPOTENCY_DIGEST_DOMAIN_V1: &[u8] =
     b"BitcoinPIR/issuer-store/POST-/v1/quotes/claim/idempotency-digest/v1";
 const QUOTE_STATUS_NONCE_DIGEST_DOMAIN_V1: &[u8] =
     b"BitcoinPIR/issuer-store/POST-/v1/quotes/status/nonce-digest/v1";
+const QUOTE_PROTOCOL_V1: i64 = 1;
+const QUOTE_PROTOCOL_BAT_V2: i64 = 2;
 /// Bounds authenticated status-write amplification for any one purchased
 /// quote during the five-minute replay window. The HTTP edge applies a
 /// separate process-wide request budget.
@@ -43,7 +51,8 @@ const QUOTE_SELECT: &str = "quote_id, creation_idempotency_digest, backend_label
     invoice_expires_at, claim_deadline, credential_not_after, initial_signed_quote_response, \
     expiry_observed_at, expired_signed_quote_response, settled_at, settlement_observed_at, settled_amount_msat, \
     settlement_evidence_digest, settled_signed_quote_response, \
-    reservation_commit_seq, finalization_commit_seq, expiry_commit_seq, settlement_commit_seq";
+    reservation_commit_seq, finalization_commit_seq, expiry_commit_seq, settlement_commit_seq, \
+    quote_protocol";
 
 impl IssuerStore {
     /// Atomically advances the `(issuer, network, payee)` delegation guard.
@@ -233,12 +242,12 @@ impl IssuerStore {
         }
         let backend_label = self.backend_label_for_quote(&reservation.quote_id)?;
         transaction.execute(
-            "INSERT INTO quotes (quote_id, issuer_id, network, creation_idempotency_digest, \
+            "INSERT INTO quotes (quote_id, issuer_id, network, quote_protocol, creation_idempotency_digest, \
              backend_label, intent_digest, intent_replay_image, payee_pubkey, delegation_epoch, \
              delegation_digest, exact_delegation, exact_amount_msat, invoice_created_not_before, \
              invoice_created_not_after, reservation_recovery_deadline, state, state_version, \
              reservation_commit_seq) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, 0, 0, ?16)",
+             VALUES (?1, ?2, ?3, 1, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, 0, 0, ?16)",
             params![
                 reservation.quote_id.as_slice(),
                 self.handle.expected_issuer_id.as_slice(),
@@ -282,21 +291,253 @@ impl IssuerStore {
         })
     }
 
+    /// Reserve one issuer-wide BAT V2 quote against the exact current class
+    /// head. Exact replay is resolved before the current-head check, so an
+    /// already durable quote remains recoverable after class rotation.
+    pub fn reserve_bat_v2_quote(
+        &self,
+        reservation: &BatV2QuoteReservation,
+    ) -> StoreResult<DurableWrite<QuoteRecord>> {
+        self.reserve_bat_v2_quote_with_capacity(reservation, QuoteCapacityV1::unbounded())
+    }
+
+    pub fn reserve_bat_v2_quote_with_capacity(
+        &self,
+        reservation: &BatV2QuoteReservation,
+        capacity: QuoteCapacityV1,
+    ) -> StoreResult<DurableWrite<QuoteRecord>> {
+        validate_quote_capacity(capacity)?;
+        let (intent, delegation) = parse_bat_v2_reservation(self, reservation)?;
+        let reservation_recovery_deadline =
+            bat_v2_reservation_recovery_deadline(reservation.invoice_created_not_after, &intent)?;
+        let creation_digest = creation_idempotency_digest(self, &intent.idempotency_key);
+        let intent_digest = intent.request_digest().map_err(StoreError::Protocol)?;
+        let replay_image = bat_v2_intent_replay_image(self, &intent)?;
+
+        let mut connection = self.open_checked(false)?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let previous_identity = verify_expected_identity(&transaction, &self.handle)?;
+        let previous_floor = self.require_exact_rollback_floor(&previous_identity)?;
+
+        if let Some(existing) = read_quote_by_creation_digest_for_protocol(
+            &transaction,
+            self,
+            &creation_digest,
+            QUOTE_PROTOCOL_BAT_V2,
+        )? {
+            if bat_v2_quote_reservation_matches(
+                self,
+                &existing,
+                reservation,
+                &intent,
+                &delegation,
+                &replay_image,
+                reservation_recovery_deadline,
+            )? {
+                return Ok(DurableWrite {
+                    disposition: WriteDisposition::ExactReplay,
+                    commit: existing.reservation_commit,
+                    value: existing,
+                });
+            }
+            return Err(StoreError::CreationIdempotencyConflict);
+        }
+        if read_quote_for_protocol(
+            &transaction,
+            self,
+            &reservation.quote_id,
+            QUOTE_PROTOCOL_BAT_V2,
+        )?
+        .is_some()
+        {
+            return Err(StoreError::QuoteConflict);
+        }
+
+        check_quote_capacity(&transaction, capacity, reservation.now_unix)?;
+
+        let current_head: Option<(i64, Vec<u8>)> = transaction
+            .query_row(
+                "SELECT highest_key_epoch, artifact_digest FROM bat_v2_class_heads \
+                 WHERE issuer_id = ?1 AND class_id = ?2",
+                params![
+                    self.handle.expected_issuer_id.as_slice(),
+                    intent.class_id.as_slice(),
+                ],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        let (head_epoch, head_digest) = current_head.ok_or(StoreError::BatV2ClassMemberMismatch)?;
+        let head_epoch = db_u64(head_epoch, "negative BAT V2 class head epoch")?;
+        let head_digest: [u8; 32] = fixed_blob(head_digest, "invalid BAT V2 class head digest")?;
+        if head_epoch != intent.class_key_epoch || head_digest != intent.class_digest {
+            return Err(StoreError::BatV2ClassMemberMismatch);
+        }
+        let class_record = read_bat_acceptance_class_v2(
+            &transaction,
+            self,
+            &intent.class_id,
+            intent.class_key_epoch,
+        )?
+        .ok_or(StoreError::BatV2ClassMemberMismatch)?;
+        let class = BatAcceptanceClassV2::decode(&class_record.exact_artifact)
+            .map_err(StoreError::Protocol)?;
+
+        let delegation_head =
+            read_delegation_head(&transaction, self, &delegation.expected_payee_pubkey)?;
+        let rollback_guard = match delegation_head.as_ref() {
+            Some(head) => Bolt11QuoteKeyRollbackGuardV1::from_persisted(
+                self.handle.expected_issuer_id,
+                self.handle.expected_network,
+                head.payee_pubkey,
+                head.highest_epoch,
+                head.delegation_digest,
+            ),
+            None => Bolt11QuoteKeyRollbackGuardV1::initial(
+                self.handle.expected_issuer_id,
+                self.handle.expected_network,
+                delegation.expected_payee_pubkey,
+            ),
+        }
+        .map_err(StoreError::Protocol)?;
+        let verified = intent
+            .verify_for_class_guarded(&class, &delegation, &rollback_guard, reservation.now_unix)
+            .map_err(StoreError::Protocol)?;
+        let upper_horizons = intent
+            .derived_horizons(reservation.invoice_created_not_after)
+            .map_err(StoreError::Protocol)?;
+        if verified.advanced_guard().highest_epoch() != delegation.key_epoch
+            || reservation.invoice_created_not_before < class.key_not_before
+            || upper_horizons.credential_not_after > class.key_not_after
+            || reservation.invoice_created_not_before < delegation.not_before
+            || reservation_recovery_deadline > delegation.not_after
+        {
+            return Err(StoreError::InvalidInput(
+                "BAT V2 class or delegation does not cover the reservation window",
+            ));
+        }
+
+        let delegation_advance = DelegationAdvance {
+            payee_pubkey: delegation.expected_payee_pubkey,
+            delegation_epoch: delegation.key_epoch,
+            delegation_digest: delegation
+                .delegation_digest()
+                .map_err(StoreError::Protocol)?,
+            exact_delegation: reservation.exact_delegation.clone(),
+            now_unix: reservation.now_unix,
+        };
+        let head_decision = delegation_head
+            .map(|head| compare_delegation(&head, &delegation_advance))
+            .transpose()?
+            .unwrap_or(HeadDecision::Advance);
+
+        let mutation = mutation_digest(
+            b"reserve-bat-v2-quote-v2",
+            &[
+                &reservation.quote_id,
+                &creation_digest,
+                &intent_digest,
+                &replay_image,
+                &intent.class_digest,
+                &delegation_advance.delegation_digest,
+                &reservation.invoice_created_not_before.to_le_bytes(),
+                &reservation.invoice_created_not_after.to_le_bytes(),
+                &reservation_recovery_deadline.to_le_bytes(),
+            ],
+        );
+        let committed_identity = advance_store_generation(
+            &transaction,
+            &previous_identity,
+            b"reserve-bat-v2-quote-v2",
+            &mutation,
+        )?;
+        let sequence = committed_identity.commit_seq;
+        if head_decision == HeadDecision::Advance {
+            write_delegation_head(&transaction, self, &delegation_advance, sequence)?;
+        }
+        let backend_label = self.backend_label_for_quote(&reservation.quote_id)?;
+        transaction.execute(
+            "INSERT INTO quotes (quote_id, issuer_id, network, quote_protocol, \
+             creation_idempotency_digest, backend_label, intent_digest, intent_replay_image, \
+             payee_pubkey, delegation_epoch, delegation_digest, exact_delegation, \
+             exact_amount_msat, invoice_created_not_before, invoice_created_not_after, \
+             reservation_recovery_deadline, state, state_version, reservation_commit_seq) \
+             VALUES (?1, ?2, ?3, 2, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, 0, 0, ?16)",
+            params![
+                reservation.quote_id.as_slice(),
+                self.handle.expected_issuer_id.as_slice(),
+                network_code(self.handle.expected_network),
+                creation_digest.as_slice(),
+                backend_label,
+                intent_digest.as_slice(),
+                replay_image.as_slice(),
+                delegation.expected_payee_pubkey.as_slice(),
+                sql_integer(delegation.key_epoch, "delegation epoch exceeds SQLite range")?,
+                delegation_advance.delegation_digest.as_slice(),
+                reservation.exact_delegation.as_slice(),
+                sql_integer(intent.exact_amount_msat, "amount exceeds SQLite range")?,
+                sql_integer(
+                    reservation.invoice_created_not_before,
+                    "invoice creation lower bound exceeds SQLite range",
+                )?,
+                sql_integer(
+                    reservation.invoice_created_not_after,
+                    "invoice creation upper bound exceeds SQLite range",
+                )?,
+                sql_integer(
+                    reservation_recovery_deadline,
+                    "reservation recovery deadline exceeds SQLite range",
+                )?,
+                sql_integer(sequence, "commit sequence exceeds SQLite range")?,
+            ],
+        )?;
+        commit(transaction)?;
+        self.anchor_committed_identity(&previous_floor, &committed_identity)?;
+        let record = self.bat_v2_quote(&reservation.quote_id)?.ok_or_else(|| {
+            StoreError::SchemaMismatch("committed BAT V2 quote missing".to_owned())
+        })?;
+        Ok(DurableWrite {
+            disposition: WriteDisposition::Committed,
+            commit: marker(self, sequence),
+            value: record,
+        })
+    }
+
     pub fn finalize_quote(
         &self,
         finalization: &QuoteFinalization,
+    ) -> StoreResult<DurableWrite<QuoteRecord>> {
+        self.finalize_quote_for_protocol(finalization, QUOTE_PROTOCOL_V1)
+    }
+
+    pub fn finalize_bat_v2_quote(
+        &self,
+        finalization: &QuoteFinalization,
+    ) -> StoreResult<DurableWrite<QuoteRecord>> {
+        self.finalize_quote_for_protocol(finalization, QUOTE_PROTOCOL_BAT_V2)
+    }
+
+    fn finalize_quote_for_protocol(
+        &self,
+        finalization: &QuoteFinalization,
+        quote_protocol: i64,
     ) -> StoreResult<DurableWrite<QuoteRecord>> {
         validate_quote_finalization(finalization)?;
         let mut connection = self.open_checked(false)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let previous_identity = verify_expected_identity(&transaction, &self.handle)?;
         let previous_floor = self.require_exact_rollback_floor(&previous_identity)?;
-        let existing = read_quote(&transaction, self, &finalization.quote_id)?
-            .ok_or(StoreError::QuoteMissing)?;
+        let existing =
+            read_quote_for_protocol(&transaction, self, &finalization.quote_id, quote_protocol)?
+                .ok_or(StoreError::QuoteMissing)?;
         if let Some(commit_marker) = existing.finalization_commit {
             if quote_finalization_matches(&existing, finalization) {
-                verify_persisted_quote_history(&transaction, self, &existing)?
-                    .ok_or(StoreError::SignedQuoteMismatch)?;
+                verify_persisted_quote_history_for_protocol(
+                    &transaction,
+                    self,
+                    &existing,
+                    quote_protocol,
+                )?
+                .ok_or(StoreError::SignedQuoteMismatch)?;
                 return Ok(DurableWrite {
                     disposition: WriteDisposition::ExactReplay,
                     commit: commit_marker,
@@ -308,10 +549,12 @@ impl IssuerStore {
         if existing.state != QuoteState::Reserved {
             return Err(StoreError::InvalidQuoteState);
         }
-        let initial_snapshot = decode_and_verify_quote_snapshot(
+        let initial_snapshot = decode_and_verify_quote_snapshot_for_protocol(
+            &transaction,
             self,
             &existing,
             &finalization.exact_signed_quote_response,
+            quote_protocol,
         )?;
         verify_initial_snapshot(&initial_snapshot, finalization)?;
 
@@ -374,9 +617,11 @@ impl IssuerStore {
         }
         commit(transaction)?;
         self.anchor_committed_identity(&previous_floor, &committed_identity)?;
-        let record = self.quote(&finalization.quote_id)?.ok_or_else(|| {
-            StoreError::SchemaMismatch("committed quote finalization missing".to_owned())
-        })?;
+        let record =
+            read_committed_quote_for_protocol(self, &finalization.quote_id, quote_protocol)?
+                .ok_or_else(|| {
+                    StoreError::SchemaMismatch("committed quote finalization missing".to_owned())
+                })?;
         Ok(DurableWrite {
             disposition: WriteDisposition::Committed,
             commit: marker(self, sequence),
@@ -388,20 +633,41 @@ impl IssuerStore {
         &self,
         expiry: &QuoteExpiry,
     ) -> StoreResult<DurableWrite<QuoteRecord>> {
+        self.mark_invoice_expired_for_protocol(expiry, QUOTE_PROTOCOL_V1)
+    }
+
+    pub fn mark_bat_v2_invoice_expired(
+        &self,
+        expiry: &QuoteExpiry,
+    ) -> StoreResult<DurableWrite<QuoteRecord>> {
+        self.mark_invoice_expired_for_protocol(expiry, QUOTE_PROTOCOL_BAT_V2)
+    }
+
+    fn mark_invoice_expired_for_protocol(
+        &self,
+        expiry: &QuoteExpiry,
+        quote_protocol: i64,
+    ) -> StoreResult<DurableWrite<QuoteRecord>> {
         validate_quote_expiry(expiry)?;
         let mut connection = self.open_checked(false)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let previous_identity = verify_expected_identity(&transaction, &self.handle)?;
         let previous_floor = self.require_exact_rollback_floor(&previous_identity)?;
         let existing =
-            read_quote(&transaction, self, &expiry.quote_id)?.ok_or(StoreError::QuoteMissing)?;
+            read_quote_for_protocol(&transaction, self, &expiry.quote_id, quote_protocol)?
+                .ok_or(StoreError::QuoteMissing)?;
         if let Some(commit_marker) = existing.expiry_commit {
             if existing.expiry_observed_at == Some(expiry.observed_at)
                 && existing.expired_signed_quote_response.as_deref()
                     == Some(expiry.exact_signed_quote_response.as_slice())
             {
-                verify_persisted_quote_history(&transaction, self, &existing)?
-                    .ok_or(StoreError::SignedQuoteMismatch)?;
+                verify_persisted_quote_history_for_protocol(
+                    &transaction,
+                    self,
+                    &existing,
+                    quote_protocol,
+                )?
+                .ok_or(StoreError::SignedQuoteMismatch)?;
                 return Ok(DurableWrite {
                     disposition: WriteDisposition::ExactReplay,
                     commit: commit_marker,
@@ -418,10 +684,20 @@ impl IssuerStore {
         {
             return Err(StoreError::InvalidQuoteState);
         }
-        let prior_snapshot = verify_persisted_quote_history(&transaction, self, &existing)?
-            .ok_or(StoreError::SignedQuoteMismatch)?;
-        let expired_snapshot =
-            decode_and_verify_quote_snapshot(self, &existing, &expiry.exact_signed_quote_response)?;
+        let prior_snapshot = verify_persisted_quote_history_for_protocol(
+            &transaction,
+            self,
+            &existing,
+            quote_protocol,
+        )?
+        .ok_or(StoreError::SignedQuoteMismatch)?;
+        let expired_snapshot = decode_and_verify_quote_snapshot_for_protocol(
+            &transaction,
+            self,
+            &existing,
+            &expiry.exact_signed_quote_response,
+            quote_protocol,
+        )?;
         verify_successor_snapshot(
             &prior_snapshot,
             &expired_snapshot,
@@ -461,9 +737,10 @@ impl IssuerStore {
         }
         commit(transaction)?;
         self.anchor_committed_identity(&previous_floor, &committed_identity)?;
-        let record = self.quote(&expiry.quote_id)?.ok_or_else(|| {
-            StoreError::SchemaMismatch("committed expiry observation missing".to_owned())
-        })?;
+        let record = read_committed_quote_for_protocol(self, &expiry.quote_id, quote_protocol)?
+            .ok_or_else(|| {
+                StoreError::SchemaMismatch("committed expiry observation missing".to_owned())
+            })?;
         Ok(DurableWrite {
             disposition: WriteDisposition::Committed,
             commit: marker(self, sequence),
@@ -475,20 +752,41 @@ impl IssuerStore {
         &self,
         settlement: &QuoteSettlement,
     ) -> StoreResult<DurableWrite<QuoteRecord>> {
+        self.record_settlement_for_protocol(settlement, QUOTE_PROTOCOL_V1)
+    }
+
+    pub fn record_bat_v2_settlement(
+        &self,
+        settlement: &QuoteSettlement,
+    ) -> StoreResult<DurableWrite<QuoteRecord>> {
+        self.record_settlement_for_protocol(settlement, QUOTE_PROTOCOL_BAT_V2)
+    }
+
+    fn record_settlement_for_protocol(
+        &self,
+        settlement: &QuoteSettlement,
+        quote_protocol: i64,
+    ) -> StoreResult<DurableWrite<QuoteRecord>> {
         validate_quote_settlement(settlement)?;
         let mut connection = self.open_checked(false)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let previous_identity = verify_expected_identity(&transaction, &self.handle)?;
         let previous_floor = self.require_exact_rollback_floor(&previous_identity)?;
-        let existing = read_quote(&transaction, self, &settlement.quote_id)?
-            .ok_or(StoreError::QuoteMissing)?;
+        let existing =
+            read_quote_for_protocol(&transaction, self, &settlement.quote_id, quote_protocol)?
+                .ok_or(StoreError::QuoteMissing)?;
         let _ = existing.payment_hash.ok_or_else(|| {
             StoreError::SchemaMismatch("settlement quote lacks payment hash".to_owned())
         })?;
         if let Some(commit_marker) = existing.settlement_commit {
             if quote_settlement_matches(&existing, settlement) {
-                verify_persisted_quote_history(&transaction, self, &existing)?
-                    .ok_or(StoreError::SignedQuoteMismatch)?;
+                verify_persisted_quote_history_for_protocol(
+                    &transaction,
+                    self,
+                    &existing,
+                    quote_protocol,
+                )?
+                .ok_or(StoreError::SignedQuoteMismatch)?;
                 return Ok(DurableWrite {
                     disposition: WriteDisposition::ExactReplay,
                     commit: commit_marker,
@@ -518,12 +816,19 @@ impl IssuerStore {
             QuoteState::InvoiceExpiredPendingReconcile => QuoteState::LateSettledReconcile,
             _ => return Err(StoreError::InvalidQuoteState),
         };
-        let prior_snapshot = verify_persisted_quote_history(&transaction, self, &existing)?
-            .ok_or(StoreError::SignedQuoteMismatch)?;
-        let settled_snapshot = decode_and_verify_quote_snapshot(
+        let prior_snapshot = verify_persisted_quote_history_for_protocol(
+            &transaction,
+            self,
+            &existing,
+            quote_protocol,
+        )?
+        .ok_or(StoreError::SignedQuoteMismatch)?;
+        let settled_snapshot = decode_and_verify_quote_snapshot_for_protocol(
+            &transaction,
             self,
             &existing,
             &settlement.exact_signed_quote_response,
+            quote_protocol,
         )?;
         let expected_status = match next_state {
             QuoteState::PaymentSettled => Bolt11QuoteStatusV1::PaymentSettled,
@@ -591,8 +896,7 @@ impl IssuerStore {
         }
         commit(transaction)?;
         self.anchor_committed_identity(&previous_floor, &committed_identity)?;
-        let record = self
-            .quote(&settlement.quote_id)?
+        let record = read_committed_quote_for_protocol(self, &settlement.quote_id, quote_protocol)?
             .ok_or_else(|| StoreError::SchemaMismatch("committed settlement missing".to_owned()))?;
         Ok(DurableWrite {
             disposition: WriteDisposition::Committed,
@@ -768,6 +1072,227 @@ impl IssuerStore {
         })
     }
 
+    /// Atomically commit one class-bound BAT V2 issuance. Exact replay is
+    /// resolved before time and cryptographic callbacks; no V2 path writes a
+    /// `receipt_serials` row.
+    pub fn record_bat_v2_claim(
+        &self,
+        write: &BatV2ClaimWrite,
+        verifier: &dyn BatV2ClaimCryptographicVerifierV2,
+    ) -> StoreResult<DurableWrite<ClaimRecord>> {
+        let (envelope, response) = parse_bat_v2_claim_write(write)?;
+        let quote_id = envelope.claim.quote_id;
+        let claim_idempotency_digest =
+            claim_idempotency_digest(self, &envelope.claim.idempotency_key);
+        let claim_request_digest = envelope
+            .claim
+            .claim_request_digest()
+            .map_err(StoreError::Protocol)?;
+
+        let mut connection = self.open_checked(false)?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let previous_identity = verify_expected_identity(&transaction, &self.handle)?;
+        let previous_floor = self.require_exact_rollback_floor(&previous_identity)?;
+        let quote = read_quote_for_protocol(&transaction, self, &quote_id, QUOTE_PROTOCOL_BAT_V2)?
+            .ok_or(StoreError::QuoteMissing)?;
+        validate_bat_v2_envelope_for_quote(self, &quote, &envelope)?;
+        let claim_replay_image = bat_v2_claim_replay_image(self, &envelope)?;
+        let exact_credential_request = envelope
+            .credential_request
+            .encode()
+            .map_err(StoreError::Protocol)?;
+
+        if let Some(existing) = read_claim_where(
+            &transaction,
+            self,
+            "claim_idempotency_digest",
+            &claim_idempotency_digest,
+            QUOTE_PROTOCOL_BAT_V2,
+        )? {
+            if bat_v2_claim_matches(
+                &existing,
+                write,
+                &quote_id,
+                claim_request_digest,
+                &claim_replay_image,
+                &exact_credential_request,
+            ) {
+                verify_persisted_quote_history_for_protocol(
+                    &transaction,
+                    self,
+                    &quote,
+                    QUOTE_PROTOCOL_BAT_V2,
+                )?
+                .ok_or(StoreError::SignedQuoteMismatch)?;
+                return Ok(DurableWrite {
+                    disposition: WriteDisposition::ExactReplay,
+                    commit: existing.claim_commit,
+                    value: existing,
+                });
+            }
+            return Err(StoreError::ClaimIdempotencyConflict);
+        }
+        if read_claim_where(
+            &transaction,
+            self,
+            "quote_id",
+            &quote_id,
+            QUOTE_PROTOCOL_BAT_V2,
+        )?
+        .is_some()
+        {
+            return Err(StoreError::QuoteAlreadyClaimed);
+        }
+        if write.now_unix == 0 {
+            return Err(StoreError::InvalidInput("claim time is zero"));
+        }
+        if !matches!(
+            quote.state,
+            QuoteState::PaymentSettled | QuoteState::LateSettledReconcile
+        ) {
+            return Err(StoreError::QuoteNotSettled);
+        }
+        let deadline = quote.claim_deadline.ok_or_else(|| {
+            StoreError::SchemaMismatch("settled BAT V2 quote lacks claim deadline".to_owned())
+        })?;
+        if write.now_unix > deadline {
+            return Err(StoreError::ClaimDeadlineExpired);
+        }
+
+        let prior_snapshot = verify_persisted_quote_history_for_protocol(
+            &transaction,
+            self,
+            &quote,
+            QUOTE_PROTOCOL_BAT_V2,
+        )?
+        .ok_or(StoreError::SignedQuoteMismatch)?;
+        let replay_intent = decode_replay_bat_v2_intent(self, &quote)?;
+        let class_record = read_bat_acceptance_class_v2(
+            &transaction,
+            self,
+            &replay_intent.class_id,
+            replay_intent.class_key_epoch,
+        )?
+        .ok_or(StoreError::ClaimProtocolMismatch)?;
+        let class = BatAcceptanceClassV2::decode(&class_record.exact_artifact)
+            .map_err(|_| StoreError::ClaimProtocolMismatch)?;
+        let delegation = Bolt11QuoteKeyDelegationV1::decode(&quote.exact_delegation)
+            .map_err(|_| StoreError::ClaimProtocolMismatch)?;
+        let verified_quote = prior_snapshot
+            .verify_persisted_bat_v2_quote_for_store(
+                PersistedBolt11BatV2QuoteExpectationV2 {
+                    original_request_digest: &quote.intent_digest,
+                    replay_intent: &replay_intent,
+                    class: &class,
+                    quote_id: &quote.quote_id,
+                    invoice: quote
+                        .invoice
+                        .as_deref()
+                        .ok_or(StoreError::SignedQuoteMismatch)?,
+                    invoice_created_at: quote
+                        .invoice_created_at
+                        .ok_or(StoreError::SignedQuoteMismatch)?,
+                    invoice_expires_at: quote
+                        .invoice_expires_at
+                        .ok_or(StoreError::SignedQuoteMismatch)?,
+                    claim_deadline: deadline,
+                    credential_not_after: quote
+                        .credential_not_after
+                        .ok_or(StoreError::SignedQuoteMismatch)?,
+                },
+                &delegation,
+                write.now_unix,
+            )
+            .map_err(|_| StoreError::ClaimProtocolMismatch)?;
+        let bip340 = envelope
+            .credential_request
+            .verify_for_verified_quote(&envelope.claim, &verified_quote, write.now_unix)
+            .map_err(|_| StoreError::ClaimProtocolMismatch)?;
+        let checked_response = response
+            .verify_for_verified_quote(&envelope.credential_request, &verified_quote)
+            .map_err(|_| StoreError::ClaimProtocolMismatch)?;
+        let claimed_snapshot = decode_and_verify_quote_snapshot_for_protocol(
+            &transaction,
+            self,
+            &quote,
+            &write.exact_signed_quote_response,
+            QUOTE_PROTOCOL_BAT_V2,
+        )?;
+        verify_successor_snapshot(
+            &prior_snapshot,
+            &claimed_snapshot,
+            Bolt11QuoteStatusV1::CredentialClaimed,
+            quote
+                .state_version
+                .checked_add(1)
+                .ok_or(StoreError::SignedQuoteMismatch)?,
+            write.now_unix,
+        )?;
+        if !verifier.verify(BatV2ClaimCryptographicVerificationInputV2 {
+            claim_envelope: &envelope,
+            issuance_response: &response,
+            checked_response: &checked_response,
+            bip340_message_digest: &bip340.message_digest,
+        }) {
+            return Err(StoreError::BadClaimCryptography);
+        }
+
+        let mutation = mutation_digest(
+            b"claim-bat-v2-quote-v2",
+            &[
+                &quote_id,
+                &claim_idempotency_digest,
+                &claim_request_digest,
+                &exact_credential_request,
+                &write.exact_claim_response,
+                &write.exact_signed_quote_response,
+            ],
+        );
+        let committed_identity = advance_store_generation(
+            &transaction,
+            &previous_identity,
+            b"claim-bat-v2-quote-v2",
+            &mutation,
+        )?;
+        let sequence = committed_identity.commit_seq;
+        transaction.execute(
+            "INSERT INTO claims (quote_id, issuer_id, claim_idempotency_digest, \
+             claim_request_digest, claim_request_replay_image, exact_credential_request, \
+             exact_claim_response, exact_signed_quote_response, claimed_at, claim_commit_seq) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                quote_id.as_slice(),
+                self.handle.expected_issuer_id.as_slice(),
+                claim_idempotency_digest.as_slice(),
+                claim_request_digest.as_slice(),
+                claim_replay_image.as_slice(),
+                exact_credential_request.as_slice(),
+                write.exact_claim_response.as_slice(),
+                write.exact_signed_quote_response.as_slice(),
+                sql_integer(write.now_unix, "claim time exceeds SQLite range")?,
+                sql_integer(sequence, "commit sequence exceeds SQLite range")?,
+            ],
+        )?;
+        let changed = transaction.execute(
+            "UPDATE quotes SET state = 3, state_version = state_version + 1 \
+             WHERE quote_id = ?1 AND quote_protocol = 2 AND state IN (2, 5)",
+            [quote_id.as_slice()],
+        )?;
+        if changed != 1 {
+            return Err(StoreError::QuoteNotSettled);
+        }
+        commit(transaction)?;
+        self.anchor_committed_identity(&previous_floor, &committed_identity)?;
+        let record = self.bat_v2_claim(&quote_id)?.ok_or_else(|| {
+            StoreError::SchemaMismatch("committed BAT V2 claim missing".to_owned())
+        })?;
+        Ok(DurableWrite {
+            disposition: WriteDisposition::Committed,
+            commit: marker(self, sequence),
+            value: record,
+        })
+    }
+
     /// Issuer-internal lookup only. An HTTP adapter MUST authenticate a
     /// possession-bound status request before exposing this record; knowledge
     /// of `quote_id` alone is not authorization to read invoice or status.
@@ -837,7 +1362,8 @@ impl IssuerStore {
         let mut statement = connection.prepare(
             "SELECT quote_id, backend_label, delegation_digest
              FROM quotes
-             WHERE ((state = 0 AND reservation_recovery_deadline >= ?1)
+             WHERE quote_protocol = 1
+               AND ((state = 0 AND reservation_recovery_deadline >= ?1)
                     OR (state IN (1, 4) AND claim_deadline >= ?1))
                AND (?2 IS NULL OR quote_id > ?2)
              ORDER BY quote_id ASC
@@ -884,6 +1410,211 @@ impl IssuerStore {
         self.confirm_anchored_read(&connection, candidates)
     }
 
+    pub fn bat_v2_quote(&self, quote_id: &[u8; 32]) -> StoreResult<Option<QuoteRecord>> {
+        if is_zero(quote_id) {
+            return Err(StoreError::InvalidInput("quote id is all zero"));
+        }
+        let connection = self.open_checked(false)?;
+        let value = read_quote_for_protocol(&connection, self, quote_id, QUOTE_PROTOCOL_BAT_V2)?;
+        self.confirm_anchored_read(&connection, value)
+    }
+
+    pub fn bat_v2_quote_by_creation_idempotency_key(
+        &self,
+        idempotency_key: &[u8; 32],
+    ) -> StoreResult<Option<QuoteRecord>> {
+        if is_zero(idempotency_key) {
+            return Err(StoreError::InvalidInput(
+                "creation idempotency key is all zero",
+            ));
+        }
+        let connection = self.open_checked(false)?;
+        let digest = creation_idempotency_digest(self, idempotency_key);
+        let value = read_quote_by_creation_digest_for_protocol(
+            &connection,
+            self,
+            &digest,
+            QUOTE_PROTOCOL_BAT_V2,
+        )?;
+        self.confirm_anchored_read(&connection, value)
+    }
+
+    pub fn bat_v2_quote_by_backend_label(&self, label: &str) -> StoreResult<Option<QuoteRecord>> {
+        if label.is_empty() || label.len() > 96 {
+            return Err(StoreError::InvalidInput("backend label length is invalid"));
+        }
+        let connection = self.open_checked(false)?;
+        let value =
+            read_quote_by_label_for_protocol(&connection, self, label, QUOTE_PROTOCOL_BAT_V2)?;
+        self.confirm_anchored_read(&connection, value)
+    }
+
+    pub fn bat_v2_quote_reconciliation_candidates_after(
+        &self,
+        after_quote_id: Option<&[u8; 32]>,
+        limit: u32,
+        now_unix: u64,
+    ) -> StoreResult<Vec<QuoteReconciliationCandidateV1>> {
+        if limit == 0 || limit > MAX_QUOTE_RECONCILIATION_BATCH_V1 {
+            return Err(StoreError::InvalidInput(
+                "quote reconciliation batch limit is invalid",
+            ));
+        }
+        if after_quote_id.is_some_and(|value| is_zero(value)) || now_unix == 0 {
+            return Err(StoreError::InvalidInput(
+                "invalid BAT V2 quote reconciliation cursor or time",
+            ));
+        }
+        let connection = self.open_checked(false)?;
+        let mut statement = connection.prepare(
+            "SELECT quote_id, backend_label, delegation_digest FROM quotes
+             WHERE quote_protocol = 2
+               AND ((state = 0 AND reservation_recovery_deadline >= ?1)
+                    OR (state IN (1, 4) AND claim_deadline >= ?1))
+               AND (?2 IS NULL OR quote_id > ?2)
+             ORDER BY quote_id ASC LIMIT ?3",
+        )?;
+        let cursor = after_quote_id.map(|value| value.as_slice());
+        let rows = statement.query_map(
+            params![
+                sql_integer(now_unix, "quote reconciliation observation time")?,
+                cursor,
+                i64::from(limit),
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Vec<u8>>(2)?,
+                ))
+            },
+        )?;
+        let mut candidates = Vec::with_capacity(limit as usize);
+        for row in rows {
+            let (quote_id, backend_label, delegation_digest) = row?;
+            let quote_id = fixed_blob(quote_id, "invalid reconciliation quote id")?;
+            let delegation_digest = fixed_blob(
+                delegation_digest,
+                "invalid reconciliation delegation digest",
+            )?;
+            if is_zero(&quote_id)
+                || is_zero(&delegation_digest)
+                || backend_label != self.backend_label_for_quote(&quote_id)?
+            {
+                return Err(StoreError::SchemaMismatch(
+                    "invalid BAT V2 quote reconciliation candidate".to_owned(),
+                ));
+            }
+            candidates.push(QuoteReconciliationCandidateV1 {
+                quote_id,
+                backend_label,
+                delegation_digest,
+            });
+        }
+        drop(statement);
+        self.confirm_anchored_read(&connection, candidates)
+    }
+
+    /// Enumerate BAT key epochs needed either for one fresh acquisition from
+    /// a live current class head or for recovery of an unfinished historical
+    /// V2 quote. Terminal and out-of-horizon historical epochs do not pin key
+    /// material.
+    pub fn bat_v2_credential_material_requirements(
+        &self,
+        now_unix: u64,
+    ) -> StoreResult<Vec<BatV2CredentialMaterialRequirementV2>> {
+        if now_unix == 0 {
+            return Err(StoreError::InvalidInput(
+                "BAT V2 credential inventory time is zero",
+            ));
+        }
+        let connection = self.open_checked(false)?;
+        let mut statement = connection.prepare(
+            "SELECT intent_replay_image FROM quotes
+             WHERE quote_protocol = 2 AND (
+                 (state = 0 AND reservation_recovery_deadline >= ?1) OR
+                 (state IN (1, 2, 4, 5) AND claim_deadline >= ?1)
+             ) ORDER BY quote_id",
+        )?;
+        let replay_images = statement
+            .query_map(
+                [sql_integer(
+                    now_unix,
+                    "BAT V2 credential inventory time exceeds SQLite range",
+                )?],
+                |row| row.get::<_, Vec<u8>>(0),
+            )?
+            .collect::<Result<Vec<_>, _>>()?;
+        drop(statement);
+
+        let mut referenced = BTreeSet::new();
+        for replay_image in replay_images {
+            let intent = Bolt11BatV2QuoteIntentV2::decode(&replay_image).map_err(|_| {
+                StoreError::SchemaMismatch(
+                    "unfinished BAT V2 quote has an invalid replay intent".to_owned(),
+                )
+            })?;
+            referenced.insert((intent.class_id, intent.class_key_epoch));
+        }
+
+        let mut head_statement = connection.prepare(
+            "SELECT class_id, highest_key_epoch FROM bat_v2_class_heads \
+             WHERE issuer_id = ?1 ORDER BY class_id",
+        )?;
+        let heads = head_statement
+            .query_map([self.handle.expected_issuer_id.as_slice()], |row| {
+                Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        drop(head_statement);
+        for (class_id, key_epoch) in heads {
+            let class_id = fixed_blob(class_id, "invalid BAT V2 class head ID")?;
+            let key_epoch = db_u64(key_epoch, "negative BAT V2 class head epoch")?;
+            let record = read_bat_acceptance_class_v2(&connection, self, &class_id, key_epoch)?
+                .ok_or_else(|| {
+                    StoreError::SchemaMismatch(
+                        "BAT V2 class head references a missing artifact".to_owned(),
+                    )
+                })?;
+            let artifact = BatAcceptanceClassV2::decode(&record.exact_artifact).map_err(|_| {
+                StoreError::SchemaMismatch("BAT V2 class head artifact is not canonical".to_owned())
+            })?;
+            let fresh_credential_horizon = now_unix
+                .checked_add(u64::from(artifact.common_terms.invoice_expiry_seconds))
+                .and_then(|value| {
+                    value.checked_add(u64::from(artifact.common_terms.claim_window_seconds))
+                })
+                .and_then(|value| {
+                    value.checked_add(u64::from(
+                        artifact.common_terms.minimum_credential_validity_seconds,
+                    ))
+                });
+            if now_unix >= artifact.key_not_before
+                && fresh_credential_horizon.is_some_and(|horizon| horizon <= artifact.key_not_after)
+            {
+                referenced.insert((class_id, key_epoch));
+            }
+        }
+
+        let mut requirements = Vec::with_capacity(referenced.len());
+        for (class_id, class_key_epoch) in referenced {
+            let class =
+                read_bat_acceptance_class_v2(&connection, self, &class_id, class_key_epoch)?
+                    .ok_or_else(|| {
+                        StoreError::SchemaMismatch(
+                            "unfinished BAT V2 quote references a missing class epoch".to_owned(),
+                        )
+                    })?;
+            requirements.push(BatV2CredentialMaterialRequirementV2 {
+                class_id,
+                class_key_epoch,
+                raw_public_key: class.raw_public_key,
+                bat_key_id: class.bat_key_id,
+            });
+        }
+        self.confirm_anchored_read(&connection, requirements)
+    }
+
     /// Authenticates and atomically consumes a fresh private quote-status
     /// request before returning issuer-confidential invoice/status data.
     ///
@@ -896,16 +1627,63 @@ impl IssuerStore {
         now_unix: u64,
         verifier: &dyn QuoteStatusBip340Verifier,
     ) -> StoreResult<DurableWrite<AuthenticatedQuoteStatus>> {
+        self.consume_quote_status_request_for_protocol(
+            request,
+            now_unix,
+            verifier,
+            QUOTE_PROTOCOL_V1,
+        )
+    }
+
+    /// BAT V2 counterpart of [`Self::consume_quote_status_request`]. The
+    /// persisted class-bound quote typestate is reconstructed before the
+    /// possession proof is accepted; a V1 quote therefore fails closed.
+    pub fn consume_bat_v2_quote_status_request(
+        &self,
+        request: &Bolt11QuoteStatusRequestV1,
+        now_unix: u64,
+        verifier: &dyn QuoteStatusBip340Verifier,
+    ) -> StoreResult<DurableWrite<AuthenticatedQuoteStatus>> {
+        self.consume_quote_status_request_for_protocol(
+            request,
+            now_unix,
+            verifier,
+            QUOTE_PROTOCOL_BAT_V2,
+        )
+    }
+
+    fn consume_quote_status_request_for_protocol(
+        &self,
+        request: &Bolt11QuoteStatusRequestV1,
+        now_unix: u64,
+        verifier: &dyn QuoteStatusBip340Verifier,
+        quote_protocol: i64,
+    ) -> StoreResult<DurableWrite<AuthenticatedQuoteStatus>> {
         if now_unix == 0 {
             return Err(StoreError::InvalidInput("status request time is zero"));
         }
         request
             .encode()
             .map_err(|_| StoreError::InvalidInput("status request is not canonical V1"))?;
-        let preliminary = self
-            .quote(&request.quote_id)?
-            .ok_or(StoreError::QuoteMissing)?;
-        verify_status_request_binding(self, request, &preliminary, now_unix, verifier)?;
+        let preliminary_connection = self.open_checked(false)?;
+        let preliminary = read_quote_for_protocol(
+            &preliminary_connection,
+            self,
+            &request.quote_id,
+            quote_protocol,
+        )?
+        .ok_or(StoreError::QuoteMissing)?;
+        verify_status_request_binding_for_protocol(
+            &preliminary_connection,
+            self,
+            request,
+            &preliminary,
+            now_unix,
+            verifier,
+            quote_protocol,
+        )?;
+        self.confirm_anchored_read(&preliminary_connection, ())?;
+        drop(preliminary_connection);
 
         let mut connection = self.open_checked(false)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
@@ -915,7 +1693,8 @@ impl IssuerStore {
             return Err(StoreError::StatusTimeRollback);
         }
         let current =
-            read_quote(&transaction, self, &request.quote_id)?.ok_or(StoreError::QuoteMissing)?;
+            read_quote_for_protocol(&transaction, self, &request.quote_id, quote_protocol)?
+                .ok_or(StoreError::QuoteMissing)?;
         if current.intent_digest != preliminary.intent_digest
             || current.intent_replay_image != preliminary.intent_replay_image
         {
@@ -923,8 +1702,13 @@ impl IssuerStore {
                 "immutable quote intent changed during status verification".to_owned(),
             ));
         }
-        let latest_snapshot = verify_persisted_quote_history(&transaction, self, &current)?
-            .ok_or(StoreError::InvalidQuoteState)?;
+        let latest_snapshot = verify_persisted_quote_history_for_protocol(
+            &transaction,
+            self,
+            &current,
+            quote_protocol,
+        )?
+        .ok_or(StoreError::InvalidQuoteState)?;
         let status = AuthenticatedQuoteStatus {
             quote_id: current.quote_id,
             state: current.state,
@@ -967,16 +1751,17 @@ impl IssuerStore {
         }
         let now = now_unix.to_le_bytes();
         let expiry = expires_at.to_le_bytes();
+        let mutation_domain: &[u8] = if quote_protocol == QUOTE_PROTOCOL_V1 {
+            b"consume-quote-status-nonce-v1"
+        } else {
+            b"consume-bat-v2-quote-status-nonce-v2"
+        };
         let digest = mutation_digest(
-            b"consume-quote-status-nonce-v1",
+            mutation_domain,
             &[&request.quote_id, &nonce_digest, &now, &expiry],
         );
-        let committed_identity = advance_store_generation(
-            &transaction,
-            &previous_identity,
-            b"consume-quote-status-nonce-v1",
-            &digest,
-        )?;
+        let committed_identity =
+            advance_store_generation(&transaction, &previous_identity, mutation_domain, &digest)?;
         let sequence = committed_identity.commit_seq;
         transaction.execute(
             "INSERT INTO quote_status_nonces (quote_id, nonce_digest, expires_at, commit_seq) \
@@ -1033,12 +1818,203 @@ impl IssuerStore {
         let value = read_claim_by_idempotency_digest(&connection, self, &digest)?;
         self.confirm_anchored_read(&connection, value)
     }
+
+    /// Issuer-internal BAT V2 exact-response recovery lookup. The quote
+    /// discriminator is checked through the claim's quote foreign key, so a
+    /// V1 claim can never be decoded or returned through this path.
+    pub fn bat_v2_claim(&self, quote_id: &[u8; 32]) -> StoreResult<Option<ClaimRecord>> {
+        if is_zero(quote_id) {
+            return Err(StoreError::InvalidInput("quote id is all zero"));
+        }
+        let connection = self.open_checked(false)?;
+        let value = read_claim_where(
+            &connection,
+            self,
+            "quote_id",
+            quote_id,
+            QUOTE_PROTOCOL_BAT_V2,
+        )?;
+        self.confirm_anchored_read(&connection, value)
+    }
+
+    /// Issuer-internal BAT V2 diagnostic recovery lookup. The raw key is
+    /// hashed in memory and is never persisted or sufficient public
+    /// authorization on its own.
+    pub fn bat_v2_claim_by_idempotency_key(
+        &self,
+        idempotency_key: &[u8; 32],
+    ) -> StoreResult<Option<ClaimRecord>> {
+        if is_zero(idempotency_key) {
+            return Err(StoreError::InvalidInput(
+                "claim idempotency key is all zero",
+            ));
+        }
+        let connection = self.open_checked(false)?;
+        let digest = claim_idempotency_digest(self, idempotency_key);
+        let value = read_claim_where(
+            &connection,
+            self,
+            "claim_idempotency_digest",
+            &digest,
+            QUOTE_PROTOCOL_BAT_V2,
+        )?;
+        self.confirm_anchored_read(&connection, value)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum HeadDecision {
     Exact,
     Advance,
+}
+
+fn validate_quote_capacity(capacity: QuoteCapacityV1) -> StoreResult<()> {
+    if capacity.max_outstanding_unpaid == 0
+        || capacity.max_active_records == 0
+        || capacity.max_outstanding_unpaid > capacity.max_active_records
+    {
+        Err(StoreError::InvalidInput("invalid quote capacity"))
+    } else {
+        Ok(())
+    }
+}
+
+fn check_quote_capacity(
+    transaction: &Transaction<'_>,
+    capacity: QuoteCapacityV1,
+    now_unix: u64,
+) -> StoreResult<()> {
+    let now = sql_integer(now_unix, "quote capacity observation time")?;
+    let active_records = db_u64(
+        transaction.query_row(
+            "SELECT COUNT(*) FROM quotes
+             WHERE (state = 0 AND reservation_recovery_deadline >= ?1)
+                OR (state IN (1, 4) AND claim_deadline >= ?1)",
+            [now],
+            |row| row.get(0),
+        )?,
+        "active quote record count is invalid",
+    )?;
+    let outstanding_unpaid = db_u64(
+        transaction.query_row(
+            "SELECT COUNT(*) FROM quotes
+             WHERE (state = 0 AND reservation_recovery_deadline >= ?1)
+                OR (state = 1 AND claim_deadline >= ?1)",
+            [now],
+            |row| row.get(0),
+        )?,
+        "outstanding quote count is invalid",
+    )?;
+    if active_records >= capacity.max_active_records
+        || outstanding_unpaid >= capacity.max_outstanding_unpaid
+    {
+        Err(StoreError::QuoteCapacityExceeded)
+    } else {
+        Ok(())
+    }
+}
+
+fn parse_bat_v2_reservation(
+    store: &IssuerStore,
+    reservation: &BatV2QuoteReservation,
+) -> StoreResult<(Bolt11BatV2QuoteIntentV2, Bolt11QuoteKeyDelegationV1)> {
+    if is_zero(&reservation.quote_id)
+        || reservation.exact_intent.is_empty()
+        || reservation.exact_intent.len() > MAX_EXACT_INTENT_BYTES
+        || reservation.exact_delegation.is_empty()
+        || reservation.exact_delegation.len() > MAX_EXACT_DELEGATION_BYTES
+        || reservation.invoice_created_not_before == 0
+        || reservation.invoice_created_not_after < reservation.invoice_created_not_before
+        || reservation.now_unix == 0
+    {
+        return Err(StoreError::InvalidInput("invalid BAT V2 quote reservation"));
+    }
+    let intent = Bolt11BatV2QuoteIntentV2::decode(&reservation.exact_intent)
+        .map_err(|_| StoreError::InvalidInput("BAT V2 intent is not canonical"))?;
+    let delegation = Bolt11QuoteKeyDelegationV1::decode(&reservation.exact_delegation)
+        .map_err(|_| StoreError::InvalidInput("delegation is not canonical V1"))?;
+    if intent.encode().map_err(StoreError::Protocol)? != reservation.exact_intent
+        || delegation.encode().map_err(StoreError::Protocol)? != reservation.exact_delegation
+        || intent.issuer_id != store.handle.expected_issuer_id
+        || intent.network != store.handle.expected_network
+        || intent.expected_payee_pubkey != delegation.expected_payee_pubkey
+        || intent.minimum_quote_key_epoch != delegation.key_epoch
+        || intent.quote_delegation_digest
+            != delegation
+                .delegation_digest()
+                .map_err(StoreError::Protocol)?
+        || delegation.issuer_id != store.handle.expected_issuer_id
+        || delegation.network != store.handle.expected_network
+    {
+        return Err(StoreError::InvalidInput(
+            "BAT V2 intent and delegation binding mismatch",
+        ));
+    }
+    let _ = sql_integer(intent.exact_amount_msat, "amount exceeds SQLite range")?;
+    let _ = sql_integer(
+        reservation.invoice_created_not_before,
+        "invoice creation lower bound exceeds SQLite range",
+    )?;
+    let _ = sql_integer(
+        reservation.invoice_created_not_after,
+        "invoice creation upper bound exceeds SQLite range",
+    )?;
+    Ok((intent, delegation))
+}
+
+fn bat_v2_reservation_recovery_deadline(
+    invoice_created_not_after: u64,
+    intent: &Bolt11BatV2QuoteIntentV2,
+) -> StoreResult<u64> {
+    let deadline = invoice_created_not_after
+        .checked_add(u64::from(intent.invoice_expiry_seconds))
+        .and_then(|value| value.checked_add(u64::from(intent.claim_window_seconds)))
+        .ok_or(StoreError::InvalidInput(
+            "BAT V2 reservation recovery horizon overflows Unix time",
+        ))?;
+    let _ = sql_integer(
+        deadline,
+        "BAT V2 reservation recovery horizon exceeds SQLite range",
+    )?;
+    Ok(deadline)
+}
+
+fn bat_v2_intent_replay_image(
+    store: &IssuerStore,
+    intent: &Bolt11BatV2QuoteIntentV2,
+) -> StoreResult<Vec<u8>> {
+    let mut replay = intent.clone();
+    replay.idempotency_key = creation_idempotency_digest(store, &intent.idempotency_key);
+    replay.encode().map_err(StoreError::Protocol)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn bat_v2_quote_reservation_matches(
+    store: &IssuerStore,
+    record: &QuoteRecord,
+    reservation: &BatV2QuoteReservation,
+    intent: &Bolt11BatV2QuoteIntentV2,
+    delegation: &Bolt11QuoteKeyDelegationV1,
+    replay_image: &[u8],
+    reservation_recovery_deadline: u64,
+) -> StoreResult<bool> {
+    Ok(record.quote_id == reservation.quote_id
+        && record.creation_idempotency_digest
+            == creation_idempotency_digest(store, &intent.idempotency_key)
+        && record.backend_label == store.backend_label_for_quote(&reservation.quote_id)?
+        && record.intent_digest == intent.request_digest().map_err(StoreError::Protocol)?
+        && record.intent_replay_image == replay_image
+        && record.payee_pubkey == delegation.expected_payee_pubkey
+        && record.delegation_epoch == delegation.key_epoch
+        && record.delegation_digest
+            == delegation
+                .delegation_digest()
+                .map_err(StoreError::Protocol)?
+        && record.exact_delegation == reservation.exact_delegation
+        && record.exact_amount_msat == intent.exact_amount_msat
+        && record.invoice_created_not_before == reservation.invoice_created_not_before
+        && record.invoice_created_not_after == reservation.invoice_created_not_after
+        && record.reservation_recovery_deadline == reservation_recovery_deadline)
 }
 
 fn validate_delegation_input(
@@ -1295,6 +2271,88 @@ fn claim_replay_image(store: &IssuerStore, value: &ClaimWrite) -> StoreResult<Ve
         .map_err(|_| StoreError::InvalidInput("failed to build claim replay image"))
 }
 
+fn parse_bat_v2_claim_write(
+    value: &BatV2ClaimWrite,
+) -> StoreResult<(Bolt11BatV2ClaimEnvelopeV2, BatV2IssuanceResponseV2)> {
+    if value.exact_claim_envelope.is_empty()
+        || value.exact_claim_envelope.len() > MAX_EXACT_CLAIM_REQUEST_BYTES
+        || value.exact_claim_response.is_empty()
+        || value.exact_claim_response.len() > MAX_EXACT_CLAIM_RESPONSE_BYTES
+        || value.exact_signed_quote_response.is_empty()
+        || value.exact_signed_quote_response.len() > MAX_SIGNED_QUOTE_BYTES
+    {
+        return Err(StoreError::InvalidInput("invalid BAT V2 claim write"));
+    }
+    let envelope = Bolt11BatV2ClaimEnvelopeV2::decode(&value.exact_claim_envelope)
+        .map_err(|_| StoreError::InvalidInput("claim envelope is not canonical BAT V2"))?;
+    if envelope.encode().ok().as_deref() != Some(value.exact_claim_envelope.as_slice()) {
+        return Err(StoreError::InvalidInput(
+            "claim envelope is not canonical BAT V2",
+        ));
+    }
+    let response = BatV2IssuanceResponseV2::decode(&value.exact_claim_response)
+        .map_err(|_| StoreError::InvalidInput("claim response is not canonical BAT V2"))?;
+    if response.encode().ok().as_deref() != Some(value.exact_claim_response.as_slice()) {
+        return Err(StoreError::InvalidInput(
+            "claim response is not canonical BAT V2",
+        ));
+    }
+    Ok((envelope, response))
+}
+
+fn validate_bat_v2_envelope_for_quote(
+    store: &IssuerStore,
+    quote: &QuoteRecord,
+    envelope: &Bolt11BatV2ClaimEnvelopeV2,
+) -> StoreResult<()> {
+    let original_intent_digest = envelope
+        .quote_intent
+        .request_digest()
+        .map_err(|_| StoreError::ClaimProtocolMismatch)?;
+    let mut replay_intent = envelope.quote_intent.clone();
+    replay_intent.idempotency_key = quote.creation_idempotency_digest;
+    let replay_image = replay_intent
+        .encode()
+        .map_err(|_| StoreError::ClaimProtocolMismatch)?;
+    if envelope.quote_intent.issuer_id != store.handle.expected_issuer_id
+        || envelope.quote_intent.network != store.handle.expected_network
+        || envelope.claim.quote_id != quote.quote_id
+        || envelope.claim.quote_request_digest != quote.intent_digest
+        || original_intent_digest != quote.intent_digest
+        || replay_image != quote.intent_replay_image
+    {
+        return Err(StoreError::ClaimProtocolMismatch);
+    }
+    Ok(())
+}
+
+fn bat_v2_claim_replay_image(
+    store: &IssuerStore,
+    envelope: &Bolt11BatV2ClaimEnvelopeV2,
+) -> StoreResult<Vec<u8>> {
+    let mut claim = envelope.claim.clone();
+    claim.idempotency_key = claim_idempotency_digest(store, &claim.idempotency_key);
+    claim
+        .encode()
+        .map_err(|_| StoreError::InvalidInput("failed to build BAT V2 claim replay image"))
+}
+
+fn bat_v2_claim_matches(
+    record: &ClaimRecord,
+    value: &BatV2ClaimWrite,
+    quote_id: &[u8; 32],
+    claim_request_digest: [u8; 32],
+    claim_replay_image: &[u8],
+    exact_credential_request: &[u8],
+) -> bool {
+    record.quote_id == *quote_id
+        && record.claim_request_digest == claim_request_digest
+        && record.claim_request_replay_image == claim_replay_image
+        && record.exact_credential_request == exact_credential_request
+        && record.exact_claim_response == value.exact_claim_response
+        && record.exact_signed_quote_response == value.exact_signed_quote_response
+}
+
 struct ParsedIssuance {
     request: CredentialIssuanceRequestV1,
     response: CredentialIssuanceResponseV1,
@@ -1436,6 +2494,102 @@ fn decode_replay_intent(
     Ok(intent)
 }
 
+fn decode_replay_bat_v2_intent(
+    store: &IssuerStore,
+    quote: &QuoteRecord,
+) -> StoreResult<Bolt11BatV2QuoteIntentV2> {
+    let intent = Bolt11BatV2QuoteIntentV2::decode(&quote.intent_replay_image)
+        .map_err(|_| StoreError::SignedQuoteMismatch)?;
+    if intent.encode().ok().as_deref() != Some(quote.intent_replay_image.as_slice())
+        || intent.issuer_id != store.handle.expected_issuer_id
+        || intent.network != store.handle.expected_network
+        || intent.expected_payee_pubkey != quote.payee_pubkey
+        || intent.minimum_quote_key_epoch != quote.delegation_epoch
+        || intent.quote_delegation_digest != quote.delegation_digest
+        || intent.exact_amount_msat != quote.exact_amount_msat
+        || intent.idempotency_key != quote.creation_idempotency_digest
+    {
+        return Err(StoreError::SignedQuoteMismatch);
+    }
+    Ok(intent)
+}
+
+fn decode_and_verify_quote_snapshot_for_protocol(
+    connection: &Connection,
+    store: &IssuerStore,
+    record: &QuoteRecord,
+    exact: &[u8],
+    quote_protocol: i64,
+) -> StoreResult<Bolt11QuoteV1> {
+    match quote_protocol {
+        QUOTE_PROTOCOL_V1 => decode_and_verify_quote_snapshot(store, record, exact),
+        QUOTE_PROTOCOL_BAT_V2 => {
+            decode_and_verify_bat_v2_quote_snapshot(connection, store, record, exact)
+        }
+        _ => Err(StoreError::SchemaMismatch(
+            "invalid quote protocol discriminator".to_owned(),
+        )),
+    }
+}
+
+fn decode_and_verify_bat_v2_quote_snapshot(
+    connection: &Connection,
+    store: &IssuerStore,
+    record: &QuoteRecord,
+    exact: &[u8],
+) -> StoreResult<Bolt11QuoteV1> {
+    if exact.is_empty() || exact.len() > MAX_SIGNED_QUOTE_BYTES || exact.len() < 64 {
+        return Err(StoreError::SignedQuoteMismatch);
+    }
+    let snapshot = Bolt11QuoteV1::decode(exact).map_err(|_| StoreError::SignedQuoteMismatch)?;
+    if snapshot.encode().ok().as_deref() != Some(exact) {
+        return Err(StoreError::SignedQuoteMismatch);
+    }
+    let intent = decode_replay_bat_v2_intent(store, record)?;
+    let class_record =
+        read_bat_acceptance_class_v2(connection, store, &intent.class_id, intent.class_key_epoch)?
+            .ok_or(StoreError::SignedQuoteMismatch)?;
+    let class = BatAcceptanceClassV2::decode(&class_record.exact_artifact)
+        .map_err(|_| StoreError::SignedQuoteMismatch)?;
+    let delegation = Bolt11QuoteKeyDelegationV1::decode(&record.exact_delegation)
+        .map_err(|_| StoreError::SignedQuoteMismatch)?;
+    if delegation.encode().ok().as_deref() != Some(record.exact_delegation.as_slice())
+        || delegation.delegation_digest().ok() != Some(record.delegation_digest)
+        || delegation.issuer_id != store.handle.expected_issuer_id
+        || delegation.network != store.handle.expected_network
+        || delegation.expected_payee_pubkey != record.payee_pubkey
+        || delegation.key_epoch != record.delegation_epoch
+        || snapshot.invoice_created_at < record.invoice_created_not_before
+        || snapshot.invoice_created_at > record.invoice_created_not_after
+    {
+        return Err(StoreError::SignedQuoteMismatch);
+    }
+    snapshot
+        .verify_persisted_bat_v2_quote_for_store(
+            PersistedBolt11BatV2QuoteExpectationV2 {
+                original_request_digest: &record.intent_digest,
+                replay_intent: &intent,
+                class: &class,
+                quote_id: &record.quote_id,
+                invoice: record.invoice.as_deref().unwrap_or(&snapshot.invoice),
+                invoice_created_at: record
+                    .invoice_created_at
+                    .unwrap_or(snapshot.invoice_created_at),
+                invoice_expires_at: record
+                    .invoice_expires_at
+                    .unwrap_or(snapshot.invoice_expires_at),
+                claim_deadline: record.claim_deadline.unwrap_or(snapshot.claim_deadline),
+                credential_not_after: record
+                    .credential_not_after
+                    .unwrap_or(snapshot.credential_not_after),
+            },
+            &delegation,
+            snapshot.status_updated_at,
+        )
+        .map_err(|_| StoreError::SignedQuoteMismatch)?;
+    Ok(snapshot)
+}
+
 fn decode_and_verify_quote_snapshot(
     store: &IssuerStore,
     record: &QuoteRecord,
@@ -1574,6 +2728,15 @@ fn verify_persisted_quote_history(
     store: &IssuerStore,
     record: &QuoteRecord,
 ) -> StoreResult<Option<Bolt11QuoteV1>> {
+    verify_persisted_quote_history_for_protocol(connection, store, record, QUOTE_PROTOCOL_V1)
+}
+
+fn verify_persisted_quote_history_for_protocol(
+    connection: &Connection,
+    store: &IssuerStore,
+    record: &QuoteRecord,
+    quote_protocol: i64,
+) -> StoreResult<Option<Bolt11QuoteV1>> {
     if record.state == QuoteState::Reserved {
         return if record.state_version == 0 && record.initial_signed_quote_response.is_none() {
             Ok(None)
@@ -1585,7 +2748,13 @@ fn verify_persisted_quote_history(
         .initial_signed_quote_response
         .as_deref()
         .ok_or(StoreError::SignedQuoteMismatch)?;
-    let initial = decode_and_verify_quote_snapshot(store, record, initial_exact)?;
+    let initial = decode_and_verify_quote_snapshot_for_protocol(
+        connection,
+        store,
+        record,
+        initial_exact,
+        quote_protocol,
+    )?;
     let persisted_finalization = QuoteFinalization {
         quote_id: record.quote_id,
         invoice: record
@@ -1611,7 +2780,13 @@ fn verify_persisted_quote_history(
     let mut latest = initial;
 
     if let Some(exact) = record.expired_signed_quote_response.as_deref() {
-        let expired = decode_and_verify_quote_snapshot(store, record, exact)?;
+        let expired = decode_and_verify_quote_snapshot_for_protocol(
+            connection,
+            store,
+            record,
+            exact,
+            quote_protocol,
+        )?;
         verify_successor_snapshot(
             &latest,
             &expired,
@@ -1624,7 +2799,13 @@ fn verify_persisted_quote_history(
         latest = expired;
     }
     if let Some(exact) = record.settled_signed_quote_response.as_deref() {
-        let settled = decode_and_verify_quote_snapshot(store, record, exact)?;
+        let settled = decode_and_verify_quote_snapshot_for_protocol(
+            connection,
+            store,
+            record,
+            exact,
+            quote_protocol,
+        )?;
         let expected_status = if record.expiry_commit.is_some() {
             Bolt11QuoteStatusV1::LateSettledReconcile
         } else {
@@ -1645,10 +2826,21 @@ fn verify_persisted_quote_history(
         latest = settled;
     }
     if record.state == QuoteState::CredentialClaimed {
-        let claim = read_claim(connection, store, &record.quote_id)?
-            .ok_or(StoreError::SignedQuoteMismatch)?;
-        let claimed =
-            decode_and_verify_quote_snapshot(store, record, &claim.exact_signed_quote_response)?;
+        let claim = read_claim_where(
+            connection,
+            store,
+            "quote_id",
+            &record.quote_id,
+            quote_protocol,
+        )?
+        .ok_or(StoreError::SignedQuoteMismatch)?;
+        let claimed = decode_and_verify_quote_snapshot_for_protocol(
+            connection,
+            store,
+            record,
+            &claim.exact_signed_quote_response,
+            quote_protocol,
+        )?;
         verify_successor_snapshot(
             &latest,
             &claimed,
@@ -1683,15 +2875,19 @@ pub(crate) fn verify_all_quote_histories(
     store: &IssuerStore,
     connection: &Connection,
 ) -> StoreResult<()> {
-    let mut statement = connection.prepare("SELECT quote_id FROM quotes ORDER BY quote_id")?;
+    let mut statement =
+        connection.prepare("SELECT quote_id, quote_protocol FROM quotes ORDER BY quote_id")?;
     let quote_ids = statement
-        .query_map([], |row| row.get::<_, Vec<u8>>(0))?
+        .query_map([], |row| {
+            Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, i64>(1)?))
+        })?
         .collect::<Result<Vec<_>, _>>()?;
-    for raw_quote_id in quote_ids {
+    for (raw_quote_id, quote_protocol) in quote_ids {
         let quote_id = fixed_blob(raw_quote_id, "invalid quote id")?;
-        let quote = read_quote(connection, store, &quote_id)?
+        let quote = read_quote_for_protocol(connection, store, &quote_id, quote_protocol)?
             .ok_or_else(|| StoreError::SchemaMismatch("enumerated quote is missing".to_owned()))?;
-        let _ = verify_persisted_quote_history(connection, store, &quote)?;
+        let _ =
+            verify_persisted_quote_history_for_protocol(connection, store, &quote, quote_protocol)?;
     }
     Ok(())
 }
@@ -1876,6 +3072,7 @@ struct RawQuote {
     finalization_seq: Option<i64>,
     expiry_seq: Option<i64>,
     settlement_seq: Option<i64>,
+    quote_protocol: i64,
 }
 
 fn raw_quote(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawQuote> {
@@ -1913,6 +3110,7 @@ fn raw_quote(row: &rusqlite::Row<'_>) -> rusqlite::Result<RawQuote> {
         finalization_seq: row.get(30)?,
         expiry_seq: row.get(31)?,
         settlement_seq: row.get(32)?,
+        quote_protocol: row.get(33)?,
     })
 }
 
@@ -1921,11 +3119,31 @@ fn read_quote(
     store: &IssuerStore,
     quote_id: &[u8; 32],
 ) -> StoreResult<Option<QuoteRecord>> {
+    read_quote_for_protocol(connection, store, quote_id, QUOTE_PROTOCOL_V1)
+}
+
+fn read_quote_for_protocol(
+    connection: &Connection,
+    store: &IssuerStore,
+    quote_id: &[u8; 32],
+    expected_protocol: i64,
+) -> StoreResult<Option<QuoteRecord>> {
     let sql = format!("SELECT {QUOTE_SELECT} FROM quotes WHERE quote_id = ?1");
     let raw = connection
         .query_row(&sql, [quote_id.as_slice()], raw_quote)
         .optional()?;
-    raw.map(|raw| convert_quote(store, raw)).transpose()
+    raw.map(|raw| convert_quote(store, raw, expected_protocol))
+        .transpose()
+}
+
+fn read_committed_quote_for_protocol(
+    store: &IssuerStore,
+    quote_id: &[u8; 32],
+    quote_protocol: i64,
+) -> StoreResult<Option<QuoteRecord>> {
+    let connection = store.open_checked(false)?;
+    let value = read_quote_for_protocol(&connection, store, quote_id, quote_protocol)?;
+    store.confirm_anchored_read(&connection, value)
 }
 
 fn read_quote_by_creation_digest(
@@ -1933,11 +3151,21 @@ fn read_quote_by_creation_digest(
     store: &IssuerStore,
     key: &[u8; 32],
 ) -> StoreResult<Option<QuoteRecord>> {
+    read_quote_by_creation_digest_for_protocol(connection, store, key, QUOTE_PROTOCOL_V1)
+}
+
+fn read_quote_by_creation_digest_for_protocol(
+    connection: &Connection,
+    store: &IssuerStore,
+    key: &[u8; 32],
+    expected_protocol: i64,
+) -> StoreResult<Option<QuoteRecord>> {
     let sql = format!("SELECT {QUOTE_SELECT} FROM quotes WHERE creation_idempotency_digest = ?1");
     let raw = connection
         .query_row(&sql, [key.as_slice()], raw_quote)
         .optional()?;
-    raw.map(|raw| convert_quote(store, raw)).transpose()
+    raw.map(|raw| convert_quote(store, raw, expected_protocol))
+        .transpose()
 }
 
 fn read_quote_by_label(
@@ -1945,12 +3173,29 @@ fn read_quote_by_label(
     store: &IssuerStore,
     label: &str,
 ) -> StoreResult<Option<QuoteRecord>> {
-    let sql = format!("SELECT {QUOTE_SELECT} FROM quotes WHERE backend_label = ?1");
-    let raw = connection.query_row(&sql, [label], raw_quote).optional()?;
-    raw.map(|raw| convert_quote(store, raw)).transpose()
+    read_quote_by_label_for_protocol(connection, store, label, QUOTE_PROTOCOL_V1)
 }
 
-fn convert_quote(store: &IssuerStore, raw: RawQuote) -> StoreResult<QuoteRecord> {
+fn read_quote_by_label_for_protocol(
+    connection: &Connection,
+    store: &IssuerStore,
+    label: &str,
+    expected_protocol: i64,
+) -> StoreResult<Option<QuoteRecord>> {
+    let sql = format!("SELECT {QUOTE_SELECT} FROM quotes WHERE backend_label = ?1");
+    let raw = connection.query_row(&sql, [label], raw_quote).optional()?;
+    raw.map(|raw| convert_quote(store, raw, expected_protocol))
+        .transpose()
+}
+
+fn convert_quote(
+    store: &IssuerStore,
+    raw: RawQuote,
+    expected_protocol: i64,
+) -> StoreResult<QuoteRecord> {
+    if raw.quote_protocol != expected_protocol {
+        return Err(StoreError::QuoteProtocolMismatch);
+    }
     let quote_id = fixed_blob(raw.quote_id, "invalid quote id")?;
     let creation_idempotency_digest = fixed_blob(raw.creation_key, "invalid creation digest")?;
     let intent_digest = fixed_blob(raw.intent_digest, "invalid intent digest")?;
@@ -1964,11 +3209,29 @@ fn convert_quote(store: &IssuerStore, raw: RawQuote) -> StoreResult<QuoteRecord>
         raw.reservation_recovery_deadline,
         "negative reservation recovery deadline",
     )?;
-    let replay_intent = Bolt11QuoteIntentV1::decode(&raw.intent_replay_image)
-        .map_err(|_| StoreError::SchemaMismatch("invalid persisted quote intent".to_owned()))?;
+    let (invoice_expiry_seconds, claim_window_seconds) = match expected_protocol {
+        QUOTE_PROTOCOL_V1 => {
+            let intent = Bolt11QuoteIntentV1::decode(&raw.intent_replay_image).map_err(|_| {
+                StoreError::SchemaMismatch("invalid persisted V1 quote intent".to_owned())
+            })?;
+            (intent.invoice_expiry_seconds, intent.claim_window_seconds)
+        }
+        QUOTE_PROTOCOL_BAT_V2 => {
+            let intent =
+                Bolt11BatV2QuoteIntentV2::decode(&raw.intent_replay_image).map_err(|_| {
+                    StoreError::SchemaMismatch("invalid persisted BAT V2 quote intent".to_owned())
+                })?;
+            (intent.invoice_expiry_seconds, intent.claim_window_seconds)
+        }
+        _ => {
+            return Err(StoreError::SchemaMismatch(
+                "invalid quote protocol discriminator".to_owned(),
+            ))
+        }
+    };
     let expected_recovery_deadline = invoice_created_not_after
-        .checked_add(u64::from(replay_intent.invoice_expiry_seconds))
-        .and_then(|value| value.checked_add(u64::from(replay_intent.claim_window_seconds)))
+        .checked_add(u64::from(invoice_expiry_seconds))
+        .and_then(|value| value.checked_add(u64::from(claim_window_seconds)))
         .ok_or_else(|| {
             StoreError::SchemaMismatch(
                 "persisted quote reservation recovery horizon overflows".to_owned(),
@@ -2079,7 +3342,7 @@ fn read_claim(
     store: &IssuerStore,
     quote_id: &[u8; 32],
 ) -> StoreResult<Option<ClaimRecord>> {
-    read_claim_where(connection, store, "quote_id", quote_id)
+    read_claim_where(connection, store, "quote_id", quote_id, QUOTE_PROTOCOL_V1)
 }
 
 fn read_claim_by_idempotency_digest(
@@ -2087,7 +3350,13 @@ fn read_claim_by_idempotency_digest(
     store: &IssuerStore,
     key: &[u8; 32],
 ) -> StoreResult<Option<ClaimRecord>> {
-    read_claim_where(connection, store, "claim_idempotency_digest", key)
+    read_claim_where(
+        connection,
+        store,
+        "claim_idempotency_digest",
+        key,
+        QUOTE_PROTOCOL_V1,
+    )
 }
 
 fn read_claim_where(
@@ -2095,6 +3364,7 @@ fn read_claim_where(
     store: &IssuerStore,
     column: &'static str,
     value: &[u8; 32],
+    expected_protocol: i64,
 ) -> StoreResult<Option<ClaimRecord>> {
     type Raw = (
         Vec<u8>,
@@ -2106,11 +3376,13 @@ fn read_claim_where(
         Vec<u8>,
         i64,
         i64,
+        i64,
     );
     let sql = format!(
-        "SELECT quote_id, claim_idempotency_digest, claim_request_digest, claim_request_replay_image, \
-         exact_credential_request, exact_claim_response, exact_signed_quote_response, claimed_at, claim_commit_seq \
-         FROM claims WHERE {column} = ?1"
+        "SELECT c.quote_id, c.claim_idempotency_digest, c.claim_request_digest, \
+         c.claim_request_replay_image, c.exact_credential_request, c.exact_claim_response, \
+         c.exact_signed_quote_response, c.claimed_at, c.claim_commit_seq, q.quote_protocol \
+         FROM claims c JOIN quotes q ON q.quote_id = c.quote_id WHERE c.{column} = ?1"
     );
     let raw: Option<Raw> = connection
         .query_row(&sql, [value.as_slice()], |row| {
@@ -2124,10 +3396,14 @@ fn read_claim_where(
                 row.get(6)?,
                 row.get(7)?,
                 row.get(8)?,
+                row.get(9)?,
             ))
         })
         .optional()?;
     raw.map(|raw| {
+        if raw.9 != expected_protocol {
+            return Err(StoreError::QuoteProtocolMismatch);
+        }
         let quote_id = fixed_blob(raw.0, "invalid claim quote id")?;
         let claim_idempotency_digest = fixed_blob(raw.1, "invalid claim idempotency digest")?;
         let claim_request_digest = fixed_blob(raw.2, "invalid claim request digest")?;
@@ -2233,6 +3509,94 @@ fn verify_status_request_binding(
         claim_pubkey_xonly: &request.claim_pubkey_xonly,
         message_digest: &message_digest,
         signature: &request.signature,
+    }) {
+        return Err(StoreError::BadStatusRequestSignature);
+    }
+    Ok(())
+}
+
+fn verify_status_request_binding_for_protocol(
+    connection: &Connection,
+    store: &IssuerStore,
+    request: &Bolt11QuoteStatusRequestV1,
+    quote: &QuoteRecord,
+    now_unix: u64,
+    verifier: &dyn QuoteStatusBip340Verifier,
+    quote_protocol: i64,
+) -> StoreResult<()> {
+    if quote_protocol == QUOTE_PROTOCOL_V1 {
+        return verify_status_request_binding(store, request, quote, now_unix, verifier);
+    }
+    if quote_protocol != QUOTE_PROTOCOL_BAT_V2 {
+        return Err(StoreError::SchemaMismatch(
+            "invalid quote protocol discriminator".to_owned(),
+        ));
+    }
+
+    let latest = verify_persisted_quote_history_for_protocol(
+        connection,
+        store,
+        quote,
+        QUOTE_PROTOCOL_BAT_V2,
+    )?
+    .ok_or(StoreError::InvalidQuoteState)?;
+    let replay_intent = decode_replay_bat_v2_intent(store, quote)?;
+    let class_record = read_bat_acceptance_class_v2(
+        connection,
+        store,
+        &replay_intent.class_id,
+        replay_intent.class_key_epoch,
+    )?
+    .ok_or_else(|| {
+        StoreError::SchemaMismatch(
+            "BAT V2 quote status references a missing retained class epoch".to_owned(),
+        )
+    })?;
+    let class = BatAcceptanceClassV2::decode(&class_record.exact_artifact)
+        .map_err(|_| StoreError::SignedQuoteMismatch)?;
+    let delegation = Bolt11QuoteKeyDelegationV1::decode(&quote.exact_delegation)
+        .map_err(|_| StoreError::SignedQuoteMismatch)?;
+    if request.requested_at > now_unix
+        || now_unix.saturating_sub(request.requested_at)
+            > MAX_BOLT11_QUOTE_STATUS_REQUEST_AGE_SECONDS_V1
+    {
+        return Err(StoreError::StatusRequestStale);
+    }
+    let verified_quote = latest
+        .verify_persisted_bat_v2_quote_for_store(
+            PersistedBolt11BatV2QuoteExpectationV2 {
+                original_request_digest: &quote.intent_digest,
+                replay_intent: &replay_intent,
+                class: &class,
+                quote_id: &quote.quote_id,
+                invoice: quote
+                    .invoice
+                    .as_deref()
+                    .ok_or(StoreError::SignedQuoteMismatch)?,
+                invoice_created_at: quote
+                    .invoice_created_at
+                    .ok_or(StoreError::SignedQuoteMismatch)?,
+                invoice_expires_at: quote
+                    .invoice_expires_at
+                    .ok_or(StoreError::SignedQuoteMismatch)?,
+                claim_deadline: quote
+                    .claim_deadline
+                    .ok_or(StoreError::SignedQuoteMismatch)?,
+                credential_not_after: quote
+                    .credential_not_after
+                    .ok_or(StoreError::SignedQuoteMismatch)?,
+            },
+            &delegation,
+            now_unix,
+        )
+        .map_err(|_| StoreError::StatusRequestBindingMismatch)?;
+    let bip340 = request
+        .unverified_bip340_input_for_verified_bat_v2_quote(&verified_quote, now_unix)
+        .map_err(|_| StoreError::StatusRequestBindingMismatch)?;
+    if !verifier.verify(QuoteStatusBip340Input {
+        claim_pubkey_xonly: &bip340.claim_pubkey_xonly,
+        message_digest: &bip340.message_digest,
+        signature: &bip340.signature,
     }) {
         return Err(StoreError::BadStatusRequestSignature);
     }

--- a/crates/payment/issuer-store/src/schema.rs
+++ b/crates/payment/issuer-store/src/schema.rs
@@ -45,6 +45,7 @@ pub(crate) fn quotes_sql() -> String {
         length(issuer_id) = 32 AND issuer_id != zeroblob(32)
     ),
     network                        INTEGER NOT NULL CHECK (network BETWEEN 1 AND 4),
+    quote_protocol                 INTEGER NOT NULL CHECK (quote_protocol IN (1, 2)),
     creation_idempotency_digest    BLOB NOT NULL UNIQUE CHECK (
         length(creation_idempotency_digest) = 32 AND
         creation_idempotency_digest != zeroblob(32)

--- a/crates/payment/issuer-store/src/types.rs
+++ b/crates/payment/issuer-store/src/types.rs
@@ -1,5 +1,6 @@
 use pir_service_protocol::{
-    AuthScheme, Bolt11QuoteClaimV1, CredentialIssuanceRequestV1, CredentialIssuanceResponseV1,
+    AuthScheme, BatV2IssuanceResponseV2, Bolt11BatV2ClaimEnvelopeV2, Bolt11QuoteClaimV1,
+    CheckedBatV2IssuanceResponseV2, CredentialIssuanceRequestV1, CredentialIssuanceResponseV1,
     CredentialKeyBindingV1, IssuerClearingApprovalV1, LightningNetworkV1, PayoutStateV1,
     ProviderClearingAuthorizationV1, ProviderRedeemRequestV1, ProviderRedeemResponseV1,
     ServiceProtocolError, SettlementUnitV1,
@@ -9,10 +10,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// On-disk schema version. This crate never performs an implicit migration.
-/// Version 6 is a fresh-schema boundary for the append-only BAT V2 class
-/// registry; existing version-5 stores must be migrated by an explicit,
+/// Version 7 is a fresh-schema boundary for protocol-discriminated BAT V2
+/// acquisition records; existing version-6 stores must be migrated by an explicit,
 /// separately reviewed operation.
-pub const SCHEMA_VERSION: u32 = 6;
+pub const SCHEMA_VERSION: u32 = 7;
 
 pub const MAX_EXACT_INTENT_BYTES: usize = 64 * 1024;
 pub const MAX_EXACT_DELEGATION_BYTES: usize = 64 * 1024;
@@ -320,6 +321,19 @@ pub struct QuoteReservation {
     pub now_unix: u64,
 }
 
+/// Minimal durable input for one issuer-wide BAT V2 quote reservation.
+/// Commercial, class, delegation, and idempotency fields are decoded from
+/// the two exact canonical protocol objects rather than repeated here.
+#[derive(Clone)]
+pub struct BatV2QuoteReservation {
+    pub quote_id: [u8; 32],
+    pub exact_intent: Vec<u8>,
+    pub exact_delegation: Vec<u8>,
+    pub invoice_created_not_before: u64,
+    pub invoice_created_not_after: u64,
+    pub now_unix: u64,
+}
+
 /// Exact BOLT11 invoice and first signed quote snapshot.
 #[derive(Clone)]
 pub struct QuoteFinalization {
@@ -433,6 +447,46 @@ pub struct ClaimWrite {
     /// persisted as `claimed_at`; an exact replay ignores a later supplied
     /// value and remains available after the deadline.
     pub now_unix: u64,
+}
+
+/// Exact BAT V2 claim envelope and issuer response to commit atomically. The
+/// quote ID and both endpoint idempotency keys are decoded from the canonical
+/// envelope; raw keys are never copied into durable replay images.
+#[derive(Clone)]
+pub struct BatV2ClaimWrite {
+    pub exact_claim_envelope: Vec<u8>,
+    pub exact_claim_response: Vec<u8>,
+    pub exact_signed_quote_response: Vec<u8>,
+    pub now_unix: u64,
+}
+
+pub struct BatV2ClaimCryptographicVerificationInputV2<'a> {
+    pub claim_envelope: &'a Bolt11BatV2ClaimEnvelopeV2,
+    pub issuance_response: &'a BatV2IssuanceResponseV2,
+    pub checked_response: &'a CheckedBatV2IssuanceResponseV2,
+    pub bip340_message_digest: &'a [u8; 32],
+}
+
+pub trait BatV2ClaimCryptographicVerifierV2 {
+    fn verify(&self, input: BatV2ClaimCryptographicVerificationInputV2<'_>) -> bool;
+}
+
+impl<F> BatV2ClaimCryptographicVerifierV2 for F
+where
+    F: Fn(BatV2ClaimCryptographicVerificationInputV2<'_>) -> bool,
+{
+    fn verify(&self, input: BatV2ClaimCryptographicVerificationInputV2<'_>) -> bool {
+        self(input)
+    }
+}
+
+/// One retained BAT key epoch still required by an unfinished V2 quote.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct BatV2CredentialMaterialRequirementV2 {
+    pub class_id: [u8; 32],
+    pub class_key_epoch: u64,
+    pub raw_public_key: [u8; 33],
+    pub bat_key_id: [u8; 32],
 }
 
 /// Exact claim recovery record. Exact request/response bytes are intentionally

--- a/crates/payment/issuer-store/tests/issuer_store.rs
+++ b/crates/payment/issuer-store/tests/issuer_store.rs
@@ -2,7 +2,8 @@ use ed25519_dalek::{Signer, SigningKey};
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use k256::{ProjectivePoint, Scalar};
 use pir_issuer_store::{
-    BatKeyLineageRegistration, ClaimCryptographicVerificationInput, ClaimWrite, DelegationAdvance,
+    BatKeyLineageRegistration, BatV2ClaimCryptographicVerificationInputV2, BatV2ClaimWrite,
+    BatV2QuoteReservation, ClaimCryptographicVerificationInput, ClaimWrite, DelegationAdvance,
     IssuerRollbackFloorAuthorityErrorV1, IssuerRollbackFloorAuthorityV1, IssuerRollbackFloorV1,
     IssuerStore, ProviderSettlementRegistrationWriteV1, QuoteCapacityV1, QuoteExpiry,
     QuoteFinalization, QuoteReservation, QuoteSettlement, QuoteState, QuoteStatusBip340Input,
@@ -11,7 +12,9 @@ use pir_issuer_store::{
 use pir_service_protocol::{
     derive_bat_key_id_v1, derive_cashu_keyset_id_v2, derive_issuer_id, paid_receipt_key_id,
     AcquisitionMethod, AuthPaddingClassV1, AuthScheme, BackendId, BatAcceptanceClassV2,
-    BatAcceptanceMemberV2, BatAcceptanceTermsV2, Bolt11QuoteClaimV1, Bolt11QuoteIntentV1,
+    BatAcceptanceMemberV2, BatAcceptanceTermsV2, BatV2IssuanceRequestV2, BatV2IssuanceResponseV2,
+    BitcoinPirCashuBatIssuanceRequestItemV1, BitcoinPirCashuBatIssuanceResponseItemV1,
+    Bolt11BatV2ClaimEnvelopeV2, Bolt11BatV2QuoteIntentV2, Bolt11QuoteClaimV1, Bolt11QuoteIntentV1,
     Bolt11QuoteKeyDelegationV1, Bolt11QuoteStatusRequestV1, Bolt11QuoteStatusV1, Bolt11QuoteV1,
     CashuDenominationKeyV1, CredentialIssuanceRequestItemsV1, CredentialIssuanceRequestV1,
     CredentialIssuanceResponseItemsV1, CredentialIssuanceResponseV1, DatasetBindingV1,
@@ -212,6 +215,10 @@ fn point(multiplier: u64) -> [u8; 33] {
         .to_affine()
         .to_encoded_point(true);
     encoded.as_bytes().try_into().expect("compressed point")
+}
+
+fn scalar(multiplier: u64) -> [u8; 32] {
+    Scalar::from(multiplier).to_bytes().into()
 }
 
 fn bat_v2_limits() -> EntitlementLimitsV1 {
@@ -503,6 +510,43 @@ fn reservation(
     reservation_with_receipt_key(quote_id_byte, idempotency_byte, delegation, 0x25)
 }
 
+fn bat_v2_reservation(
+    quote_id_byte: u8,
+    idempotency_byte: u8,
+    class: &BatAcceptanceClassV2,
+    delegation: &Bolt11QuoteKeyDelegationV1,
+) -> (BatV2QuoteReservation, Bolt11BatV2QuoteIntentV2) {
+    let intent = Bolt11BatV2QuoteIntentV2 {
+        issuer_id: issuer_id(),
+        class_id: class.class_id,
+        class_digest: class.class_digest().expect("BAT V2 class digest"),
+        class_key_epoch: class.key_epoch,
+        bat_key_id: class.bat_key_id(),
+        network: LightningNetworkV1::Regtest,
+        expected_payee_pubkey: delegation.expected_payee_pubkey,
+        minimum_quote_key_epoch: delegation.key_epoch,
+        quote_delegation_digest: delegation
+            .delegation_digest()
+            .expect("BAT V2 delegation digest"),
+        exact_amount_msat: class.common_terms.price_msat,
+        credential_count: class.common_terms.credential_count,
+        invoice_expiry_seconds: class.common_terms.invoice_expiry_seconds,
+        claim_window_seconds: class.common_terms.claim_window_seconds,
+        minimum_credential_validity_seconds: class.common_terms.minimum_credential_validity_seconds,
+        claim_pubkey_xonly: xonly(3),
+        idempotency_key: [idempotency_byte; 32],
+    };
+    let reservation = BatV2QuoteReservation {
+        quote_id: [quote_id_byte; 32],
+        exact_intent: intent.encode().expect("encode BAT V2 intent"),
+        exact_delegation: delegation.encode().expect("encode BAT V2 delegation"),
+        invoice_created_not_before: 250,
+        invoice_created_not_after: 350,
+        now_unix: 200,
+    };
+    (reservation, intent)
+}
+
 fn signed_quote(
     quote_id_byte: u8,
     quote_request_digest: [u8; 32],
@@ -535,6 +579,166 @@ fn signed_quote(
     preimage.extend_from_slice(&placeholder[..placeholder.len() - 64]);
     snapshot.signature = quote_key().sign(&preimage).to_bytes();
     snapshot.encode().expect("encode signed quote")
+}
+
+fn bat_v2_signed_quote(
+    quote_id_byte: u8,
+    quote_request_digest: [u8; 32],
+    invoice_suffix: u8,
+    status: Bolt11QuoteStatusV1,
+    state_version: u64,
+    status_updated_at: u64,
+) -> Vec<u8> {
+    let delegation = delegation(1, 0x22);
+    let mut snapshot = Bolt11QuoteV1 {
+        request_digest: quote_request_digest,
+        quote_id: [quote_id_byte; 32],
+        quote_key_id: delegation.quote_key_id,
+        invoice: format!("lnbcrt1bitcoinpirbatv2fixture{invoice_suffix}"),
+        network: LightningNetworkV1::Regtest,
+        payee_pubkey: point(2),
+        amount_msat: 2_000,
+        invoice_created_at: 300,
+        invoice_expires_at: 360,
+        claim_deadline: 480,
+        credential_not_after: 780,
+        status,
+        state_version,
+        status_updated_at,
+        signature: [1; 64],
+    };
+    let placeholder = snapshot.encode().expect("encode BAT V2 quote placeholder");
+    let mut preimage = Vec::new();
+    preimage.extend_from_slice(BOLT11_QUOTE_SIGNATURE_DOMAIN);
+    preimage.extend_from_slice(&placeholder[..placeholder.len() - 64]);
+    snapshot.signature = quote_key().sign(&preimage).to_bytes();
+    snapshot.encode().expect("encode signed BAT V2 quote")
+}
+
+fn bat_v2_finalization(
+    quote_id_byte: u8,
+    invoice_suffix: u8,
+    quote_request_digest: [u8; 32],
+) -> QuoteFinalization {
+    QuoteFinalization {
+        quote_id: [quote_id_byte; 32],
+        invoice: format!("lnbcrt1bitcoinpirbatv2fixture{invoice_suffix}"),
+        payment_hash: [invoice_suffix; 32],
+        invoice_created_at: 300,
+        invoice_expires_at: 360,
+        claim_deadline: 480,
+        credential_not_after: 780,
+        exact_signed_quote_response: bat_v2_signed_quote(
+            quote_id_byte,
+            quote_request_digest,
+            invoice_suffix,
+            Bolt11QuoteStatusV1::InvoiceOpen,
+            1,
+            300,
+        ),
+    }
+}
+
+fn bat_v2_settlement(
+    quote_id_byte: u8,
+    quote_request_digest: [u8; 32],
+    invoice_suffix: u8,
+) -> QuoteSettlement {
+    QuoteSettlement {
+        quote_id: [quote_id_byte; 32],
+        settled_at: 350,
+        observed_at: 350,
+        settled_amount_msat: 2_000,
+        settlement_evidence_digest: [invoice_suffix; 32],
+        exact_signed_quote_response: bat_v2_signed_quote(
+            quote_id_byte,
+            quote_request_digest,
+            invoice_suffix,
+            Bolt11QuoteStatusV1::PaymentSettled,
+            2,
+            350,
+        ),
+    }
+}
+
+fn bat_v2_claim_write(
+    quote_id_byte: u8,
+    intent: &Bolt11BatV2QuoteIntentV2,
+    claim_idempotency_byte: u8,
+    invoice_suffix: u8,
+) -> BatV2ClaimWrite {
+    let quote_request_digest = intent.request_digest().expect("BAT V2 intent digest");
+    let credential_request = BatV2IssuanceRequestV2 {
+        issuer_id: issuer_id(),
+        quote_id: [quote_id_byte; 32],
+        quote_request_digest,
+        class_id: intent.class_id,
+        class_digest: intent.class_digest,
+        class_key_epoch: intent.class_key_epoch,
+        bat_key_id: intent.bat_key_id,
+        items: vec![
+            BitcoinPirCashuBatIssuanceRequestItemV1 {
+                blinded_message: point(70),
+            },
+            BitcoinPirCashuBatIssuanceRequestItemV1 {
+                blinded_message: point(71),
+            },
+        ],
+    };
+    let credential_request_digest = credential_request
+        .request_digest()
+        .expect("BAT V2 issuance request digest");
+    let claim = Bolt11QuoteClaimV1 {
+        issuer_id: issuer_id(),
+        quote_id: [quote_id_byte; 32],
+        quote_request_digest,
+        credential_request_digest,
+        claim_pubkey_xonly: intent.claim_pubkey_xonly,
+        idempotency_key: [claim_idempotency_byte; 32],
+        signature: [0x62; 64],
+    };
+    let envelope = Bolt11BatV2ClaimEnvelopeV2 {
+        quote_intent: intent.clone(),
+        claim,
+        credential_request: credential_request.clone(),
+    };
+    let response = BatV2IssuanceResponseV2 {
+        issuer_id: issuer_id(),
+        quote_id: [quote_id_byte; 32],
+        quote_request_digest,
+        credential_request_digest,
+        class_id: intent.class_id,
+        class_digest: intent.class_digest,
+        class_key_epoch: intent.class_key_epoch,
+        bat_key_id: intent.bat_key_id,
+        items: vec![
+            BitcoinPirCashuBatIssuanceResponseItemV1 {
+                blinded_message: point(70),
+                blinded_signature: point(72),
+                dleq_e: scalar(1),
+                dleq_s: scalar(2),
+            },
+            BitcoinPirCashuBatIssuanceResponseItemV1 {
+                blinded_message: point(71),
+                blinded_signature: point(73),
+                dleq_e: scalar(3),
+                dleq_s: scalar(4),
+            },
+        ],
+    };
+    BatV2ClaimWrite {
+        exact_claim_envelope: envelope.encode().expect("encode BAT V2 claim envelope"),
+        exact_claim_response: response.encode().expect("encode BAT V2 issuance response"),
+        exact_signed_quote_response: bat_v2_signed_quote(
+            quote_id_byte,
+            quote_request_digest,
+            invoice_suffix,
+            Bolt11QuoteStatusV1::CredentialClaimed,
+            3,
+            400,
+        ),
+        now_unix: 400,
+    }
 }
 
 fn finalization(
@@ -670,6 +874,14 @@ fn claim(
 
 fn accept_claim_crypto(_input: ClaimCryptographicVerificationInput<'_>) -> bool {
     true
+}
+
+fn accept_bat_v2_claim_crypto(_input: BatV2ClaimCryptographicVerificationInputV2<'_>) -> bool {
+    true
+}
+
+fn reject_bat_v2_claim_crypto(_input: BatV2ClaimCryptographicVerificationInputV2<'_>) -> bool {
+    false
 }
 
 fn reject_claim_crypto(_input: ClaimCryptographicVerificationInput<'_>) -> bool {
@@ -2504,6 +2716,233 @@ fn bat_and_settlement_key_lineages_are_immutable_and_survive_restart() {
 }
 
 #[test]
+fn bat_v2_acquisition_reservation_is_current_head_only_but_old_exact_replay_survives() {
+    let test_path = TestPath::new();
+    let store = create_store(&test_path);
+    let class_id = [0x70; 32];
+    let first_members = register_bat_v2_members(&store, class_id, 1);
+    let first_class = bat_v2_class(class_id, 1, 70, bat_v2_terms(), first_members);
+    let _ = store
+        .register_bat_acceptance_class_v2(&first_class, 200)
+        .unwrap();
+    let live_head_only = store.bat_v2_credential_material_requirements(200).unwrap();
+    assert_eq!(live_head_only.len(), 1);
+    assert_eq!(live_head_only[0].class_key_epoch, 1);
+    assert_eq!(live_head_only[0].raw_public_key, point(70));
+    let first_delegation = delegation(1, 0x22);
+    let (first_reservation, _) = bat_v2_reservation(0x70, 0x71, &first_class, &first_delegation);
+    let committed = store.reserve_bat_v2_quote(&first_reservation).unwrap();
+    assert_eq!(committed.disposition, WriteDisposition::Committed);
+    assert_eq!(
+        store
+            .reserve_bat_v2_quote(&first_reservation)
+            .unwrap()
+            .disposition,
+        WriteDisposition::ExactReplay
+    );
+    assert!(matches!(
+        store.quote(&first_reservation.quote_id),
+        Err(StoreError::QuoteProtocolMismatch)
+    ));
+
+    let requirements = store.bat_v2_credential_material_requirements(400).unwrap();
+    assert_eq!(requirements.len(), 1);
+    assert_eq!(requirements[0].class_id, class_id);
+    assert_eq!(requirements[0].class_key_epoch, 1);
+    assert_eq!(
+        requirements[0].raw_public_key,
+        first_class.bat_verification_key
+    );
+    assert_eq!(requirements[0].bat_key_id, first_class.bat_key_id());
+
+    let second_members = register_bat_v2_members(&store, class_id, 2);
+    let second_class = bat_v2_class(class_id, 2, 71, bat_v2_terms(), second_members);
+    let _ = store
+        .register_bat_acceptance_class_v2(&second_class, 200)
+        .unwrap();
+    let rotated_requirements = store.bat_v2_credential_material_requirements(400).unwrap();
+    assert_eq!(rotated_requirements.len(), 2);
+    assert_eq!(rotated_requirements[0].class_key_epoch, 1);
+    assert_eq!(rotated_requirements[1].class_key_epoch, 2);
+    assert_eq!(
+        store
+            .reserve_bat_v2_quote(&first_reservation)
+            .unwrap()
+            .disposition,
+        WriteDisposition::ExactReplay,
+        "an already durable historical quote must recover after class rotation"
+    );
+    let (fresh_old_epoch, _) = bat_v2_reservation(0x72, 0x73, &first_class, &first_delegation);
+    assert!(matches!(
+        store.reserve_bat_v2_quote(&fresh_old_epoch),
+        Err(StoreError::BatV2ClassMemberMismatch)
+    ));
+
+    let conflicting_v1 = reservation(0x73, 0x71, &first_delegation);
+    assert!(matches!(
+        store.reserve_quote(&conflicting_v1),
+        Err(StoreError::QuoteProtocolMismatch)
+    ));
+    let v1_first = reservation(0x74, 0x75, &first_delegation);
+    let _ = store.reserve_quote(&v1_first).unwrap();
+    let (conflicting_v2, _) = bat_v2_reservation(0x75, 0x75, &second_class, &first_delegation);
+    assert!(matches!(
+        store.reserve_bat_v2_quote(&conflicting_v2),
+        Err(StoreError::QuoteProtocolMismatch)
+    ));
+    drop(store);
+
+    let reopened = open_store(&test_path).unwrap();
+    let mut historical_recovery = first_reservation.clone();
+    historical_recovery.now_unix = 2_000;
+    assert_eq!(
+        reopened
+            .reserve_bat_v2_quote(&historical_recovery)
+            .unwrap()
+            .disposition,
+        WriteDisposition::ExactReplay
+    );
+    assert_eq!(
+        reopened
+            .bat_v2_quote_by_creation_idempotency_key(&[0x71; 32])
+            .unwrap()
+            .unwrap()
+            .quote_id,
+        first_reservation.quote_id
+    );
+    let current_only = reopened
+        .bat_v2_credential_material_requirements(531)
+        .unwrap();
+    assert_eq!(current_only.len(), 1);
+    assert_eq!(current_only[0].class_key_epoch, 2);
+    assert_eq!(current_only[0].raw_public_key, point(71));
+    assert!(reopened
+        .bat_v2_credential_material_requirements(1_001)
+        .unwrap()
+        .is_empty());
+}
+
+#[test]
+fn bat_v2_acquisition_claim_status_and_restart_are_protocol_isolated() {
+    let test_path = TestPath::new();
+    let store = create_store(&test_path);
+    let class_id = [0x76; 32];
+    let members = register_bat_v2_members(&store, class_id, 1);
+    let mixed_v1_member = members[0].clone();
+    let class = bat_v2_class(class_id, 1, 76, bat_v2_terms(), members);
+    let _ = store.register_bat_acceptance_class_v2(&class, 200).unwrap();
+    let (reservation, intent) = bat_v2_reservation(0x76, 0x77, &class, &delegation(1, 0x22));
+    let intent_digest = intent.request_digest().unwrap();
+    let _ = store.reserve_bat_v2_quote(&reservation).unwrap();
+    let _ = store
+        .finalize_bat_v2_quote(&bat_v2_finalization(0x76, 0x78, intent_digest))
+        .unwrap();
+
+    let mut mixed_v1 = reservation_with_receipt_key(0x79, 0x80, &delegation(1, 0x22), 0x25);
+    let mut mixed_v1_intent = Bolt11QuoteIntentV1::decode(&mixed_v1.exact_intent).unwrap();
+    mixed_v1_intent.provider_id = mixed_v1_member.provider_id;
+    mixed_v1_intent.policy_digest = mixed_v1_member.policy_digest;
+    mixed_v1.intent_digest = mixed_v1_intent.request_digest().unwrap();
+    mixed_v1.exact_intent = mixed_v1_intent.encode().unwrap();
+    let _ = store.reserve_quote(&mixed_v1).unwrap();
+    drop(store);
+
+    let store = open_store(&test_path).unwrap();
+    let v1_requirements = store
+        .service_policies_requiring_credential_material(320)
+        .expect("mixed V1 plus open BAT V2 readiness must decode only V1 intents");
+    assert!(v1_requirements.iter().any(|record| {
+        record.provider_id == mixed_v1_member.provider_id
+            && record.policy_digest == mixed_v1_member.policy_digest
+    }));
+    assert_eq!(
+        store
+            .quote_delegation_digests_requiring_signing_material(320)
+            .expect("mixed V1 plus open BAT V2 signer readiness"),
+        vec![delegation(1, 0x22).delegation_digest().unwrap()]
+    );
+
+    let status = status_request(0x76, intent_digest, 320, 0x79);
+    let authenticated = store
+        .consume_bat_v2_quote_status_request(&status, 320, &accept_status_signature)
+        .unwrap();
+    assert_eq!(authenticated.value.state, QuoteState::InvoiceOpen);
+    assert!(matches!(
+        store.consume_bat_v2_quote_status_request(&status, 320, &accept_status_signature),
+        Err(StoreError::StatusNonceReplay)
+    ));
+    assert!(matches!(
+        store.consume_quote_status_request(&status, 320, &accept_status_signature),
+        Err(StoreError::QuoteProtocolMismatch)
+    ));
+
+    let _ = store
+        .record_bat_v2_settlement(&bat_v2_settlement(0x76, intent_digest, 0x78))
+        .unwrap();
+    let v2_claim = bat_v2_claim_write(0x76, &intent, 0x7a, 0x78);
+    let committed = store
+        .record_bat_v2_claim(&v2_claim, &accept_bat_v2_claim_crypto)
+        .unwrap();
+    assert_eq!(committed.disposition, WriteDisposition::Committed);
+    assert!(committed.value.receipt_serials.is_empty());
+    assert!(matches!(
+        store.claim(&reservation.quote_id),
+        Err(StoreError::QuoteProtocolMismatch)
+    ));
+
+    let mut replay_after_deadline = v2_claim.clone();
+    replay_after_deadline.now_unix = 999;
+    let replay = store
+        .record_bat_v2_claim(&replay_after_deadline, &reject_bat_v2_claim_crypto)
+        .unwrap();
+    assert_eq!(replay.disposition, WriteDisposition::ExactReplay);
+    assert!(replay.value == committed.value);
+
+    let connection = Connection::open(&test_path.database).unwrap();
+    let receipt_rows: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM receipt_serials r JOIN quotes q ON q.quote_id = r.quote_id \
+             WHERE q.quote_protocol = 2",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(receipt_rows, 0);
+    drop(connection);
+    drop(store);
+
+    let reopened = open_store(&test_path).unwrap();
+    assert!(
+        reopened
+            .bat_v2_claim_by_idempotency_key(&[0x7a; 32])
+            .unwrap()
+            .unwrap()
+            == committed.value
+    );
+    let second_members = register_bat_v2_members(&reopened, class_id, 2);
+    let second_class = bat_v2_class(class_id, 2, 77, bat_v2_terms(), second_members);
+    let _ = reopened
+        .register_bat_acceptance_class_v2(&second_class, 400)
+        .unwrap();
+    let terminal_old_epoch_does_not_pin = reopened
+        .bat_v2_credential_material_requirements(400)
+        .unwrap();
+    assert_eq!(terminal_old_epoch_does_not_pin.len(), 1);
+    assert_eq!(terminal_old_epoch_does_not_pin[0].class_key_epoch, 2);
+    assert_eq!(terminal_old_epoch_does_not_pin[0].raw_public_key, point(77));
+
+    let v1 = reserve_finalize_settle(&reopened, 0x7b, 0x7c, 0x7d);
+    let v1_claim = claim(0x7b, v1.intent_digest, 0x7e, 0x7d, 0x7f, 0x25, 3);
+    let _ = reopened
+        .record_claim(&v1_claim, &accept_claim_crypto, None)
+        .unwrap();
+    assert!(matches!(
+        reopened.bat_v2_claim(&v1.quote_id),
+        Err(StoreError::QuoteProtocolMismatch)
+    ));
+}
+
+#[test]
 fn bat_v2_registry_accepts_two_provider_epochs_and_survives_restart() {
     let test_path = TestPath::new();
     let store = create_store(&test_path);
@@ -2682,12 +3121,12 @@ fn bat_v2_registry_rejects_bidirectional_legacy_raw_key_reuse() {
 }
 
 #[test]
-fn bat_v2_schema_v6_rejects_implicit_v5_open() {
+fn bat_v2_acquisition_schema_v7_rejects_implicit_v6_open() {
     let test_path = TestPath::new();
     let store = create_store(&test_path);
     drop(store);
     let connection = Connection::open(&test_path.database).unwrap();
-    connection.pragma_update(None, "user_version", 5).unwrap();
+    connection.pragma_update(None, "user_version", 6).unwrap();
     drop(connection);
     assert!(matches!(
         open_store(&test_path),

--- a/crates/protocol/service/src/bat_v2_acquisition.rs
+++ b/crates/protocol/service/src/bat_v2_acquisition.rs
@@ -1,0 +1,1599 @@
+//! Class-bound BOLT11 acquisition for issuer-wide BitcoinPIR Cashu BAT V2.
+//!
+//! This module deliberately does not reinterpret the provider-bound V1
+//! credential binding. A V2 quote commits to an issuer-signed acceptance
+//! class and key epoch; no provider, policy, scope, offer, or
+//! `CredentialKeyBindingV1` digest is part of the issued BAT.
+
+use core::fmt;
+use std::collections::HashSet;
+
+use k256::elliptic_curve::PrimeField;
+use k256::Scalar;
+use sha2::{Digest, Sha256};
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::cashu_manifest::is_valid_compressed_point;
+use crate::codec::{put_bytes_u32, Decoder};
+use crate::{
+    BatAcceptanceClassV2, BitcoinPirCashuBatIssuanceRequestItemV1,
+    BitcoinPirCashuBatIssuanceResponseItemV1, Bolt11QuoteClaimV1, Bolt11QuoteHorizonsV1,
+    Bolt11QuoteKeyDelegationV1, Bolt11QuoteKeyRollbackGuardV1, Bolt11QuoteV1, LightningNetworkV1,
+    ServiceProtocolError, UnverifiedBip340ClaimV1, UnverifiedCashuBatDleqTupleV1,
+    VerifiedBatAcceptanceMemberV2, MAX_BITCOIN_MSAT_V1, MAX_BOLT11_CLAIM_WINDOW_SECONDS_V1,
+    MAX_BOLT11_CREDENTIAL_VALIDITY_SECONDS_V1, MAX_BOLT11_INVOICE_EXPIRY_SECONDS_V1,
+    MAX_BOLT11_QUOTE_CLAIM_LEN, MAX_CREDENTIALS_PER_ACQUISITION_V1,
+};
+
+pub const BAT_V2_QUOTE_INTENT_CODEC_MAGIC: &[u8; 8] = b"BPIRBQI2";
+pub const BAT_V2_QUOTE_INTENT_WIRE_VERSION: u8 = 2;
+pub const BAT_V2_QUOTE_INTENT_DIGEST_DOMAIN: &[u8] =
+    b"BitcoinPIR/bat-v2-bolt11-quote-intent-digest/v2";
+
+pub const BAT_V2_ISSUANCE_REQUEST_CODEC_MAGIC: &[u8; 8] = b"BPIRBQR2";
+pub const BAT_V2_ISSUANCE_REQUEST_WIRE_VERSION: u8 = 2;
+pub const BAT_V2_ISSUANCE_REQUEST_DIGEST_DOMAIN: &[u8] =
+    b"BitcoinPIR/bat-v2-issuance-request-digest/v2";
+
+pub const BAT_V2_ISSUANCE_RESPONSE_CODEC_MAGIC: &[u8; 8] = b"BPIRBQS2";
+pub const BAT_V2_ISSUANCE_RESPONSE_WIRE_VERSION: u8 = 2;
+
+pub const BAT_V2_CLAIM_ENVELOPE_CODEC_MAGIC: &[u8; 8] = b"BPIRBQE2";
+pub const BAT_V2_CLAIM_ENVELOPE_WIRE_VERSION: u8 = 2;
+
+pub const MAX_BAT_V2_QUOTE_INTENT_LEN: usize = 512;
+pub const MAX_BAT_V2_ISSUANCE_REQUEST_LEN: usize = 64 * 1024;
+pub const MAX_BAT_V2_ISSUANCE_RESPONSE_LEN: usize = 128 * 1024;
+pub const MAX_BAT_V2_CLAIM_ENVELOPE_LEN: usize = 1
+    + BAT_V2_CLAIM_ENVELOPE_CODEC_MAGIC.len()
+    + 4
+    + MAX_BAT_V2_QUOTE_INTENT_LEN
+    + 4
+    + MAX_BOLT11_QUOTE_CLAIM_LEN
+    + 4
+    + MAX_BAT_V2_ISSUANCE_REQUEST_LEN;
+
+/// Immutable, class-only BOLT11 acquisition intent.
+///
+/// The provider member used to discover this class is checked by the safe
+/// constructor but intentionally does not appear on this wire object.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Bolt11BatV2QuoteIntentV2 {
+    pub issuer_id: [u8; 32],
+    pub class_id: [u8; 32],
+    pub class_digest: [u8; 32],
+    pub class_key_epoch: u64,
+    pub bat_key_id: [u8; 32],
+    pub network: LightningNetworkV1,
+    pub expected_payee_pubkey: [u8; 33],
+    pub minimum_quote_key_epoch: u64,
+    pub quote_delegation_digest: [u8; 32],
+    pub exact_amount_msat: u64,
+    pub credential_count: u32,
+    pub invoice_expiry_seconds: u32,
+    pub claim_window_seconds: u32,
+    pub minimum_credential_validity_seconds: u32,
+    /// BIP340 x-only public key controlling private status and claim calls.
+    pub claim_pubkey_xonly: [u8; 32],
+    pub idempotency_key: [u8; 32],
+}
+
+impl fmt::Debug for Bolt11BatV2QuoteIntentV2 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Bolt11BatV2QuoteIntentV2")
+            .field("class_key_epoch", &self.class_key_epoch)
+            .field("commercial_and_client_binding", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl Drop for Bolt11BatV2QuoteIntentV2 {
+    fn drop(&mut self) {
+        self.idempotency_key.zeroize();
+    }
+}
+
+impl Bolt11BatV2QuoteIntentV2 {
+    /// Client integration entry point. The selected verified provider-policy
+    /// member is checked against the exact issuer-signed class, but its
+    /// provider coordinates are deliberately omitted from the resulting BAT.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_verified_class_member_guarded(
+        verified_member: &VerifiedBatAcceptanceMemberV2,
+        class: &BatAcceptanceClassV2,
+        quote_delegation: &Bolt11QuoteKeyDelegationV1,
+        rollback_guard: &Bolt11QuoteKeyRollbackGuardV1,
+        now_unix: u64,
+        claim_pubkey_xonly: [u8; 32],
+        idempotency_key: [u8; 32],
+    ) -> Result<(Self, Bolt11QuoteKeyRollbackGuardV1), ServiceProtocolError> {
+        validate_verified_member_for_class(verified_member, class, now_unix)?;
+        let advanced_guard = rollback_guard.verify_and_advance(quote_delegation, now_unix)?;
+        let intent = Self::from_verified_class(
+            class,
+            quote_delegation,
+            &advanced_guard,
+            now_unix,
+            claim_pubkey_xonly,
+            idempotency_key,
+        )?;
+        Ok((intent, advanced_guard))
+    }
+
+    /// Recheck both the selected member and the exact class-only wire intent.
+    pub fn verify_for_class_member_guarded<'a>(
+        &'a self,
+        verified_member: &VerifiedBatAcceptanceMemberV2,
+        class: &'a BatAcceptanceClassV2,
+        quote_delegation: &'a Bolt11QuoteKeyDelegationV1,
+        rollback_guard: &Bolt11QuoteKeyRollbackGuardV1,
+        now_unix: u64,
+    ) -> Result<VerifiedBolt11BatV2QuoteIntentV2<'a>, ServiceProtocolError> {
+        validate_verified_member_for_class(verified_member, class, now_unix)?;
+        self.verify_for_class_guarded(class, quote_delegation, rollback_guard, now_unix)
+    }
+
+    /// Issuer entry point. The wire intent carries no purchase-source member,
+    /// so the issuer validates it directly against its authoritative exact
+    /// class artifact and current-or-recovery selection policy.
+    pub fn verify_for_class_guarded<'a>(
+        &'a self,
+        class: &'a BatAcceptanceClassV2,
+        quote_delegation: &'a Bolt11QuoteKeyDelegationV1,
+        rollback_guard: &Bolt11QuoteKeyRollbackGuardV1,
+        now_unix: u64,
+    ) -> Result<VerifiedBolt11BatV2QuoteIntentV2<'a>, ServiceProtocolError> {
+        let advanced_guard = rollback_guard.verify_and_advance(quote_delegation, now_unix)?;
+        let expected = Self::from_verified_class(
+            class,
+            quote_delegation,
+            &advanced_guard,
+            now_unix,
+            self.claim_pubkey_xonly,
+            self.idempotency_key,
+        )?;
+        if self != &expected {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.class_binding",
+                reason: "intent differs from the exact signed class or quote-key delegation",
+            });
+        }
+        Ok(VerifiedBolt11BatV2QuoteIntentV2 {
+            intent: self,
+            class,
+            delegation: quote_delegation,
+            advanced_guard,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn from_verified_class(
+        class: &BatAcceptanceClassV2,
+        quote_delegation: &Bolt11QuoteKeyDelegationV1,
+        advanced_guard: &Bolt11QuoteKeyRollbackGuardV1,
+        now_unix: u64,
+        claim_pubkey_xonly: [u8; 32],
+        idempotency_key: [u8; 32],
+    ) -> Result<Self, ServiceProtocolError> {
+        class.verify()?;
+        if now_unix == 0 || now_unix < class.key_not_before || now_unix > class.key_not_after {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceClassV2.key_validity",
+                reason: "class key is not active at quote verification time",
+            });
+        }
+        quote_delegation.verify_for(
+            &class.issuer_id,
+            advanced_guard.network(),
+            &advanced_guard.expected_payee_pubkey(),
+            advanced_guard.highest_epoch(),
+            now_unix,
+        )?;
+        let value = Self {
+            issuer_id: class.issuer_id,
+            class_id: class.class_id,
+            class_digest: class.class_digest()?,
+            class_key_epoch: class.key_epoch,
+            bat_key_id: class.bat_key_id(),
+            network: advanced_guard.network(),
+            expected_payee_pubkey: advanced_guard.expected_payee_pubkey(),
+            minimum_quote_key_epoch: advanced_guard.highest_epoch(),
+            quote_delegation_digest: quote_delegation.delegation_digest()?,
+            exact_amount_msat: class.common_terms.price_msat,
+            credential_count: class.common_terms.credential_count,
+            invoice_expiry_seconds: class.common_terms.invoice_expiry_seconds,
+            claim_window_seconds: class.common_terms.claim_window_seconds,
+            minimum_credential_validity_seconds: class
+                .common_terms
+                .minimum_credential_validity_seconds,
+            claim_pubkey_xonly,
+            idempotency_key,
+        };
+        value.validate()?;
+        if value.derived_horizons(now_unix)?.credential_not_after > class.key_not_after {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatAcceptanceClassV2.key_not_after",
+                reason: "class key does not cover a newly created quote and credential horizon",
+            });
+        }
+        Ok(value)
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, ServiceProtocolError> {
+        self.validate()?;
+        let mut out = Zeroizing::new(Vec::with_capacity(320));
+        out.extend_from_slice(BAT_V2_QUOTE_INTENT_CODEC_MAGIC);
+        out.push(BAT_V2_QUOTE_INTENT_WIRE_VERSION);
+        out.extend_from_slice(&self.issuer_id);
+        out.extend_from_slice(&self.class_id);
+        out.extend_from_slice(&self.class_digest);
+        out.extend_from_slice(&self.class_key_epoch.to_le_bytes());
+        out.extend_from_slice(&self.bat_key_id);
+        out.push(self.network as u8);
+        out.extend_from_slice(&self.expected_payee_pubkey);
+        out.extend_from_slice(&self.minimum_quote_key_epoch.to_le_bytes());
+        out.extend_from_slice(&self.quote_delegation_digest);
+        out.extend_from_slice(&self.exact_amount_msat.to_le_bytes());
+        out.extend_from_slice(&self.credential_count.to_le_bytes());
+        out.extend_from_slice(&self.invoice_expiry_seconds.to_le_bytes());
+        out.extend_from_slice(&self.claim_window_seconds.to_le_bytes());
+        out.extend_from_slice(&self.minimum_credential_validity_seconds.to_le_bytes());
+        out.extend_from_slice(&self.claim_pubkey_xonly);
+        out.extend_from_slice(&self.idempotency_key);
+        check_len(
+            out.len(),
+            MAX_BAT_V2_QUOTE_INTENT_LEN,
+            "Bolt11BatV2QuoteIntentV2",
+        )?;
+        Ok(std::mem::take(&mut *out))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, ServiceProtocolError> {
+        check_len(
+            bytes.len(),
+            MAX_BAT_V2_QUOTE_INTENT_LEN,
+            "Bolt11BatV2QuoteIntentV2",
+        )?;
+        let mut decoder = Decoder::new(bytes);
+        expect_magic(
+            decoder.fixed("Bolt11BatV2QuoteIntentV2.magic")?,
+            BAT_V2_QUOTE_INTENT_CODEC_MAGIC,
+            "Bolt11BatV2QuoteIntentV2.magic",
+        )?;
+        expect_v2(
+            decoder.u8("Bolt11BatV2QuoteIntentV2.version")?,
+            "Bolt11BatV2QuoteIntentV2",
+        )?;
+        let value = Self {
+            issuer_id: decoder.fixed("Bolt11BatV2QuoteIntentV2.issuer_id")?,
+            class_id: decoder.fixed("Bolt11BatV2QuoteIntentV2.class_id")?,
+            class_digest: decoder.fixed("Bolt11BatV2QuoteIntentV2.class_digest")?,
+            class_key_epoch: decoder.u64("Bolt11BatV2QuoteIntentV2.class_key_epoch")?,
+            bat_key_id: decoder.fixed("Bolt11BatV2QuoteIntentV2.bat_key_id")?,
+            network: LightningNetworkV1::decode(decoder.u8("Bolt11BatV2QuoteIntentV2.network")?)?,
+            expected_payee_pubkey: decoder
+                .fixed("Bolt11BatV2QuoteIntentV2.expected_payee_pubkey")?,
+            minimum_quote_key_epoch: decoder
+                .u64("Bolt11BatV2QuoteIntentV2.minimum_quote_key_epoch")?,
+            quote_delegation_digest: decoder
+                .fixed("Bolt11BatV2QuoteIntentV2.quote_delegation_digest")?,
+            exact_amount_msat: decoder.u64("Bolt11BatV2QuoteIntentV2.exact_amount_msat")?,
+            credential_count: decoder.u32("Bolt11BatV2QuoteIntentV2.credential_count")?,
+            invoice_expiry_seconds: decoder
+                .u32("Bolt11BatV2QuoteIntentV2.invoice_expiry_seconds")?,
+            claim_window_seconds: decoder.u32("Bolt11BatV2QuoteIntentV2.claim_window_seconds")?,
+            minimum_credential_validity_seconds: decoder
+                .u32("Bolt11BatV2QuoteIntentV2.minimum_credential_validity_seconds")?,
+            claim_pubkey_xonly: decoder.fixed("Bolt11BatV2QuoteIntentV2.claim_pubkey_xonly")?,
+            idempotency_key: decoder.fixed("Bolt11BatV2QuoteIntentV2.idempotency_key")?,
+        };
+        decoder.finish()?;
+        value.validate()?;
+        if value.encode()?.as_slice() != bytes {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2",
+                reason: "non-canonical V2 quote intent encoding",
+            });
+        }
+        Ok(value)
+    }
+
+    pub fn request_digest(&self) -> Result<[u8; 32], ServiceProtocolError> {
+        let mut hasher = Sha256::new();
+        hasher.update(BAT_V2_QUOTE_INTENT_DIGEST_DOMAIN);
+        let encoded = Zeroizing::new(self.encode()?);
+        hasher.update(encoded.as_slice());
+        Ok(hasher.finalize().into())
+    }
+
+    pub fn derived_horizons(
+        &self,
+        invoice_created_at: u64,
+    ) -> Result<Bolt11QuoteHorizonsV1, ServiceProtocolError> {
+        self.validate()?;
+        let invoice_expires_at = invoice_created_at
+            .checked_add(u64::from(self.invoice_expiry_seconds))
+            .ok_or(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.invoice_expiry_seconds",
+                reason: "invoice expiry overflows Unix time",
+            })?;
+        let claim_deadline = invoice_expires_at
+            .checked_add(u64::from(self.claim_window_seconds))
+            .ok_or(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.claim_window_seconds",
+                reason: "claim deadline overflows Unix time",
+            })?;
+        let credential_not_after = claim_deadline
+            .checked_add(u64::from(self.minimum_credential_validity_seconds))
+            .ok_or(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.minimum_credential_validity_seconds",
+                reason: "credential horizon overflows Unix time",
+            })?;
+        Ok(Bolt11QuoteHorizonsV1 {
+            invoice_expires_at,
+            claim_deadline,
+            credential_not_after,
+        })
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), ServiceProtocolError> {
+        if self.issuer_id.iter().all(|byte| *byte == 0)
+            || self.class_id.iter().all(|byte| *byte == 0)
+            || self.class_digest.iter().all(|byte| *byte == 0)
+            || self.class_key_epoch == 0
+            || self.bat_key_id.iter().all(|byte| *byte == 0)
+            || self.minimum_quote_key_epoch == 0
+            || self.quote_delegation_digest.iter().all(|byte| *byte == 0)
+            || self.idempotency_key.iter().all(|byte| *byte == 0)
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.binding",
+                reason: "issuer, class, key epochs/digests, and idempotency must be non-zero",
+            });
+        }
+        if !is_valid_compressed_point(&self.expected_payee_pubkey) {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.expected_payee_pubkey",
+                reason: "must be a compressed secp256k1 public key",
+            });
+        }
+        crate::quote::validate_xonly_pubkey(&self.claim_pubkey_xonly)?;
+        if self.exact_amount_msat == 0 || self.exact_amount_msat > MAX_BITCOIN_MSAT_V1 {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.exact_amount_msat",
+                reason: "must be non-zero and within the Bitcoin supply bound",
+            });
+        }
+        if self.credential_count == 0 || self.credential_count > MAX_CREDENTIALS_PER_ACQUISITION_V1
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.credential_count",
+                reason: "must be non-zero and within the acquisition bound",
+            });
+        }
+        validate_horizons(
+            self.invoice_expiry_seconds,
+            self.claim_window_seconds,
+            self.minimum_credential_validity_seconds,
+            "Bolt11BatV2QuoteIntentV2.horizons",
+        )
+    }
+
+    pub(crate) fn verify_exact_class_binding(
+        &self,
+        class: &BatAcceptanceClassV2,
+        invoice_created_at: u64,
+    ) -> Result<(), ServiceProtocolError> {
+        class.verify_for(&self.issuer_id, &self.class_id)?;
+        let horizons = self.derived_horizons(invoice_created_at)?;
+        if self.class_digest != class.class_digest()?
+            || self.class_key_epoch != class.key_epoch
+            || self.bat_key_id != class.bat_key_id()
+            || self.exact_amount_msat != class.common_terms.price_msat
+            || self.credential_count != class.common_terms.credential_count
+            || self.invoice_expiry_seconds != class.common_terms.invoice_expiry_seconds
+            || self.claim_window_seconds != class.common_terms.claim_window_seconds
+            || self.minimum_credential_validity_seconds
+                != class.common_terms.minimum_credential_validity_seconds
+            || invoice_created_at < class.key_not_before
+            || horizons.credential_not_after > class.key_not_after
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.class_binding",
+                reason: "intent terms, key epoch, or actual quote horizon differ from the class",
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Typestate proving the class signature/terms and quote-key rollback stream
+/// were checked without inventing a provider-bound credential binding.
+#[derive(Clone, Copy, Debug)]
+pub struct VerifiedBolt11BatV2QuoteIntentV2<'a> {
+    intent: &'a Bolt11BatV2QuoteIntentV2,
+    class: &'a BatAcceptanceClassV2,
+    delegation: &'a Bolt11QuoteKeyDelegationV1,
+    advanced_guard: Bolt11QuoteKeyRollbackGuardV1,
+}
+
+impl<'a> VerifiedBolt11BatV2QuoteIntentV2<'a> {
+    pub const fn intent(&self) -> &'a Bolt11BatV2QuoteIntentV2 {
+        self.intent
+    }
+
+    pub const fn class(&self) -> &'a BatAcceptanceClassV2 {
+        self.class
+    }
+
+    pub const fn delegation(&self) -> &'a Bolt11QuoteKeyDelegationV1 {
+        self.delegation
+    }
+
+    pub const fn advanced_guard(&self) -> Bolt11QuoteKeyRollbackGuardV1 {
+        self.advanced_guard
+    }
+}
+
+/// Typestate proving one signed BOLT11 snapshot is bound to an exact V2 class
+/// intent and class artifact.
+#[derive(Clone, Copy, Debug)]
+pub struct VerifiedBolt11BatV2QuoteV2<'a> {
+    pub(crate) quote: &'a Bolt11QuoteV1,
+    pub(crate) intent: &'a Bolt11BatV2QuoteIntentV2,
+    pub(crate) class: &'a BatAcceptanceClassV2,
+    pub(crate) request_digest: [u8; 32],
+}
+
+impl<'a> VerifiedBolt11BatV2QuoteV2<'a> {
+    pub const fn quote(&self) -> &'a Bolt11QuoteV1 {
+        self.quote
+    }
+
+    pub const fn intent(&self) -> &'a Bolt11BatV2QuoteIntentV2 {
+        self.intent
+    }
+
+    pub const fn class(&self) -> &'a BatAcceptanceClassV2 {
+        self.class
+    }
+
+    /// Authoritative digest of the original client intent. For a persisted
+    /// privacy-safe replay image this intentionally differs from recomputing
+    /// the digest after its raw idempotency key was replaced.
+    pub const fn request_digest(&self) -> [u8; 32] {
+        self.request_digest
+    }
+
+    pub fn ensure_payable_at(&self, now_unix: u64) -> Result<(), ServiceProtocolError> {
+        crate::quote::ensure_quote_payable_at(self.quote, now_unix)
+    }
+
+    pub fn ensure_claim_submission_at(&self, now_unix: u64) -> Result<(), ServiceProtocolError> {
+        crate::quote::ensure_quote_claim_submission_at(self.quote, now_unix)
+    }
+}
+
+/// Durable BAT V2 quote facts needed to reconstruct a verified snapshot after
+/// restart without retaining the client's raw creation-idempotency key.
+/// `original_request_digest` remains the digest signed into the quote, while
+/// `replay_intent` is the canonical privacy-safe image persisted by the store.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PersistedBolt11BatV2QuoteExpectationV2<'a> {
+    pub original_request_digest: &'a [u8; 32],
+    pub replay_intent: &'a Bolt11BatV2QuoteIntentV2,
+    pub class: &'a BatAcceptanceClassV2,
+    pub quote_id: &'a [u8; 32],
+    pub invoice: &'a str,
+    pub invoice_created_at: u64,
+    pub invoice_expires_at: u64,
+    pub claim_deadline: u64,
+    pub credential_not_after: u64,
+}
+
+impl fmt::Debug for PersistedBolt11BatV2QuoteExpectationV2<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PersistedBolt11BatV2QuoteExpectationV2")
+            .field("class_key_epoch", &self.replay_intent.class_key_epoch)
+            .field("payment_artifacts", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Exact ordered blinded messages for one BAT V2 quote claim.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BatV2IssuanceRequestV2 {
+    pub issuer_id: [u8; 32],
+    pub quote_id: [u8; 32],
+    pub quote_request_digest: [u8; 32],
+    pub class_id: [u8; 32],
+    pub class_digest: [u8; 32],
+    pub class_key_epoch: u64,
+    pub bat_key_id: [u8; 32],
+    pub items: Vec<BitcoinPirCashuBatIssuanceRequestItemV1>,
+}
+
+impl BatV2IssuanceRequestV2 {
+    pub fn encode(&self) -> Result<Vec<u8>, ServiceProtocolError> {
+        self.validate()?;
+        let mut out = Zeroizing::new(Vec::with_capacity(256 + self.items.len() * 33));
+        out.extend_from_slice(BAT_V2_ISSUANCE_REQUEST_CODEC_MAGIC);
+        out.push(BAT_V2_ISSUANCE_REQUEST_WIRE_VERSION);
+        encode_issuance_binding(
+            &mut out,
+            &self.issuer_id,
+            &self.quote_id,
+            &self.quote_request_digest,
+            &self.class_id,
+            &self.class_digest,
+            self.class_key_epoch,
+            &self.bat_key_id,
+        );
+        out.extend_from_slice(&(self.items.len() as u16).to_le_bytes());
+        for item in &self.items {
+            out.extend_from_slice(&item.blinded_message);
+        }
+        check_len(
+            out.len(),
+            MAX_BAT_V2_ISSUANCE_REQUEST_LEN,
+            "BatV2IssuanceRequestV2",
+        )?;
+        Ok(std::mem::take(&mut *out))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, ServiceProtocolError> {
+        check_len(
+            bytes.len(),
+            MAX_BAT_V2_ISSUANCE_REQUEST_LEN,
+            "BatV2IssuanceRequestV2",
+        )?;
+        let mut decoder = Decoder::new(bytes);
+        expect_magic(
+            decoder.fixed("BatV2IssuanceRequestV2.magic")?,
+            BAT_V2_ISSUANCE_REQUEST_CODEC_MAGIC,
+            "BatV2IssuanceRequestV2.magic",
+        )?;
+        expect_v2(
+            decoder.u8("BatV2IssuanceRequestV2.version")?,
+            "BatV2IssuanceRequestV2",
+        )?;
+        let issuer_id = decoder.fixed("BatV2IssuanceRequestV2.issuer_id")?;
+        let quote_id = decoder.fixed("BatV2IssuanceRequestV2.quote_id")?;
+        let quote_request_digest = decoder.fixed("BatV2IssuanceRequestV2.quote_request_digest")?;
+        let class_id = decoder.fixed("BatV2IssuanceRequestV2.class_id")?;
+        let class_digest = decoder.fixed("BatV2IssuanceRequestV2.class_digest")?;
+        let class_key_epoch = decoder.u64("BatV2IssuanceRequestV2.class_key_epoch")?;
+        let bat_key_id = decoder.fixed("BatV2IssuanceRequestV2.bat_key_id")?;
+        let count = usize::from(decoder.u16("BatV2IssuanceRequestV2.item_count")?);
+        validate_item_count(count, "BatV2IssuanceRequestV2.items")?;
+        let mut items = Vec::with_capacity(count);
+        for _ in 0..count {
+            items.push(BitcoinPirCashuBatIssuanceRequestItemV1 {
+                blinded_message: decoder.fixed("BatV2IssuanceRequestV2.items.blinded_message")?,
+            });
+        }
+        decoder.finish()?;
+        let value = Self {
+            issuer_id,
+            quote_id,
+            quote_request_digest,
+            class_id,
+            class_digest,
+            class_key_epoch,
+            bat_key_id,
+            items,
+        };
+        value.validate()?;
+        if value.encode()?.as_slice() != bytes {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatV2IssuanceRequestV2",
+                reason: "non-canonical V2 issuance request encoding",
+            });
+        }
+        Ok(value)
+    }
+
+    pub fn request_digest(&self) -> Result<[u8; 32], ServiceProtocolError> {
+        let mut hasher = Sha256::new();
+        hasher.update(BAT_V2_ISSUANCE_REQUEST_DIGEST_DOMAIN);
+        let encoded = Zeroizing::new(self.encode()?);
+        hasher.update(encoded.as_slice());
+        Ok(hasher.finalize().into())
+    }
+
+    pub fn verify_for_verified_quote(
+        &self,
+        claim: &Bolt11QuoteClaimV1,
+        verified_quote: &VerifiedBolt11BatV2QuoteV2<'_>,
+        now_unix: u64,
+    ) -> Result<UnverifiedBip340ClaimV1, ServiceProtocolError> {
+        self.verify_terms_for_quote(verified_quote)?;
+        if claim.credential_request_digest != self.request_digest()? {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteClaimV1.credential_request_digest",
+                reason: "claim does not commit to the exact V2 issuance request",
+            });
+        }
+        claim.unverified_bip340_input_for_bat_v2(verified_quote, now_unix)
+    }
+
+    pub(crate) fn verify_terms_for_quote(
+        &self,
+        verified_quote: &VerifiedBolt11BatV2QuoteV2<'_>,
+    ) -> Result<(), ServiceProtocolError> {
+        self.validate()?;
+        let quote = verified_quote.quote();
+        let intent = verified_quote.intent();
+        if self.issuer_id != intent.issuer_id
+            || self.quote_id != quote.quote_id
+            || self.quote_request_digest != quote.request_digest
+            || self.class_id != intent.class_id
+            || self.class_digest != intent.class_digest
+            || self.class_key_epoch != intent.class_key_epoch
+            || self.bat_key_id != intent.bat_key_id
+            || self.items.len() != intent.credential_count as usize
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatV2IssuanceRequestV2.quote_binding",
+                reason: "request differs from the exact class-bound quote",
+            });
+        }
+        Ok(())
+    }
+
+    fn validate(&self) -> Result<(), ServiceProtocolError> {
+        validate_issuance_binding(
+            &self.issuer_id,
+            &self.quote_id,
+            &self.quote_request_digest,
+            &self.class_id,
+            &self.class_digest,
+            self.class_key_epoch,
+            &self.bat_key_id,
+            "BatV2IssuanceRequestV2.binding",
+        )?;
+        validate_item_count(self.items.len(), "BatV2IssuanceRequestV2.items")?;
+        let mut messages = HashSet::with_capacity(self.items.len());
+        if self.items.iter().all(|item| {
+            is_valid_compressed_point(&item.blinded_message)
+                && messages.insert(item.blinded_message)
+        }) {
+            Ok(())
+        } else {
+            Err(ServiceProtocolError::InvalidValue {
+                field: "BatV2IssuanceRequestV2.items",
+                reason: "blinded messages must be valid, unique compressed points",
+            })
+        }
+    }
+}
+
+/// Exact ordered blind signatures and NUT-12 transcripts for BAT V2.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BatV2IssuanceResponseV2 {
+    pub issuer_id: [u8; 32],
+    pub quote_id: [u8; 32],
+    pub quote_request_digest: [u8; 32],
+    pub credential_request_digest: [u8; 32],
+    pub class_id: [u8; 32],
+    pub class_digest: [u8; 32],
+    pub class_key_epoch: u64,
+    pub bat_key_id: [u8; 32],
+    pub items: Vec<BitcoinPirCashuBatIssuanceResponseItemV1>,
+}
+
+impl BatV2IssuanceResponseV2 {
+    pub fn encode(&self) -> Result<Vec<u8>, ServiceProtocolError> {
+        self.validate()?;
+        let mut out = Zeroizing::new(Vec::with_capacity(288 + self.items.len() * 130));
+        out.extend_from_slice(BAT_V2_ISSUANCE_RESPONSE_CODEC_MAGIC);
+        out.push(BAT_V2_ISSUANCE_RESPONSE_WIRE_VERSION);
+        encode_issuance_binding(
+            &mut out,
+            &self.issuer_id,
+            &self.quote_id,
+            &self.quote_request_digest,
+            &self.class_id,
+            &self.class_digest,
+            self.class_key_epoch,
+            &self.bat_key_id,
+        );
+        out.extend_from_slice(&self.credential_request_digest);
+        out.extend_from_slice(&(self.items.len() as u16).to_le_bytes());
+        for item in &self.items {
+            out.extend_from_slice(&item.blinded_message);
+            out.extend_from_slice(&item.blinded_signature);
+            out.extend_from_slice(&item.dleq_e);
+            out.extend_from_slice(&item.dleq_s);
+        }
+        check_len(
+            out.len(),
+            MAX_BAT_V2_ISSUANCE_RESPONSE_LEN,
+            "BatV2IssuanceResponseV2",
+        )?;
+        Ok(std::mem::take(&mut *out))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, ServiceProtocolError> {
+        check_len(
+            bytes.len(),
+            MAX_BAT_V2_ISSUANCE_RESPONSE_LEN,
+            "BatV2IssuanceResponseV2",
+        )?;
+        let mut decoder = Decoder::new(bytes);
+        expect_magic(
+            decoder.fixed("BatV2IssuanceResponseV2.magic")?,
+            BAT_V2_ISSUANCE_RESPONSE_CODEC_MAGIC,
+            "BatV2IssuanceResponseV2.magic",
+        )?;
+        expect_v2(
+            decoder.u8("BatV2IssuanceResponseV2.version")?,
+            "BatV2IssuanceResponseV2",
+        )?;
+        let issuer_id = decoder.fixed("BatV2IssuanceResponseV2.issuer_id")?;
+        let quote_id = decoder.fixed("BatV2IssuanceResponseV2.quote_id")?;
+        let quote_request_digest = decoder.fixed("BatV2IssuanceResponseV2.quote_request_digest")?;
+        let class_id = decoder.fixed("BatV2IssuanceResponseV2.class_id")?;
+        let class_digest = decoder.fixed("BatV2IssuanceResponseV2.class_digest")?;
+        let class_key_epoch = decoder.u64("BatV2IssuanceResponseV2.class_key_epoch")?;
+        let bat_key_id = decoder.fixed("BatV2IssuanceResponseV2.bat_key_id")?;
+        let credential_request_digest =
+            decoder.fixed("BatV2IssuanceResponseV2.credential_request_digest")?;
+        let count = usize::from(decoder.u16("BatV2IssuanceResponseV2.item_count")?);
+        validate_item_count(count, "BatV2IssuanceResponseV2.items")?;
+        let mut items = Vec::with_capacity(count);
+        for _ in 0..count {
+            items.push(BitcoinPirCashuBatIssuanceResponseItemV1 {
+                blinded_message: decoder.fixed("BatV2IssuanceResponseV2.items.blinded_message")?,
+                blinded_signature: decoder
+                    .fixed("BatV2IssuanceResponseV2.items.blinded_signature")?,
+                dleq_e: decoder.fixed("BatV2IssuanceResponseV2.items.dleq_e")?,
+                dleq_s: decoder.fixed("BatV2IssuanceResponseV2.items.dleq_s")?,
+            });
+        }
+        decoder.finish()?;
+        let value = Self {
+            issuer_id,
+            quote_id,
+            quote_request_digest,
+            credential_request_digest,
+            class_id,
+            class_digest,
+            class_key_epoch,
+            bat_key_id,
+            items,
+        };
+        value.validate()?;
+        if value.encode()?.as_slice() != bytes {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatV2IssuanceResponseV2",
+                reason: "non-canonical V2 issuance response encoding",
+            });
+        }
+        Ok(value)
+    }
+
+    pub fn verify_for_verified_quote(
+        &self,
+        request: &BatV2IssuanceRequestV2,
+        verified_quote: &VerifiedBolt11BatV2QuoteV2<'_>,
+    ) -> Result<CheckedBatV2IssuanceResponseV2, ServiceProtocolError> {
+        self.validate()?;
+        request.verify_terms_for_quote(verified_quote)?;
+        let intent = verified_quote.intent();
+        let quote = verified_quote.quote();
+        if self.issuer_id != intent.issuer_id
+            || self.quote_id != quote.quote_id
+            || self.quote_request_digest != quote.request_digest
+            || self.credential_request_digest != request.request_digest()?
+            || self.class_id != request.class_id
+            || self.class_digest != request.class_digest
+            || self.class_key_epoch != request.class_key_epoch
+            || self.bat_key_id != request.bat_key_id
+            || self.items.len() != request.items.len()
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatV2IssuanceResponseV2.binding",
+                reason: "response differs from the exact class-bound quote or request",
+            });
+        }
+        let issuer_public_key = verified_quote.class().bat_verification_key;
+        let mut unverified_dleq = Vec::with_capacity(self.items.len());
+        for (request_item, response_item) in request.items.iter().zip(&self.items) {
+            if request_item.blinded_message != response_item.blinded_message {
+                return Err(ServiceProtocolError::InvalidValue {
+                    field: "BatV2IssuanceResponseV2.items.order",
+                    reason: "response must echo every blinded message in exact request order",
+                });
+            }
+            unverified_dleq.push(UnverifiedCashuBatDleqTupleV1 {
+                issuer_public_key,
+                blinded_message: response_item.blinded_message,
+                blinded_signature: response_item.blinded_signature,
+                dleq_e: response_item.dleq_e,
+                dleq_s: response_item.dleq_s,
+            });
+        }
+        Ok(CheckedBatV2IssuanceResponseV2 { unverified_dleq })
+    }
+
+    fn validate(&self) -> Result<(), ServiceProtocolError> {
+        validate_issuance_binding(
+            &self.issuer_id,
+            &self.quote_id,
+            &self.quote_request_digest,
+            &self.class_id,
+            &self.class_digest,
+            self.class_key_epoch,
+            &self.bat_key_id,
+            "BatV2IssuanceResponseV2.binding",
+        )?;
+        if self.credential_request_digest.iter().all(|byte| *byte == 0) {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "BatV2IssuanceResponseV2.credential_request_digest",
+                reason: "must bind a non-zero V2 issuance request digest",
+            });
+        }
+        validate_item_count(self.items.len(), "BatV2IssuanceResponseV2.items")?;
+        let mut messages = HashSet::with_capacity(self.items.len());
+        let mut signatures = HashSet::with_capacity(self.items.len());
+        if self.items.iter().all(|item| {
+            is_valid_compressed_point(&item.blinded_message)
+                && is_valid_compressed_point(&item.blinded_signature)
+                && is_valid_nonzero_scalar(&item.dleq_e)
+                && is_valid_nonzero_scalar(&item.dleq_s)
+                && messages.insert(item.blinded_message)
+                && signatures.insert(item.blinded_signature)
+        }) {
+            Ok(())
+        } else {
+            Err(ServiceProtocolError::InvalidValue {
+                field: "BatV2IssuanceResponseV2.items",
+                reason: "BAT points must be valid/unique and DLEQ scalars canonical/non-zero",
+            })
+        }
+    }
+}
+
+/// Structurally checked NUT-12 tuples. The wallet still has to perform the
+/// actual DLEQ equations before unblinding or storing a BAT.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CheckedBatV2IssuanceResponseV2 {
+    unverified_dleq: Vec<UnverifiedCashuBatDleqTupleV1>,
+}
+
+impl CheckedBatV2IssuanceResponseV2 {
+    pub fn unverified_dleq(&self) -> &[UnverifiedCashuBatDleqTupleV1] {
+        &self.unverified_dleq
+    }
+
+    pub fn into_unverified_dleq(self) -> Vec<UnverifiedCashuBatDleqTupleV1> {
+        self.unverified_dleq
+    }
+}
+
+/// Canonical binary body for the V2 quote claim endpoint.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Bolt11BatV2ClaimEnvelopeV2 {
+    pub quote_intent: Bolt11BatV2QuoteIntentV2,
+    pub claim: Bolt11QuoteClaimV1,
+    pub credential_request: BatV2IssuanceRequestV2,
+}
+
+impl fmt::Debug for Bolt11BatV2ClaimEnvelopeV2 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Bolt11BatV2ClaimEnvelopeV2")
+            .field("claim_envelope", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl Bolt11BatV2ClaimEnvelopeV2 {
+    pub fn encode(&self) -> Result<Vec<u8>, ServiceProtocolError> {
+        self.validate_binding()?;
+        let intent = Zeroizing::new(self.quote_intent.encode()?);
+        let claim = Zeroizing::new(self.claim.encode()?);
+        let request = Zeroizing::new(self.credential_request.encode()?);
+        let mut out = Zeroizing::new(Vec::with_capacity(
+            BAT_V2_CLAIM_ENVELOPE_CODEC_MAGIC.len()
+                + 1
+                + 12
+                + intent.len()
+                + claim.len()
+                + request.len(),
+        ));
+        out.extend_from_slice(BAT_V2_CLAIM_ENVELOPE_CODEC_MAGIC);
+        out.push(BAT_V2_CLAIM_ENVELOPE_WIRE_VERSION);
+        put_bytes_u32(&mut out, &intent);
+        put_bytes_u32(&mut out, &claim);
+        put_bytes_u32(&mut out, &request);
+        check_len(
+            out.len(),
+            MAX_BAT_V2_CLAIM_ENVELOPE_LEN,
+            "Bolt11BatV2ClaimEnvelopeV2",
+        )?;
+        Ok(std::mem::take(&mut *out))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, ServiceProtocolError> {
+        check_len(
+            bytes.len(),
+            MAX_BAT_V2_CLAIM_ENVELOPE_LEN,
+            "Bolt11BatV2ClaimEnvelopeV2",
+        )?;
+        let mut decoder = Decoder::new(bytes);
+        expect_magic(
+            decoder.fixed("Bolt11BatV2ClaimEnvelopeV2.magic")?,
+            BAT_V2_CLAIM_ENVELOPE_CODEC_MAGIC,
+            "Bolt11BatV2ClaimEnvelopeV2.magic",
+        )?;
+        expect_v2(
+            decoder.u8("Bolt11BatV2ClaimEnvelopeV2.version")?,
+            "Bolt11BatV2ClaimEnvelopeV2",
+        )?;
+        let intent = Zeroizing::new(decoder.bytes_u32(
+            "Bolt11BatV2ClaimEnvelopeV2.quote_intent",
+            MAX_BAT_V2_QUOTE_INTENT_LEN,
+        )?);
+        let claim = Zeroizing::new(decoder.bytes_u32(
+            "Bolt11BatV2ClaimEnvelopeV2.claim",
+            MAX_BOLT11_QUOTE_CLAIM_LEN,
+        )?);
+        let request = Zeroizing::new(decoder.bytes_u32(
+            "Bolt11BatV2ClaimEnvelopeV2.credential_request",
+            MAX_BAT_V2_ISSUANCE_REQUEST_LEN,
+        )?);
+        decoder.finish()?;
+        let value = Self {
+            quote_intent: Bolt11BatV2QuoteIntentV2::decode(&intent)?,
+            claim: Bolt11QuoteClaimV1::decode(&claim)?,
+            credential_request: BatV2IssuanceRequestV2::decode(&request)?,
+        };
+        value.validate_binding()?;
+        if value.encode()?.as_slice() != bytes {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2ClaimEnvelopeV2",
+                reason: "nested V2 claim object is not canonical",
+            });
+        }
+        Ok(value)
+    }
+
+    fn validate_binding(&self) -> Result<(), ServiceProtocolError> {
+        let intent_digest = self.quote_intent.request_digest()?;
+        let request_digest = self.credential_request.request_digest()?;
+        if self.claim.issuer_id != self.quote_intent.issuer_id
+            || self.claim.quote_request_digest != intent_digest
+            || self.claim.credential_request_digest != request_digest
+            || self.credential_request.issuer_id != self.quote_intent.issuer_id
+            || self.credential_request.quote_id != self.claim.quote_id
+            || self.credential_request.quote_request_digest != intent_digest
+            || self.credential_request.class_id != self.quote_intent.class_id
+            || self.credential_request.class_digest != self.quote_intent.class_digest
+            || self.credential_request.class_key_epoch != self.quote_intent.class_key_epoch
+            || self.credential_request.bat_key_id != self.quote_intent.bat_key_id
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2ClaimEnvelopeV2.binding",
+                reason: "claim, quote intent, and V2 issuance request differ",
+            });
+        }
+        Ok(())
+    }
+}
+
+fn validate_verified_member_for_class(
+    verified_member: &VerifiedBatAcceptanceMemberV2,
+    class: &BatAcceptanceClassV2,
+    now_unix: u64,
+) -> Result<(), ServiceProtocolError> {
+    class.verify_for(&verified_member.issuer_id, &verified_member.class_id)?;
+    if verified_member.common_terms != class.common_terms
+        || class
+            .members
+            .binary_search(&verified_member.member)
+            .is_err()
+        || class.key_not_before > verified_member.policy_issued_at
+        || class.key_not_after > verified_member.redemption_deadline
+        || now_unix < verified_member.policy_issued_at
+        || now_unix > verified_member.policy_expires_at
+    {
+        return Err(ServiceProtocolError::InvalidValue {
+            field: "VerifiedBatAcceptanceMemberV2.class_binding",
+            reason: "selected current policy member differs from the exact signed class",
+        });
+    }
+    Ok(())
+}
+
+fn validate_horizons(
+    invoice_expiry_seconds: u32,
+    claim_window_seconds: u32,
+    minimum_credential_validity_seconds: u32,
+    field: &'static str,
+) -> Result<(), ServiceProtocolError> {
+    if invoice_expiry_seconds == 0
+        || invoice_expiry_seconds > MAX_BOLT11_INVOICE_EXPIRY_SECONDS_V1
+        || claim_window_seconds == 0
+        || claim_window_seconds > MAX_BOLT11_CLAIM_WINDOW_SECONDS_V1
+        || minimum_credential_validity_seconds == 0
+        || minimum_credential_validity_seconds > MAX_BOLT11_CREDENTIAL_VALIDITY_SECONDS_V1
+    {
+        Err(ServiceProtocolError::InvalidValue {
+            field,
+            reason: "invoice, claim, and credential horizons must be non-zero and bounded",
+        })
+    } else {
+        Ok(())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn encode_issuance_binding(
+    out: &mut Vec<u8>,
+    issuer_id: &[u8; 32],
+    quote_id: &[u8; 32],
+    quote_request_digest: &[u8; 32],
+    class_id: &[u8; 32],
+    class_digest: &[u8; 32],
+    class_key_epoch: u64,
+    bat_key_id: &[u8; 32],
+) {
+    out.extend_from_slice(issuer_id);
+    out.extend_from_slice(quote_id);
+    out.extend_from_slice(quote_request_digest);
+    out.extend_from_slice(class_id);
+    out.extend_from_slice(class_digest);
+    out.extend_from_slice(&class_key_epoch.to_le_bytes());
+    out.extend_from_slice(bat_key_id);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_issuance_binding(
+    issuer_id: &[u8; 32],
+    quote_id: &[u8; 32],
+    quote_request_digest: &[u8; 32],
+    class_id: &[u8; 32],
+    class_digest: &[u8; 32],
+    class_key_epoch: u64,
+    bat_key_id: &[u8; 32],
+    field: &'static str,
+) -> Result<(), ServiceProtocolError> {
+    if issuer_id.iter().all(|byte| *byte == 0)
+        || quote_id.iter().all(|byte| *byte == 0)
+        || quote_request_digest.iter().all(|byte| *byte == 0)
+        || class_id.iter().all(|byte| *byte == 0)
+        || class_digest.iter().all(|byte| *byte == 0)
+        || class_key_epoch == 0
+        || bat_key_id.iter().all(|byte| *byte == 0)
+    {
+        Err(ServiceProtocolError::InvalidValue {
+            field,
+            reason: "issuer, quote, class, epoch, and digests must be non-zero",
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_item_count(count: usize, field: &'static str) -> Result<(), ServiceProtocolError> {
+    if count == 0
+        || u32::try_from(count)
+            .map(|count| count > MAX_CREDENTIALS_PER_ACQUISITION_V1)
+            .unwrap_or(true)
+    {
+        Err(ServiceProtocolError::InvalidValue {
+            field,
+            reason: "BAT V2 item count must be non-zero and bounded",
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn is_valid_nonzero_scalar(bytes: &[u8; 32]) -> bool {
+    bytes.iter().any(|byte| *byte != 0)
+        && Option::<Scalar>::from(Scalar::from_repr((*bytes).into())).is_some()
+}
+
+fn check_len(len: usize, max: usize, field: &'static str) -> Result<(), ServiceProtocolError> {
+    if len > max {
+        Err(ServiceProtocolError::FieldTooLong { field, len, max })
+    } else {
+        Ok(())
+    }
+}
+
+fn expect_v2(version: u8, kind: &'static str) -> Result<(), ServiceProtocolError> {
+    if version == 2 {
+        Ok(())
+    } else {
+        Err(ServiceProtocolError::UnknownVersion { kind, version })
+    }
+}
+
+fn expect_magic(
+    actual: [u8; 8],
+    expected: &[u8; 8],
+    field: &'static str,
+) -> Result<(), ServiceProtocolError> {
+    if &actual == expected {
+        Ok(())
+    } else {
+        Err(ServiceProtocolError::InvalidValue {
+            field,
+            reason: "wrong BAT V2 acquisition codec domain",
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        AuthPaddingClassV1, BackendId, BatAcceptanceMemberV2, BatAcceptanceTermsV2,
+        Bolt11QuoteStatusRequestV1, Bolt11QuoteStatusV1, DatasetBindingV1, DeploymentStatus,
+        EntitlementLimitsV1, ParsedBolt11InvoiceV1, PrivacyLeakageV1, WorkloadId,
+        BOLT11_QUOTE_INTENT_DIGEST_DOMAIN,
+    };
+    use ed25519_dalek::SigningKey;
+    use k256::elliptic_curve::sec1::ToEncodedPoint;
+    use k256::ProjectivePoint;
+
+    const NOW: u64 = 1_000;
+    const INVOICE: &str = "lnbc20n1qqqqqqqq";
+
+    struct Fixture {
+        quote_key: SigningKey,
+        class: BatAcceptanceClassV2,
+        first_member: VerifiedBatAcceptanceMemberV2,
+        second_member: VerifiedBatAcceptanceMemberV2,
+        delegation: Bolt11QuoteKeyDelegationV1,
+        initial_guard: Bolt11QuoteKeyRollbackGuardV1,
+        parsed_invoice: ParsedBolt11InvoiceV1,
+    }
+
+    fn point(multiplier: u64) -> [u8; 33] {
+        (ProjectivePoint::GENERATOR * Scalar::from(multiplier))
+            .to_affine()
+            .to_encoded_point(true)
+            .as_bytes()
+            .try_into()
+            .unwrap()
+    }
+
+    fn xonly_point(multiplier: u64) -> [u8; 32] {
+        point(multiplier)[1..].try_into().unwrap()
+    }
+
+    fn scalar(multiplier: u64) -> [u8; 32] {
+        Scalar::from(multiplier).to_bytes().into()
+    }
+
+    fn common_terms() -> BatAcceptanceTermsV2 {
+        BatAcceptanceTermsV2 {
+            auth_padding_class: AuthPaddingClassV1::Class16KiB,
+            backend: BackendId::DpfPirV1,
+            workload: WorkloadId::DpfEvaluateJobV1,
+            protocol_version: 1,
+            dataset: DatasetBindingV1::Class { class_id: 1 },
+            operation_profile: 1,
+            entitlement_profile: 2,
+            limits: EntitlementLimitsV1 {
+                max_logical_inputs: 4,
+                max_frames: 200,
+                max_request_bytes: 1_000_000,
+                max_response_bytes: 2_000_000,
+                max_wall_time_ms: 60_000,
+                max_concurrent_sockets: 1,
+                max_hint_groups: 0,
+                max_work_units: 9_000,
+            },
+            priority_class: 1,
+            deployment_status: DeploymentStatus::Stable,
+            price_msat: 2_000,
+            issuer_endpoint: "https://issuer.invalid".into(),
+            invoice_expiry_seconds: 60,
+            claim_window_seconds: 120,
+            minimum_credential_validity_seconds: 300,
+            retired_policy_grace_seconds: 480,
+            credential_count: 2,
+            credential_presentation_limit: 1,
+            privacy_leakage: PrivacyLeakageV1::from_bits(
+                PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                    | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                    | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+            )
+            .unwrap(),
+        }
+    }
+
+    fn fixture() -> Fixture {
+        let issuer_key = SigningKey::from_bytes(&[8; 32]);
+        let quote_key = SigningKey::from_bytes(&[9; 32]);
+        let members = vec![
+            BatAcceptanceMemberV2 {
+                provider_id: [2; 32],
+                policy_digest: [3; 32],
+                scope_id: [4; 32],
+                offer_id: 5,
+            },
+            BatAcceptanceMemberV2 {
+                provider_id: [6; 32],
+                policy_digest: [7; 32],
+                scope_id: [8; 32],
+                offer_id: 9,
+            },
+        ];
+        let class = BatAcceptanceClassV2::sign(
+            [0x42; 32],
+            3,
+            900,
+            10_000,
+            point(11),
+            common_terms(),
+            members.clone(),
+            &issuer_key,
+        )
+        .unwrap();
+        let member = |member: BatAcceptanceMemberV2| VerifiedBatAcceptanceMemberV2 {
+            issuer_id: class.issuer_id,
+            class_id: class.class_id,
+            member,
+            common_terms: class.common_terms.clone(),
+            policy_issued_at: 900,
+            policy_expires_at: 10_000,
+            redemption_deadline: 10_000,
+        };
+        let first_member = member(members[0].clone());
+        let second_member = member(members[1].clone());
+        let payee = point(3);
+        let delegation = Bolt11QuoteKeyDelegationV1::sign(
+            LightningNetworkV1::Bitcoin,
+            payee,
+            4,
+            900,
+            10_000,
+            quote_key.verifying_key().to_bytes(),
+            &issuer_key,
+        )
+        .unwrap();
+        let initial_guard = Bolt11QuoteKeyRollbackGuardV1::initial(
+            class.issuer_id,
+            LightningNetworkV1::Bitcoin,
+            payee,
+        )
+        .unwrap();
+        let parsed_invoice = ParsedBolt11InvoiceV1::from_signature_verified_invoice(
+            INVOICE,
+            LightningNetworkV1::Bitcoin,
+            payee,
+            class.common_terms.price_msat,
+            NOW,
+            class.common_terms.invoice_expiry_seconds,
+        )
+        .unwrap();
+        Fixture {
+            quote_key,
+            class,
+            first_member,
+            second_member,
+            delegation,
+            initial_guard,
+            parsed_invoice,
+        }
+    }
+
+    fn intent_for(
+        fixture: &Fixture,
+        member: &VerifiedBatAcceptanceMemberV2,
+    ) -> Bolt11BatV2QuoteIntentV2 {
+        Bolt11BatV2QuoteIntentV2::from_verified_class_member_guarded(
+            member,
+            &fixture.class,
+            &fixture.delegation,
+            &fixture.initial_guard,
+            NOW,
+            xonly_point(5),
+            [0x51; 32],
+        )
+        .unwrap()
+        .0
+    }
+
+    fn settled_quote(fixture: &Fixture) -> (Bolt11BatV2QuoteIntentV2, Bolt11QuoteV1) {
+        let intent = intent_for(fixture, &fixture.first_member);
+        let verified_intent = intent
+            .verify_for_class_member_guarded(
+                &fixture.first_member,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.initial_guard,
+                NOW,
+            )
+            .unwrap();
+        let open = Bolt11QuoteV1::sign_for_verified_bat_v2_intent(
+            &verified_intent,
+            [0x52; 32],
+            INVOICE.into(),
+            &fixture.parsed_invoice,
+            Bolt11QuoteStatusV1::InvoiceOpen,
+            NOW,
+            &fixture.quote_key,
+        )
+        .unwrap();
+        let verified_open = open
+            .verify_bat_v2_for_payment(
+                &intent,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.parsed_invoice,
+                NOW + 1,
+            )
+            .unwrap();
+        let settled = Bolt11QuoteV1::with_status_from_verified_bat_v2_snapshot(
+            &verified_open,
+            Bolt11QuoteStatusV1::PaymentSettled,
+            NOW + 1,
+            &fixture.delegation,
+            &fixture.quote_key,
+        )
+        .unwrap();
+        (intent, settled)
+    }
+
+    fn issuance_request(
+        intent: &Bolt11BatV2QuoteIntentV2,
+        quote: &Bolt11QuoteV1,
+    ) -> BatV2IssuanceRequestV2 {
+        BatV2IssuanceRequestV2 {
+            issuer_id: intent.issuer_id,
+            quote_id: quote.quote_id,
+            quote_request_digest: quote.request_digest,
+            class_id: intent.class_id,
+            class_digest: intent.class_digest,
+            class_key_epoch: intent.class_key_epoch,
+            bat_key_id: intent.bat_key_id,
+            items: vec![
+                BitcoinPirCashuBatIssuanceRequestItemV1 {
+                    blinded_message: point(13),
+                },
+                BitcoinPirCashuBatIssuanceRequestItemV1 {
+                    blinded_message: point(14),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn bat_v2_acquisition_intent_is_class_bound_and_provider_independent() {
+        let fixture = fixture();
+        let first = intent_for(&fixture, &fixture.first_member);
+        let second = intent_for(&fixture, &fixture.second_member);
+        assert_eq!(first, second);
+        assert_eq!(
+            first.request_digest().unwrap(),
+            second.request_digest().unwrap()
+        );
+
+        let encoded = first.encode().unwrap();
+        assert_eq!(&encoded[..8], BAT_V2_QUOTE_INTENT_CODEC_MAGIC);
+        assert_eq!(encoded[8], BAT_V2_QUOTE_INTENT_WIRE_VERSION);
+        assert_ne!(
+            BAT_V2_QUOTE_INTENT_DIGEST_DOMAIN,
+            BOLT11_QUOTE_INTENT_DIGEST_DOMAIN
+        );
+        assert!(!encoded
+            .windows(32)
+            .any(|window| window == fixture.first_member.member.provider_id));
+        assert!(!encoded
+            .windows(32)
+            .any(|window| window == fixture.second_member.member.provider_id));
+        assert_eq!(Bolt11BatV2QuoteIntentV2::decode(&encoded).unwrap(), first);
+
+        first
+            .verify_for_class_member_guarded(
+                &fixture.second_member,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.initial_guard,
+                NOW,
+            )
+            .unwrap();
+        let mut wrong_class = first.clone();
+        wrong_class.class_digest[0] ^= 1;
+        assert!(wrong_class
+            .verify_for_class_guarded(
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.initial_guard,
+                NOW,
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn bat_v2_acquisition_quote_claim_and_status_bind_v2_digest() {
+        let fixture = fixture();
+        let (intent, settled) = settled_quote(&fixture);
+        let verified_settled = settled
+            .verify_bat_v2_for_claim_submission(
+                &intent,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.parsed_invoice,
+                NOW + 2,
+            )
+            .unwrap();
+        let request = issuance_request(&intent, &settled);
+        let claim = Bolt11QuoteClaimV1 {
+            issuer_id: intent.issuer_id,
+            quote_id: settled.quote_id,
+            quote_request_digest: intent.request_digest().unwrap(),
+            credential_request_digest: request.request_digest().unwrap(),
+            claim_pubkey_xonly: intent.claim_pubkey_xonly,
+            idempotency_key: [0x53; 32],
+            signature: [0x54; 64],
+        };
+        let unverified = request
+            .verify_for_verified_quote(&claim, &verified_settled, NOW + 2)
+            .unwrap();
+        assert_eq!(unverified.claim_pubkey_xonly, intent.claim_pubkey_xonly);
+        assert_eq!(
+            unverified.message_digest,
+            claim.bip340_signing_digest().unwrap()
+        );
+
+        let status = Bolt11QuoteStatusRequestV1 {
+            issuer_id: intent.issuer_id,
+            quote_id: settled.quote_id,
+            quote_request_digest: intent.request_digest().unwrap(),
+            claim_pubkey_xonly: intent.claim_pubkey_xonly,
+            requested_at: NOW + 2,
+            request_nonce: [0x55; 32],
+            signature: [0x56; 64],
+        };
+        let status_input = status
+            .unverified_bip340_input_for_bat_v2(&intent, &settled.quote_id, NOW + 3)
+            .unwrap();
+        assert_eq!(status_input.quote_id, settled.quote_id);
+        assert_eq!(
+            status_input.message_digest,
+            status.bip340_signing_digest().unwrap()
+        );
+
+        let mut wrong_request = request.clone();
+        wrong_request.class_id[0] ^= 1;
+        assert!(wrong_request
+            .verify_for_verified_quote(&claim, &verified_settled, NOW + 2)
+            .is_err());
+
+        let original_request_digest = intent.request_digest().unwrap();
+        let mut replay_intent = intent.clone();
+        replay_intent.idempotency_key = [0xa5; 32];
+        assert_ne!(
+            replay_intent.request_digest().unwrap(),
+            original_request_digest
+        );
+        let persisted = settled
+            .verify_persisted_bat_v2_quote_for_store(
+                PersistedBolt11BatV2QuoteExpectationV2 {
+                    original_request_digest: &original_request_digest,
+                    replay_intent: &replay_intent,
+                    class: &fixture.class,
+                    quote_id: &settled.quote_id,
+                    invoice: &settled.invoice,
+                    invoice_created_at: settled.invoice_created_at,
+                    invoice_expires_at: settled.invoice_expires_at,
+                    claim_deadline: settled.claim_deadline,
+                    credential_not_after: settled.credential_not_after,
+                },
+                &fixture.delegation,
+                NOW + 2,
+            )
+            .unwrap();
+        assert_eq!(persisted.request_digest(), original_request_digest);
+        status
+            .unverified_bip340_input_for_verified_bat_v2_quote(&persisted, NOW + 3)
+            .unwrap();
+        let claimed = Bolt11QuoteV1::with_status_from_verified_bat_v2_snapshot(
+            &persisted,
+            Bolt11QuoteStatusV1::CredentialClaimed,
+            NOW + 2,
+            &fixture.delegation,
+            &fixture.quote_key,
+        )
+        .unwrap();
+        assert_eq!(claimed.status, Bolt11QuoteStatusV1::CredentialClaimed);
+    }
+
+    #[test]
+    fn bat_v2_acquisition_issuance_and_envelope_preserve_exact_order() {
+        let fixture = fixture();
+        let (intent, settled) = settled_quote(&fixture);
+        let verified_settled = settled
+            .verify_bat_v2_for_claim_submission(
+                &intent,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.parsed_invoice,
+                NOW + 2,
+            )
+            .unwrap();
+        let request = issuance_request(&intent, &settled);
+        let request_bytes = request.encode().unwrap();
+        assert_eq!(
+            BatV2IssuanceRequestV2::decode(&request_bytes).unwrap(),
+            request
+        );
+        let claim = Bolt11QuoteClaimV1 {
+            issuer_id: intent.issuer_id,
+            quote_id: settled.quote_id,
+            quote_request_digest: intent.request_digest().unwrap(),
+            credential_request_digest: request.request_digest().unwrap(),
+            claim_pubkey_xonly: intent.claim_pubkey_xonly,
+            idempotency_key: [0x57; 32],
+            signature: [0x58; 64],
+        };
+        let envelope = Bolt11BatV2ClaimEnvelopeV2 {
+            quote_intent: intent.clone(),
+            claim: claim.clone(),
+            credential_request: request.clone(),
+        };
+        let envelope_bytes = envelope.encode().unwrap();
+        assert_eq!(
+            Bolt11BatV2ClaimEnvelopeV2::decode(&envelope_bytes).unwrap(),
+            envelope
+        );
+
+        let response = BatV2IssuanceResponseV2 {
+            issuer_id: intent.issuer_id,
+            quote_id: settled.quote_id,
+            quote_request_digest: settled.request_digest,
+            credential_request_digest: request.request_digest().unwrap(),
+            class_id: intent.class_id,
+            class_digest: intent.class_digest,
+            class_key_epoch: intent.class_key_epoch,
+            bat_key_id: intent.bat_key_id,
+            items: vec![
+                BitcoinPirCashuBatIssuanceResponseItemV1 {
+                    blinded_message: request.items[0].blinded_message,
+                    blinded_signature: point(21),
+                    dleq_e: scalar(1),
+                    dleq_s: scalar(2),
+                },
+                BitcoinPirCashuBatIssuanceResponseItemV1 {
+                    blinded_message: request.items[1].blinded_message,
+                    blinded_signature: point(22),
+                    dleq_e: scalar(3),
+                    dleq_s: scalar(4),
+                },
+            ],
+        };
+        let response_bytes = response.encode().unwrap();
+        assert_eq!(
+            BatV2IssuanceResponseV2::decode(&response_bytes).unwrap(),
+            response
+        );
+        let checked = response
+            .verify_for_verified_quote(&request, &verified_settled)
+            .unwrap();
+        assert_eq!(checked.unverified_dleq().len(), 2);
+        assert_eq!(
+            checked.unverified_dleq()[0].issuer_public_key,
+            fixture.class.bat_verification_key
+        );
+
+        let mut reordered = response.clone();
+        reordered.items.swap(0, 1);
+        assert!(reordered
+            .verify_for_verified_quote(&request, &verified_settled)
+            .is_err());
+        let mut zero_dleq = response;
+        zero_dleq.items[0].dleq_e = [0; 32];
+        assert!(zero_dleq.encode().is_err());
+    }
+}

--- a/crates/protocol/service/src/lib.rs
+++ b/crates/protocol/service/src/lib.rs
@@ -8,6 +8,7 @@ mod attach;
 mod auth;
 mod auth_verify;
 mod bat_v2;
+mod bat_v2_acquisition;
 mod binding;
 mod cashu_manifest;
 mod challenge;
@@ -49,6 +50,18 @@ pub use bat_v2::{
     BAT_ACCEPTANCE_KEY_ID_DOMAIN_V2, BAT_ACCEPTANCE_TERMS_DIGEST_DOMAIN_V2,
     MAX_BAT_ACCEPTANCE_CLASS_LEN_V2, MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2,
     MAX_BAT_ACCEPTANCE_TERMS_LEN_V2,
+};
+pub use bat_v2_acquisition::{
+    BatV2IssuanceRequestV2, BatV2IssuanceResponseV2, Bolt11BatV2ClaimEnvelopeV2,
+    Bolt11BatV2QuoteIntentV2, CheckedBatV2IssuanceResponseV2,
+    PersistedBolt11BatV2QuoteExpectationV2, VerifiedBolt11BatV2QuoteIntentV2,
+    VerifiedBolt11BatV2QuoteV2, BAT_V2_CLAIM_ENVELOPE_CODEC_MAGIC,
+    BAT_V2_CLAIM_ENVELOPE_WIRE_VERSION, BAT_V2_ISSUANCE_REQUEST_CODEC_MAGIC,
+    BAT_V2_ISSUANCE_REQUEST_DIGEST_DOMAIN, BAT_V2_ISSUANCE_REQUEST_WIRE_VERSION,
+    BAT_V2_ISSUANCE_RESPONSE_CODEC_MAGIC, BAT_V2_ISSUANCE_RESPONSE_WIRE_VERSION,
+    BAT_V2_QUOTE_INTENT_CODEC_MAGIC, BAT_V2_QUOTE_INTENT_DIGEST_DOMAIN,
+    BAT_V2_QUOTE_INTENT_WIRE_VERSION, MAX_BAT_V2_CLAIM_ENVELOPE_LEN,
+    MAX_BAT_V2_ISSUANCE_REQUEST_LEN, MAX_BAT_V2_ISSUANCE_RESPONSE_LEN, MAX_BAT_V2_QUOTE_INTENT_LEN,
 };
 pub use binding::{
     derive_bat_key_id_v1, derive_issuer_id, CredentialKeyBindingClaimsV1,

--- a/crates/protocol/service/src/quote.rs
+++ b/crates/protocol/service/src/quote.rs
@@ -18,9 +18,11 @@ use zeroize::{Zeroize, Zeroizing};
 use crate::cashu_manifest::is_valid_compressed_point;
 use crate::codec::{expect_v1, put_bytes_u16, Decoder};
 use crate::{
-    derive_issuer_id, AcquisitionMethod, AuthScheme, PriceV1, ProviderId, ScopeId,
-    ServiceProtocolError, VerifiedServiceOfferV1, MAX_BITCOIN_MSAT_V1,
-    MAX_CREDENTIALS_PER_ACQUISITION_V1, MAX_CREDENTIAL_KEY_ID_LEN, MAX_CREDENTIAL_PRESENTATIONS_V1,
+    derive_issuer_id, AcquisitionMethod, AuthScheme, BatAcceptanceClassV2,
+    Bolt11BatV2QuoteIntentV2, PersistedBolt11BatV2QuoteExpectationV2, PriceV1, ProviderId, ScopeId,
+    ServiceProtocolError, VerifiedBolt11BatV2QuoteIntentV2, VerifiedBolt11BatV2QuoteV2,
+    VerifiedServiceOfferV1, MAX_BITCOIN_MSAT_V1, MAX_CREDENTIALS_PER_ACQUISITION_V1,
+    MAX_CREDENTIAL_KEY_ID_LEN, MAX_CREDENTIAL_PRESENTATIONS_V1,
     MAX_TOTAL_PRESENTATIONS_PER_ACQUISITION_V1, SERVICE_PROTOCOL_VERSION,
 };
 
@@ -63,7 +65,7 @@ pub enum LightningNetworkV1 {
 }
 
 impl LightningNetworkV1 {
-    fn decode(value: u8) -> Result<Self, ServiceProtocolError> {
+    pub(crate) fn decode(value: u8) -> Result<Self, ServiceProtocolError> {
         match value {
             1 => Ok(Self::Bitcoin),
             2 => Ok(Self::Testnet),
@@ -1211,6 +1213,99 @@ impl Bolt11QuoteV1 {
         )
     }
 
+    /// Initial quote signing for issuer-wide BAT V2. The signed quote wire is
+    /// the existing BOLT11 lifecycle snapshot, while its request digest binds
+    /// the independent class-only V2 intent codec.
+    #[allow(clippy::too_many_arguments)]
+    pub fn sign_for_verified_bat_v2_intent(
+        verified_intent: &VerifiedBolt11BatV2QuoteIntentV2<'_>,
+        quote_id: [u8; 32],
+        invoice: String,
+        parsed_invoice: &ParsedBolt11InvoiceV1,
+        status: Bolt11QuoteStatusV1,
+        status_updated_at: u64,
+        quote_signing_key: &SigningKey,
+    ) -> Result<Self, ServiceProtocolError> {
+        let mut invoice = Zeroizing::new(invoice);
+        let intent = verified_intent.intent();
+        let class = verified_intent.class();
+        let delegation = verified_intent.delegation();
+        intent.validate()?;
+        parsed_invoice.validate()?;
+        validate_invoice_text(&invoice)?;
+        if status != Bolt11QuoteStatusV1::InvoiceOpen {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteStatusV1.initial",
+                reason: "the initial quote snapshot must be InvoiceOpen",
+            });
+        }
+        if parsed_invoice.invoice_text_digest != bolt11_invoice_text_digest_v1(&invoice)
+            || parsed_invoice.network != intent.network
+            || parsed_invoice.payee_pubkey != intent.expected_payee_pubkey
+            || parsed_invoice.amount_msat != intent.exact_amount_msat
+            || parsed_invoice.expiry_seconds != intent.invoice_expiry_seconds
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "ParsedBolt11InvoiceV1.bat_v2_class_binding",
+                reason: "invoice parser facts do not match the verified BAT V2 quote intent",
+            });
+        }
+        intent.verify_exact_class_binding(class, parsed_invoice.created_at)?;
+        if intent.quote_delegation_digest != delegation.delegation_digest()? {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.quote_delegation_digest",
+                reason: "intent does not bind the exact signed quote-key delegation",
+            });
+        }
+        let horizons = intent.derived_horizons(parsed_invoice.created_at)?;
+        delegation.verify_for(
+            &intent.issuer_id,
+            intent.network,
+            &intent.expected_payee_pubkey,
+            intent.minimum_quote_key_epoch,
+            parsed_invoice.created_at,
+        )?;
+        delegation.verify_for(
+            &intent.issuer_id,
+            intent.network,
+            &intent.expected_payee_pubkey,
+            intent.minimum_quote_key_epoch,
+            status_updated_at,
+        )?;
+        delegation.verify_for(
+            &intent.issuer_id,
+            intent.network,
+            &intent.expected_payee_pubkey,
+            intent.minimum_quote_key_epoch,
+            horizons.claim_deadline,
+        )?;
+        if quote_signing_key.verifying_key().to_bytes() != delegation.quote_verifying_key {
+            return Err(ServiceProtocolError::WrongSigningKeyId);
+        }
+        let mut value = Self {
+            request_digest: intent.request_digest()?,
+            quote_id,
+            quote_key_id: delegation.quote_key_id,
+            invoice: std::mem::take(&mut *invoice),
+            network: intent.network,
+            payee_pubkey: intent.expected_payee_pubkey,
+            amount_msat: intent.exact_amount_msat,
+            invoice_created_at: parsed_invoice.created_at,
+            invoice_expires_at: horizons.invoice_expires_at,
+            claim_deadline: horizons.claim_deadline,
+            credential_not_after: horizons.credential_not_after,
+            status,
+            state_version: 1,
+            status_updated_at,
+            signature: [0; 64],
+        };
+        value.validate_structure()?;
+        value.signature = quote_signing_key
+            .sign(&value.signing_preimage()?)
+            .to_bytes();
+        Ok(value)
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn sign_verified_fields(
         intent: &Bolt11QuoteIntentV1,
@@ -1414,6 +1509,84 @@ impl Bolt11QuoteV1 {
         )
     }
 
+    /// Sign a lifecycle successor from an already verified BAT V2 snapshot.
+    pub fn with_status_from_verified_bat_v2_snapshot(
+        verified_snapshot: &VerifiedBolt11BatV2QuoteV2<'_>,
+        status: Bolt11QuoteStatusV1,
+        status_updated_at: u64,
+        delegation: &Bolt11QuoteKeyDelegationV1,
+        quote_signing_key: &SigningKey,
+    ) -> Result<Self, ServiceProtocolError> {
+        let previous = verified_snapshot.quote();
+        let intent = verified_snapshot.intent();
+        intent
+            .verify_exact_class_binding(verified_snapshot.class(), previous.invoice_created_at)?;
+        if !previous.status.allows_transition_to(status) {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteStatusV1.transition",
+                reason: "invalid quote status transition",
+            });
+        }
+        if status == previous.status && status_updated_at != previous.status_updated_at {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.status_updated_at",
+                reason: "an idempotent status replay must preserve the exact transition time",
+            });
+        }
+        if status != previous.status && status_updated_at <= previous.status_updated_at {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.status_updated_at",
+                reason: "status transition time must strictly increase",
+            });
+        }
+        if intent.quote_delegation_digest != delegation.delegation_digest()? {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.quote_delegation_digest",
+                reason: "intent does not bind the exact signed quote-key delegation",
+            });
+        }
+        delegation.verify_for(
+            &intent.issuer_id,
+            intent.network,
+            &intent.expected_payee_pubkey,
+            intent.minimum_quote_key_epoch,
+            status_updated_at,
+        )?;
+        delegation.verify_for(
+            &intent.issuer_id,
+            intent.network,
+            &intent.expected_payee_pubkey,
+            intent.minimum_quote_key_epoch,
+            previous.claim_deadline,
+        )?;
+        if previous.request_digest != verified_snapshot.request_digest()
+            || previous.quote_key_id != delegation.quote_key_id
+            || previous.network != delegation.network
+            || previous.payee_pubkey != delegation.expected_payee_pubkey
+            || quote_signing_key.verifying_key().to_bytes() != delegation.quote_verifying_key
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.bat_v2_status_signing_key",
+                reason: "status signer is outside the original root delegation",
+            });
+        }
+        let mut next = previous.clone();
+        next.status = status;
+        if status != previous.status {
+            next.state_version = previous.state_version.checked_add(1).ok_or(
+                ServiceProtocolError::InvalidValue {
+                    field: "Bolt11QuoteV1.state_version",
+                    reason: "state version overflow",
+                },
+            )?;
+        }
+        next.status_updated_at = status_updated_at;
+        next.signature = [0; 64];
+        next.validate_structure()?;
+        next.signature = quote_signing_key.sign(&next.signing_preimage()?).to_bytes();
+        Ok(next)
+    }
+
     pub fn encode(&self) -> Result<Vec<u8>, ServiceProtocolError> {
         let mut out = self.encode_unsigned()?;
         out.extend_from_slice(&self.signature);
@@ -1572,6 +1745,225 @@ impl Bolt11QuoteV1 {
         now_unix: u64,
     ) -> Result<VerifiedBolt11QuoteV1<'a>, ServiceProtocolError> {
         let verified = self.verify_snapshot(intent, delegation, parsed_invoice, now_unix)?;
+        verified.ensure_claim_submission_at(now_unix)?;
+        Ok(verified)
+    }
+
+    /// Verify the shared BOLT11 quote snapshot against an independent BAT V2
+    /// class intent and its exact issuer-signed class artifact.
+    pub fn verify_bat_v2_snapshot<'a>(
+        &'a self,
+        intent: &'a Bolt11BatV2QuoteIntentV2,
+        class: &'a BatAcceptanceClassV2,
+        delegation: &Bolt11QuoteKeyDelegationV1,
+        parsed_invoice: &ParsedBolt11InvoiceV1,
+        now_unix: u64,
+    ) -> Result<VerifiedBolt11BatV2QuoteV2<'a>, ServiceProtocolError> {
+        self.validate_structure()?;
+        intent.validate()?;
+        parsed_invoice.validate()?;
+        intent.verify_exact_class_binding(class, self.invoice_created_at)?;
+        if intent.quote_delegation_digest != delegation.delegation_digest()? {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11BatV2QuoteIntentV2.quote_delegation_digest",
+                reason: "intent does not bind the exact signed quote-key delegation",
+            });
+        }
+        if self.request_digest != intent.request_digest()?
+            || self.network != intent.network
+            || self.payee_pubkey != intent.expected_payee_pubkey
+            || self.amount_msat != intent.exact_amount_msat
+            || self.quote_key_id != delegation.quote_key_id
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.bat_v2_intent",
+                reason: "quote does not echo the immutable BAT V2 request terms",
+            });
+        }
+        let quote_verifying_key = delegation.verify_for(
+            &intent.issuer_id,
+            intent.network,
+            &intent.expected_payee_pubkey,
+            intent.minimum_quote_key_epoch,
+            self.invoice_created_at,
+        )?;
+        delegation.verify_for(
+            &intent.issuer_id,
+            intent.network,
+            &intent.expected_payee_pubkey,
+            intent.minimum_quote_key_epoch,
+            self.status_updated_at,
+        )?;
+        let horizons = intent.derived_horizons(self.invoice_created_at)?;
+        delegation.verify_for(
+            &intent.issuer_id,
+            intent.network,
+            &intent.expected_payee_pubkey,
+            intent.minimum_quote_key_epoch,
+            horizons.claim_deadline,
+        )?;
+        if self.invoice_expires_at != horizons.invoice_expires_at
+            || self.claim_deadline != horizons.claim_deadline
+            || self.credential_not_after != horizons.credential_not_after
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.bat_v2_horizons",
+                reason: "response deadlines do not exactly match the BAT V2 intent",
+            });
+        }
+        if parsed_invoice.invoice_text_digest != bolt11_invoice_text_digest_v1(&self.invoice)
+            || parsed_invoice.network != self.network
+            || parsed_invoice.payee_pubkey != self.payee_pubkey
+            || parsed_invoice.amount_msat != self.amount_msat
+            || parsed_invoice.created_at != self.invoice_created_at
+            || parsed_invoice.expiry_seconds != intent.invoice_expiry_seconds
+            || parsed_invoice.expires_at()? != self.invoice_expires_at
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.bat_v2_invoice",
+                reason: "parsed BOLT11 facts differ from the BAT V2 intent",
+            });
+        }
+        if self.invoice_created_at > now_unix || self.status_updated_at > now_unix {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.time",
+                reason: "quote or status update is from the future",
+            });
+        }
+        quote_verifying_key
+            .verify_strict(
+                &self.signing_preimage()?,
+                &Signature::from_bytes(&self.signature),
+            )
+            .map_err(|_| ServiceProtocolError::BadSignature)?;
+        Ok(VerifiedBolt11BatV2QuoteV2 {
+            quote: self,
+            intent,
+            class,
+            request_digest: self.request_digest,
+        })
+    }
+
+    /// Reconstruct the BAT V2 verified-quote typestate from an issuer store's
+    /// privacy-safe intent replay image plus the authoritative original
+    /// request digest. This path deliberately never hashes the replay image as
+    /// though it were the original client request.
+    pub fn verify_persisted_bat_v2_quote_for_store<'a>(
+        &'a self,
+        expected: PersistedBolt11BatV2QuoteExpectationV2<'a>,
+        delegation: &Bolt11QuoteKeyDelegationV1,
+        now_unix: u64,
+    ) -> Result<VerifiedBolt11BatV2QuoteV2<'a>, ServiceProtocolError> {
+        self.validate_structure()?;
+        expected.replay_intent.validate()?;
+        expected
+            .replay_intent
+            .verify_exact_class_binding(expected.class, expected.invoice_created_at)?;
+        if expected
+            .original_request_digest
+            .iter()
+            .all(|byte| *byte == 0)
+            || expected.quote_id.iter().all(|byte| *byte == 0)
+            || expected.invoice.is_empty()
+            || expected.invoice_created_at == 0
+            || expected.invoice_created_at > expected.invoice_expires_at
+            || expected.invoice_expires_at > expected.claim_deadline
+            || expected.claim_deadline > expected.credential_not_after
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "PersistedBolt11BatV2QuoteExpectationV2",
+                reason: "persisted quote identity, invoice, or horizon is invalid",
+            });
+        }
+        let intent = expected.replay_intent;
+        if intent.quote_delegation_digest != delegation.delegation_digest()? {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "PersistedBolt11BatV2QuoteExpectationV2.delegation",
+                reason: "replay intent does not bind the exact persisted delegation",
+            });
+        }
+        let horizons = intent.derived_horizons(expected.invoice_created_at)?;
+        if expected.invoice_expires_at != horizons.invoice_expires_at
+            || expected.claim_deadline != horizons.claim_deadline
+            || expected.credential_not_after != horizons.credential_not_after
+            || self.request_digest != *expected.original_request_digest
+            || self.quote_id != *expected.quote_id
+            || self.invoice != expected.invoice
+            || self.network != intent.network
+            || self.payee_pubkey != intent.expected_payee_pubkey
+            || self.amount_msat != intent.exact_amount_msat
+            || self.quote_key_id != delegation.quote_key_id
+            || self.invoice_created_at != expected.invoice_created_at
+            || self.invoice_expires_at != expected.invoice_expires_at
+            || self.claim_deadline != expected.claim_deadline
+            || self.credential_not_after != expected.credential_not_after
+            || self.invoice_created_at > now_unix
+            || self.status_updated_at > now_unix
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "PersistedBolt11BatV2QuoteExpectationV2",
+                reason: "signed quote differs from the persisted class-bound facts",
+            });
+        }
+        let quote_verifying_key = delegation.verify_for(
+            &intent.issuer_id,
+            intent.network,
+            &intent.expected_payee_pubkey,
+            intent.minimum_quote_key_epoch,
+            self.invoice_created_at,
+        )?;
+        delegation.verify_for(
+            &intent.issuer_id,
+            intent.network,
+            &intent.expected_payee_pubkey,
+            intent.minimum_quote_key_epoch,
+            self.status_updated_at,
+        )?;
+        delegation.verify_for(
+            &intent.issuer_id,
+            intent.network,
+            &intent.expected_payee_pubkey,
+            intent.minimum_quote_key_epoch,
+            self.claim_deadline,
+        )?;
+        quote_verifying_key
+            .verify_strict(
+                &self.signing_preimage()?,
+                &Signature::from_bytes(&self.signature),
+            )
+            .map_err(|_| ServiceProtocolError::BadSignature)?;
+        Ok(VerifiedBolt11BatV2QuoteV2 {
+            quote: self,
+            intent,
+            class: expected.class,
+            request_digest: *expected.original_request_digest,
+        })
+    }
+
+    pub fn verify_bat_v2_for_payment<'a>(
+        &'a self,
+        intent: &'a Bolt11BatV2QuoteIntentV2,
+        class: &'a BatAcceptanceClassV2,
+        delegation: &Bolt11QuoteKeyDelegationV1,
+        parsed_invoice: &ParsedBolt11InvoiceV1,
+        now_unix: u64,
+    ) -> Result<VerifiedBolt11BatV2QuoteV2<'a>, ServiceProtocolError> {
+        let verified =
+            self.verify_bat_v2_snapshot(intent, class, delegation, parsed_invoice, now_unix)?;
+        verified.ensure_payable_at(now_unix)?;
+        Ok(verified)
+    }
+
+    pub fn verify_bat_v2_for_claim_submission<'a>(
+        &'a self,
+        intent: &'a Bolt11BatV2QuoteIntentV2,
+        class: &'a BatAcceptanceClassV2,
+        delegation: &Bolt11QuoteKeyDelegationV1,
+        parsed_invoice: &ParsedBolt11InvoiceV1,
+        now_unix: u64,
+    ) -> Result<VerifiedBolt11BatV2QuoteV2<'a>, ServiceProtocolError> {
+        let verified =
+            self.verify_bat_v2_snapshot(intent, class, delegation, parsed_invoice, now_unix)?;
         verified.ensure_claim_submission_at(now_unix)?;
         Ok(verified)
     }
@@ -2148,6 +2540,85 @@ impl Bolt11QuoteStatusRequestV1 {
         })
     }
 
+    /// Bind a private quote-status request to the independent BAT V2 intent
+    /// digest and claim key.
+    pub fn unverified_bip340_input_for_bat_v2(
+        &self,
+        intent: &Bolt11BatV2QuoteIntentV2,
+        expected_quote_id: &[u8; 32],
+        now_unix: u64,
+    ) -> Result<UnverifiedBip340QuoteStatusRequestV1, ServiceProtocolError> {
+        self.validate_structure()?;
+        intent.validate()?;
+        if &self.quote_id != expected_quote_id
+            || self.issuer_id != intent.issuer_id
+            || self.quote_request_digest != intent.request_digest()?
+            || self.claim_pubkey_xonly != intent.claim_pubkey_xonly
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteStatusRequestV1.bat_v2_binding",
+                reason: "issuer, quote, V2 request, or x-only claim key mismatch",
+            });
+        }
+        if self.requested_at > now_unix
+            || now_unix.saturating_sub(self.requested_at)
+                > MAX_BOLT11_QUOTE_STATUS_REQUEST_AGE_SECONDS_V1
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteStatusRequestV1.requested_at",
+                reason: "status request is from the future or outside the freshness window",
+            });
+        }
+        Ok(UnverifiedBip340QuoteStatusRequestV1 {
+            claim_pubkey_xonly: self.claim_pubkey_xonly,
+            message_digest: self.bip340_signing_digest()?,
+            signature: self.signature,
+            quote_id: self.quote_id,
+            requested_at: self.requested_at,
+            request_nonce: self.request_nonce,
+        })
+    }
+
+    /// Persisted-store counterpart of `unverified_bip340_input_for_bat_v2`.
+    /// It uses the verified snapshot's authoritative original request digest,
+    /// not the digest of its privacy-safe intent replay image.
+    pub fn unverified_bip340_input_for_verified_bat_v2_quote(
+        &self,
+        verified_quote: &VerifiedBolt11BatV2QuoteV2<'_>,
+        now_unix: u64,
+    ) -> Result<UnverifiedBip340QuoteStatusRequestV1, ServiceProtocolError> {
+        self.validate_structure()?;
+        let quote = verified_quote.quote();
+        let intent = verified_quote.intent();
+        if self.quote_id != quote.quote_id
+            || self.issuer_id != intent.issuer_id
+            || self.quote_request_digest != verified_quote.request_digest()
+            || self.claim_pubkey_xonly != intent.claim_pubkey_xonly
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteStatusRequestV1.bat_v2_verified_binding",
+                reason: "issuer, quote, original V2 request, or x-only claim key mismatch",
+            });
+        }
+        if self.requested_at > now_unix
+            || now_unix.saturating_sub(self.requested_at)
+                > MAX_BOLT11_QUOTE_STATUS_REQUEST_AGE_SECONDS_V1
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteStatusRequestV1.requested_at",
+                reason: "status request is from the future or outside the freshness window",
+            });
+        }
+        Ok(UnverifiedBip340QuoteStatusRequestV1 {
+            claim_pubkey_xonly: self.claim_pubkey_xonly,
+            message_digest: self.bip340_signing_digest()?,
+            signature: self.signature,
+            quote_id: self.quote_id,
+            requested_at: self.requested_at,
+            request_nonce: self.request_nonce,
+        })
+    }
+
     fn encode_unsigned(&self) -> Result<Zeroizing<Vec<u8>>, ServiceProtocolError> {
         self.validate_structure()?;
         let mut out = Zeroizing::new(Vec::with_capacity(MAX_BOLT11_QUOTE_STATUS_REQUEST_LEN - 64));
@@ -2328,6 +2799,35 @@ impl Bolt11QuoteClaimV1 {
         })
     }
 
+    /// Bind the same quote-ownership claim primitive to an independently
+    /// versioned BAT V2 intent. No provider-bound credential digest is
+    /// synthesized or accepted by this path.
+    pub fn unverified_bip340_input_for_bat_v2(
+        &self,
+        verified_quote: &VerifiedBolt11BatV2QuoteV2<'_>,
+        now_unix: u64,
+    ) -> Result<UnverifiedBip340ClaimV1, ServiceProtocolError> {
+        self.validate_structure()?;
+        verified_quote.ensure_claim_submission_at(now_unix)?;
+        let quote = verified_quote.quote();
+        let intent = verified_quote.intent();
+        if self.issuer_id != intent.issuer_id
+            || self.quote_id != quote.quote_id
+            || self.quote_request_digest != quote.request_digest
+            || self.claim_pubkey_xonly != intent.claim_pubkey_xonly
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteClaimV1.bat_v2_binding",
+                reason: "issuer, quote, V2 request, or x-only claim key mismatch",
+            });
+        }
+        Ok(UnverifiedBip340ClaimV1 {
+            claim_pubkey_xonly: self.claim_pubkey_xonly,
+            message_digest: self.bip340_signing_digest()?,
+            signature: self.signature,
+        })
+    }
+
     fn encode_unsigned(&self) -> Result<Zeroizing<Vec<u8>>, ServiceProtocolError> {
         self.validate_structure()?;
         let mut out = Zeroizing::new(Vec::with_capacity(256));
@@ -2409,7 +2909,7 @@ fn validate_invoice_text(invoice: &str) -> Result<(), ServiceProtocolError> {
     Ok(())
 }
 
-fn validate_xonly_pubkey(key: &[u8; 32]) -> Result<(), ServiceProtocolError> {
+pub(crate) fn validate_xonly_pubkey(key: &[u8; 32]) -> Result<(), ServiceProtocolError> {
     let mut even_y_point = [0u8; 33];
     even_y_point[0] = 0x02;
     even_y_point[1..].copy_from_slice(key);
@@ -2417,6 +2917,42 @@ fn validate_xonly_pubkey(key: &[u8; 32]) -> Result<(), ServiceProtocolError> {
         return Err(ServiceProtocolError::InvalidValue {
             field: "BIP340.xonly_pubkey",
             reason: "must be the x-coordinate of a secp256k1 point",
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_quote_payable_at(
+    quote: &Bolt11QuoteV1,
+    now_unix: u64,
+) -> Result<(), ServiceProtocolError> {
+    if quote.status != Bolt11QuoteStatusV1::InvoiceOpen
+        || now_unix < quote.invoice_created_at
+        || now_unix > quote.invoice_expires_at
+    {
+        return Err(ServiceProtocolError::InvalidValue {
+            field: "Bolt11QuoteV1.payment",
+            reason: "quote is not open and unexpired",
+        });
+    }
+    Ok(())
+}
+
+pub(crate) fn ensure_quote_claim_submission_at(
+    quote: &Bolt11QuoteV1,
+    now_unix: u64,
+) -> Result<(), ServiceProtocolError> {
+    let eligible_status = matches!(
+        quote.status,
+        Bolt11QuoteStatusV1::PaymentSettled | Bolt11QuoteStatusV1::LateSettledReconcile
+    );
+    let idempotent_recovery = quote.status == Bolt11QuoteStatusV1::CredentialClaimed;
+    if now_unix < quote.invoice_created_at
+        || (!idempotent_recovery && (!eligible_status || now_unix > quote.claim_deadline))
+    {
+        return Err(ServiceProtocolError::InvalidValue {
+            field: "Bolt11QuoteV1.claim",
+            reason: "payment is not settled or the claim window has ended",
         });
     }
     Ok(())

--- a/crates/protocol/service/tests/payment_v1_adversarial.rs
+++ b/crates/protocol/service/tests/payment_v1_adversarial.rs
@@ -79,6 +79,18 @@ fn public_v1_decoders() -> Vec<(&'static str, DecoderV1)> {
         ("BatAcceptanceClassV2", |bytes| {
             BatAcceptanceClassV2::decode(bytes).is_ok()
         }),
+        ("Bolt11BatV2QuoteIntentV2", |bytes| {
+            Bolt11BatV2QuoteIntentV2::decode(bytes).is_ok()
+        }),
+        ("BatV2IssuanceRequestV2", |bytes| {
+            BatV2IssuanceRequestV2::decode(bytes).is_ok()
+        }),
+        ("BatV2IssuanceResponseV2", |bytes| {
+            BatV2IssuanceResponseV2::decode(bytes).is_ok()
+        }),
+        ("Bolt11BatV2ClaimEnvelopeV2", |bytes| {
+            Bolt11BatV2ClaimEnvelopeV2::decode(bytes).is_ok()
+        }),
         ("CashuKeysetBindingV1", |bytes| {
             CashuKeysetBindingV1::decode(bytes).is_ok()
         }),
@@ -353,7 +365,7 @@ fn payment_v1_public_decoders_are_total_for_bounded_adversarial_corpus() {
     );
     assert_eq!(
         decoders.len(),
-        54,
+        58,
         "the explicit public-decoder inventory must not shrink silently"
     );
     assert!(

--- a/docs/payment/ARCHITECTURE.md
+++ b/docs/payment/ARCHITECTURE.md
@@ -448,10 +448,11 @@ raw-key epoch, identical commercial/entitlement terms, and the canonical exact
 provider-policy members allowed to receive that credential. The raw key may be
 shared only inside that signed member set. A member or policy rotation uses a
 fresh raw key/epoch and retains the old artifact; different terms use a new
-class ID. The class codec/policy shape and issuer-store v6 registry are the only
-implemented V2 components at this stage. They prevent V1/V2 raw-key rebinding
-and class rollback, but do not yet expose V2 acquisition, redemption or
-provider admission.
+class ID. The class codec/policy shape, issuer-store v7 registry and class-bound
+issuer acquisition path are implemented. They prevent V1/V2 raw-key
+rebinding, class rollback and provider provenance from leaking into the issued
+credential. V2 redemption, provider admission and SDK/Web wallet handling are
+not implemented yet.
 
 V1 does not send Cashu DLEQ blinding material to a provider for public-key-only
 offline verification and later batch redemption. Although such a receiver can

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -22,21 +22,33 @@ activated the path with real money.
       stable, preallocated 32-byte class ID and no V1 provider binding. A
       separately signed issuer artifact fixes one immutable key epoch, common
       commercial/entitlement terms and a canonical set of exact provider
-      policy members. Issuer-store schema v6 registers the complete artifact
+      policy members. Issuer-store schema v7 registers the complete artifact
       atomically, retains old epochs, rejects class forks/terms changes and
       prevents a raw BAT key from crossing either V2 classes or the legacy V1
       lineage namespace. Focused protocol and store tests cover canonical
       bytes, two-provider membership, epoch rotation/restart, validity bounds
-      and bidirectional V1/V2 key isolation. Version 5 stores are not migrated
-      implicitly.
-- [ ] **Issuer-wide V2 acquisition and redemption pending.** V1 quote, claim,
-      issuance, redeem and ProviderStore paths deliberately reject scheme 6;
-      no old replayable V1 success is reinterpreted. The class-bound quote/
-      wallet record, issuer-global first-spend transaction, non-grantable
-      replay response, storeless provider commit, SDK/Web selection and render
-      gates remain to implement. Current `main` also retains the old Direct
-      Mainnet issuer unit and stateful V1 provider profiles. An old draft's
-      fixed 2-policy/12-key/2-clearing shape remains superseded and is not V2
+      and bidirectional V1/V2 key isolation. Version 5 or 6 stores are not
+      migrated implicitly.
+- [x] **Issuer-wide V2 acquisition implemented.** A separate class-only V2
+      quote intent, issuance request/response and claim envelope use their own
+      codecs and domains; none carries a fake V1 credential-binding digest.
+      Issuer-store schema v7 marks every quote as V1 or V2, creates new V2
+      quotes only at the current class head, recovers retained historical
+      epochs after restart, and forbids V2 receipt-serial rows. The issuer
+      exposes independent `/v2/quotes/...` create, status and claim routes,
+      selects the exact class raw key, verifies BIP340 plus NUT-12 DLEQ, and
+      replays only the byte-identical committed issuance response after a lost
+      claim response. Focused tests cover protocol codecs, mixed V1/V2 store
+      restart, class-key selection, claim-before-restart recovery and route
+      isolation.
+- [ ] **Issuer-wide V2 redemption and provider path pending.** V1 redeem and
+      ProviderStore paths still deliberately reject scheme 6; no old
+      replayable V1 redeem success is reinterpreted. The V2 presentation,
+      issuer-global first-spend transaction, non-grantable redeem replay,
+      storeless provider commit, SDK/Web class wallet and render gates remain
+      to implement. Current `main` also retains the old Direct Mainnet issuer
+      unit and stateful V1 provider profiles. An old draft's fixed
+      2-policy/12-key/2-clearing shape remains superseded and is not V2
       readiness evidence.
 - [ ] **Payment-storeless provider mode pending.** The current shared-BAT
       committer still uses ProviderStore for a local delivery claim and the

--- a/docs/payment/MAINNET_SHARED_BAT_PRODUCTION_PLAN.md
+++ b/docs/payment/MAINNET_SHARED_BAT_PRODUCTION_PLAN.md
@@ -485,6 +485,17 @@ usable V2 purchase or redemption path; the remaining Phase-B work below is
 unchanged. Version-5 issuer stores require a separately reviewed explicit
 migration or isolated legacy retention and are never upgraded at startup.
 
+Source checkpoint (2026-08-19, acquisition slice): independent V2 quote intent,
+claim envelope and blind issuance codecs now bind only the exact class/key
+epoch and common terms. Issuer-store schema v7 discriminates V1/V2 quotes,
+allows new V2 quotes only at the current class head, retains exact historical
+epochs for paid-claim recovery, and rejects implicit v5/v6 migration. Separate
+`/v2/quotes/...` routes perform class-key selection, BIP340 claim verification,
+NUT-12 DLEQ issuance and byte-identical lost-response recovery. This completes
+issuer-side acquisition only; no V2 presentation, global first-spend,
+provider grant, SDK/Web class wallet or production activation follows from
+this checkpoint.
+
 Acceptance:
 
 - one BAT acquired through a class member can redeem at another compatible

--- a/docs/payment/PROTOCOL.md
+++ b/docs/payment/PROTOCOL.md
@@ -245,17 +245,41 @@ do not form a digest cycle. The class artifact and terms use independent V2
 signature/digest domains; the raw-key ID additionally commits issuer, class,
 key epoch and raw key.
 
-Issuer-store schema v6 atomically installs a complete class epoch against each
+Issuer-store schema v7 atomically installs a complete class epoch against each
 provider's current exact signed policy head. A class ID keeps the same common
 terms across epochs; a changed exact member set requires a fresh epoch and raw
 key, while the old signed artifact remains available through its promised
 retired-policy horizon. The store rejects epoch rollback/forks, incomplete or
 incompatible members, and raw-key reuse across V2 classes or legacy BAT V1.
-Schema v6 has no implicit migration from v5.
+Schema v7 has no implicit migration from v5 or v6.
 
-This registry is only the first V2 source slice. Class-bound quote/claim
-records, issuer-global first-spend redemption, non-grantable replay results,
-storeless provider admission and SDK/Web wallet handling are still pending.
+The class-bound BOLT11 acquisition path uses independent
+`Bolt11BatV2QuoteIntentV2`, `BatV2IssuanceRequestV2`,
+`BatV2IssuanceResponseV2` and `Bolt11BatV2ClaimEnvelopeV2` codecs and digest
+domains. The intent binds only issuer/class/key and shared commercial terms;
+it deliberately omits the provider member through which the user discovered
+the class. A new quote must reference the current class head, while an existing
+quote may finish against its exact retained class epoch through the promised
+claim horizon. The issuer selects that epoch's raw key, verifies the quote
+claim and blind issuance request, produces NUT-12 DLEQ evidence and commits the
+exact response before releasing it.
+
+Issuer-store v7 carries an explicit V1/V2 quote discriminator. V1 and V2
+lookups, transitions and idempotency namespaces reject the opposite protocol;
+V2 claims never create Direct-receipt serial rows. The HTTP surface is also
+separate:
+
+```text
+POST /v2/quotes/bolt11
+POST /v2/quotes/{quote_id}/status
+POST /v2/quotes/{quote_id}/claim
+```
+
+An exact replay of a committed V2 *acquisition claim* returns the same blind
+issuance response so a paid invoice is recoverable after a lost response. This
+does not define redeem replay: issuer-global first-spend redemption,
+non-grantable redeem replay, storeless provider admission and SDK/Web class
+wallet handling are still pending.
 
 ## PIR wire messages
 

--- a/docs/payment/TEST_PLAN.md
+++ b/docs/payment/TEST_PLAN.md
@@ -1253,8 +1253,18 @@ across two exact provider policies, advance to a fresh key epoch, retain and
 reopen the old epoch, and reject member/terms mismatches, epoch rollback/fork,
 invalid key-validity horizons, cross-class raw-key reuse and both V1-to-V2 and
 V2-to-V1 raw-key reuse. A v5 store is rejected rather than implicitly
-migrated. These tests do not claim that V2 quote, redeem, provider, SDK or Web
-paths exist.
+migrated.
+
+The acquisition slice adds three equally narrow groups. Protocol tests bind
+the class-only quote intent, V2 issuance request/response, independent codecs
+and persisted-safe status typestate without inventing a V1 binding digest.
+Issuer-store tests cover the V1/V2 discriminator, fresh-current versus
+retained-recovery epochs, mixed-protocol restart, status/claim idempotency,
+receipt-serial exclusion and unfinished-quote key inventory. Issuer-service
+tests execute V2 create, settlement, status and blind claim with BIP340 and
+NUT-12 DLEQ, restart before claim, and byte-identical lost-response recovery;
+the app test locks V1/V2 route separation. These tests do not claim that V2
+redeem, provider, SDK or Web paths exist.
 
 - identified redeem credits only the authenticated provider;
 - blind redeem also requires provider authentication and signs exactly the


### PR DESCRIPTION
## Summary

- add class-only BAT V2 quote, claim, and blind issuance codecs without a V1 credential-binding sentinel
- add schema v7 V1/V2 quote discrimination, current-head creation, retained-epoch recovery, and mixed-protocol restart integrity
- add exact class-key BAT issuance with BIP340 ownership and NUT-12 DLEQ verification
- expose isolated /v2/quotes create, status, and claim routes while keeping every V1 path fail-closed
- pin current live and recoverable historical class mint keys at startup

## Boundary

This PR completes issuer-side acquisition only. It does not add BAT V2 presentation/redemption, issuer-global first-spend, provider grants, ProviderStore changes, SDK/Web wallet handling, deployment, or implicit v5/v6 store migration.

## Verification

- pir-service-protocol: 145 unit + 2 adversarial tests passed
- pir-issuer-store: 46 tests passed
- pir-issuer-service acquisition: 7 tests passed
- payment-issuer V1/V2 route parser: 1 test passed
- all-targets cargo check for protocol, store, credentials, core, service, and payment-issuer
- scoped rustfmt --check and git diff --check

No browser, production, VPSBG, deployment, or funds operation was run.