### PR TITLE
Add issuer-wide BAT V2 redemption store

### DIFF
--- a/crates/payment/issuer-core/src/lib.rs
+++ b/crates/payment/issuer-core/src/lib.rs
@@ -1915,8 +1915,12 @@ fn map_store_error(error: StoreError) -> IssuerCoreErrorV1 {
         | StoreError::SettlementKeyLineageConflict
         | StoreError::ProviderRegistrationRollback
         | StoreError::ProviderRegistrationFork
+        | StoreError::ProviderAccountBindingConflict
         | StoreError::ClearingAuthorizationRollback
         | StoreError::ClearingAuthorizationFork
+        | StoreError::BatV2ClearingAuthorizationRollback
+        | StoreError::BatV2ClearingAuthorizationFork
+        | StoreError::BatV2RedeemPreconditionChanged
         | StoreError::RedeemIdempotencyConflict
         | StoreError::CredentialAlreadySpent
         | StoreError::LedgerBalanceOverflow

--- a/crates/payment/issuer-store/src/bat_v2_clearing_ops.rs
+++ b/crates/payment/issuer-store/src/bat_v2_clearing_ops.rs
@@ -1,0 +1,1099 @@
+use crate::bat_v2_ops::read_bat_acceptance_class_v2;
+use crate::db::{
+    advance_store_generation, commit, db_u64, fixed_blob, is_zero, sql_integer,
+    verify_expected_identity,
+};
+use crate::rollback::mutation_digest;
+use crate::{
+    BatV2AccountingAuthorizationRecordV2, CommitMarker, DurableWrite, IssuerStore,
+    ProviderAccountBindingRecordV2, StoreError, StoreResult, WriteDisposition,
+    MAX_EXACT_BAT_V2_ACCOUNTING_APPROVAL_BYTES, MAX_EXACT_BAT_V2_ACCOUNTING_AUTHORIZATION_BYTES,
+    MAX_EXACT_BAT_V2_REDEEM_SUCCESS_BYTES,
+};
+use ed25519_dalek::VerifyingKey;
+use pir_service_protocol::{
+    bat_v2_redeem_ledger_transaction_id_v2, BatV2RedeemCommitStoreV2, IssuerAccountingApprovalV2,
+    ProviderAccountingAuthorizationV2, ProviderRedeemOutcomeV2, ProviderRedeemRequestV2,
+    ProviderRedeemResponseV2, SettlementUnitV1, VerifiedBatV2RedeemCommitV2,
+};
+use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
+use sha2::{Digest, Sha256};
+
+const SYSTEM_LEDGER_ACCOUNT_ID_DOMAIN_V1: &[u8] =
+    b"BitcoinPIR/issuer-store/system-ledger-account-id/v1";
+const SYSTEM_ACCOUNT_CREDENTIAL_SOURCE: u8 = 1;
+const SYSTEM_ACCOUNT_ISSUER_FEE: u8 = 2;
+const ACCOUNT_KIND_PROVIDER: i64 = 1;
+const ACCOUNT_KIND_CREDENTIAL_SOURCE: i64 = 2;
+const ACCOUNT_KIND_ISSUER_FEE: i64 = 3;
+const BAT_V2_LEDGER_TRANSACTION_KIND: i64 = 7;
+
+type RawBatV2Authorization = (
+    Vec<u8>,
+    i64,
+    Vec<u8>,
+    Vec<u8>,
+    Vec<u8>,
+    Vec<u8>,
+    i64,
+    i64,
+    Vec<u8>,
+    Vec<u8>,
+    i64,
+);
+
+/// Store adapter for the protocol fresh-commit gate. `now_unix` is captured
+/// by the issuer before precheck and reused for transaction-time revalidation.
+pub struct IssuerBatV2RedeemCommitterV2<'a> {
+    store: &'a IssuerStore,
+    now_unix: u64,
+}
+
+impl<'a> IssuerBatV2RedeemCommitterV2<'a> {
+    pub fn new(store: &'a IssuerStore, now_unix: u64) -> StoreResult<Self> {
+        if now_unix == 0 {
+            return Err(StoreError::InvalidInput("BAT V2 redeem time is zero"));
+        }
+        Ok(Self { store, now_unix })
+    }
+}
+
+impl BatV2RedeemCommitStoreV2 for IssuerBatV2RedeemCommitterV2<'_> {
+    type Error = StoreError;
+
+    fn commit_fresh(
+        &mut self,
+        verified: &VerifiedBatV2RedeemCommitV2,
+        signed_initial_success: &ProviderRedeemResponseV2,
+    ) -> Result<bool, Self::Error> {
+        self.store
+            .commit_fresh_bat_v2_redeem(verified, signed_initial_success, self.now_unix)
+    }
+}
+
+impl IssuerStore {
+    /// Registers exact BAT V2 operator and issuer accounting artifacts. The
+    /// external keys are explicit pinned roots, never learned from the input.
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_bat_v2_accounting_authorization(
+        &self,
+        authorization: &ProviderAccountingAuthorizationV2,
+        approval: &IssuerAccountingApprovalV2,
+        expected_operator_key: &VerifyingKey,
+        expected_issuer_settlement_key: &VerifyingKey,
+        now_unix: u64,
+    ) -> StoreResult<DurableWrite<BatV2AccountingAuthorizationRecordV2>> {
+        if now_unix == 0 {
+            return Err(StoreError::InvalidInput(
+                "BAT V2 accounting registration time is zero",
+            ));
+        }
+        let exact_authorization = authorization.encode()?;
+        let exact_approval = approval.encode().to_vec();
+        let operator_root = expected_operator_key.to_bytes();
+        let settlement_root = expected_issuer_settlement_key.to_bytes();
+        if exact_authorization.len() > MAX_EXACT_BAT_V2_ACCOUNTING_AUTHORIZATION_BYTES
+            || exact_approval.len() > MAX_EXACT_BAT_V2_ACCOUNTING_APPROVAL_BYTES
+        {
+            return Err(StoreError::InvalidInput(
+                "BAT V2 accounting artifact exceeds store bound",
+            ));
+        }
+        let digest = authorization.authorization_digest()?;
+        let provider_id = authorization.claims.provider_id;
+        let account_id = authorization.claims.settlement_account_id;
+
+        let mut connection = self.open_checked(false)?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let previous_identity = verify_expected_identity(&transaction, &self.handle)?;
+        let previous_floor = self.require_exact_rollback_floor(&previous_identity)?;
+
+        if let Some(existing) = read_bat_v2_authorization(&transaction, self, &digest)? {
+            if existing.exact_authorization == exact_authorization
+                && existing.exact_approval == exact_approval
+                && existing.operator_verifying_key == operator_root
+                && existing.issuer_settlement_verifying_key == settlement_root
+            {
+                return Ok(DurableWrite {
+                    disposition: WriteDisposition::ExactReplay,
+                    commit: existing.commit,
+                    value: existing,
+                });
+            }
+            return Err(StoreError::BatV2ClearingAuthorizationFork);
+        }
+
+        let highest_epoch: Option<i64> = transaction.query_row(
+            "SELECT MAX(authorization_epoch) FROM bat_v2_clearing_authorizations \
+             WHERE issuer_id = ?1 AND provider_id = ?2",
+            params![
+                self.handle.expected_issuer_id.as_slice(),
+                provider_id.as_slice(),
+            ],
+            |row| row.get(0),
+        )?;
+        let highest_epoch = highest_epoch
+            .map(|value| db_u64(value, "negative BAT V2 authorization epoch"))
+            .transpose()?
+            .unwrap_or(0);
+        if authorization.claims.authorization_epoch < highest_epoch {
+            return Err(StoreError::BatV2ClearingAuthorizationRollback);
+        }
+        if authorization.claims.authorization_epoch == highest_epoch && highest_epoch != 0 {
+            return Err(StoreError::BatV2ClearingAuthorizationFork);
+        }
+        authorization.verify_for(
+            &provider_id,
+            &self.handle.expected_issuer_id,
+            expected_operator_key,
+            now_unix,
+            highest_epoch,
+        )?;
+        approval.verify_for(
+            authorization,
+            expected_issuer_settlement_key,
+            now_unix,
+            highest_epoch,
+        )?;
+
+        let mutation = mutation_digest(
+            b"register-bat-v2-accounting-authorization-v2",
+            &[
+                &digest,
+                &provider_id,
+                &authorization.claims.authorization_epoch.to_le_bytes(),
+                &account_id,
+                &operator_root,
+                &settlement_root,
+                &exact_approval,
+            ],
+        );
+        let committed_identity = advance_store_generation(
+            &transaction,
+            &previous_identity,
+            b"register-bat-v2-accounting-authorization-v2",
+            &mutation,
+        )?;
+        let sequence = committed_identity.commit_seq;
+        ensure_provider_account_binding(
+            &transaction,
+            self,
+            &provider_id,
+            &account_id,
+            SettlementUnitV1::AuthCredit,
+            sequence,
+        )?;
+        ensure_ledger_account(
+            &transaction,
+            self,
+            &provider_id,
+            &account_id,
+            SettlementUnitV1::AuthCredit,
+            sequence,
+        )?;
+        transaction.execute(
+            "INSERT INTO bat_v2_clearing_authorizations \
+             (authorization_digest, issuer_id, authorization_id, authorization_epoch, \
+              provider_id, settlement_account_id, operator_verifying_key, \
+              issuer_settlement_verifying_key, not_before, not_after, exact_authorization, \
+              exact_approval, commit_seq) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, \
+              ?9, ?10, ?11, ?12, ?13)",
+            params![
+                digest.as_slice(),
+                self.handle.expected_issuer_id.as_slice(),
+                authorization.claims.authorization_id.as_slice(),
+                sql_integer(
+                    authorization.claims.authorization_epoch,
+                    "BAT V2 authorization epoch exceeds SQLite range"
+                )?,
+                provider_id.as_slice(),
+                account_id.as_slice(),
+                operator_root.as_slice(),
+                settlement_root.as_slice(),
+                sql_integer(
+                    authorization.claims.not_before.max(approval.approved_at),
+                    "BAT V2 authorization not_before exceeds SQLite range"
+                )?,
+                sql_integer(
+                    approval.not_after,
+                    "BAT V2 authorization not_after exceeds SQLite range"
+                )?,
+                exact_authorization.as_slice(),
+                exact_approval.as_slice(),
+                sql_integer(sequence, "commit sequence exceeds SQLite range")?,
+            ],
+        )?;
+        commit(transaction)?;
+        self.anchor_committed_identity(&previous_floor, &committed_identity)?;
+        let value = self
+            .bat_v2_accounting_authorization(&digest)?
+            .ok_or_else(|| {
+                StoreError::SchemaMismatch(
+                    "committed BAT V2 accounting authorization missing".to_owned(),
+                )
+            })?;
+        Ok(DurableWrite {
+            disposition: WriteDisposition::Committed,
+            commit: marker(self, sequence),
+            value,
+        })
+    }
+
+    pub fn bat_v2_accounting_authorization(
+        &self,
+        digest: &[u8; 32],
+    ) -> StoreResult<Option<BatV2AccountingAuthorizationRecordV2>> {
+        if is_zero(digest) {
+            return Err(StoreError::InvalidInput(
+                "BAT V2 accounting authorization digest is zero",
+            ));
+        }
+        let connection = self.open_checked(false)?;
+        let value = read_bat_v2_authorization(&connection, self, digest)?;
+        self.confirm_anchored_read(&connection, value)
+    }
+
+    /// Returns the sole authorization eligible for new debt for this
+    /// provider. Digest-addressed history remains available only so callers
+    /// can classify an old request without treating it as current authority.
+    pub fn current_bat_v2_accounting_authorization(
+        &self,
+        provider_id: &[u8; 32],
+    ) -> StoreResult<Option<BatV2AccountingAuthorizationRecordV2>> {
+        if is_zero(provider_id) {
+            return Err(StoreError::InvalidInput("BAT V2 provider id is zero"));
+        }
+        let connection = self.open_checked(false)?;
+        let digest: Option<Vec<u8>> = connection
+            .query_row(
+                "SELECT authorization_digest FROM bat_v2_clearing_authorizations \
+                 WHERE issuer_id = ?1 AND provider_id = ?2 \
+                 ORDER BY authorization_epoch DESC LIMIT 1",
+                params![
+                    self.handle.expected_issuer_id.as_slice(),
+                    provider_id.as_slice(),
+                ],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let value = digest
+            .map(|digest| {
+                let digest = fixed_blob(digest, "invalid current BAT V2 authorization digest")?;
+                read_bat_v2_authorization(&connection, self, &digest)?.ok_or_else(|| {
+                    StoreError::SchemaMismatch(
+                        "current BAT V2 authorization disappeared".to_owned(),
+                    )
+                })
+            })
+            .transpose()?;
+        self.confirm_anchored_read(&connection, value)
+    }
+
+    /// Returns only terminal attempt state. Prior success bytes are never
+    /// exposed or replayed by a public API.
+    pub fn bat_v2_attempt_is_committed(
+        &self,
+        provider_id: &[u8; 32],
+        attempt_id: &[u8; 32],
+    ) -> StoreResult<bool> {
+        if is_zero(provider_id) || is_zero(attempt_id) {
+            return Err(StoreError::InvalidInput(
+                "BAT V2 provider or attempt id is zero",
+            ));
+        }
+        let connection = self.open_checked(false)?;
+        let found: bool = connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM bat_v2_redemptions \
+             WHERE issuer_id = ?1 AND provider_id = ?2 AND attempt_id = ?3)",
+            params![
+                self.handle.expected_issuer_id.as_slice(),
+                provider_id.as_slice(),
+                attempt_id.as_slice(),
+            ],
+            |row| row.get(0),
+        )?;
+        self.confirm_anchored_read(&connection, found)
+    }
+
+    pub fn bat_v2_redeem_committer(
+        &self,
+        now_unix: u64,
+    ) -> StoreResult<IssuerBatV2RedeemCommitterV2<'_>> {
+        IssuerBatV2RedeemCommitterV2::new(self, now_unix)
+    }
+
+    fn commit_fresh_bat_v2_redeem(
+        &self,
+        verified: &VerifiedBatV2RedeemCommitV2,
+        signed_initial_success: &ProviderRedeemResponseV2,
+        now_unix: u64,
+    ) -> StoreResult<bool> {
+        let request = verified.request();
+        if now_unix == 0 || request.issuer_id != self.handle.expected_issuer_id {
+            return Err(StoreError::BatV2RedeemPreconditionChanged);
+        }
+        let request_digest = request.request_digest()?;
+        let ledger_transaction_id = bat_v2_redeem_ledger_transaction_id_v2(request)?;
+        let exact_success = signed_initial_success.encode()?;
+        if exact_success.len() > MAX_EXACT_BAT_V2_REDEEM_SUCCESS_BYTES
+            || is_zero(verified.global_spend_key())
+        {
+            return Err(StoreError::InvalidInput(
+                "BAT V2 success encoding or spend key is invalid",
+            ));
+        }
+
+        let mut connection = self.open_checked(false)?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let previous_identity = verify_expected_identity(&transaction, &self.handle)?;
+        let previous_floor = self.require_exact_rollback_floor(&previous_identity)?;
+
+        // BEGIN IMMEDIATE serializes this cross-table global-spend decision.
+        // Conflicts are terminal but prior success bytes are never read.
+        let already_committed: bool = transaction.query_row(
+            "SELECT EXISTS(SELECT 1 FROM bat_v2_redemptions \
+                 WHERE issuer_id = ?1 AND provider_id = ?2 AND attempt_id = ?3) \
+             OR EXISTS(SELECT 1 FROM bat_v2_redemptions WHERE global_spend_key = ?4) \
+             OR EXISTS(SELECT 1 FROM redemptions WHERE credential_spend_key = ?4)",
+            params![
+                self.handle.expected_issuer_id.as_slice(),
+                request.provider_id.as_slice(),
+                request.attempt_id.as_slice(),
+                verified.global_spend_key().as_slice(),
+            ],
+            |row| row.get(0),
+        )?;
+        if already_committed {
+            return Ok(false);
+        }
+
+        let authorization = read_bat_v2_authorization(
+            &transaction,
+            self,
+            &request.accounting_authorization_digest,
+        )?
+        .ok_or(StoreError::BatV2RedeemPreconditionChanged)?;
+        let highest_epoch: i64 = transaction.query_row(
+            "SELECT MAX(authorization_epoch) FROM bat_v2_clearing_authorizations \
+             WHERE issuer_id = ?1 AND provider_id = ?2",
+            params![
+                self.handle.expected_issuer_id.as_slice(),
+                request.provider_id.as_slice(),
+            ],
+            |row| row.get(0),
+        )?;
+        if db_u64(highest_epoch, "negative BAT V2 authorization epoch")?
+            != authorization.authorization_epoch
+            || now_unix < authorization.not_before
+            || now_unix > authorization.not_after
+            || authorization.provider_id != request.provider_id
+            || authorization.settlement_account_id != request.settlement_account_id
+        {
+            return Err(StoreError::BatV2RedeemPreconditionChanged);
+        }
+        let (exact_authorization, exact_approval) = authorization.decode_exact()?;
+        exact_authorization.verify_for(
+            &request.provider_id,
+            &self.handle.expected_issuer_id,
+            &VerifyingKey::from_bytes(&authorization.operator_verifying_key)
+                .map_err(|_| StoreError::BatV2RedeemPreconditionChanged)?,
+            now_unix,
+            authorization.authorization_epoch,
+        )?;
+        let settlement_key =
+            VerifyingKey::from_bytes(&authorization.issuer_settlement_verifying_key)
+                .map_err(|_| StoreError::BatV2RedeemPreconditionChanged)?;
+        exact_approval.verify_for(
+            &exact_authorization,
+            &settlement_key,
+            now_unix,
+            authorization.authorization_epoch,
+        )?;
+        let rule = exact_authorization
+            .claims
+            .rules
+            .iter()
+            .find(|rule| {
+                rule.class_id == request.class_id
+                    && rule.policy_digest == request.policy_digest
+                    && rule.scope_id == request.scope_id
+                    && rule.offer_id == request.offer_id
+            })
+            .ok_or(StoreError::BatV2RedeemPreconditionChanged)?;
+        if rule.unit != request.unit
+            || rule.accepted_value != request.accepted_value
+            || rule.provider_credit != verified.provider_credit()
+            || rule.issuer_fee != verified.issuer_fee()
+        {
+            return Err(StoreError::BatV2RedeemPreconditionChanged);
+        }
+
+        let class = read_bat_acceptance_class_v2(
+            &transaction,
+            self,
+            &request.class_id,
+            request.class_key_epoch,
+        )?
+        .ok_or(StoreError::BatV2RedeemPreconditionChanged)?;
+        let member = class
+            .members
+            .iter()
+            .find(|member| {
+                member.provider_id == request.provider_id
+                    && member.policy_digest == request.policy_digest
+                    && member.scope_id == request.scope_id
+                    && member.offer_id == request.offer_id
+            })
+            .ok_or(StoreError::BatV2RedeemPreconditionChanged)?;
+        if class.artifact_digest != request.class_digest
+            || class.bat_key_id != request.bat_key_id
+            || now_unix < class.key_not_before
+            || now_unix > class.key_not_after
+            || now_unix > member.redemption_deadline
+        {
+            return Err(StoreError::BatV2RedeemPreconditionChanged);
+        }
+        require_provider_account_binding(
+            &transaction,
+            self,
+            &request.provider_id,
+            &request.settlement_account_id,
+            request.unit,
+        )?;
+        signed_initial_success.verify_for_exact_request(request, &settlement_key)?;
+        match &signed_initial_success.outcome {
+            ProviderRedeemOutcomeV2::GrantableSuccess {
+                account_id,
+                ledger_transaction_id: response_transaction_id,
+                unit,
+                accepted_value,
+                provider_credit,
+                issuer_fee,
+            } if account_id == &request.settlement_account_id
+                && response_transaction_id == &ledger_transaction_id
+                && unit == &request.unit
+                && accepted_value == &request.accepted_value
+                && *provider_credit == verified.provider_credit()
+                && *issuer_fee == verified.issuer_fee() => {}
+            _ => return Err(StoreError::BatV2RedeemPreconditionChanged),
+        }
+
+        let mutation = mutation_digest(
+            b"commit-bat-v2-redeem-v2",
+            &[
+                &request_digest,
+                verified.global_spend_key(),
+                &ledger_transaction_id,
+                &exact_success,
+            ],
+        );
+        let committed_identity = advance_store_generation(
+            &transaction,
+            &previous_identity,
+            b"commit-bat-v2-redeem-v2",
+            &mutation,
+        )?;
+        let sequence = committed_identity.commit_seq;
+        credit_provider_account(
+            &transaction,
+            self,
+            &request.provider_id,
+            &request.settlement_account_id,
+            request.unit,
+            verified.provider_credit(),
+            sequence,
+        )?;
+        insert_bat_v2_ledger_transaction(
+            &transaction,
+            self,
+            request,
+            verified.provider_credit(),
+            verified.issuer_fee(),
+            &ledger_transaction_id,
+            &request_digest,
+            now_unix,
+            sequence,
+        )?;
+        transaction.execute(
+            "INSERT INTO bat_v2_redemptions \
+             (issuer_id, provider_id, attempt_id, request_digest, authorization_digest, \
+              settlement_account_id, class_id, class_key_epoch, class_digest, member_index, \
+              credential_digest, global_spend_key, accepted_value, provider_credit, issuer_fee, \
+              unit, ledger_transaction_id, exact_initial_success, redeemed_at, commit_seq) \
+              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, \
+                      ?15, ?16, ?17, ?18, ?19, ?20)",
+            params![
+                self.handle.expected_issuer_id.as_slice(),
+                request.provider_id.as_slice(),
+                request.attempt_id.as_slice(),
+                request_digest.as_slice(),
+                request.accounting_authorization_digest.as_slice(),
+                request.settlement_account_id.as_slice(),
+                request.class_id.as_slice(),
+                sql_integer(
+                    request.class_key_epoch,
+                    "BAT V2 class epoch exceeds SQLite range"
+                )?,
+                request.class_digest.as_slice(),
+                i64::from(member.member_index),
+                request.credential_digest.as_slice(),
+                verified.global_spend_key().as_slice(),
+                sql_integer(
+                    request.accepted_value,
+                    "BAT V2 accepted value exceeds SQLite range"
+                )?,
+                sql_integer(
+                    verified.provider_credit(),
+                    "BAT V2 provider credit exceeds SQLite range"
+                )?,
+                sql_integer(
+                    verified.issuer_fee(),
+                    "BAT V2 issuer fee exceeds SQLite range"
+                )?,
+                request.unit as u8,
+                ledger_transaction_id.as_slice(),
+                exact_success.as_slice(),
+                sql_integer(now_unix, "BAT V2 redeem time exceeds SQLite range")?,
+                sql_integer(sequence, "commit sequence exceeds SQLite range")?,
+            ],
+        )?;
+        commit(transaction)?;
+        self.anchor_committed_identity(&previous_floor, &committed_identity)?;
+        Ok(true)
+    }
+}
+
+pub(crate) fn ensure_provider_account_binding(
+    connection: &Connection,
+    store: &IssuerStore,
+    provider_id: &[u8; 32],
+    account_id: &[u8; 32],
+    unit: SettlementUnitV1,
+    sequence: u64,
+) -> StoreResult<()> {
+    connection.execute(
+        "INSERT OR IGNORE INTO provider_account_bindings \
+         (issuer_id, provider_id, settlement_account_id, unit, commit_seq) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            store.handle.expected_issuer_id.as_slice(),
+            provider_id.as_slice(),
+            account_id.as_slice(),
+            unit as u8,
+            sql_integer(sequence, "commit sequence exceeds SQLite range")?,
+        ],
+    )?;
+    require_provider_account_binding(connection, store, provider_id, account_id, unit).map(|_| ())
+}
+
+fn require_provider_account_binding(
+    connection: &Connection,
+    store: &IssuerStore,
+    provider_id: &[u8; 32],
+    account_id: &[u8; 32],
+    unit: SettlementUnitV1,
+) -> StoreResult<ProviderAccountBindingRecordV2> {
+    let raw: Option<(Vec<u8>, i64, i64)> = connection
+        .query_row(
+            "SELECT settlement_account_id, unit, commit_seq FROM provider_account_bindings \
+             WHERE issuer_id = ?1 AND provider_id = ?2",
+            params![
+                store.handle.expected_issuer_id.as_slice(),
+                provider_id.as_slice(),
+            ],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .optional()?;
+    let Some((stored_account, stored_unit, commit_seq)) = raw else {
+        return Err(StoreError::ProviderAccountBindingConflict);
+    };
+    if stored_account.as_slice() != account_id || stored_unit != unit as i64 {
+        return Err(StoreError::ProviderAccountBindingConflict);
+    }
+    Ok(ProviderAccountBindingRecordV2 {
+        provider_id: *provider_id,
+        settlement_account_id: fixed_blob(stored_account, "invalid provider account binding")?,
+        unit,
+        commit: marker(
+            store,
+            db_u64(commit_seq, "negative provider account binding commit")?,
+        ),
+    })
+}
+
+pub(crate) fn ensure_ledger_account(
+    connection: &Connection,
+    store: &IssuerStore,
+    provider_id: &[u8; 32],
+    account_id: &[u8; 32],
+    unit: SettlementUnitV1,
+    sequence: u64,
+) -> StoreResult<()> {
+    connection.execute(
+        "INSERT OR IGNORE INTO ledger_accounts \
+         (account_id, issuer_id, provider_id, unit, available_value, reserved_value, \
+          ledger_sequence, commit_seq) VALUES (?1, ?2, ?3, ?4, 0, 0, 0, ?5)",
+        params![
+            account_id.as_slice(),
+            store.handle.expected_issuer_id.as_slice(),
+            provider_id.as_slice(),
+            unit as u8,
+            sql_integer(sequence, "commit sequence exceeds SQLite range")?,
+        ],
+    )?;
+    let exact: bool = connection.query_row(
+        "SELECT EXISTS(SELECT 1 FROM ledger_accounts WHERE issuer_id = ?1 \
+         AND provider_id = ?2 AND account_id = ?3 AND unit = ?4)",
+        params![
+            store.handle.expected_issuer_id.as_slice(),
+            provider_id.as_slice(),
+            account_id.as_slice(),
+            unit as u8,
+        ],
+        |row| row.get(0),
+    )?;
+    if !exact {
+        return Err(StoreError::ProviderAccountBindingConflict);
+    }
+    Ok(())
+}
+
+fn read_bat_v2_authorization(
+    connection: &Connection,
+    store: &IssuerStore,
+    digest: &[u8; 32],
+) -> StoreResult<Option<BatV2AccountingAuthorizationRecordV2>> {
+    let raw: Option<RawBatV2Authorization> = connection
+        .query_row(
+            "SELECT authorization_id, authorization_epoch, provider_id, settlement_account_id, \
+             operator_verifying_key, issuer_settlement_verifying_key, not_before, not_after, \
+             exact_authorization, exact_approval, commit_seq \
+             FROM bat_v2_clearing_authorizations \
+             WHERE issuer_id = ?1 AND authorization_digest = ?2",
+            params![
+                store.handle.expected_issuer_id.as_slice(),
+                digest.as_slice(),
+            ],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                    row.get(8)?,
+                    row.get(9)?,
+                    row.get(10)?,
+                ))
+            },
+        )
+        .optional()?;
+    raw.map(|raw| rebuild_bat_v2_authorization(store, digest, raw))
+        .transpose()
+}
+
+fn rebuild_bat_v2_authorization(
+    store: &IssuerStore,
+    digest: &[u8; 32],
+    raw: RawBatV2Authorization,
+) -> StoreResult<BatV2AccountingAuthorizationRecordV2> {
+    let exact_authorization = raw.8;
+    let exact_approval = raw.9;
+    let authorization = ProviderAccountingAuthorizationV2::decode(&exact_authorization)?;
+    let approval = IssuerAccountingApprovalV2::decode(&exact_approval)?;
+    let operator_verifying_key = fixed_blob(raw.4, "invalid BAT V2 operator key")?;
+    let issuer_settlement_verifying_key =
+        fixed_blob(raw.5, "invalid BAT V2 issuer settlement key")?;
+    let operator_key = VerifyingKey::from_bytes(&operator_verifying_key)
+        .map_err(|_| StoreError::SchemaMismatch("invalid BAT V2 operator root".to_owned()))?;
+    let settlement_key = VerifyingKey::from_bytes(&issuer_settlement_verifying_key)
+        .map_err(|_| StoreError::SchemaMismatch("invalid BAT V2 settlement root".to_owned()))?;
+    let authorization_epoch = db_u64(raw.1, "negative BAT V2 authorization epoch")?;
+    let not_before = db_u64(raw.6, "negative BAT V2 authorization not_before")?;
+    let not_after = db_u64(raw.7, "negative BAT V2 authorization not_after")?;
+    let signature_time = not_before.min(not_after);
+    if authorization.encode()? != exact_authorization
+        || approval.encode().as_slice() != exact_approval.as_slice()
+        || authorization.authorization_digest()? != *digest
+        || authorization.claims.authorization_id.as_slice() != raw.0.as_slice()
+        || authorization.claims.authorization_epoch != authorization_epoch
+        || authorization.claims.provider_id.as_slice() != raw.2.as_slice()
+        || authorization.claims.settlement_account_id.as_slice() != raw.3.as_slice()
+        || authorization.claims.issuer_id != store.handle.expected_issuer_id
+        || authorization.operator_verifying_key != operator_verifying_key
+        || authorization
+            .verify_for(
+                &authorization.claims.provider_id,
+                &store.handle.expected_issuer_id,
+                &operator_key,
+                signature_time,
+                authorization_epoch,
+            )
+            .is_err()
+        || approval
+            .verify_for(
+                &authorization,
+                &settlement_key,
+                signature_time,
+                authorization_epoch,
+            )
+            .is_err()
+        || not_before != authorization.claims.not_before.max(approval.approved_at)
+        || not_after != approval.not_after
+    {
+        return Err(StoreError::SchemaMismatch(
+            "BAT V2 accounting authorization row is not canonical or root-bound".to_owned(),
+        ));
+    }
+    Ok(BatV2AccountingAuthorizationRecordV2 {
+        authorization_digest: *digest,
+        authorization_id: fixed_blob(raw.0, "invalid BAT V2 authorization id")?,
+        authorization_epoch,
+        provider_id: fixed_blob(raw.2, "invalid BAT V2 provider id")?,
+        settlement_account_id: fixed_blob(raw.3, "invalid BAT V2 settlement account")?,
+        operator_verifying_key,
+        issuer_settlement_verifying_key,
+        not_before,
+        not_after,
+        exact_authorization,
+        exact_approval,
+        commit: marker(
+            store,
+            db_u64(raw.10, "negative BAT V2 authorization commit")?,
+        ),
+    })
+}
+
+fn credit_provider_account(
+    connection: &Connection,
+    store: &IssuerStore,
+    provider_id: &[u8; 32],
+    account_id: &[u8; 32],
+    unit: SettlementUnitV1,
+    credit: u64,
+    sequence: u64,
+) -> StoreResult<()> {
+    let current: (i64, i64, i64) = connection.query_row(
+        "SELECT available_value, reserved_value, ledger_sequence FROM ledger_accounts \
+         WHERE issuer_id = ?1 AND provider_id = ?2 AND account_id = ?3 AND unit = ?4",
+        params![
+            store.handle.expected_issuer_id.as_slice(),
+            provider_id.as_slice(),
+            account_id.as_slice(),
+            unit as u8,
+        ],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )?;
+    let next = db_u64(current.0, "negative available ledger balance")?
+        .checked_add(credit)
+        .filter(|value| *value <= i64::MAX as u64)
+        .ok_or(StoreError::LedgerBalanceOverflow)?;
+    let ledger_sequence = db_u64(current.2, "negative ledger sequence")?
+        .checked_add(1)
+        .ok_or(StoreError::LedgerBalanceOverflow)?;
+    let changed = connection.execute(
+        "UPDATE ledger_accounts SET available_value = ?1, ledger_sequence = ?2, commit_seq = ?3 \
+         WHERE account_id = ?4 AND available_value = ?5 AND reserved_value = ?6 \
+         AND ledger_sequence = ?7",
+        params![
+            sql_integer(next, "available ledger balance exceeds SQLite range")?,
+            sql_integer(ledger_sequence, "ledger sequence exceeds SQLite range")?,
+            sql_integer(sequence, "commit sequence exceeds SQLite range")?,
+            account_id.as_slice(),
+            current.0,
+            current.1,
+            current.2,
+        ],
+    )?;
+    if changed != 1 {
+        return Err(StoreError::SchemaMismatch(
+            "BAT V2 provider ledger compare-and-set failed".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_bat_v2_ledger_transaction(
+    connection: &Connection,
+    store: &IssuerStore,
+    request: &ProviderRedeemRequestV2,
+    provider_credit: u64,
+    issuer_fee: u64,
+    transaction_id: &[u8; 32],
+    request_digest: &[u8; 32],
+    now_unix: u64,
+    sequence: u64,
+) -> StoreResult<()> {
+    connection.execute(
+        "INSERT INTO ledger_transactions (transaction_id, issuer_id, provider_id, kind, \
+         reference_digest, unit, created_at, commit_seq) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            transaction_id.as_slice(),
+            store.handle.expected_issuer_id.as_slice(),
+            request.provider_id.as_slice(),
+            BAT_V2_LEDGER_TRANSACTION_KIND,
+            request_digest.as_slice(),
+            request.unit as u8,
+            sql_integer(now_unix, "BAT V2 ledger time exceeds SQLite range")?,
+            sql_integer(sequence, "commit sequence exceeds SQLite range")?,
+        ],
+    )?;
+    let provider_credit =
+        i64::try_from(provider_credit).map_err(|_| StoreError::LedgerBalanceOverflow)?;
+    let accepted =
+        i64::try_from(request.accepted_value).map_err(|_| StoreError::LedgerBalanceOverflow)?;
+    connection.execute(
+        "INSERT INTO ledger_postings \
+         (transaction_id, line_no, account_kind, account_id, signed_amount) \
+         VALUES (?1, 1, ?2, ?3, ?4)",
+        params![
+            transaction_id.as_slice(),
+            ACCOUNT_KIND_PROVIDER,
+            request.settlement_account_id.as_slice(),
+            provider_credit,
+        ],
+    )?;
+    let mut source_line = 2i64;
+    if issuer_fee != 0 {
+        let issuer_fee =
+            i64::try_from(issuer_fee).map_err(|_| StoreError::LedgerBalanceOverflow)?;
+        connection.execute(
+            "INSERT INTO ledger_postings \
+             (transaction_id, line_no, account_kind, account_id, signed_amount) \
+             VALUES (?1, 2, ?2, ?3, ?4)",
+            params![
+                transaction_id.as_slice(),
+                ACCOUNT_KIND_ISSUER_FEE,
+                system_account_id(store, SYSTEM_ACCOUNT_ISSUER_FEE).as_slice(),
+                issuer_fee,
+            ],
+        )?;
+        source_line = 3;
+    }
+    connection.execute(
+        "INSERT INTO ledger_postings \
+         (transaction_id, line_no, account_kind, account_id, signed_amount) \
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            transaction_id.as_slice(),
+            source_line,
+            ACCOUNT_KIND_CREDENTIAL_SOURCE,
+            system_account_id(store, SYSTEM_ACCOUNT_CREDENTIAL_SOURCE).as_slice(),
+            -accepted,
+        ],
+    )?;
+    Ok(())
+}
+
+fn system_account_id(store: &IssuerStore, kind: u8) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(SYSTEM_LEDGER_ACCOUNT_ID_DOMAIN_V1);
+    hasher.update(store.handle.expected_issuer_id);
+    hasher.update([kind]);
+    hasher.finalize().into()
+}
+
+pub(crate) fn verify_all_bat_v2_clearing(
+    store: &IssuerStore,
+    connection: &Connection,
+) -> StoreResult<()> {
+    let mut statement = connection.prepare(
+        "SELECT authorization_digest FROM bat_v2_clearing_authorizations \
+         WHERE issuer_id = ?1 ORDER BY provider_id, authorization_epoch",
+    )?;
+    let digests = statement
+        .query_map([store.handle.expected_issuer_id.as_slice()], |row| {
+            row.get::<_, Vec<u8>>(0)
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    for digest in digests {
+        let digest = fixed_blob(digest, "invalid BAT V2 authorization digest")?;
+        if read_bat_v2_authorization(connection, store, &digest)?.is_none() {
+            return Err(StoreError::SchemaMismatch(
+                "BAT V2 accounting authorization disappeared during integrity read".to_owned(),
+            ));
+        }
+    }
+    let bad_epoch_order: i64 = connection.query_row(
+        "SELECT COUNT(*) FROM bat_v2_clearing_authorizations current \
+         WHERE EXISTS (SELECT 1 FROM bat_v2_clearing_authorizations prior \
+             WHERE prior.issuer_id = current.issuer_id \
+               AND prior.provider_id = current.provider_id \
+               AND prior.authorization_epoch < current.authorization_epoch \
+               AND prior.commit_seq >= current.commit_seq)",
+        [],
+        |row| row.get(0),
+    )?;
+    if bad_epoch_order != 0 {
+        return Err(StoreError::SchemaMismatch(
+            "BAT V2 authorization epoch and commit order disagree".to_owned(),
+        ));
+    }
+    verify_bat_v2_redemption_rows(store, connection)
+}
+
+fn verify_bat_v2_redemption_rows(store: &IssuerStore, connection: &Connection) -> StoreResult<()> {
+    let mut statement = connection.prepare(
+        "SELECT r.provider_id, r.attempt_id, r.request_digest, r.authorization_digest, \
+         r.settlement_account_id, r.class_id, r.class_key_epoch, r.class_digest, \
+         r.member_index, r.credential_digest, r.accepted_value, r.provider_credit, r.issuer_fee, \
+         r.unit, r.ledger_transaction_id, r.exact_initial_success, r.redeemed_at, r.commit_seq \
+         FROM bat_v2_redemptions r WHERE r.issuer_id = ?1 ORDER BY r.provider_id, r.attempt_id",
+    )?;
+    let mut rows = statement.query([store.handle.expected_issuer_id.as_slice()])?;
+    while let Some(row) = rows.next()? {
+        let provider_id: [u8; 32] = fixed_blob(row.get(0)?, "invalid BAT V2 redeem provider")?;
+        let attempt_id: [u8; 32] = fixed_blob(row.get(1)?, "invalid BAT V2 attempt")?;
+        let request_digest: [u8; 32] = fixed_blob(row.get(2)?, "invalid BAT V2 request digest")?;
+        let authorization_digest: [u8; 32] =
+            fixed_blob(row.get(3)?, "invalid BAT V2 authorization digest")?;
+        let account_id: [u8; 32] = fixed_blob(row.get(4)?, "invalid BAT V2 account")?;
+        let class_id: [u8; 32] = fixed_blob(row.get(5)?, "invalid BAT V2 class")?;
+        let class_epoch = db_u64(row.get(6)?, "negative BAT V2 class epoch")?;
+        let class_digest: [u8; 32] = fixed_blob(row.get(7)?, "invalid BAT V2 class digest")?;
+        let member_index = usize::try_from(row.get::<_, i64>(8)?)
+            .map_err(|_| StoreError::SchemaMismatch("invalid BAT V2 member index".to_owned()))?;
+        let credential_digest: [u8; 32] =
+            fixed_blob(row.get(9)?, "invalid BAT V2 credential digest")?;
+        let accepted_value = db_u64(row.get(10)?, "negative BAT V2 accepted value")?;
+        let provider_credit = db_u64(row.get(11)?, "negative BAT V2 provider credit")?;
+        let issuer_fee = db_u64(row.get(12)?, "negative BAT V2 issuer fee")?;
+        let unit = settlement_unit_from_db(row.get(13)?)?;
+        let ledger_transaction_id: [u8; 32] =
+            fixed_blob(row.get(14)?, "invalid BAT V2 ledger transaction")?;
+        let exact_success: Vec<u8> = row.get(15)?;
+        let redeemed_at = db_u64(row.get(16)?, "negative BAT V2 redeem time")?;
+        let redemption_commit = db_u64(row.get(17)?, "negative BAT V2 redeem commit")?;
+        let authorization = read_bat_v2_authorization(connection, store, &authorization_digest)?
+            .ok_or_else(|| {
+                StoreError::SchemaMismatch("BAT V2 redeem authorization missing".to_owned())
+            })?;
+        let (exact_authorization, _) = authorization.decode_exact()?;
+        let class = read_bat_acceptance_class_v2(connection, store, &class_id, class_epoch)?
+            .ok_or_else(|| StoreError::SchemaMismatch("BAT V2 redeem class missing".to_owned()))?;
+        let member = class
+            .members
+            .get(member_index)
+            .ok_or_else(|| StoreError::SchemaMismatch("BAT V2 redeem member missing".to_owned()))?;
+        let request = ProviderRedeemRequestV2 {
+            accounting_authorization_digest: authorization_digest,
+            issuer_id: store.handle.expected_issuer_id,
+            provider_id,
+            policy_digest: member.policy_digest,
+            scope_id: member.scope_id,
+            offer_id: member.offer_id,
+            class_id,
+            class_digest,
+            class_key_epoch: class_epoch,
+            bat_key_id: class.bat_key_id,
+            credential_digest,
+            unit,
+            accepted_value,
+            settlement_account_id: account_id,
+            attempt_id,
+        };
+        let rule = exact_authorization
+            .claims
+            .rules
+            .iter()
+            .find(|rule| {
+                rule.class_id == class_id
+                    && rule.policy_digest == member.policy_digest
+                    && rule.scope_id == member.scope_id
+                    && rule.offer_id == member.offer_id
+            })
+            .ok_or_else(|| {
+                StoreError::SchemaMismatch("BAT V2 redeem accounting rule missing".to_owned())
+            })?;
+        let response = ProviderRedeemResponseV2::decode(&exact_success)?;
+        let settlement_key =
+            VerifyingKey::from_bytes(&authorization.issuer_settlement_verifying_key)
+                .map_err(|_| StoreError::SchemaMismatch("invalid settlement root".to_owned()))?;
+        if request.request_digest()? != request_digest
+            || bat_v2_redeem_ledger_transaction_id_v2(&request)? != ledger_transaction_id
+            || response.encode()? != exact_success
+            || response
+                .verify_for_exact_request(&request, &settlement_key)
+                .is_err()
+            || authorization.provider_id != provider_id
+            || authorization.settlement_account_id != account_id
+            || member.provider_id != provider_id
+            || class.artifact_digest != class_digest
+            || rule.unit != unit
+            || rule.accepted_value != accepted_value
+            || rule.provider_credit != provider_credit
+            || rule.issuer_fee != issuer_fee
+            || redeemed_at < authorization.not_before
+            || redeemed_at > authorization.not_after
+            || redeemed_at < class.key_not_before
+            || redeemed_at > class.key_not_after
+            || redeemed_at > member.redemption_deadline
+            || !matches!(
+                response.outcome,
+                ProviderRedeemOutcomeV2::GrantableSuccess {
+                    account_id: response_account,
+                    ledger_transaction_id: response_transaction,
+                    unit: response_unit,
+                    accepted_value: response_accepted,
+                    provider_credit: response_credit,
+                    issuer_fee: response_fee,
+                } if response_account == account_id
+                    && response_transaction == ledger_transaction_id
+                    && response_unit == unit
+                    && response_accepted == accepted_value
+                    && response_credit == provider_credit
+                    && response_fee == issuer_fee
+            )
+        {
+            return Err(StoreError::SchemaMismatch(
+                "BAT V2 redemption row or exact initial success is inconsistent".to_owned(),
+            ));
+        }
+        let superseded_at_commit: bool = connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM bat_v2_clearing_authorizations later \
+             WHERE later.issuer_id = ?1 AND later.provider_id = ?2 \
+               AND later.authorization_epoch > ?3 AND later.commit_seq <= ?4)",
+            params![
+                store.handle.expected_issuer_id.as_slice(),
+                provider_id.as_slice(),
+                sql_integer(
+                    authorization.authorization_epoch,
+                    "BAT V2 authorization epoch exceeds SQLite range"
+                )?,
+                sql_integer(
+                    redemption_commit,
+                    "BAT V2 redeem commit exceeds SQLite range"
+                )?,
+            ],
+            |row| row.get(0),
+        )?;
+        if superseded_at_commit {
+            return Err(StoreError::SchemaMismatch(
+                "BAT V2 redemption used a superseded authorization".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn settlement_unit_from_db(value: i64) -> StoreResult<SettlementUnitV1> {
+    match value {
+        1 => Ok(SettlementUnitV1::MilliSatoshi),
+        2 => Ok(SettlementUnitV1::Satoshi),
+        3 => Ok(SettlementUnitV1::AuthCredit),
+        _ => Err(StoreError::SchemaMismatch(
+            "invalid BAT V2 ledger unit".to_owned(),
+        )),
+    }
+}
+
+fn marker(store: &IssuerStore, sequence: u64) -> CommitMarker {
+    CommitMarker {
+        store_instance_id: store.handle.expected_store_instance_id,
+        commit_seq: sequence,
+    }
+}

--- a/crates/payment/issuer-store/src/bat_v2_clearing_ops.rs
+++ b/crates/payment/issuer-store/src/bat_v2_clearing_ops.rs
@@ -61,6 +61,11 @@ impl<'a> IssuerBatV2RedeemCommitterV2<'a> {
 impl BatV2RedeemCommitStoreV2 for IssuerBatV2RedeemCommitterV2<'_> {
     type Error = StoreError;
 
+    fn attempt_is_committed(&self, request: &ProviderRedeemRequestV2) -> Result<bool, Self::Error> {
+        self.store
+            .bat_v2_attempt_is_committed(&request.provider_id, &request.attempt_id)
+    }
+
     fn commit_fresh(
         &mut self,
         verified: &VerifiedBatV2RedeemCommitV2,

--- a/crates/payment/issuer-store/src/clearing_ops.rs
+++ b/crates/payment/issuer-store/src/clearing_ops.rs
@@ -1,3 +1,4 @@
+use crate::bat_v2_clearing_ops::{ensure_ledger_account, ensure_provider_account_binding};
 use crate::db::{
     advance_store_generation, commit, db_u64, fixed_blob, is_zero, sql_integer,
     verify_expected_identity,
@@ -219,6 +220,22 @@ impl IssuerStore {
             &digest,
         )?;
         let sequence = committed_identity.commit_seq;
+        ensure_provider_account_binding(
+            &transaction,
+            self,
+            &candidate.provider_id,
+            &candidate.settlement_account_id,
+            SettlementUnitV1::AuthCredit,
+            sequence,
+        )?;
+        ensure_ledger_account(
+            &transaction,
+            self,
+            &candidate.provider_id,
+            &candidate.settlement_account_id,
+            SettlementUnitV1::AuthCredit,
+            sequence,
+        )?;
         transaction.execute(
             "INSERT INTO provider_registrations (issuer_id, provider_id, registration_epoch, \
              registration_digest, settlement_account_id, provider_request_verifying_key, \
@@ -266,19 +283,6 @@ impl IssuerStore {
                     candidate.not_after,
                     "registration not_after exceeds SQLite range"
                 )?,
-                sql_integer(sequence, "commit sequence exceeds SQLite range")?,
-            ],
-        )?;
-        transaction.execute(
-            "INSERT INTO ledger_accounts (account_id, issuer_id, provider_id, unit, \
-             available_value, reserved_value, ledger_sequence, commit_seq) \
-             VALUES (?1, ?2, ?3, ?4, 0, 0, 0, ?5) \
-             ON CONFLICT(account_id) DO UPDATE SET commit_seq = excluded.commit_seq",
-            params![
-                candidate.settlement_account_id.as_slice(),
-                self.handle.expected_issuer_id.as_slice(),
-                candidate.provider_id.as_slice(),
-                SettlementUnitV1::AuthCredit as u8,
                 sql_integer(sequence, "commit sequence exceeds SQLite range")?,
             ],
         )?;
@@ -546,7 +550,8 @@ impl IssuerStore {
         }
         let spent: Option<i64> = transaction
             .query_row(
-                "SELECT 1 FROM redemptions WHERE credential_spend_key = ?1",
+                "SELECT 1 FROM redemptions WHERE credential_spend_key = ?1 \
+                 UNION ALL SELECT 1 FROM bat_v2_redemptions WHERE global_spend_key = ?1 LIMIT 1",
                 params![redeem.spend_key.as_slice()],
                 |row| row.get(0),
             )

--- a/crates/payment/issuer-store/src/db.rs
+++ b/crates/payment/issuer-store/src/db.rs
@@ -306,7 +306,10 @@ fn run_integrity_checks(connection: &Connection, handle: &StoreHandle) -> StoreR
             (SELECT COUNT(*) FROM bat_v2_class_artifacts WHERE issuer_id != ?1) + \
             (SELECT COUNT(*) FROM bat_v2_class_heads WHERE issuer_id != ?1) + \
             (SELECT COUNT(*) FROM bat_v2_class_members WHERE issuer_id != ?1) + \
+            (SELECT COUNT(*) FROM bat_v2_clearing_authorizations WHERE issuer_id != ?1) + \
+            (SELECT COUNT(*) FROM bat_v2_redemptions WHERE issuer_id != ?1) + \
             (SELECT COUNT(*) FROM settlement_key_lineages WHERE issuer_id != ?1) + \
+            (SELECT COUNT(*) FROM provider_account_bindings WHERE issuer_id != ?1) + \
             (SELECT COUNT(*) FROM provider_registration_history WHERE issuer_id != ?1) + \
             (SELECT COUNT(*) FROM provider_registrations WHERE issuer_id != ?1) + \
             (SELECT COUNT(*) FROM clearing_authorizations WHERE issuer_id != ?1) + \
@@ -441,9 +444,23 @@ fn run_integrity_checks(connection: &Connection, handle: &StoreHandle) -> StoreR
                 ON t.transaction_id = r.ledger_transaction_id \
                 WHERE t.transaction_id IS NULL OR t.reference_digest != r.request_digest \
                 OR t.provider_id != r.provider_id OR t.unit != r.unit) + \
-            (SELECT COUNT(*) FROM ledger_accounts a LEFT JOIN provider_registrations p \
-                ON p.provider_id = a.provider_id \
-                WHERE p.provider_id IS NULL OR p.settlement_account_id != a.account_id) + \
+            (SELECT COUNT(*) FROM bat_v2_redemptions r LEFT JOIN ledger_transactions t \
+                ON t.transaction_id = r.ledger_transaction_id \
+                WHERE t.transaction_id IS NULL OR t.reference_digest != r.request_digest \
+                OR t.provider_id != r.provider_id OR t.unit != r.unit OR t.kind != 7) + \
+            (SELECT COUNT(*) FROM ledger_accounts a LEFT JOIN provider_account_bindings b \
+                ON b.issuer_id = a.issuer_id AND b.provider_id = a.provider_id \
+                AND b.settlement_account_id = a.account_id \
+                WHERE b.provider_id IS NULL OR b.unit != a.unit) + \
+            (SELECT COUNT(*) FROM provider_registrations p LEFT JOIN provider_account_bindings b \
+                ON b.issuer_id = p.issuer_id AND b.provider_id = p.provider_id \
+                AND b.settlement_account_id = p.settlement_account_id \
+                WHERE b.provider_id IS NULL) + \
+            (SELECT COUNT(*) FROM bat_v2_clearing_authorizations a \
+                LEFT JOIN provider_account_bindings b ON b.issuer_id = a.issuer_id \
+                AND b.provider_id = a.provider_id \
+                AND b.settlement_account_id = a.settlement_account_id \
+                WHERE b.provider_id IS NULL) + \
             (SELECT COUNT(*) FROM settlement_deposits d LEFT JOIN ledger_transactions t \
                 ON t.transaction_id = d.ledger_transaction_id \
                 WHERE t.transaction_id IS NULL OR t.reference_digest != d.request_digest \
@@ -488,6 +505,18 @@ fn run_integrity_checks(connection: &Connection, handle: &StoreHandle) -> StoreR
         ));
     }
 
+    let cross_protocol_bat_spends: i64 = connection.query_row(
+        "SELECT COUNT(*) FROM redemptions v1 JOIN bat_v2_redemptions v2 \
+         ON v2.global_spend_key = v1.credential_spend_key",
+        [],
+        |row| row.get(0),
+    )?;
+    if cross_protocol_bat_spends != 0 {
+        return Err(StoreError::SchemaMismatch(
+            "one BAT spend key is committed in both V1 and V2".to_owned(),
+        ));
+    }
+
     let identity = read_identity(connection)?;
     let max_referenced: i64 = connection.query_row(
         "SELECT MAX(value) FROM (\
@@ -503,7 +532,10 @@ fn run_integrity_checks(connection: &Connection, handle: &StoreHandle) -> StoreR
             UNION ALL SELECT commit_seq FROM bat_v2_class_artifacts \
             UNION ALL SELECT commit_seq FROM bat_v2_class_heads \
             UNION ALL SELECT commit_seq FROM bat_v2_class_members \
+            UNION ALL SELECT commit_seq FROM bat_v2_clearing_authorizations \
+            UNION ALL SELECT commit_seq FROM bat_v2_redemptions \
             UNION ALL SELECT commit_seq FROM settlement_key_lineages \
+            UNION ALL SELECT commit_seq FROM provider_account_bindings \
             UNION ALL SELECT commit_seq FROM provider_registration_history \
             UNION ALL SELECT commit_seq FROM provider_registrations \
             UNION ALL SELECT commit_seq FROM clearing_authorizations \

--- a/crates/payment/issuer-store/src/error.rs
+++ b/crates/payment/issuer-store/src/error.rs
@@ -64,8 +64,12 @@ pub enum StoreError {
     SettlementKeyLineageConflict,
     ProviderRegistrationRollback,
     ProviderRegistrationFork,
+    ProviderAccountBindingConflict,
     ClearingAuthorizationRollback,
     ClearingAuthorizationFork,
+    BatV2ClearingAuthorizationRollback,
+    BatV2ClearingAuthorizationFork,
+    BatV2RedeemPreconditionChanged,
     RedeemIdempotencyConflict,
     CredentialAlreadySpent,
     LedgerBalanceOverflow,
@@ -248,12 +252,28 @@ impl fmt::Display for StoreError {
                 f,
                 "different provider settlement registration at an accepted epoch rejected"
             ),
+            Self::ProviderAccountBindingConflict => write!(
+                f,
+                "provider settlement account differs from its immutable issuer binding"
+            ),
             Self::ClearingAuthorizationRollback => {
                 write!(f, "provider clearing authorization epoch rollback rejected")
             }
             Self::ClearingAuthorizationFork => write!(
                 f,
                 "different provider clearing authorization at an accepted epoch rejected"
+            ),
+            Self::BatV2ClearingAuthorizationRollback => write!(
+                f,
+                "BAT V2 provider accounting authorization epoch rollback rejected"
+            ),
+            Self::BatV2ClearingAuthorizationFork => write!(
+                f,
+                "different BAT V2 provider accounting authorization at an accepted epoch rejected"
+            ),
+            Self::BatV2RedeemPreconditionChanged => write!(
+                f,
+                "BAT V2 redeem authorization, account, or class precondition changed before commit"
             ),
             Self::RedeemIdempotencyConflict => {
                 write!(f, "redeem idempotency key conflicts with durable state")

--- a/crates/payment/issuer-store/src/lib.rs
+++ b/crates/payment/issuer-store/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![forbid(unsafe_code)]
 
+mod bat_v2_clearing_ops;
 mod bat_v2_ops;
 mod clearing_ops;
 mod db;
@@ -30,20 +31,22 @@ pub use sqlite_rollback::SqliteIssuerRollbackFloorAuthorityV1;
 pub use types::{
     ArcKeyLineageV1, AuthenticatedQuoteStatus, BatAcceptanceClassMemberRecordV2,
     BatAcceptanceClassRecordV2, BatKeyLineage, BatKeyLineageRegistration,
-    BatV2ClaimCryptographicVerificationInputV2, BatV2ClaimCryptographicVerifierV2, BatV2ClaimWrite,
-    BatV2CredentialMaterialRequirementV2, BatV2QuoteReservation,
-    ClaimCryptographicVerificationInput, ClaimCryptographicVerifier, ClaimRecord, ClaimWrite,
-    ClearingAuthorizationRecordV1, CommitMarker, DelegationAdvance, DelegationHead, DurableWrite,
-    IssuerServicePolicyRecordV1, IssuerStoreOperationalInventoryV1, LedgerTransactionKindV1,
-    PayoutIntentRecordV1, PayoutOutboxCommandV1, PayoutOutboxStateV1, PayoutRecordV1,
-    ProviderLedgerBalanceV1, ProviderSettlementRegistrationRecordV1,
-    ProviderSettlementRegistrationWriteV1, QuoteCapacityV1, QuoteExpiry, QuoteFinalization,
-    QuoteReconciliationCandidateV1, QuoteRecord, QuoteReservation, QuoteSettlement, QuoteState,
-    QuoteStatusBip340Input, QuoteStatusBip340Verifier, ReceiptSerial, RedeemRecordV1,
-    SettlementDepositRecordV1, SettlementKeyLineage, SettlementKeyLineageRegistration,
-    SharedCredentialCryptographicVerifierV1, SharedCredentialSpendSinkV1,
-    SharedCredentialVerificationInputV1, StoreIdentity, StoreOptions, VerifiedRedeemCommitV1,
-    VerifiedSharedIssuerRedeemV1, WriteDisposition, MAX_EXACT_BAT_V2_CLASS_BYTES,
+    BatV2AccountingAuthorizationRecordV2, BatV2ClaimCryptographicVerificationInputV2,
+    BatV2ClaimCryptographicVerifierV2, BatV2ClaimWrite, BatV2CredentialMaterialRequirementV2,
+    BatV2QuoteReservation, ClaimCryptographicVerificationInput, ClaimCryptographicVerifier,
+    ClaimRecord, ClaimWrite, ClearingAuthorizationRecordV1, CommitMarker, DelegationAdvance,
+    DelegationHead, DurableWrite, IssuerServicePolicyRecordV1, IssuerStoreOperationalInventoryV1,
+    LedgerTransactionKindV1, PayoutIntentRecordV1, PayoutOutboxCommandV1, PayoutOutboxStateV1,
+    PayoutRecordV1, ProviderAccountBindingRecordV2, ProviderLedgerBalanceV1,
+    ProviderSettlementRegistrationRecordV1, ProviderSettlementRegistrationWriteV1, QuoteCapacityV1,
+    QuoteExpiry, QuoteFinalization, QuoteReconciliationCandidateV1, QuoteRecord, QuoteReservation,
+    QuoteSettlement, QuoteState, QuoteStatusBip340Input, QuoteStatusBip340Verifier, ReceiptSerial,
+    RedeemRecordV1, SettlementDepositRecordV1, SettlementKeyLineage,
+    SettlementKeyLineageRegistration, SharedCredentialCryptographicVerifierV1,
+    SharedCredentialSpendSinkV1, SharedCredentialVerificationInputV1, StoreIdentity, StoreOptions,
+    VerifiedRedeemCommitV1, VerifiedSharedIssuerRedeemV1, WriteDisposition,
+    MAX_EXACT_BAT_V2_ACCOUNTING_APPROVAL_BYTES, MAX_EXACT_BAT_V2_ACCOUNTING_AUTHORIZATION_BYTES,
+    MAX_EXACT_BAT_V2_CLASS_BYTES, MAX_EXACT_BAT_V2_REDEEM_SUCCESS_BYTES,
     MAX_EXACT_CLAIM_REQUEST_BYTES, MAX_EXACT_CLAIM_RESPONSE_BYTES,
     MAX_EXACT_CLEARING_APPROVAL_BYTES, MAX_EXACT_CLEARING_AUTHORIZATION_BYTES,
     MAX_EXACT_DELEGATION_BYTES, MAX_EXACT_INTENT_BYTES, MAX_EXACT_PAYOUT_INTENT_REQUEST_BYTES,
@@ -54,6 +57,8 @@ pub use types::{
     MAX_EXACT_SETTLEMENT_DEPOSIT_RESPONSE_BYTES, MAX_INVOICE_BYTES, MAX_RECEIPT_SERIALS_PER_CLAIM,
     MAX_SIGNED_QUOTE_BYTES, SCHEMA_VERSION,
 };
+
+pub use bat_v2_clearing_ops::IssuerBatV2RedeemCommitterV2;
 
 pub use clearing_ops::{
     issuer_redeem_ledger_transaction_id_v1, issuer_settlement_deposit_transaction_id_v1,
@@ -236,7 +241,7 @@ impl IssuerStore {
     /// material.
     pub fn operational_inventory(&self) -> StoreResult<IssuerStoreOperationalInventoryV1> {
         let connection = self.open_checked(false)?;
-        type RawInventory = (i64, i64, i64, i64, i64, i64, i64, i64, i64);
+        type RawInventory = (i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64);
         let raw: RawInventory = connection.query_row(
             "SELECT (SELECT commit_seq FROM store_identity WHERE singleton = 1), \
                     (SELECT COUNT(*) FROM quotes), \
@@ -245,7 +250,10 @@ impl IssuerStore {
                     (SELECT COUNT(*) FROM bat_v2_class_artifacts), \
                     (SELECT COUNT(*) FROM bat_v2_class_heads), \
                     (SELECT COUNT(*) FROM bat_v2_class_members), \
+                    (SELECT COUNT(*) FROM provider_account_bindings), \
+                    (SELECT COUNT(*) FROM bat_v2_clearing_authorizations), \
                     (SELECT COUNT(*) FROM redemptions), \
+                    (SELECT COUNT(*) FROM bat_v2_redemptions), \
                     (SELECT COUNT(*) FROM payouts)",
             [],
             |row| {
@@ -259,6 +267,9 @@ impl IssuerStore {
                     row.get(6)?,
                     row.get(7)?,
                     row.get(8)?,
+                    row.get(9)?,
+                    row.get(10)?,
+                    row.get(11)?,
                 ))
             },
         )?;
@@ -270,8 +281,17 @@ impl IssuerStore {
             bat_v2_class_rows: db::db_u64(raw.4, "negative BAT V2 class row count")?,
             bat_v2_class_head_rows: db::db_u64(raw.5, "negative BAT V2 class head row count")?,
             bat_v2_class_member_rows: db::db_u64(raw.6, "negative BAT V2 class member row count")?,
-            redemption_rows: db::db_u64(raw.7, "negative redemption row count")?,
-            payout_rows: db::db_u64(raw.8, "negative payout row count")?,
+            provider_account_binding_rows: db::db_u64(
+                raw.7,
+                "negative provider account binding row count",
+            )?,
+            bat_v2_accounting_authorization_rows: db::db_u64(
+                raw.8,
+                "negative BAT V2 accounting authorization row count",
+            )?,
+            redemption_rows: db::db_u64(raw.9, "negative redemption row count")?,
+            bat_v2_redemption_rows: db::db_u64(raw.10, "negative BAT V2 redemption row count")?,
+            payout_rows: db::db_u64(raw.11, "negative payout row count")?,
         };
         self.confirm_anchored_read(&connection, inventory)
     }
@@ -299,6 +319,7 @@ impl IssuerStore {
             quote_ops::verify_all_quote_histories(self, &connection)?;
             clearing_ops::verify_all_provider_registration_histories(self, &connection)?;
             bat_v2_ops::verify_all_bat_acceptance_classes_v2(self, &connection)?;
+            bat_v2_clearing_ops::verify_all_bat_v2_clearing(self, &connection)?;
         }
         Ok(connection)
     }

--- a/crates/payment/issuer-store/src/quote_ops.rs
+++ b/crates/payment/issuer-store/src/quote_ops.rs
@@ -1515,10 +1515,15 @@ impl IssuerStore {
         self.confirm_anchored_read(&connection, candidates)
     }
 
-    /// Enumerate BAT key epochs needed either for one fresh acquisition from
-    /// a live current class head or for recovery of an unfinished historical
-    /// V2 quote. Terminal and out-of-horizon historical epochs do not pin key
-    /// material.
+    /// Enumerate BAT key epochs needed for one fresh acquisition from a live
+    /// current class head, recovery of an unfinished historical V2 quote, or
+    /// redemption of an already-issued credential while its retained class
+    /// and at least one member remain redeemable.
+    ///
+    /// Each result carries the exact compressed public key that identifies a
+    /// required private mint scalar in the caller's keyring. This store never
+    /// persists or returns the scalar itself. Duplicate requirements from the
+    /// three retention sources are collapsed by `(class_id, key_epoch)`.
     pub fn bat_v2_credential_material_requirements(
         &self,
         now_unix: u64,
@@ -1555,6 +1560,46 @@ impl IssuerStore {
                 )
             })?;
             referenced.insert((intent.class_id, intent.class_key_epoch));
+        }
+
+        let mut issued_statement = connection.prepare(
+            "SELECT q.intent_replay_image
+             FROM claims c
+             JOIN quotes q ON q.quote_id = c.quote_id
+             WHERE q.quote_protocol = 2 AND q.issuer_id = ?1
+             ORDER BY q.quote_id",
+        )?;
+        let issued_replay_images = issued_statement
+            .query_map([self.handle.expected_issuer_id.as_slice()], |row| {
+                row.get::<_, Vec<u8>>(0)
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        drop(issued_statement);
+        for replay_image in issued_replay_images {
+            let intent = Bolt11BatV2QuoteIntentV2::decode(&replay_image).map_err(|_| {
+                StoreError::SchemaMismatch(
+                    "issued BAT V2 credential has an invalid replay intent".to_owned(),
+                )
+            })?;
+            let class = read_bat_acceptance_class_v2(
+                &connection,
+                self,
+                &intent.class_id,
+                intent.class_key_epoch,
+            )?
+            .ok_or_else(|| {
+                StoreError::SchemaMismatch(
+                    "issued BAT V2 credential references a missing class epoch".to_owned(),
+                )
+            })?;
+            if class.key_not_after >= now_unix
+                && class
+                    .members
+                    .iter()
+                    .any(|member| member.redemption_deadline >= now_unix)
+            {
+                referenced.insert((intent.class_id, intent.class_key_epoch));
+            }
         }
 
         let mut head_statement = connection.prepare(

--- a/crates/payment/issuer-store/src/schema.rs
+++ b/crates/payment/issuer-store/src/schema.rs
@@ -1,5 +1,7 @@
 use crate::{
-    MAX_EXACT_BAT_V2_CLASS_BYTES, MAX_EXACT_CLAIM_REQUEST_BYTES, MAX_EXACT_CLAIM_RESPONSE_BYTES,
+    MAX_EXACT_BAT_V2_ACCOUNTING_APPROVAL_BYTES, MAX_EXACT_BAT_V2_ACCOUNTING_AUTHORIZATION_BYTES,
+    MAX_EXACT_BAT_V2_CLASS_BYTES, MAX_EXACT_BAT_V2_REDEEM_SUCCESS_BYTES,
+    MAX_EXACT_CLAIM_REQUEST_BYTES, MAX_EXACT_CLAIM_RESPONSE_BYTES,
     MAX_EXACT_CLEARING_APPROVAL_BYTES, MAX_EXACT_CLEARING_AUTHORIZATION_BYTES,
     MAX_EXACT_DELEGATION_BYTES, MAX_EXACT_INTENT_BYTES, MAX_EXACT_PAYOUT_INTENT_REQUEST_BYTES,
     MAX_EXACT_PAYOUT_INTENT_RESPONSE_BYTES, MAX_EXACT_PAYOUT_REQUEST_BYTES,
@@ -382,6 +384,7 @@ pub(crate) fn bat_v2_class_artifacts_sql() -> String {
     commit_seq            INTEGER NOT NULL CHECK (commit_seq > 0),
     PRIMARY KEY (issuer_id, class_id, key_epoch),
     UNIQUE (issuer_id, artifact_digest),
+    UNIQUE (issuer_id, class_id, key_epoch, artifact_digest),
     UNIQUE (issuer_id, raw_public_key),
     UNIQUE (issuer_id, key_fingerprint),
     UNIQUE (issuer_id, bat_key_id)
@@ -556,7 +559,10 @@ pub(crate) const PROVIDER_REGISTRATIONS_SQL: &str = r#"CREATE TABLE provider_reg
     ),
     not_before                    INTEGER NOT NULL CHECK (not_before > 0),
     not_after                     INTEGER NOT NULL CHECK (not_after >= not_before),
-    commit_seq                    INTEGER NOT NULL CHECK (commit_seq > 0)
+    commit_seq                    INTEGER NOT NULL CHECK (commit_seq > 0),
+    FOREIGN KEY (issuer_id, provider_id, settlement_account_id)
+        REFERENCES provider_account_bindings(issuer_id, provider_id, settlement_account_id)
+        ON DELETE RESTRICT
 ) STRICT, WITHOUT ROWID"#;
 
 /// Append-only provider request-key history used only to authenticate an
@@ -589,6 +595,73 @@ pub(crate) const PROVIDER_REGISTRATION_HISTORY_SQL: &str = r#"CREATE TABLE provi
     commit_seq                    INTEGER NOT NULL CHECK (commit_seq > 0),
     UNIQUE (issuer_id, provider_id, registration_epoch)
 ) STRICT, WITHOUT ROWID"#;
+
+/// Immutable account ownership shared by V1 and V2 clearing. Neither protocol
+/// is allowed to manufacture a registration row in the other's namespace.
+pub(crate) const PROVIDER_ACCOUNT_BINDINGS_SQL: &str = r#"CREATE TABLE provider_account_bindings (
+    issuer_id            BLOB NOT NULL CHECK (
+        length(issuer_id) = 32 AND issuer_id != zeroblob(32)
+    ),
+    provider_id          BLOB NOT NULL CHECK (
+        length(provider_id) = 32 AND provider_id != zeroblob(32)
+    ),
+    settlement_account_id BLOB NOT NULL CHECK (
+        length(settlement_account_id) = 32 AND settlement_account_id != zeroblob(32)
+    ),
+    unit                 INTEGER NOT NULL CHECK (unit BETWEEN 1 AND 3),
+    commit_seq           INTEGER NOT NULL CHECK (commit_seq > 0),
+    PRIMARY KEY (issuer_id, provider_id),
+    UNIQUE (issuer_id, settlement_account_id),
+    UNIQUE (issuer_id, provider_id, settlement_account_id),
+    UNIQUE (provider_id),
+    UNIQUE (settlement_account_id)
+) STRICT, WITHOUT ROWID"#;
+
+pub(crate) fn bat_v2_clearing_authorizations_sql() -> String {
+    format!(
+        r#"CREATE TABLE bat_v2_clearing_authorizations (
+    authorization_digest          BLOB NOT NULL PRIMARY KEY CHECK (
+        length(authorization_digest) = 32 AND authorization_digest != zeroblob(32)
+    ),
+    issuer_id                     BLOB NOT NULL CHECK (
+        length(issuer_id) = 32 AND issuer_id != zeroblob(32)
+    ),
+    authorization_id              BLOB NOT NULL CHECK (
+        length(authorization_id) = 16 AND authorization_id != zeroblob(16)
+    ),
+    authorization_epoch           INTEGER NOT NULL CHECK (authorization_epoch > 0),
+    provider_id                   BLOB NOT NULL CHECK (
+        length(provider_id) = 32 AND provider_id != zeroblob(32)
+    ),
+    settlement_account_id         BLOB NOT NULL CHECK (
+        length(settlement_account_id) = 32 AND settlement_account_id != zeroblob(32)
+    ),
+    operator_verifying_key        BLOB NOT NULL CHECK (
+        length(operator_verifying_key) = 32 AND operator_verifying_key != zeroblob(32)
+    ),
+    issuer_settlement_verifying_key BLOB NOT NULL CHECK (
+        length(issuer_settlement_verifying_key) = 32 AND
+        issuer_settlement_verifying_key != zeroblob(32)
+    ),
+    not_before                    INTEGER NOT NULL CHECK (not_before > 0),
+    not_after                     INTEGER NOT NULL CHECK (not_after >= not_before),
+    exact_authorization           BLOB NOT NULL CHECK (
+        length(exact_authorization) BETWEEN 1 AND {max_authorization}
+    ),
+    exact_approval                BLOB NOT NULL CHECK (
+        length(exact_approval) BETWEEN 1 AND {max_approval}
+    ),
+    commit_seq                    INTEGER NOT NULL CHECK (commit_seq > 0),
+    UNIQUE (issuer_id, authorization_digest),
+    UNIQUE (issuer_id, provider_id, authorization_epoch),
+    FOREIGN KEY (issuer_id, provider_id, settlement_account_id)
+        REFERENCES provider_account_bindings(issuer_id, provider_id, settlement_account_id)
+        ON DELETE RESTRICT
+) STRICT, WITHOUT ROWID"#,
+        max_authorization = MAX_EXACT_BAT_V2_ACCOUNTING_AUTHORIZATION_BYTES,
+        max_approval = MAX_EXACT_BAT_V2_ACCOUNTING_APPROVAL_BYTES,
+    )
+}
 
 pub(crate) fn redemptions_sql() -> String {
     format!(
@@ -645,6 +718,77 @@ pub(crate) fn redemptions_sql() -> String {
     )
 }
 
+pub(crate) fn bat_v2_redemptions_sql() -> String {
+    format!(
+        r#"CREATE TABLE bat_v2_redemptions (
+    issuer_id                    BLOB NOT NULL CHECK (
+        length(issuer_id) = 32 AND issuer_id != zeroblob(32)
+    ),
+    provider_id                  BLOB NOT NULL CHECK (
+        length(provider_id) = 32 AND provider_id != zeroblob(32)
+    ),
+    attempt_id                   BLOB NOT NULL CHECK (
+        length(attempt_id) = 32 AND attempt_id != zeroblob(32)
+    ),
+    request_digest               BLOB NOT NULL UNIQUE CHECK (
+        length(request_digest) = 32 AND request_digest != zeroblob(32)
+    ),
+    authorization_digest         BLOB NOT NULL CHECK (
+        length(authorization_digest) = 32 AND authorization_digest != zeroblob(32)
+    ),
+    settlement_account_id        BLOB NOT NULL CHECK (
+        length(settlement_account_id) = 32 AND settlement_account_id != zeroblob(32)
+    ),
+    class_id                     BLOB NOT NULL CHECK (
+        length(class_id) = 32 AND class_id != zeroblob(32)
+    ),
+    class_key_epoch              INTEGER NOT NULL CHECK (class_key_epoch > 0),
+    class_digest                 BLOB NOT NULL CHECK (
+        length(class_digest) = 32 AND class_digest != zeroblob(32)
+    ),
+    member_index                 INTEGER NOT NULL CHECK (
+        member_index BETWEEN 0 AND {max_member_index}
+    ),
+    credential_digest            BLOB NOT NULL CHECK (
+        length(credential_digest) = 32 AND credential_digest != zeroblob(32)
+    ),
+    global_spend_key             BLOB NOT NULL UNIQUE CHECK (
+        length(global_spend_key) = 32 AND global_spend_key != zeroblob(32)
+    ),
+    accepted_value               INTEGER NOT NULL CHECK (accepted_value > 0),
+    provider_credit              INTEGER NOT NULL CHECK (provider_credit > 0),
+    issuer_fee                   INTEGER NOT NULL CHECK (issuer_fee >= 0),
+    unit                         INTEGER NOT NULL CHECK (unit BETWEEN 1 AND 3),
+    ledger_transaction_id        BLOB NOT NULL UNIQUE CHECK (
+        length(ledger_transaction_id) = 32 AND ledger_transaction_id != zeroblob(32)
+    ),
+    exact_initial_success        BLOB NOT NULL CHECK (
+        length(exact_initial_success) BETWEEN 1 AND {max_success}
+    ),
+    redeemed_at                  INTEGER NOT NULL CHECK (redeemed_at > 0),
+    commit_seq                   INTEGER NOT NULL CHECK (commit_seq > 0),
+    PRIMARY KEY (issuer_id, provider_id, attempt_id),
+    FOREIGN KEY (issuer_id, authorization_digest)
+        REFERENCES bat_v2_clearing_authorizations(issuer_id, authorization_digest)
+        ON DELETE RESTRICT,
+    FOREIGN KEY (issuer_id, provider_id, settlement_account_id)
+        REFERENCES provider_account_bindings(issuer_id, provider_id, settlement_account_id)
+        ON DELETE RESTRICT,
+    FOREIGN KEY (issuer_id, class_id, class_key_epoch, class_digest)
+        REFERENCES bat_v2_class_artifacts(issuer_id, class_id, key_epoch, artifact_digest)
+        ON DELETE RESTRICT,
+    FOREIGN KEY (issuer_id, class_id, class_key_epoch, member_index)
+        REFERENCES bat_v2_class_members(issuer_id, class_id, key_epoch, member_index)
+        ON DELETE RESTRICT,
+    FOREIGN KEY (ledger_transaction_id)
+        REFERENCES ledger_transactions(transaction_id) ON DELETE RESTRICT,
+    CHECK (provider_credit + issuer_fee = accepted_value)
+) STRICT, WITHOUT ROWID"#,
+        max_member_index = MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2 - 1,
+        max_success = MAX_EXACT_BAT_V2_REDEEM_SUCCESS_BYTES,
+    )
+}
+
 pub(crate) const LEDGER_ACCOUNTS_SQL: &str = r#"CREATE TABLE ledger_accounts (
     account_id       BLOB NOT NULL PRIMARY KEY CHECK (
         length(account_id) = 32 AND account_id != zeroblob(32)
@@ -660,7 +804,9 @@ pub(crate) const LEDGER_ACCOUNTS_SQL: &str = r#"CREATE TABLE ledger_accounts (
     reserved_value   INTEGER NOT NULL CHECK (reserved_value >= 0),
     ledger_sequence  INTEGER NOT NULL CHECK (ledger_sequence >= 0),
     commit_seq       INTEGER NOT NULL CHECK (commit_seq > 0),
-    FOREIGN KEY (provider_id) REFERENCES provider_registrations(provider_id) ON DELETE RESTRICT
+    FOREIGN KEY (issuer_id, provider_id, account_id)
+        REFERENCES provider_account_bindings(issuer_id, provider_id, settlement_account_id)
+        ON DELETE RESTRICT
 ) STRICT, WITHOUT ROWID"#;
 
 pub(crate) const LEDGER_TRANSACTIONS_SQL: &str = r#"CREATE TABLE ledger_transactions (
@@ -673,7 +819,7 @@ pub(crate) const LEDGER_TRANSACTIONS_SQL: &str = r#"CREATE TABLE ledger_transact
     provider_id     BLOB NOT NULL CHECK (
         length(provider_id) = 32 AND provider_id != zeroblob(32)
     ),
-    kind            INTEGER NOT NULL CHECK (kind BETWEEN 1 AND 6),
+    kind            INTEGER NOT NULL CHECK (kind BETWEEN 1 AND 7),
     reference_digest BLOB NOT NULL UNIQUE CHECK (
         length(reference_digest) = 32 AND reference_digest != zeroblob(32)
     ),
@@ -927,6 +1073,11 @@ pub(crate) fn schema() -> Vec<(&'static str, String)> {
         ("bat_v2_class_artifacts", bat_v2_class_artifacts_sql()),
         ("bat_v2_class_heads", BAT_V2_CLASS_HEADS_SQL.to_owned()),
         ("bat_v2_class_members", bat_v2_class_members_sql()),
+        (
+            "bat_v2_clearing_authorizations",
+            bat_v2_clearing_authorizations_sql(),
+        ),
+        ("bat_v2_redemptions", bat_v2_redemptions_sql()),
         ("claims", claims_sql()),
         ("clearing_authorizations", clearing_authorizations_sql()),
         (
@@ -948,6 +1099,10 @@ pub(crate) fn schema() -> Vec<(&'static str, String)> {
         ("payout_intents", payout_intents_sql()),
         ("payout_outbox", PAYOUT_OUTBOX_SQL.to_owned()),
         ("payouts", payouts_sql()),
+        (
+            "provider_account_bindings",
+            PROVIDER_ACCOUNT_BINDINGS_SQL.to_owned(),
+        ),
         (
             "provider_registration_history",
             PROVIDER_REGISTRATION_HISTORY_SQL.to_owned(),

--- a/crates/payment/issuer-store/src/types.rs
+++ b/crates/payment/issuer-store/src/types.rs
@@ -1,7 +1,8 @@
 use pir_service_protocol::{
     AuthScheme, BatV2IssuanceResponseV2, Bolt11BatV2ClaimEnvelopeV2, Bolt11QuoteClaimV1,
     CheckedBatV2IssuanceResponseV2, CredentialIssuanceRequestV1, CredentialIssuanceResponseV1,
-    CredentialKeyBindingV1, IssuerClearingApprovalV1, LightningNetworkV1, PayoutStateV1,
+    CredentialKeyBindingV1, IssuerAccountingApprovalV2, IssuerClearingApprovalV1,
+    LightningNetworkV1, PayoutStateV1, ProviderAccountingAuthorizationV2,
     ProviderClearingAuthorizationV1, ProviderRedeemRequestV1, ProviderRedeemResponseV1,
     ServiceProtocolError, SettlementUnitV1,
 };
@@ -10,10 +11,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// On-disk schema version. This crate never performs an implicit migration.
-/// Version 7 is a fresh-schema boundary for protocol-discriminated BAT V2
-/// acquisition records; existing version-6 stores must be migrated by an explicit,
-/// separately reviewed operation.
-pub const SCHEMA_VERSION: u32 = 7;
+/// Version 8 is a fresh-schema boundary for issuer-global BAT V2 redemption
+/// and protocol-neutral provider-account bindings. This crate never upgrades
+/// a version-7 store implicitly; deployment must isolate a fresh v8 store or
+/// use an explicit, separately reviewed migration.
+pub const SCHEMA_VERSION: u32 = 8;
 
 pub const MAX_EXACT_INTENT_BYTES: usize = 64 * 1024;
 pub const MAX_EXACT_DELEGATION_BYTES: usize = 64 * 1024;
@@ -38,6 +40,12 @@ pub const MAX_EXACT_SERVICE_POLICY_BYTES: usize = pir_service_protocol::MAX_SIGN
 /// an artifact that the protocol layer cannot decode and re-encode exactly.
 pub const MAX_EXACT_BAT_V2_CLASS_BYTES: usize =
     pir_service_protocol::MAX_BAT_ACCEPTANCE_CLASS_LEN_V2;
+pub const MAX_EXACT_BAT_V2_ACCOUNTING_AUTHORIZATION_BYTES: usize =
+    pir_service_protocol::MAX_BAT_V2_PROVIDER_ACCOUNTING_AUTHORIZATION_LEN_V2;
+pub const MAX_EXACT_BAT_V2_ACCOUNTING_APPROVAL_BYTES: usize =
+    pir_service_protocol::BAT_V2_ISSUER_ACCOUNTING_APPROVAL_LEN_V2;
+pub const MAX_EXACT_BAT_V2_REDEEM_SUCCESS_BYTES: usize =
+    pir_service_protocol::MAX_BAT_V2_PROVIDER_REDEEM_RESPONSE_LEN_V2;
 /// V1 protocol acquisition cap. Store limits may not exceed the wire cap.
 pub const MAX_RECEIPT_SERIALS_PER_CLAIM: usize = 256;
 
@@ -86,7 +94,10 @@ pub struct IssuerStoreOperationalInventoryV1 {
     pub bat_v2_class_rows: u64,
     pub bat_v2_class_head_rows: u64,
     pub bat_v2_class_member_rows: u64,
+    pub provider_account_binding_rows: u64,
+    pub bat_v2_accounting_authorization_rows: u64,
     pub redemption_rows: u64,
+    pub bat_v2_redemption_rows: u64,
     pub payout_rows: u64,
 }
 
@@ -633,6 +644,51 @@ pub struct ClearingAuthorizationRecordV1 {
     pub commit: CommitMarker,
 }
 
+/// Protocol-neutral immutable binding between one provider and the one issuer
+/// ledger account into which both V1 and V2 clearing may post.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProviderAccountBindingRecordV2 {
+    pub provider_id: [u8; 32],
+    pub settlement_account_id: [u8; 32],
+    pub unit: SettlementUnitV1,
+    pub commit: CommitMarker,
+}
+
+/// Append-only, issuer-verified BAT V2 accounting authority. Exact encoded
+/// artifacts remain the only truth; duplicated columns are checked indexes.
+#[derive(Clone, Eq, PartialEq)]
+pub struct BatV2AccountingAuthorizationRecordV2 {
+    pub authorization_digest: [u8; 32],
+    pub authorization_id: [u8; 16],
+    pub authorization_epoch: u64,
+    pub provider_id: [u8; 32],
+    pub settlement_account_id: [u8; 32],
+    pub operator_verifying_key: [u8; 32],
+    pub issuer_settlement_verifying_key: [u8; 32],
+    pub not_before: u64,
+    pub not_after: u64,
+    pub exact_authorization: Vec<u8>,
+    pub exact_approval: Vec<u8>,
+    pub commit: CommitMarker,
+}
+
+impl BatV2AccountingAuthorizationRecordV2 {
+    pub fn decode_exact(
+        &self,
+    ) -> Result<
+        (
+            ProviderAccountingAuthorizationV2,
+            IssuerAccountingApprovalV2,
+        ),
+        ServiceProtocolError,
+    > {
+        Ok((
+            ProviderAccountingAuthorizationV2::decode(&self.exact_authorization)?,
+            IssuerAccountingApprovalV2::decode(&self.exact_approval)?,
+        ))
+    }
+}
+
 /// Exact inputs a reviewed shared-credential adapter must authenticate. The
 /// adapter returns its private cryptographic result only through the sink.
 pub struct SharedCredentialVerificationInputV1<'a> {
@@ -722,6 +778,7 @@ pub enum LedgerTransactionKindV1 {
     PayoutDebit = 4,
     PayoutSucceeded = 5,
     PayoutFailed = 6,
+    BatV2RedeemLedgerCredit = 7,
 }
 
 #[derive(Clone, Eq, PartialEq)]

--- a/crates/payment/issuer-store/src/types.rs
+++ b/crates/payment/issuer-store/src/types.rs
@@ -491,11 +491,16 @@ where
     }
 }
 
-/// One retained BAT key epoch still required by an unfinished V2 quote.
+/// One retained BAT key epoch whose private mint scalar must remain loaded.
+///
+/// `raw_public_key` is only the exact compressed-public-key locator used to
+/// select that scalar from an in-memory keyring. It is not the scalar itself;
+/// issuer-store never persists or returns BAT private key material.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BatV2CredentialMaterialRequirementV2 {
     pub class_id: [u8; 32],
     pub class_key_epoch: u64,
+    /// Exact compressed BAT verification key identifying the required scalar.
     pub raw_public_key: [u8; 33],
     pub bat_key_id: [u8; 32],
 }

--- a/crates/payment/issuer-store/tests/issuer_store.rs
+++ b/crates/payment/issuer-store/tests/issuer_store.rs
@@ -11,17 +11,24 @@ use pir_issuer_store::{
 };
 use pir_service_protocol::{
     derive_bat_key_id_v1, derive_cashu_keyset_id_v2, derive_issuer_id, paid_receipt_key_id,
-    AcquisitionMethod, AuthPaddingClassV1, AuthScheme, BackendId, BatAcceptanceClassV2,
-    BatAcceptanceMemberV2, BatAcceptanceTermsV2, BatV2IssuanceRequestV2, BatV2IssuanceResponseV2,
+    precheck_bat_v2_redeem_v2, sign_and_commit_grantable_success_v2,
+    verify_bat_v2_credential_for_commit_v2, AcquisitionMethod, AuthPaddingClassV1, AuthScheme,
+    BackendId, BatAcceptanceClassV2, BatAcceptanceMemberV2, BatAcceptanceTermsV2,
+    BatV2CredentialCheckV2, BatV2IssuanceRequestV2, BatV2IssuanceResponseV2,
+    BatV2ProofVerificationInputV2, BatV2RedeemCommitResultV2, BatV2RedeemPrecheckV2,
     BitcoinPirCashuBatIssuanceRequestItemV1, BitcoinPirCashuBatIssuanceResponseItemV1,
-    Bolt11BatV2ClaimEnvelopeV2, Bolt11BatV2QuoteIntentV2, Bolt11QuoteClaimV1, Bolt11QuoteIntentV1,
-    Bolt11QuoteKeyDelegationV1, Bolt11QuoteStatusRequestV1, Bolt11QuoteStatusV1, Bolt11QuoteV1,
-    CashuDenominationKeyV1, CredentialIssuanceRequestItemsV1, CredentialIssuanceRequestV1,
+    BitcoinPirCashuBatProofV2, Bolt11BatV2ClaimEnvelopeV2, Bolt11BatV2QuoteIntentV2,
+    Bolt11QuoteClaimV1, Bolt11QuoteIntentV1, Bolt11QuoteKeyDelegationV1,
+    Bolt11QuoteStatusRequestV1, Bolt11QuoteStatusV1, Bolt11QuoteV1, CashuDenominationKeyV1,
+    CredentialIssuanceRequestItemsV1, CredentialIssuanceRequestV1,
     CredentialIssuanceResponseItemsV1, CredentialIssuanceResponseV1, DatasetBindingV1,
-    DeploymentStatus, EntitlementLimitsV1, FreeModeV1, LightningNetworkV1, PaidReceiptBindingV1,
-    PaidReceiptV1, PriceV1, PrivacyLeakageV1, ServiceOfferV1, ServicePolicyV1,
-    ServiceScopePolicyV1, ServiceScopeV1, VerificationMode, WorkloadId,
-    BOLT11_QUOTE_SIGNATURE_DOMAIN,
+    DeploymentStatus, EntitlementLimitsV1, FreeModeV1, IssuerAccountingApprovalV2,
+    LightningNetworkV1, PaidReceiptBindingV1, PaidReceiptV1, PriceV1, PrivacyLeakageV1,
+    ProviderAccountingAuthorizationClaimsV2, ProviderAccountingAuthorizationV2,
+    ProviderAccountingExpectationV2, ProviderAccountingRuleV2, ProviderRedeemEnvelopeV2,
+    ProviderRedeemRequestAuthV2, ServiceOfferV1, ServicePolicyV1, ServiceScopePolicyV1,
+    ServiceScopeV1, SettlementUnitV1, VerificationMode, VerifiedBatAcceptanceMemberV2,
+    VerifiedBatV2RedeemCommitV2, WorkloadId, BOLT11_QUOTE_SIGNATURE_DOMAIN,
 };
 use rusqlite::Connection;
 use std::path::{Path, PathBuf};
@@ -394,6 +401,188 @@ fn bat_v2_class_with_validity(
         &root_key(),
     )
     .expect("sign BAT V2 class")
+}
+
+#[derive(Clone)]
+struct BatV2RedemptionAuthorityFixture {
+    authorization: ProviderAccountingAuthorizationV2,
+    approval: IssuerAccountingApprovalV2,
+    operator_key: SigningKey,
+    clearing_key: SigningKey,
+    settlement_key: SigningKey,
+}
+
+fn bat_v2_verified_member(
+    class: &BatAcceptanceClassV2,
+    member: &BatAcceptanceMemberV2,
+) -> VerifiedBatAcceptanceMemberV2 {
+    VerifiedBatAcceptanceMemberV2 {
+        issuer_id: class.issuer_id,
+        class_id: class.class_id,
+        member: member.clone(),
+        common_terms: class.common_terms.clone(),
+        policy_issued_at: 100,
+        policy_expires_at: 1_000,
+        redemption_deadline: 1_480,
+    }
+}
+
+fn bat_v2_redemption_authority(
+    store: &IssuerStore,
+    class: &BatAcceptanceClassV2,
+    member: &BatAcceptanceMemberV2,
+    account_byte: u8,
+    key_byte: u8,
+    epoch: u64,
+) -> BatV2RedemptionAuthorityFixture {
+    let operator_key = SigningKey::from_bytes(&[key_byte; 32]);
+    let clearing_key = SigningKey::from_bytes(&[key_byte.wrapping_add(1); 32]);
+    let settlement_key = SigningKey::from_bytes(&[0xd1; 32]);
+    let authorization = ProviderAccountingAuthorizationV2::sign(
+        ProviderAccountingAuthorizationClaimsV2 {
+            authorization_id: [key_byte.wrapping_add(2); 16],
+            authorization_epoch: epoch,
+            provider_id: member.provider_id,
+            issuer_id: issuer_id(),
+            redeem_endpoint: "https://issuer.invalid".to_owned(),
+            redeem_leaf_spki_sha256_pins: vec![[key_byte.wrapping_add(3); 32]],
+            settlement_account_id: [account_byte; 32],
+            clearing_verifying_key: clearing_key.verifying_key().to_bytes(),
+            not_before: 100,
+            not_after: 2_000,
+            rules: vec![ProviderAccountingRuleV2 {
+                class_id: class.class_id,
+                policy_digest: member.policy_digest,
+                scope_id: member.scope_id,
+                offer_id: member.offer_id,
+                unit: SettlementUnitV1::AuthCredit,
+                accepted_value: 10,
+                provider_credit: 7,
+                issuer_fee: 3,
+            }],
+        },
+        &operator_key,
+    )
+    .expect("sign BAT V2 accounting authorization");
+    let approval = IssuerAccountingApprovalV2::sign(&authorization, 200, 2_000, &settlement_key)
+        .expect("sign BAT V2 issuer approval");
+    let _ = store
+        .register_bat_v2_accounting_authorization(
+            &authorization,
+            &approval,
+            &operator_key.verifying_key(),
+            &settlement_key.verifying_key(),
+            200,
+        )
+        .expect("register BAT V2 accounting authorization");
+    BatV2RedemptionAuthorityFixture {
+        authorization,
+        approval,
+        operator_key,
+        clearing_key,
+        settlement_key,
+    }
+}
+
+fn bat_v2_redemption_precheck(
+    class: &BatAcceptanceClassV2,
+    member: &VerifiedBatAcceptanceMemberV2,
+    authority: &BatV2RedemptionAuthorityFixture,
+    attempt_byte: u8,
+    secret_byte: u8,
+    now_unix: u64,
+) -> BatV2RedeemPrecheckV2 {
+    let proof = BitcoinPirCashuBatProofV2::from_class(
+        class,
+        [secret_byte; 32],
+        point(u64::from(secret_byte) + 100),
+    )
+    .expect("construct BAT V2 proof");
+    let (request, _) = pir_service_protocol::ProviderRedeemRequestV2::prepare(
+        &authority.authorization,
+        member,
+        class,
+        &proof,
+        [attempt_byte; 32],
+    )
+    .expect("prepare BAT V2 redeem request")
+    .into_parts();
+    let request_auth = ProviderRedeemRequestAuthV2::sign(&request, &authority.clearing_key)
+        .expect("sign BAT V2 request");
+    precheck_bat_v2_redeem_v2(
+        ProviderRedeemEnvelopeV2 {
+            request,
+            request_auth,
+            credential: proof,
+        },
+        &authority.authorization,
+        &authority.approval,
+        class,
+        member,
+        ProviderAccountingExpectationV2 {
+            provider_id: member.member.provider_id,
+            issuer_id: issuer_id(),
+            operator_verifying_key: &authority.operator_key.verifying_key(),
+            issuer_settlement_verifying_key: &authority.settlement_key.verifying_key(),
+            now_unix,
+            minimum_authorization_epoch: authority.authorization.claims.authorization_epoch,
+        },
+    )
+    .expect("precheck BAT V2 redeem")
+}
+
+fn bat_v2_verified_redeem(
+    class: &BatAcceptanceClassV2,
+    member: &VerifiedBatAcceptanceMemberV2,
+    authority: &BatV2RedemptionAuthorityFixture,
+    attempt_byte: u8,
+    secret_byte: u8,
+    now_unix: u64,
+) -> VerifiedBatV2RedeemCommitV2 {
+    let BatV2RedeemPrecheckV2::Authorized(authorized) = bat_v2_redemption_precheck(
+        class,
+        member,
+        authority,
+        attempt_byte,
+        secret_byte,
+        now_unix,
+    ) else {
+        panic!("BAT V2 redeem should be authorized")
+    };
+    fn accept_bat_v2_proof(_input: BatV2ProofVerificationInputV2<'_>) -> Result<bool, ()> {
+        Ok(true)
+    }
+    let verified = verify_bat_v2_credential_for_commit_v2(*authorized, &accept_bat_v2_proof)
+        .expect("verify BAT V2 credential");
+    let BatV2CredentialCheckV2::Verified(verified) = verified else {
+        panic!("BAT V2 credential should be valid")
+    };
+    verified
+}
+
+fn install_bat_v2_redemption_class(
+    store: &IssuerStore,
+    class_id: [u8; 32],
+    key_epoch: u64,
+    raw_key_multiplier: u64,
+    policy_epoch: u64,
+) -> (BatAcceptanceClassV2, Vec<VerifiedBatAcceptanceMemberV2>) {
+    let members = register_bat_v2_members(store, class_id, policy_epoch);
+    let class = bat_v2_class(
+        class_id,
+        key_epoch,
+        raw_key_multiplier,
+        bat_v2_terms(),
+        members.clone(),
+    );
+    let _ = store
+        .register_bat_acceptance_class_v2(&class, 200)
+        .expect("register BAT V2 redemption class");
+    let verified = members
+        .iter()
+        .map(|member| bat_v2_verified_member(&class, member))
+        .collect();
+    (class, verified)
 }
 
 fn xonly(multiplier: u64) -> [u8; 32] {
@@ -3121,12 +3310,12 @@ fn bat_v2_registry_rejects_bidirectional_legacy_raw_key_reuse() {
 }
 
 #[test]
-fn bat_v2_acquisition_schema_v7_rejects_implicit_v6_open() {
+fn bat_v2_redemption_schema_v8_rejects_implicit_v7_open() {
     let test_path = TestPath::new();
     let store = create_store(&test_path);
     drop(store);
     let connection = Connection::open(&test_path.database).unwrap();
-    connection.pragma_update(None, "user_version", 6).unwrap();
+    connection.pragma_update(None, "user_version", 7).unwrap();
     drop(connection);
     assert!(matches!(
         open_store(&test_path),
@@ -3176,4 +3365,410 @@ fn schema_extension_and_semantic_backend_label_corruption_fail_closed() {
         ),
         Err(StoreError::SchemaMismatch(_))
     ));
+}
+
+#[test]
+fn bat_v2_redemption_v1_registration_uses_neutral_binding_and_reopens() {
+    let test_path = TestPath::new();
+    let store = create_store(&test_path);
+    let provider_id = [0x31; 32];
+    let account_id = [0x32; 32];
+    let _ = store
+        .register_provider_settlement(&ProviderSettlementRegistrationWriteV1 {
+            registration_epoch: 1,
+            provider_id,
+            settlement_account_id: account_id,
+            provider_request_verifying_key: SigningKey::from_bytes(&[0x33; 32])
+                .verifying_key()
+                .to_bytes(),
+            payout_target_id: [0x34; 32],
+            not_before: 100,
+            not_after: 2_000,
+        })
+        .expect("register V1 provider through neutral account binding");
+    let inventory = store.operational_inventory().unwrap();
+    assert_eq!(inventory.provider_account_binding_rows, 1);
+    assert_eq!(inventory.bat_v2_accounting_authorization_rows, 0);
+    assert_eq!(inventory.bat_v2_redemption_rows, 0);
+    assert_eq!(
+        store
+            .provider_ledger_balance(&provider_id)
+            .unwrap()
+            .unwrap()
+            .account_id,
+        account_id
+    );
+    drop(store);
+
+    let reopened = open_store(&test_path).expect("reopen v8 store with V1 registration");
+    assert_eq!(
+        reopened
+            .provider_settlement_registration(&provider_id)
+            .unwrap()
+            .unwrap()
+            .settlement_account_id,
+        account_id
+    );
+    assert_eq!(
+        reopened
+            .operational_inventory()
+            .unwrap()
+            .provider_account_binding_rows,
+        1
+    );
+}
+
+#[test]
+fn bat_v2_redemption_authorization_replay_epoch_fork_and_account_mismatch() {
+    let test_path = TestPath::new();
+    let store = create_store(&test_path);
+    let (class, members) = install_bat_v2_redemption_class(&store, [0x81; 32], 1, 81, 1);
+    let first = bat_v2_redemption_authority(&store, &class, &members[0].member, 0x82, 0x83, 1);
+    let replay = store
+        .register_bat_v2_accounting_authorization(
+            &first.authorization,
+            &first.approval,
+            &first.operator_key.verifying_key(),
+            &first.settlement_key.verifying_key(),
+            200,
+        )
+        .unwrap();
+    assert_eq!(replay.disposition, WriteDisposition::ExactReplay);
+
+    let fork = ProviderAccountingAuthorizationV2::sign(
+        ProviderAccountingAuthorizationClaimsV2 {
+            authorization_id: [0x84; 16],
+            ..first.authorization.claims.clone()
+        },
+        &first.operator_key,
+    )
+    .unwrap();
+    let fork_approval =
+        IssuerAccountingApprovalV2::sign(&fork, 200, 2_000, &first.settlement_key).unwrap();
+    assert!(matches!(
+        store.register_bat_v2_accounting_authorization(
+            &fork,
+            &fork_approval,
+            &first.operator_key.verifying_key(),
+            &first.settlement_key.verifying_key(),
+            200,
+        ),
+        Err(StoreError::BatV2ClearingAuthorizationFork)
+    ));
+
+    let second = ProviderAccountingAuthorizationV2::sign(
+        ProviderAccountingAuthorizationClaimsV2 {
+            authorization_id: [0x85; 16],
+            authorization_epoch: 2,
+            ..first.authorization.claims.clone()
+        },
+        &first.operator_key,
+    )
+    .unwrap();
+    let second_approval =
+        IssuerAccountingApprovalV2::sign(&second, 200, 2_000, &first.settlement_key).unwrap();
+    let _ = store
+        .register_bat_v2_accounting_authorization(
+            &second,
+            &second_approval,
+            &first.operator_key.verifying_key(),
+            &first.settlement_key.verifying_key(),
+            200,
+        )
+        .expect("append BAT V2 authorization epoch");
+    assert_eq!(
+        store
+            .current_bat_v2_accounting_authorization(&members[0].member.provider_id)
+            .unwrap()
+            .unwrap()
+            .authorization_epoch,
+        2
+    );
+
+    let rollback = ProviderAccountingAuthorizationV2::sign(
+        ProviderAccountingAuthorizationClaimsV2 {
+            authorization_id: [0x86; 16],
+            ..first.authorization.claims.clone()
+        },
+        &first.operator_key,
+    )
+    .unwrap();
+    let rollback_approval =
+        IssuerAccountingApprovalV2::sign(&rollback, 200, 2_000, &first.settlement_key).unwrap();
+    assert!(matches!(
+        store.register_bat_v2_accounting_authorization(
+            &rollback,
+            &rollback_approval,
+            &first.operator_key.verifying_key(),
+            &first.settlement_key.verifying_key(),
+            200,
+        ),
+        Err(StoreError::BatV2ClearingAuthorizationRollback)
+    ));
+
+    let before_account_fork = store.identity().unwrap().commit_seq;
+    let account_fork = ProviderAccountingAuthorizationV2::sign(
+        ProviderAccountingAuthorizationClaimsV2 {
+            authorization_id: [0x87; 16],
+            authorization_epoch: 3,
+            settlement_account_id: [0x88; 32],
+            ..first.authorization.claims.clone()
+        },
+        &first.operator_key,
+    )
+    .unwrap();
+    let account_fork_approval =
+        IssuerAccountingApprovalV2::sign(&account_fork, 200, 2_000, &first.settlement_key).unwrap();
+    assert!(matches!(
+        store.register_bat_v2_accounting_authorization(
+            &account_fork,
+            &account_fork_approval,
+            &first.operator_key.verifying_key(),
+            &first.settlement_key.verifying_key(),
+            200,
+        ),
+        Err(StoreError::ProviderAccountBindingConflict)
+    ));
+    assert_eq!(store.identity().unwrap().commit_seq, before_account_fork);
+}
+
+#[test]
+fn bat_v2_redemption_same_proof_two_providers_has_one_global_winner_and_no_restart_grant() {
+    let test_path = TestPath::new();
+    let store = Arc::new(create_store(&test_path));
+    let (class, members) = install_bat_v2_redemption_class(store.as_ref(), [0x91; 32], 1, 91, 1);
+    let authorities = [
+        bat_v2_redemption_authority(store.as_ref(), &class, &members[0].member, 0x92, 0x93, 1),
+        bat_v2_redemption_authority(store.as_ref(), &class, &members[1].member, 0x94, 0x95, 1),
+    ];
+    let verified = [
+        bat_v2_verified_redeem(&class, &members[0], &authorities[0], 0x96, 0x97, 400),
+        bat_v2_verified_redeem(&class, &members[1], &authorities[1], 0x98, 0x97, 400),
+    ];
+    let barrier = Arc::new(Barrier::new(2));
+    let workers = verified
+        .into_iter()
+        .zip(authorities.clone())
+        .map(|(verified, authority)| {
+            let store = Arc::clone(&store);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                let mut committer = store.bat_v2_redeem_committer(400).unwrap();
+                sign_and_commit_grantable_success_v2(
+                    verified,
+                    &authority.settlement_key,
+                    &mut committer,
+                )
+                .expect("commit or classify globally spent BAT V2 proof")
+            })
+        })
+        .collect::<Vec<_>>();
+    let outcomes = workers
+        .into_iter()
+        .map(|worker| worker.join().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, BatV2RedeemCommitResultV2::FreshCommitted(_)))
+            .count(),
+        1
+    );
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(
+                outcome,
+                BatV2RedeemCommitResultV2::TerminalInvalidOrSpent(_)
+            ))
+            .count(),
+        1
+    );
+    assert_eq!(
+        members
+            .iter()
+            .map(|member| {
+                store
+                    .provider_ledger_balance(&member.member.provider_id)
+                    .unwrap()
+                    .unwrap()
+                    .available_value
+            })
+            .sum::<u64>(),
+        7
+    );
+    assert_eq!(
+        store
+            .operational_inventory()
+            .unwrap()
+            .bat_v2_redemption_rows,
+        1
+    );
+    let ledger_rows: i64 = Connection::open(&test_path.database)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM ledger_transactions WHERE kind = 7",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(ledger_rows, 1);
+    let redemption_columns: Vec<String> = Connection::open(&test_path.database)
+        .unwrap()
+        .prepare("SELECT name FROM pragma_table_info('bat_v2_redemptions')")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    for forbidden in [
+        "raw_proof",
+        "proof",
+        "secret_raw",
+        "quote_id",
+        "request_replay_image",
+        "rejection_reason",
+    ] {
+        assert!(!redemption_columns.iter().any(|column| column == forbidden));
+    }
+    assert!(redemption_columns
+        .iter()
+        .any(|column| column == "exact_initial_success"));
+    drop(store);
+
+    let reopened = open_store(&test_path).expect("reopen committed BAT V2 redemption");
+    let replay = bat_v2_verified_redeem(&class, &members[0], &authorities[0], 0x96, 0x97, 400);
+    let mut committer = reopened.bat_v2_redeem_committer(400).unwrap();
+    assert!(matches!(
+        sign_and_commit_grantable_success_v2(
+            replay,
+            &authorities[0].settlement_key,
+            &mut committer,
+        )
+        .unwrap(),
+        BatV2RedeemCommitResultV2::TerminalInvalidOrSpent(_)
+    ));
+}
+
+#[test]
+fn bat_v2_redemption_bad_auth_account_and_member_are_zero_mutation_then_valid_succeeds() {
+    let test_path = TestPath::new();
+    let store = create_store(&test_path);
+    let (class, members) = install_bat_v2_redemption_class(&store, [0xa1; 32], 1, 101, 1);
+    let authority = bat_v2_redemption_authority(&store, &class, &members[0].member, 0xa2, 0xa3, 1);
+    let baseline = store.identity().unwrap().commit_seq;
+
+    let proof = BitcoinPirCashuBatProofV2::from_class(&class, [0xa4; 32], point(204)).unwrap();
+    let (base_request, _) = pir_service_protocol::ProviderRedeemRequestV2::prepare(
+        &authority.authorization,
+        &members[0],
+        &class,
+        &proof,
+        [0xa5; 32],
+    )
+    .unwrap()
+    .into_parts();
+    let classify = |request: pir_service_protocol::ProviderRedeemRequestV2,
+                    signing_key: &SigningKey| {
+        let request_auth = ProviderRedeemRequestAuthV2::sign(&request, signing_key).unwrap();
+        precheck_bat_v2_redeem_v2(
+            ProviderRedeemEnvelopeV2 {
+                request,
+                request_auth,
+                credential: proof.clone(),
+            },
+            &authority.authorization,
+            &authority.approval,
+            &class,
+            &members[0],
+            ProviderAccountingExpectationV2 {
+                provider_id: members[0].member.provider_id,
+                issuer_id: issuer_id(),
+                operator_verifying_key: &authority.operator_key.verifying_key(),
+                issuer_settlement_verifying_key: &authority.settlement_key.verifying_key(),
+                now_unix: 400,
+                minimum_authorization_epoch: 1,
+            },
+        )
+        .unwrap()
+    };
+    assert!(matches!(
+        classify(base_request.clone(), &SigningKey::from_bytes(&[0xa6; 32])),
+        BatV2RedeemPrecheckV2::RetrySafeNonConsuming(_)
+    ));
+    let mut wrong_account = base_request.clone();
+    wrong_account.settlement_account_id = [0xa7; 32];
+    assert!(matches!(
+        classify(wrong_account, &authority.clearing_key),
+        BatV2RedeemPrecheckV2::RetrySafeNonConsuming(_)
+    ));
+    let mut wrong_member = base_request;
+    wrong_member.policy_digest = [0xa8; 32];
+    assert!(matches!(
+        classify(wrong_member, &authority.clearing_key),
+        BatV2RedeemPrecheckV2::RetrySafeNonConsuming(_)
+    ));
+    assert_eq!(store.identity().unwrap().commit_seq, baseline);
+    assert_eq!(
+        store
+            .operational_inventory()
+            .unwrap()
+            .bat_v2_redemption_rows,
+        0
+    );
+
+    let verified = bat_v2_verified_redeem(&class, &members[0], &authority, 0xa9, 0xaa, 400);
+    let mut committer = store.bat_v2_redeem_committer(400).unwrap();
+    assert!(matches!(
+        sign_and_commit_grantable_success_v2(verified, &authority.settlement_key, &mut committer,)
+            .unwrap(),
+        BatV2RedeemCommitResultV2::FreshCommitted(_)
+    ));
+    assert_eq!(store.identity().unwrap().commit_seq, baseline + 1);
+}
+
+#[test]
+fn bat_v2_redemption_retained_member_works_until_exact_deadline_then_is_terminal() {
+    let test_path = TestPath::new();
+    let store = create_store(&test_path);
+    let class_id = [0xb1; 32];
+    let (first_class, first_members) = install_bat_v2_redemption_class(&store, class_id, 1, 111, 1);
+    let authority = bat_v2_redemption_authority(
+        &store,
+        &first_class,
+        &first_members[0].member,
+        0xb2,
+        0xb3,
+        1,
+    );
+    let _ = install_bat_v2_redemption_class(&store, class_id, 2, 112, 2);
+
+    let within = bat_v2_verified_redeem(
+        &first_class,
+        &first_members[0],
+        &authority,
+        0xb4,
+        0xb5,
+        1_480,
+    );
+    let mut committer = store.bat_v2_redeem_committer(1_480).unwrap();
+    assert!(matches!(
+        sign_and_commit_grantable_success_v2(within, &authority.settlement_key, &mut committer,)
+            .unwrap(),
+        BatV2RedeemCommitResultV2::FreshCommitted(_)
+    ));
+    let before_expired = store.identity().unwrap().commit_seq;
+    assert!(matches!(
+        bat_v2_redemption_precheck(
+            &first_class,
+            &first_members[0],
+            &authority,
+            0xb6,
+            0xb7,
+            1_481,
+        ),
+        BatV2RedeemPrecheckV2::TerminalInvalidOrSpent(_)
+    ));
+    assert_eq!(store.identity().unwrap().commit_seq, before_expired);
 }

--- a/crates/payment/issuer-store/tests/issuer_store.rs
+++ b/crates/payment/issuer-store/tests/issuer_store.rs
@@ -3113,12 +3113,24 @@ fn bat_v2_acquisition_claim_status_and_restart_are_protocol_isolated() {
     let _ = reopened
         .register_bat_acceptance_class_v2(&second_class, 400)
         .unwrap();
-    let terminal_old_epoch_does_not_pin = reopened
+    let issued_old_epoch_remains_pinned = reopened
         .bat_v2_credential_material_requirements(400)
         .unwrap();
-    assert_eq!(terminal_old_epoch_does_not_pin.len(), 1);
-    assert_eq!(terminal_old_epoch_does_not_pin[0].class_key_epoch, 2);
-    assert_eq!(terminal_old_epoch_does_not_pin[0].raw_public_key, point(77));
+    assert_eq!(issued_old_epoch_remains_pinned.len(), 2);
+    assert_eq!(issued_old_epoch_remains_pinned[0].class_key_epoch, 1);
+    assert_eq!(issued_old_epoch_remains_pinned[0].raw_public_key, point(76));
+    assert_eq!(issued_old_epoch_remains_pinned[1].class_key_epoch, 2);
+    assert_eq!(issued_old_epoch_remains_pinned[1].raw_public_key, point(77));
+    let at_redemption_deadline = reopened
+        .bat_v2_credential_material_requirements(1_480)
+        .unwrap();
+    assert_eq!(at_redemption_deadline.len(), 1);
+    assert_eq!(at_redemption_deadline[0].class_key_epoch, 1);
+    assert_eq!(at_redemption_deadline[0].raw_public_key, point(76));
+    assert!(reopened
+        .bat_v2_credential_material_requirements(1_481)
+        .unwrap()
+        .is_empty());
 
     let v1 = reserve_finalize_settle(&reopened, 0x7b, 0x7c, 0x7d);
     let v1_claim = claim(0x7b, v1.intent_digest, 0x7e, 0x7d, 0x7f, 0x25, 3);


### PR DESCRIPTION
## Summary
- bump fresh issuer stores to schema v8 with neutral provider-account bindings
- add append-only BAT V2 accounting authorizations and successful-redemption records
- enforce issuer-global V1/V2 spend exclusion inside BEGIN IMMEDIATE transactions
- re-read current authorization, retained class/member, account binding, and deadlines at commit time
- expose only committed-attempt existence; the exact initial success remains private integrity evidence and is never replayed as a grant

## Compatibility and migration
- V1 registration and redemption history keep their existing semantics
- v7 and older stores remain fail-closed; this PR does not perform an implicit SQLite or rollback-authority migration
- this PR does not add the HTTP service route, provider runtime, SDK/Web changes, or any production activation

## Verification
- cargo test --locked --offline -p pir-issuer-store bat_v2_redemption_ (6 passed)
- cargo test --locked --offline -p pir-issuer-store provider_registration_rotation_retains_digest_addressed_history -- --exact (1 passed)
- cargo check --locked --offline -p pir-issuer-store --all-targets
- cargo clippy --locked --offline -p pir-issuer-store --all-targets --no-deps -- -D warnings
- scoped rustfmt and diff checks passed

Independent P0/P1 review and security diff scan found no reportable issue.