### PR TITLE
Serve issuer-wide BAT V2 redemptions

### DIFF
--- a/apps/payment-issuer/src/main.rs
+++ b/apps/payment-issuer/src/main.rs
@@ -34,15 +34,16 @@ use pir_issuer_credentials::IssuerCredentialDerivationKeyV1;
 #[cfg(test)]
 use pir_issuer_service::SettlementPayoutPolicyV1;
 use pir_issuer_service::{
-    ensure_shared_clearing_binding_material_v1, IssuerAcquisitionServiceV1,
-    IssuerReconciliationBatchV1, IssuerServiceErrorV1, QuoteSigningMaterialV1,
-    ReceiptSigningMaterialV1, SharedIssuerClearingServiceV1, TrustedClearingProviderV1,
-    LEDGER_ONLY_DISABLED_PAYOUT_TARGET_ID_V1,
+    ensure_shared_clearing_binding_material_v1, BatV2IssuerRedemptionServiceV2,
+    IssuerAcquisitionServiceV1, IssuerReconciliationBatchV1, IssuerServiceErrorV1,
+    QuoteSigningMaterialV1, ReceiptSigningMaterialV1, SharedIssuerClearingServiceV1,
+    TrustedClearingProviderV1, LEDGER_ONLY_DISABLED_PAYOUT_TARGET_ID_V1,
 };
 use pir_issuer_store::{
     BatKeyLineageRegistration, IssuerRollbackFloorAuthorityV1, IssuerStore,
     ProviderSettlementRegistrationWriteV1, QuoteCapacityV1, RemoteIssuerRollbackFloorAuthorityV1,
-    SqliteIssuerRollbackFloorAuthorityV1, StoreOptions, MAX_EXACT_CLEARING_APPROVAL_BYTES,
+    SqliteIssuerRollbackFloorAuthorityV1, StoreOptions, MAX_EXACT_BAT_V2_ACCOUNTING_APPROVAL_BYTES,
+    MAX_EXACT_BAT_V2_ACCOUNTING_AUTHORIZATION_BYTES, MAX_EXACT_CLEARING_APPROVAL_BYTES,
     MAX_EXACT_CLEARING_AUTHORIZATION_BYTES, MAX_QUOTE_RECONCILIATION_BATCH_V1,
     SCHEMA_VERSION as ISSUER_STORE_SCHEMA_VERSION,
 };
@@ -61,14 +62,15 @@ use pir_rollback_authority_client::load_remote_rollback_authority_deployment_for
 use pir_service_protocol::{
     AuthScheme, BatAcceptanceClassV2, Bolt11BatV2ClaimEnvelopeV2, Bolt11BatV2QuoteIntentV2,
     Bolt11QuoteClaimEnvelopeV1, Bolt11QuoteIntentV1, Bolt11QuoteKeyDelegationV1,
-    IssuerClearingApprovalV1, LightningNetworkV1, ProviderClearingAuthorizationV1,
-    ProviderRedeemEnvelopeV1, ServicePolicyV1, SettlementModesV1, SettlementUnitV1,
+    IssuerAccountingApprovalV2, IssuerClearingApprovalV1, LightningNetworkV1,
+    ProviderAccountingAuthorizationV2, ProviderClearingAuthorizationV1, ProviderRedeemEnvelopeV1,
+    ServicePolicyV1, SettlementModesV1, SettlementUnitV1, BAT_V2_PROVIDER_REDEEM_ENVELOPE_LEN_V2,
     MAX_BAT_ACCEPTANCE_CLASS_LEN_V2, MAX_BAT_V2_CLAIM_ENVELOPE_LEN,
-    MAX_BAT_V2_ISSUANCE_RESPONSE_LEN, MAX_BAT_V2_QUOTE_INTENT_LEN,
-    MAX_BOLT11_QUOTE_CLAIM_ENVELOPE_LEN_V1, MAX_BOLT11_QUOTE_INTENT_LEN,
-    MAX_BOLT11_QUOTE_KEY_DELEGATION_LEN, MAX_BOLT11_QUOTE_STATUS_REQUEST_LEN,
-    MAX_CREDENTIAL_ISSUANCE_RESPONSE_LEN_V1, MAX_EXECUTABLE_SETTLEMENT_HTTP_ENVELOPE_LEN_V1,
-    MAX_PROVIDER_REDEEM_ENVELOPE_LEN_V1,
+    MAX_BAT_V2_ISSUANCE_RESPONSE_LEN, MAX_BAT_V2_PROVIDER_REDEEM_RESPONSE_LEN_V2,
+    MAX_BAT_V2_QUOTE_INTENT_LEN, MAX_BOLT11_QUOTE_CLAIM_ENVELOPE_LEN_V1,
+    MAX_BOLT11_QUOTE_INTENT_LEN, MAX_BOLT11_QUOTE_KEY_DELEGATION_LEN,
+    MAX_BOLT11_QUOTE_STATUS_REQUEST_LEN, MAX_CREDENTIAL_ISSUANCE_RESPONSE_LEN_V1,
+    MAX_EXECUTABLE_SETTLEMENT_HTTP_ENVELOPE_LEN_V1, MAX_PROVIDER_REDEEM_ENVELOPE_LEN_V1,
 };
 #[cfg(test)]
 use pir_service_protocol::{
@@ -87,6 +89,7 @@ const MAX_HTTP_BODY_BYTES: usize =
         MAX_BOLT11_QUOTE_CLAIM_ENVELOPE_LEN_V1
     };
 const _: () = assert!(MAX_PROVIDER_REDEEM_ENVELOPE_LEN_V1 <= MAX_HTTP_BODY_BYTES);
+const _: () = assert!(BAT_V2_PROVIDER_REDEEM_ENVELOPE_LEN_V2 <= MAX_HTTP_BODY_BYTES);
 const _: () = assert!(MAX_EXECUTABLE_SETTLEMENT_HTTP_ENVELOPE_LEN_V1 <= MAX_HTTP_BODY_BYTES);
 const MAX_HTTP_RESPONSE_BYTES: usize =
     if MAX_BAT_V2_ISSUANCE_RESPONSE_LEN > MAX_CREDENTIAL_ISSUANCE_RESPONSE_LEN_V1 {
@@ -119,6 +122,10 @@ const CT_ISSUANCE_RESPONSE: &str = "application/vnd.bitcoinpir.credential-issuan
 const CT_BAT_V2_ISSUANCE_RESPONSE: &str = "application/vnd.bitcoinpir.bat-v2-issuance-response-v2";
 const CT_REDEEM: &str = "application/vnd.bitcoinpir.redeem-v1";
 const CT_REDEEM_RESULT: &str = "application/vnd.bitcoinpir.redeem-result-v1";
+const CT_BAT_V2_REDEEM: &str = "application/vnd.bitcoinpir.bat-v2-provider-redeem-envelope-v2";
+const CT_BAT_V2_REDEEM_RESULT: &str =
+    "application/vnd.bitcoinpir.bat-v2-provider-redeem-response-v2";
+const _: () = assert!(MAX_BAT_V2_PROVIDER_REDEEM_RESPONSE_LEN_V2 <= MAX_HTTP_RESPONSE_BYTES);
 #[cfg(any(test, feature = "test-only-fake-lightning"))]
 const CT_FAKE_SETTLEMENT: &str = "application/vnd.bitcoinpir.fake-settlement-v1";
 const CT_BALANCE_ENVELOPE: &str = "application/vnd.bitcoinpir.provider-balance-envelope-v1";
@@ -339,6 +346,19 @@ struct ServeCommonArgs {
     /// production ledger-only mode.
     #[arg(long = "clearing-provider-request-verifying-key")]
     clearing_provider_request_verifying_keys: Vec<PathBuf>,
+    /// Repeat one canonical operator-signed BAT V2 provider accounting
+    /// authorization. V2 redemption is issuer-global and does not use the V1
+    /// provider registration, response-derivation key, or replay contract.
+    #[arg(long = "bat-v2-accounting-authorization")]
+    bat_v2_accounting_authorizations: Vec<PathBuf>,
+    /// Repeat one matching issuer BAT V2 accounting approval, in the same
+    /// order as its authorization.
+    #[arg(long = "bat-v2-accounting-approval")]
+    bat_v2_accounting_approvals: Vec<PathBuf>,
+    /// Repeat one independently pinned raw Ed25519 operator verifying key, in
+    /// the same order as the BAT V2 accounting authorization.
+    #[arg(long = "bat-v2-accounting-operator-verifying-key")]
+    bat_v2_accounting_operator_verifying_keys: Vec<PathBuf>,
     /// Issuer Ed25519 settlement signing key; required when clearing is enabled.
     #[arg(long)]
     issuer_settlement_signing_key: Option<PathBuf>,
@@ -472,6 +492,7 @@ struct ServerState {
     current_quote_delegation: Vec<u8>,
     quote_delegations: BTreeMap<[u8; 16], Vec<u8>>,
     clearing: Option<SharedIssuerClearingServiceV1>,
+    bat_v2_redemption: Option<BatV2IssuerRedemptionServiceV2>,
     store: IssuerStore,
     #[cfg(any(test, feature = "test-only-fake-lightning"))]
     fake_lightning: Option<Arc<FakeLightningNodeV1>>,
@@ -494,6 +515,7 @@ impl core::fmt::Debug for ServerState {
             .field("acquisition", &"[redacted]")
             .field("quote_delegation_count", &self.quote_delegations.len())
             .field("clearing", &self.clearing.is_some())
+            .field("bat_v2_redemption", &self.bat_v2_redemption.is_some())
             .field("store", &"[redacted]");
         #[cfg(any(test, feature = "test-only-fake-lightning"))]
         debug.field("fake_settlement_route", &self.fake_lightning.is_some());
@@ -776,6 +798,21 @@ fn is_exact_redeem_replay(store: &IssuerStore, canonical_envelope: &[u8]) -> boo
     store
         .redeem_by_idempotency(&envelope.request)
         .is_ok_and(|existing| existing.is_some())
+}
+
+fn require_bat_v2_mutation_budget(
+    committed_attempt: bool,
+    limiter: &FixedWindowRateLimiterV1,
+    now: Instant,
+) -> Result<(), IssuerServiceErrorV1> {
+    if committed_attempt || limiter.try_acquire(now) {
+        Ok(())
+    } else {
+        // The issuer received a credential-bearing request. Even though this
+        // process rejected it before commit, V2 never emits a generic retry
+        // instruction for an attempt the caller can no longer prove unsent.
+        Err(IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)
+    }
 }
 
 #[cfg(test)]
@@ -1639,7 +1676,17 @@ fn serve_with_backend(
         now_unix,
     )
     .map_err(|error| format!("build acquisition service failed: {error}"))?;
-    let clearing = load_ledger_clearing(&args, &store, bat_keyring, arc_keyring, now_unix)?;
+    let clearing = load_ledger_clearing(&args, &store, bat_keyring.clone(), arc_keyring, now_unix)?;
+    let bat_v2_redemption = load_bat_v2_redemption(&args, &store, bat_keyring, now_unix)?;
+    if args.issuer_settlement_signing_key.is_some()
+        && clearing.is_none()
+        && bat_v2_redemption.is_none()
+    {
+        return Err(
+            "--issuer-settlement-signing-key requires V1 clearing or BAT V2 accounting configuration"
+                .to_owned(),
+        );
+    }
     drop(policies);
 
     let listener = TcpListener::bind(args.bind)
@@ -1649,6 +1696,7 @@ fn serve_with_backend(
         current_quote_delegation: delegation_bytes,
         quote_delegations,
         clearing,
+        bat_v2_redemption,
         store,
         #[cfg(any(test, feature = "test-only-fake-lightning"))]
         fake_lightning: match lightning.as_ref() {
@@ -1879,6 +1927,136 @@ fn load_arc_keyring(specs: &[String]) -> Result<Option<Arc<ArcSecretKeyringV1>>,
         .map_err(|_| "experimental ARC keyring is invalid".to_owned())
 }
 
+/// Registers issuer-global BAT V2 accounting authority and builds the
+/// storeless redemption service. The provider operator roots are independent
+/// public trust inputs; no provider registration, provider-request key,
+/// response-derivation secret, or provider-local replay state is created.
+fn load_bat_v2_redemption(
+    args: &ServeCommonArgs,
+    store: &IssuerStore,
+    bat_keyring: Option<Arc<K256CashuMintKeyringV1>>,
+    now_unix: u64,
+) -> Result<Option<BatV2IssuerRedemptionServiceV2>, String> {
+    let any_configured = !args.bat_v2_accounting_authorizations.is_empty()
+        || !args.bat_v2_accounting_approvals.is_empty()
+        || !args.bat_v2_accounting_operator_verifying_keys.is_empty();
+    if !any_configured {
+        return Ok(None);
+    }
+    if args.bat_v2_accounting_authorizations.is_empty()
+        || args.bat_v2_accounting_authorizations.len() != args.bat_v2_accounting_approvals.len()
+        || args.bat_v2_accounting_authorizations.len()
+            != args.bat_v2_accounting_operator_verifying_keys.len()
+    {
+        return Err(
+            "BAT V2 redemption requires the same non-zero number of --bat-v2-accounting-authorization, --bat-v2-accounting-approval and --bat-v2-accounting-operator-verifying-key files"
+                .to_owned(),
+        );
+    }
+    let bat_keyring = bat_keyring
+        .ok_or_else(|| "BAT V2 redemption requires at least one --bat-key".to_owned())?;
+    let settlement_key_path = args
+        .issuer_settlement_signing_key
+        .as_deref()
+        .ok_or_else(|| "BAT V2 redemption requires --issuer-settlement-signing-key".to_owned())?;
+    let mut settlement_key_bytes =
+        read_secret_exact::<32>(settlement_key_path, "issuer settlement signing key")?;
+    let issuer_settlement_signing_key = SigningKey::from_bytes(&settlement_key_bytes);
+    settlement_key_bytes.zeroize();
+    let settlement_verifying_key = issuer_settlement_signing_key.verifying_key();
+    let identity = store
+        .identity()
+        .map_err(|error| format!("read issuer identity failed: {error}"))?;
+
+    let mut seen_providers = BTreeMap::new();
+    let mut seen_role_keys =
+        BTreeMap::from([(settlement_verifying_key.to_bytes(), "issuer settlement key")]);
+    for ((authorization_path, approval_path), operator_key_path) in args
+        .bat_v2_accounting_authorizations
+        .iter()
+        .zip(&args.bat_v2_accounting_approvals)
+        .zip(&args.bat_v2_accounting_operator_verifying_keys)
+    {
+        let authorization_bytes = read_public_file(
+            authorization_path,
+            MAX_EXACT_BAT_V2_ACCOUNTING_AUTHORIZATION_BYTES,
+            "BAT V2 accounting authorization",
+        )?;
+        let authorization = ProviderAccountingAuthorizationV2::decode(&authorization_bytes)
+            .map_err(|_| "BAT V2 accounting authorization is not canonical V2".to_owned())?;
+        if authorization
+            .encode()
+            .map_err(|_| "BAT V2 accounting authorization cannot be encoded".to_owned())?
+            != authorization_bytes
+        {
+            return Err("BAT V2 accounting authorization is non-canonical".to_owned());
+        }
+        let approval_bytes = read_public_file(
+            approval_path,
+            MAX_EXACT_BAT_V2_ACCOUNTING_APPROVAL_BYTES,
+            "BAT V2 accounting approval",
+        )?;
+        let approval = IssuerAccountingApprovalV2::decode(&approval_bytes)
+            .map_err(|_| "BAT V2 accounting approval is not canonical V2".to_owned())?;
+        if approval.encode().as_slice() != approval_bytes.as_slice() {
+            return Err("BAT V2 accounting approval is non-canonical".to_owned());
+        }
+        let operator_key_bytes = read_public_file(
+            operator_key_path,
+            32,
+            "BAT V2 accounting operator verifying key",
+        )?;
+        let operator_key_bytes: [u8; 32] = operator_key_bytes
+            .try_into()
+            .map_err(|_| "BAT V2 accounting operator verifying key must be 32 bytes".to_owned())?;
+        let operator_key = VerifyingKey::from_bytes(&operator_key_bytes)
+            .map_err(|_| "BAT V2 accounting operator verifying key is invalid".to_owned())?;
+        if authorization.claims.issuer_id != identity.issuer_id {
+            return Err("BAT V2 accounting authorization targets a different issuer".to_owned());
+        }
+        if seen_providers
+            .insert(authorization.claims.provider_id, ())
+            .is_some()
+        {
+            return Err(
+                "only one current BAT V2 accounting authorization per provider is allowed"
+                    .to_owned(),
+            );
+        }
+        for (key, role) in [
+            (operator_key_bytes, "provider operator key"),
+            (
+                authorization.claims.clearing_verifying_key,
+                "provider BAT V2 clearing key",
+            ),
+        ] {
+            if let Some(previous_role) = seen_role_keys.insert(key, role) {
+                return Err(format!(
+                    "BAT V2 role keys must be globally distinct: {role} reuses {previous_role}"
+                ));
+            }
+        }
+        let _registration = store
+            .register_bat_v2_accounting_authorization(
+                &authorization,
+                &approval,
+                &operator_key,
+                &settlement_verifying_key,
+                now_unix,
+            )
+            .map_err(|error| format!("register BAT V2 accounting authorization failed: {error}"))?;
+    }
+
+    BatV2IssuerRedemptionServiceV2::new(
+        store.clone(),
+        bat_keyring,
+        issuer_settlement_signing_key,
+        now_unix,
+    )
+    .map(Some)
+    .map_err(|error| format!("build BAT V2 redemption service failed: {error}"))
+}
+
 /// Installs the local trust configuration for the shared issuer routes used by
 /// provider servers. The V1 production HTTP surface deliberately supports only
 /// credential redeem and identified-ledger balance reads. Anonymous blind
@@ -1894,7 +2072,6 @@ fn load_ledger_clearing(
     let any_configured = !args.clearing_authorizations.is_empty()
         || !args.clearing_approvals.is_empty()
         || !args.clearing_provider_request_verifying_keys.is_empty()
-        || args.issuer_settlement_signing_key.is_some()
         || !args.retained_issuer_settlement_verifying_keys.is_empty()
         || args.redeem_response_derivation_key.is_some();
     if !any_configured {
@@ -2382,6 +2559,24 @@ fn route_request(
                 .ok_or(IssuerServiceErrorV1::NotFound)?
                 .redeem(&request.body, now_unix)
                 .map(|body| (CT_REDEEM_RESULT, body))
+        }
+        "/v2/redeems" => {
+            require_content_type(request, CT_BAT_V2_REDEEM)?;
+            if request.body.len() > BAT_V2_PROVIDER_REDEEM_ENVELOPE_LEN_V2 {
+                return Err(IssuerServiceErrorV1::InvalidRequest);
+            }
+            let service = state
+                .bat_v2_redemption
+                .as_ref()
+                .ok_or(IssuerServiceErrorV1::NotFound)?;
+            require_bat_v2_mutation_budget(
+                service.committed_attempt_for_canonical_envelope(&request.body)?,
+                &state.mutation_rate,
+                Instant::now(),
+            )?;
+            service
+                .redeem_v2(&request.body, now_unix)
+                .map(|body| (CT_BAT_V2_REDEEM_RESULT, body))
         }
         "/v1/settlement/balance" => {
             require_executable_settlement_request(request, CT_BALANCE_ENVELOPE)?;
@@ -3054,6 +3249,7 @@ mod tests {
         EntitlementLimitsV1, FreeModeV1, IssuerBalanceResponseV1, IssuerPayoutIntentResponseV1,
         IssuerPayoutResponseV1, IssuerPayoutStatusResponseV1, OperationStartV1,
         ParsedBolt11InvoiceV1, PayoutStateV1, PolicyRollbackGuardV1, PriceV1, PrivacyLeakageV1,
+        ProviderAccountingAuthorizationClaimsV2, ProviderAccountingRuleV2,
         ProviderBalanceEnvelopeV1, ProviderBalanceRequestV1, ProviderClearingAuthorizationClaimsV1,
         ProviderClearingRequestAuthV1, ProviderPayoutIntentRequestV1, ProviderPayoutRequestV1,
         ProviderPayoutStatusRequestV1, ProviderRedeemRequestV1, ProviderSettlementRequestAuthV1,
@@ -3435,6 +3631,7 @@ mod tests {
                 current_quote_delegation: delegation_bytes.clone(),
                 quote_delegations: BTreeMap::from([(delegation.quote_key_id, delegation_bytes)]),
                 clearing: Some(clearing),
+                bat_v2_redemption: None,
                 store,
                 fake_lightning: None,
                 allow_origin: None,
@@ -3448,6 +3645,256 @@ mod tests {
                 test_only_payout_http,
             })
         }
+    }
+
+    #[test]
+    fn bat_v2_redeem_route_is_exact_and_media_isolated_when_disabled() {
+        let fixture = SettlementHttpFixture::new();
+        let state = fixture.state(fixture.now_unix);
+
+        let disabled = http_exchange(
+            Arc::clone(&state),
+            "POST",
+            "/v2/redeems",
+            Some(CT_BAT_V2_REDEEM),
+            CT_BAT_V2_REDEEM_RESULT,
+            &[],
+        );
+        assert_eq!(disabled.0, 404);
+
+        let wrong_v2_media = http_exchange(
+            Arc::clone(&state),
+            "POST",
+            "/v2/redeems",
+            Some(CT_REDEEM),
+            CT_BAT_V2_REDEEM_RESULT,
+            &[],
+        );
+        assert_eq!(wrong_v2_media.0, 400);
+        let v1_does_not_accept_v2_media = http_exchange(
+            Arc::clone(&state),
+            "POST",
+            "/v1/redeems",
+            Some(CT_BAT_V2_REDEEM),
+            CT_REDEEM_RESULT,
+            &[],
+        );
+        assert_eq!(v1_does_not_accept_v2_media.0, 400);
+        let near_miss_path = http_exchange(
+            state,
+            "POST",
+            "/v2/redeems/",
+            Some(CT_BAT_V2_REDEEM),
+            CT_BAT_V2_REDEEM_RESULT,
+            &[],
+        );
+        assert_eq!(near_miss_path.0, 404);
+        assert_ne!(CT_BAT_V2_REDEEM, CT_REDEEM);
+        assert_ne!(CT_BAT_V2_REDEEM_RESULT, CT_REDEEM_RESULT);
+    }
+
+    #[test]
+    fn bat_v2_new_attempt_rate_limit_is_burn_no_retry_but_committed_terminal_bypasses() {
+        let limiter = FixedWindowRateLimiterV1::new(1, "BAT V2 mutation test")
+            .expect("BAT V2 mutation limiter");
+        let now = Instant::now();
+        require_bat_v2_mutation_budget(false, &limiter, now)
+            .expect("first BAT V2 mutation receives the only token");
+        let error = require_bat_v2_mutation_budget(false, &limiter, now)
+            .expect_err("a received V2 attempt must not get a generic retry instruction");
+        assert_eq!(error, IssuerServiceErrorV1::OutcomeUnknownCredentialBurned);
+        assert_eq!(error.public_code(), "outcome_unknown_credential_burned");
+        require_bat_v2_mutation_budget(true, &limiter, now)
+            .expect("durably committed attempt may return its non-granting terminal");
+    }
+
+    #[cfg(unix)]
+    fn parse_cln_common_with_pairs(pairs: &[(&str, &str)]) -> ServeCommonArgs {
+        let mut argv = vec![
+            "payment-issuer".to_owned(),
+            "serve-cln".to_owned(),
+            "--store".to_owned(),
+            "/tmp/issuer.sqlite".to_owned(),
+            "--rollback-authority".to_owned(),
+            "/tmp/rollback.sqlite".to_owned(),
+            "--allow-local-rollback-authority-dev".to_owned(),
+            "--quote-delegation".to_owned(),
+            "/tmp/delegation.bin".to_owned(),
+            "--quote-signing-key".to_owned(),
+            "/tmp/quote.key".to_owned(),
+            "--credential-derivation-key".to_owned(),
+            "/tmp/credential.key".to_owned(),
+            "--cln-rpc-socket".to_owned(),
+            "/tmp/lightning-rpc".to_owned(),
+            "--cln-rpc-expected-uid".to_owned(),
+            "501".to_owned(),
+        ];
+        for (flag, value) in pairs {
+            argv.extend([(*flag).to_owned(), (*value).to_owned()]);
+        }
+        let cli = Cli::try_parse_from(argv).expect("parse BAT V2 CLN arguments");
+        let Command::ServeCln(args) = cli.command else {
+            panic!("expected serve-cln command");
+        };
+        args.common
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bat_v2_accounting_cli_preserves_aligned_repeated_groups_and_rejects_mismatch() {
+        let common = parse_cln_common_with_pairs(&[
+            ("--bat-v2-accounting-authorization", "/tmp/auth-1.bin"),
+            ("--bat-v2-accounting-approval", "/tmp/approval-1.bin"),
+            (
+                "--bat-v2-accounting-operator-verifying-key",
+                "/tmp/operator-1.pub",
+            ),
+            ("--bat-v2-accounting-authorization", "/tmp/auth-2.bin"),
+            ("--bat-v2-accounting-approval", "/tmp/approval-2.bin"),
+            (
+                "--bat-v2-accounting-operator-verifying-key",
+                "/tmp/operator-2.pub",
+            ),
+        ]);
+        assert_eq!(
+            common.bat_v2_accounting_authorizations,
+            ["/tmp/auth-1.bin", "/tmp/auth-2.bin"]
+                .map(PathBuf::from)
+                .to_vec()
+        );
+        assert_eq!(
+            common.bat_v2_accounting_approvals,
+            ["/tmp/approval-1.bin", "/tmp/approval-2.bin"]
+                .map(PathBuf::from)
+                .to_vec()
+        );
+        assert_eq!(
+            common.bat_v2_accounting_operator_verifying_keys,
+            ["/tmp/operator-1.pub", "/tmp/operator-2.pub"]
+                .map(PathBuf::from)
+                .to_vec()
+        );
+
+        let mismatch = parse_cln_common_with_pairs(&[(
+            "--bat-v2-accounting-authorization",
+            "/tmp/auth-only.bin",
+        )]);
+        let fixture = SettlementHttpFixture::new();
+        let state = fixture.state(fixture.now_unix);
+        let error = load_bat_v2_redemption(&mismatch, &state.store, None, fixture.now_unix)
+            .expect_err("reject unequal BAT V2 accounting argument groups");
+        assert!(error.contains("same non-zero number"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bat_v2_only_configuration_does_not_enable_v1_clearing_loader() {
+        let common = parse_cln_common_with_pairs(&[
+            ("--bat-v2-accounting-authorization", "/tmp/auth.bin"),
+            ("--bat-v2-accounting-approval", "/tmp/approval.bin"),
+            (
+                "--bat-v2-accounting-operator-verifying-key",
+                "/tmp/operator.pub",
+            ),
+            ("--issuer-settlement-signing-key", "/tmp/settlement.key"),
+            ("--bat-key", "/tmp/bat.key"),
+        ]);
+        let fixture = SettlementHttpFixture::new();
+        let state = fixture.state(fixture.now_unix);
+        let clearing = load_ledger_clearing(&common, &state.store, None, None, fixture.now_unix)
+            .expect("V2-only configuration must not be interpreted as V1 clearing");
+        assert!(clearing.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bat_v2_loader_rejects_operator_and_settlement_role_key_reuse() {
+        let fixture = SettlementHttpFixture::new();
+        let state = fixture.state(fixture.now_unix);
+        let directory = private_tempdir();
+        let authorization_path = directory.path().join("accounting-authorization.bin");
+        let approval_path = directory.path().join("accounting-approval.bin");
+        let operator_key_path = directory.path().join("operator.pub");
+        let settlement_key_path = directory.path().join("settlement.key");
+
+        let shared_role_key_bytes = [0x61; 32];
+        let operator = SigningKey::from_bytes(&shared_role_key_bytes);
+        let settlement = SigningKey::from_bytes(&shared_role_key_bytes);
+        let clearing = SigningKey::from_bytes(&[0x62; 32]);
+        let authorization = ProviderAccountingAuthorizationV2::sign(
+            ProviderAccountingAuthorizationClaimsV2 {
+                authorization_id: [0x63; 16],
+                authorization_epoch: 1,
+                provider_id: [0x64; 32],
+                issuer_id: fixture.issuer_id,
+                redeem_endpoint: "https://issuer.test.invalid".to_owned(),
+                redeem_leaf_spki_sha256_pins: vec![[0x65; 32]],
+                settlement_account_id: [0x66; 32],
+                clearing_verifying_key: clearing.verifying_key().to_bytes(),
+                not_before: fixture.now_unix.saturating_sub(60),
+                not_after: fixture.now_unix + 120,
+                rules: vec![ProviderAccountingRuleV2 {
+                    class_id: [0x67; 32],
+                    policy_digest: [0x68; 32],
+                    scope_id: [0x69; 32],
+                    offer_id: 1,
+                    unit: SettlementUnitV1::AuthCredit,
+                    accepted_value: 10,
+                    provider_credit: 9,
+                    issuer_fee: 1,
+                }],
+            },
+            &operator,
+        )
+        .expect("sign BAT V2 accounting authorization");
+        let approval = IssuerAccountingApprovalV2::sign(
+            &authorization,
+            fixture.now_unix,
+            fixture.now_unix + 120,
+            &settlement,
+        )
+        .expect("sign BAT V2 accounting approval");
+        fs::write(
+            &authorization_path,
+            authorization.encode().expect("encode BAT V2 authorization"),
+        )
+        .expect("write BAT V2 accounting authorization");
+        fs::write(&approval_path, approval.encode()).expect("write BAT V2 accounting approval");
+        fs::write(&operator_key_path, operator.verifying_key().to_bytes())
+            .expect("write BAT V2 operator key");
+        write_secret(&settlement_key_path, &shared_role_key_bytes, 0o600);
+
+        let common = parse_cln_common_with_pairs(&[
+            (
+                "--bat-v2-accounting-authorization",
+                authorization_path
+                    .to_str()
+                    .expect("authorization path UTF-8"),
+            ),
+            (
+                "--bat-v2-accounting-approval",
+                approval_path.to_str().expect("approval path UTF-8"),
+            ),
+            (
+                "--bat-v2-accounting-operator-verifying-key",
+                operator_key_path.to_str().expect("operator path UTF-8"),
+            ),
+            (
+                "--issuer-settlement-signing-key",
+                settlement_key_path.to_str().expect("settlement path UTF-8"),
+            ),
+        ]);
+        let error = load_bat_v2_redemption(
+            &common,
+            &state.store,
+            Some(SettlementHttpFixture::bat_keyring()),
+            fixture.now_unix,
+        )
+        .expect_err("reject reused BAT V2 role key");
+        assert!(
+            error.contains("provider operator key reuses issuer settlement key"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -4744,6 +5191,7 @@ mod tests {
             current_quote_delegation: delegation_bytes.clone(),
             quote_delegations: BTreeMap::from([(delegation.quote_key_id, delegation_bytes)]),
             clearing: None,
+            bat_v2_redemption: None,
             store: issuer_store,
             fake_lightning: Some(Arc::clone(&fake_lightning)),
             allow_origin: None,

--- a/crates/payment/issuer-service/src/bat_v2_redemption_service.rs
+++ b/crates/payment/issuer-service/src/bat_v2_redemption_service.rs
@@ -1,0 +1,343 @@
+use std::collections::BTreeSet;
+use std::fmt;
+use std::sync::Arc;
+
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use pir_issuer_store::{
+    BatAcceptanceClassMemberRecordV2, BatAcceptanceClassRecordV2,
+    BatV2AccountingAuthorizationRecordV2, IssuerStore,
+};
+use pir_payment_crypto::{K256CashuMintKeyringV1, PaymentCryptoError};
+use pir_service_protocol::{
+    bat_acceptance_member_from_retained_policy_v2, precheck_bat_v2_redeem_v2,
+    sign_and_commit_grantable_success_v2, sign_retry_safe_non_consuming_v2,
+    sign_terminal_if_attempt_committed_v2, sign_terminal_invalid_or_spent_v2,
+    verify_bat_v2_credential_for_commit_v2, BatAcceptanceClassV2, BatV2CredentialCheckV2,
+    BatV2ProofVerificationInputV2, BatV2RedeemCommitResultV2, BatV2RedeemPrecheckV2,
+    ProviderAccountingAuthorizationV2, ProviderAccountingExpectationV2, ProviderRedeemEnvelopeV2,
+    ProviderRedeemRequestV2, ProviderRedeemResponseV2, VerifiedBatAcceptanceMemberV2,
+};
+
+use super::{decode_policy_key, decode_retained_policy, IssuerServiceErrorV1};
+
+/// Transport-neutral issuer-global BAT V2 redemption service.
+///
+/// This service has no provider-local idempotency key, delivery claim, or
+/// ProviderStore. The issuer store is the sole durable spend and ledger
+/// authority; only the request that wins the fresh commit may receive a
+/// grantable success.
+pub struct BatV2IssuerRedemptionServiceV2 {
+    store: IssuerStore,
+    bat_keyring: Arc<K256CashuMintKeyringV1>,
+    issuer_settlement_signing_key: SigningKey,
+}
+
+impl fmt::Debug for BatV2IssuerRedemptionServiceV2 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BatV2IssuerRedemptionServiceV2")
+            .field("store", &"[redacted]")
+            .field("bat_keyring", &"[redacted]")
+            .field("issuer_settlement_signing_key", &"[redacted]")
+            .finish()
+    }
+}
+
+impl BatV2IssuerRedemptionServiceV2 {
+    pub fn new(
+        store: IssuerStore,
+        bat_keyring: Arc<K256CashuMintKeyringV1>,
+        issuer_settlement_signing_key: SigningKey,
+        now_unix: u64,
+    ) -> Result<Self, IssuerServiceErrorV1> {
+        if now_unix == 0 {
+            return Err(IssuerServiceErrorV1::InvalidRequest);
+        }
+        let loaded: BTreeSet<[u8; 33]> =
+            bat_keyring.denomination_public_keys().into_iter().collect();
+        let required = store
+            .bat_v2_credential_material_requirements(now_unix)
+            .map_err(|_| IssuerServiceErrorV1::Internal)?;
+        if required
+            .iter()
+            .any(|requirement| !loaded.contains(&requirement.raw_public_key))
+        {
+            return Err(IssuerServiceErrorV1::InvalidRequest);
+        }
+        Ok(Self {
+            store,
+            bat_keyring,
+            issuer_settlement_signing_key,
+        })
+    }
+
+    /// Read-only mutation-budget classification. Only a canonical request
+    /// whose provider/attempt pair is already durable may bypass the new-write
+    /// budget, and the later handler will return a non-granting terminal.
+    pub fn committed_attempt_for_canonical_envelope(
+        &self,
+        canonical_envelope: &[u8],
+    ) -> Result<bool, IssuerServiceErrorV1> {
+        let envelope = decode_canonical_envelope(canonical_envelope)?;
+        self.store
+            .bat_v2_attempt_is_committed(
+                &envelope.request.provider_id,
+                &envelope.request.attempt_id,
+            )
+            .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)
+    }
+
+    /// `POST /v2/redeems` body handler. Any operational error after canonical
+    /// decode is explicit burn-on-ambiguity and never asks the caller to retry
+    /// the credential.
+    pub fn redeem_v2(
+        &self,
+        canonical_envelope: &[u8],
+        now_unix: u64,
+    ) -> Result<Vec<u8>, IssuerServiceErrorV1> {
+        if now_unix == 0 {
+            return Err(IssuerServiceErrorV1::InvalidRequest);
+        }
+        let envelope = decode_canonical_envelope(canonical_envelope)?;
+        let request = envelope.request.clone();
+        let mut committer = self
+            .store
+            .bat_v2_redeem_committer(now_unix)
+            .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+
+        if let Some(terminal) = sign_terminal_if_attempt_committed_v2(
+            &request,
+            &self.issuer_settlement_signing_key,
+            &committer,
+        )
+        .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?
+        {
+            return encode_response(terminal);
+        }
+
+        let authorization_record = self
+            .store
+            .current_bat_v2_accounting_authorization(&request.provider_id)
+            .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?
+            .ok_or(IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+        let (authorization, approval) = authorization_record
+            .decode_exact()
+            .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+        let operator_key = VerifyingKey::from_bytes(&authorization_record.operator_verifying_key)
+            .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+        let settlement_key =
+            VerifyingKey::from_bytes(&authorization_record.issuer_settlement_verifying_key)
+                .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+        if settlement_key != self.issuer_settlement_signing_key.verifying_key() {
+            return Err(IssuerServiceErrorV1::OutcomeUnknownCredentialBurned);
+        }
+
+        let class_record = self
+            .store
+            .bat_acceptance_class_v2(&request.class_id, request.class_key_epoch)
+            .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?
+            .ok_or(IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+        let class = decode_exact_class(&class_record)?;
+        let member = self.verified_member_for_request(
+            &request,
+            &authorization_record,
+            &authorization,
+            &class_record,
+            &class,
+        )?;
+
+        let expectation = ProviderAccountingExpectationV2 {
+            provider_id: authorization_record.provider_id,
+            issuer_id: authorization.claims.issuer_id,
+            operator_verifying_key: &operator_key,
+            issuer_settlement_verifying_key: &settlement_key,
+            now_unix,
+            minimum_authorization_epoch: authorization_record.authorization_epoch,
+        };
+        let authorized = match precheck_bat_v2_redeem_v2(
+            envelope,
+            &authorization,
+            &approval,
+            &class,
+            &member,
+            expectation,
+        )
+        .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?
+        {
+            BatV2RedeemPrecheckV2::Authorized(value) => *value,
+            BatV2RedeemPrecheckV2::RetrySafeNonConsuming(value) => {
+                return encode_response(
+                    sign_retry_safe_non_consuming_v2(value, &self.issuer_settlement_signing_key)
+                        .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?,
+                )
+            }
+            BatV2RedeemPrecheckV2::TerminalInvalidOrSpent(value) => {
+                return encode_response(
+                    sign_terminal_invalid_or_spent_v2(value, &self.issuer_settlement_signing_key)
+                        .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?,
+                )
+            }
+        };
+
+        let verifier = |input: BatV2ProofVerificationInputV2<'_>| match self
+            .bat_keyring
+            .verify_raw_cashu_signature(input.bat_verification_key, input.secret_raw, input.c)
+        {
+            Ok(_) => Ok(true),
+            Err(PaymentCryptoError::CashuMintKeyNotFound) => Err(()),
+            Err(_) => Ok(false),
+        };
+        let verified = match verify_bat_v2_credential_for_commit_v2(authorized, &verifier)
+            .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?
+        {
+            BatV2CredentialCheckV2::Verified(value) => value,
+            BatV2CredentialCheckV2::TerminalInvalidOrSpent(value) => {
+                return encode_response(
+                    sign_terminal_invalid_or_spent_v2(value, &self.issuer_settlement_signing_key)
+                        .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?,
+                )
+            }
+        };
+
+        match sign_and_commit_grantable_success_v2(
+            verified,
+            &self.issuer_settlement_signing_key,
+            &mut committer,
+        )
+        .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?
+        {
+            BatV2RedeemCommitResultV2::FreshCommitted(value) => {
+                encode_response(value.into_response())
+            }
+            BatV2RedeemCommitResultV2::TerminalInvalidOrSpent(value) => encode_response(value),
+        }
+    }
+
+    fn verified_member_for_request(
+        &self,
+        request: &ProviderRedeemRequestV2,
+        authorization_record: &BatV2AccountingAuthorizationRecordV2,
+        authorization: &ProviderAccountingAuthorizationV2,
+        class_record: &BatAcceptanceClassRecordV2,
+        class: &BatAcceptanceClassV2,
+    ) -> Result<VerifiedBatAcceptanceMemberV2, IssuerServiceErrorV1> {
+        let exact = class_record.members.iter().find(|member| {
+            member.provider_id == request.provider_id
+                && member.policy_digest == request.policy_digest
+                && member.scope_id == request.scope_id
+                && member.offer_id == request.offer_id
+        });
+        if let Some(member) = exact {
+            return self.load_verified_member(member, class_record, class);
+        }
+
+        let fallback = class_record
+            .members
+            .iter()
+            .find(|member| {
+                if member.provider_id != authorization_record.provider_id {
+                    return false;
+                }
+                let tuple = member_tuple(member);
+                authorization
+                    .rule_for_member(&tuple, &class.class_id)
+                    .is_some()
+            })
+            .or_else(|| {
+                class_record
+                    .members
+                    .iter()
+                    .find(|member| member.provider_id == authorization_record.provider_id)
+            })
+            .or_else(|| class_record.members.first());
+        let fallback = fallback.ok_or(IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+        self.load_verified_member(fallback, class_record, class)
+    }
+
+    fn load_verified_member(
+        &self,
+        member: &BatAcceptanceClassMemberRecordV2,
+        class_record: &BatAcceptanceClassRecordV2,
+        class: &BatAcceptanceClassV2,
+    ) -> Result<VerifiedBatAcceptanceMemberV2, IssuerServiceErrorV1> {
+        let policy_record = self
+            .store
+            .service_policy(&member.provider_id, &member.policy_digest)
+            .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?
+            .ok_or(IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+        let policy = decode_retained_policy(&policy_record)
+            .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+        let policy_key = decode_policy_key(&policy_record.policy_verifying_key)
+            .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+        let verified = bat_acceptance_member_from_retained_policy_v2(
+            &policy,
+            &member.provider_id,
+            &member.policy_digest,
+            &member.scope_id,
+            member.offer_id,
+            &policy_key,
+        )
+        .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+        if verified.class_id != class_record.class_id
+            || verified.common_terms != class.common_terms
+            || verified.redemption_deadline != member.redemption_deadline
+            || verified.member != member_tuple(member)
+            || !class.members.contains(&verified.member)
+        {
+            return Err(IssuerServiceErrorV1::OutcomeUnknownCredentialBurned);
+        }
+        Ok(verified)
+    }
+}
+
+fn decode_canonical_envelope(
+    canonical_envelope: &[u8],
+) -> Result<ProviderRedeemEnvelopeV2, IssuerServiceErrorV1> {
+    let envelope = ProviderRedeemEnvelopeV2::decode(canonical_envelope)
+        .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?;
+    if envelope
+        .encode()
+        .map_err(|_| IssuerServiceErrorV1::InvalidRequest)?
+        .as_slice()
+        != canonical_envelope
+    {
+        return Err(IssuerServiceErrorV1::InvalidRequest);
+    }
+    Ok(envelope)
+}
+
+fn decode_exact_class(
+    record: &BatAcceptanceClassRecordV2,
+) -> Result<BatAcceptanceClassV2, IssuerServiceErrorV1> {
+    let class = BatAcceptanceClassV2::decode(&record.exact_artifact)
+        .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?;
+    if class
+        .encode()
+        .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?
+        != record.exact_artifact
+        || class
+            .class_digest()
+            .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)?
+            != record.artifact_digest
+    {
+        return Err(IssuerServiceErrorV1::OutcomeUnknownCredentialBurned);
+    }
+    Ok(class)
+}
+
+fn member_tuple(
+    member: &BatAcceptanceClassMemberRecordV2,
+) -> pir_service_protocol::BatAcceptanceMemberV2 {
+    pir_service_protocol::BatAcceptanceMemberV2 {
+        provider_id: member.provider_id,
+        policy_digest: member.policy_digest,
+        scope_id: member.scope_id,
+        offer_id: member.offer_id,
+    }
+}
+
+fn encode_response(response: ProviderRedeemResponseV2) -> Result<Vec<u8>, IssuerServiceErrorV1> {
+    response
+        .encode()
+        .map_err(|_| IssuerServiceErrorV1::OutcomeUnknownCredentialBurned)
+}

--- a/crates/payment/issuer-service/src/lib.rs
+++ b/crates/payment/issuer-service/src/lib.rs
@@ -5,6 +5,10 @@
 
 #![forbid(unsafe_code)]
 
+mod bat_v2_redemption_service;
+
+pub use bat_v2_redemption_service::BatV2IssuerRedemptionServiceV2;
+
 use std::collections::BTreeSet;
 use std::fmt;
 use std::sync::Arc;
@@ -64,6 +68,7 @@ pub enum IssuerServiceErrorV1 {
     Conflict,
     RetryableUnavailable,
     OutcomeUnknown,
+    OutcomeUnknownCredentialBurned,
     Internal,
 }
 
@@ -109,6 +114,7 @@ impl IssuerServiceErrorV1 {
             Self::Conflict => 409,
             Self::RetryableUnavailable => 503,
             Self::OutcomeUnknown => 503,
+            Self::OutcomeUnknownCredentialBurned => 503,
             Self::Internal => 500,
         }
     }
@@ -121,6 +127,7 @@ impl IssuerServiceErrorV1 {
             Self::Conflict => "conflict",
             Self::RetryableUnavailable => "retryable_unavailable",
             Self::OutcomeUnknown => "outcome_unknown_retry_exact_request",
+            Self::OutcomeUnknownCredentialBurned => "outcome_unknown_credential_burned",
             Self::Internal => "internal_error",
         }
     }

--- a/crates/payment/issuer-service/tests/bat_v2_redemption.rs
+++ b/crates/payment/issuer-service/tests/bat_v2_redemption.rs
@@ -1,0 +1,629 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ed25519_dalek::SigningKey;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::{ProjectivePoint, Scalar};
+use pir_issuer_service::{BatV2IssuerRedemptionServiceV2, IssuerServiceErrorV1};
+use pir_issuer_store::{IssuerStore, SqliteIssuerRollbackFloorAuthorityV1, StoreOptions};
+use pir_payment_crypto::{
+    blind_cashu_message_v1, verify_and_unblind_cashu_promise_v1, K256CashuMintKeyringV1,
+};
+use pir_service_protocol::{
+    bat_acceptance_member_from_verified_policy_v2, derive_issuer_id, AcquisitionMethod,
+    AuthPaddingClassV1, AuthScheme, BackendId, BatAcceptanceClassV2, BitcoinPirCashuBatProofV2,
+    DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1, FreeModeV1,
+    IssuerAccountingApprovalV2, LightningNetworkV1, PolicyRollbackGuardV1, PriceV1,
+    PrivacyLeakageV1, ProviderAccountingAuthorizationClaimsV2, ProviderAccountingAuthorizationV2,
+    ProviderAccountingRuleV2, ProviderRedeemEnvelopeV2, ProviderRedeemOutcomeV2,
+    ProviderRedeemRequestAuthV2, ProviderRedeemRequestV2, ProviderRedeemResponseV2,
+    RetrySafeNonConsumingReasonV2, ServiceOfferV1, ServicePolicyEpochFloorsV1, ServicePolicyV1,
+    ServiceScopePolicyV1, ServiceScopeV1, SettlementUnitV1, VerificationMode,
+    VerifiedBatAcceptanceMemberV2, WorkloadId,
+};
+use tempfile::{Builder, TempDir};
+
+const NOW: u64 = 400;
+const BAT_KEY_MULTIPLIER: u64 = 101;
+
+struct TestPath {
+    _directory: TempDir,
+    database: PathBuf,
+    rollback_authority: Arc<SqliteIssuerRollbackFloorAuthorityV1>,
+}
+
+impl TestPath {
+    fn new() -> Self {
+        let directory = Builder::new()
+            .prefix("bitcoinpir-issuer-service-bat-v2-redemption-test-")
+            .tempdir()
+            .expect("create task-specific temporary directory");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700))
+                .expect("restrict task-specific temporary directory permissions");
+        }
+        let options = StoreOptions::default();
+        let rollback_authority = Arc::new(
+            SqliteIssuerRollbackFloorAuthorityV1::create(
+                directory.path().join("rollback.sqlite3"),
+                options.busy_timeout,
+            )
+            .expect("create rollback authority"),
+        );
+        Self {
+            database: directory.path().join("issuer.sqlite3"),
+            rollback_authority,
+            _directory: directory,
+        }
+    }
+
+    fn create_store(&self, issuer_id: [u8; 32]) -> IssuerStore {
+        IssuerStore::create(
+            &self.database,
+            [0x11; 16],
+            issuer_id,
+            LightningNetworkV1::Regtest,
+            StoreOptions::default(),
+            self.rollback_authority.clone(),
+        )
+        .expect("create issuer store")
+    }
+
+    fn reopen_store(&self, issuer_id: [u8; 32]) -> IssuerStore {
+        IssuerStore::open_existing(
+            &self.database,
+            issuer_id,
+            LightningNetworkV1::Regtest,
+            StoreOptions::default(),
+            self.rollback_authority.clone(),
+        )
+        .expect("reopen issuer store")
+    }
+}
+
+struct Fixture {
+    path: TestPath,
+    store: IssuerStore,
+    issuer_id: [u8; 32],
+    class: BatAcceptanceClassV2,
+    member: VerifiedBatAcceptanceMemberV2,
+    authorization: ProviderAccountingAuthorizationV2,
+    clearing_key: SigningKey,
+    settlement_key: SigningKey,
+    keyring: Arc<K256CashuMintKeyringV1>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let issuer_root = SigningKey::from_bytes(&[0x21; 32]);
+        let issuer_id = derive_issuer_id(&issuer_root.verifying_key().to_bytes());
+        let provider_id = [0xa1; 32];
+        let class_id = [0x81; 32];
+        let scope = ServiceScopeV1 {
+            provider_id,
+            backend: BackendId::DpfPirV1,
+            workload: WorkloadId::DpfEvaluateJobV1,
+            protocol_version: 1,
+            dataset: DatasetBindingV1::Class { class_id: 1 },
+            operation_profile: 1,
+            entitlement_profile: 2,
+        };
+        let scope_id = scope.scope_id();
+        let limits = EntitlementLimitsV1 {
+            max_logical_inputs: 4,
+            max_frames: 200,
+            max_request_bytes: 1_000_000,
+            max_response_bytes: 2_000_000,
+            max_wall_time_ms: 60_000,
+            max_concurrent_sockets: 1,
+            max_hint_groups: 0,
+            max_work_units: 9_000,
+        };
+        let privacy_leakage = PrivacyLeakageV1::from_bits(
+            PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+        )
+        .expect("BAT V2 privacy flags");
+        let offer = ServiceOfferV1 {
+            offer_id: 7,
+            acquisition: AcquisitionMethod::Bolt11V1,
+            free_mode: FreeModeV1::NotFree,
+            free_quota: 0,
+            free_window_seconds: 0,
+            free_pow_difficulty_bits: 0,
+            priority_class: 1,
+            authorization: AuthScheme::BitcoinPirCashuBatV2,
+            verification: VerificationMode::SharedIssuerOnline,
+            deployment_status: DeploymentStatus::Stable,
+            price: PriceV1::MilliSatoshi(2_000),
+            issuer_id,
+            key_id: class_id.to_vec(),
+            credential_binding: None,
+            cashu_mint_manifest: None,
+            endpoint: "https://issuer.invalid".to_owned(),
+            invoice_expiry_seconds: 60,
+            claim_window_seconds: 120,
+            minimum_credential_validity_seconds: 300,
+            retired_policy_grace_seconds: 480,
+            credential_count: 2,
+            credential_presentation_limit: 1,
+            privacy_leakage,
+        };
+        let policy_key = SigningKey::from_bytes(&[0xb1; 32]);
+        let policy = ServicePolicyV1::sign(
+            provider_id,
+            1,
+            100,
+            1_000,
+            AuthPaddingClassV1::Class16KiB,
+            vec![ServiceScopePolicyV1 {
+                scope,
+                limits,
+                offers: vec![offer],
+            }],
+            &policy_key,
+        )
+        .expect("sign BAT V2 member policy");
+        let verified_policy = policy
+            .verify_current_for_acquisition(
+                &provider_id,
+                200,
+                &PolicyRollbackGuardV1::initial(),
+                &ServicePolicyEpochFloorsV1::initial(),
+                &policy_key.verifying_key(),
+            )
+            .expect("verify BAT V2 member policy");
+        let member = bat_acceptance_member_from_verified_policy_v2(&verified_policy, &scope_id, 7)
+            .expect("project verified BAT V2 member");
+        let class = BatAcceptanceClassV2::sign(
+            class_id,
+            1,
+            100,
+            1_480,
+            point(BAT_KEY_MULTIPLIER),
+            member.common_terms.clone(),
+            vec![member.member.clone()],
+            &issuer_root,
+        )
+        .expect("sign BAT V2 class");
+
+        let path = TestPath::new();
+        let store = path.create_store(issuer_id);
+        let _ = store
+            .register_service_policy(&policy, &policy_key.verifying_key(), 200)
+            .expect("register BAT V2 member policy");
+        let _ = store
+            .register_bat_acceptance_class_v2(&class, 200)
+            .expect("register BAT V2 class");
+
+        let operator_key = SigningKey::from_bytes(&[0xc1; 32]);
+        let clearing_key = SigningKey::from_bytes(&[0xc2; 32]);
+        let settlement_key = SigningKey::from_bytes(&[0xd1; 32]);
+        let authorization = ProviderAccountingAuthorizationV2::sign(
+            ProviderAccountingAuthorizationClaimsV2 {
+                authorization_id: [0xc3; 16],
+                authorization_epoch: 1,
+                provider_id,
+                issuer_id,
+                redeem_endpoint: "https://issuer.invalid".to_owned(),
+                redeem_leaf_spki_sha256_pins: vec![[0xc4; 32]],
+                settlement_account_id: [0xc5; 32],
+                clearing_verifying_key: clearing_key.verifying_key().to_bytes(),
+                not_before: 100,
+                not_after: 2_000,
+                rules: vec![ProviderAccountingRuleV2 {
+                    class_id,
+                    policy_digest: member.member.policy_digest,
+                    scope_id,
+                    offer_id: 7,
+                    unit: SettlementUnitV1::AuthCredit,
+                    accepted_value: 10,
+                    provider_credit: 7,
+                    issuer_fee: 3,
+                }],
+            },
+            &operator_key,
+        )
+        .expect("sign BAT V2 accounting authorization");
+        let approval =
+            IssuerAccountingApprovalV2::sign(&authorization, 200, 2_000, &settlement_key)
+                .expect("sign BAT V2 issuer accounting approval");
+        let _ = store
+            .register_bat_v2_accounting_authorization(
+                &authorization,
+                &approval,
+                &operator_key.verifying_key(),
+                &settlement_key.verifying_key(),
+                200,
+            )
+            .expect("register BAT V2 accounting authorization");
+        let keyring = Arc::new(
+            K256CashuMintKeyringV1::from_secret_keys([scalar(BAT_KEY_MULTIPLIER)])
+                .expect("construct BAT V2 keyring"),
+        );
+
+        Self {
+            path,
+            store,
+            issuer_id,
+            class,
+            member,
+            authorization,
+            clearing_key,
+            settlement_key,
+            keyring,
+        }
+    }
+
+    fn service(&self) -> BatV2IssuerRedemptionServiceV2 {
+        BatV2IssuerRedemptionServiceV2::new(
+            self.store.clone(),
+            Arc::clone(&self.keyring),
+            self.settlement_key.clone(),
+            NOW,
+        )
+        .expect("construct BAT V2 redemption service")
+    }
+
+    fn proof(&self, secret_byte: u8) -> BitcoinPirCashuBatProofV2 {
+        let secret_raw = [secret_byte; 32];
+        let blinding_scalar = scalar(u64::from(secret_byte) + 17);
+        let blinded_message = blind_cashu_message_v1(&secret_raw, &blinding_scalar)
+            .expect("blind BAT V2 Cashu message");
+        let promise = self
+            .keyring
+            .blind_sign_with_dleq_v1(
+                &self.class.bat_verification_key,
+                &blinded_message,
+                &scalar(u64::from(secret_byte) + 37),
+            )
+            .expect("blind-sign BAT V2 Cashu message");
+        let unblinded = verify_and_unblind_cashu_promise_v1(
+            &secret_raw,
+            &blinding_scalar,
+            &self.class.bat_verification_key,
+            &blinded_message,
+            promise.blinded_signature(),
+            promise.dleq_e(),
+            promise.dleq_s(),
+        )
+        .expect("DLEQ-check and unblind BAT V2 Cashu promise");
+        BitcoinPirCashuBatProofV2::from_class(
+            &self.class,
+            secret_raw,
+            *unblinded.unblinded_signature(),
+        )
+        .expect("construct class-bound BAT V2 proof")
+    }
+
+    fn envelope(
+        &self,
+        proof: &BitcoinPirCashuBatProofV2,
+        attempt_byte: u8,
+        request_signing_key: &SigningKey,
+    ) -> ProviderRedeemEnvelopeV2 {
+        let (request, _) = ProviderRedeemRequestV2::prepare(
+            &self.authorization,
+            &self.member,
+            &self.class,
+            proof,
+            [attempt_byte; 32],
+        )
+        .expect("prepare BAT V2 redeem request")
+        .into_parts();
+        let request_auth = ProviderRedeemRequestAuthV2::sign(&request, request_signing_key)
+            .expect("sign BAT V2 redeem request");
+        ProviderRedeemEnvelopeV2 {
+            request,
+            request_auth,
+            credential: proof.clone(),
+        }
+    }
+}
+
+fn point(multiplier: u64) -> [u8; 33] {
+    let encoded = (ProjectivePoint::GENERATOR * Scalar::from(multiplier))
+        .to_affine()
+        .to_encoded_point(true);
+    encoded.as_bytes().try_into().expect("compressed point")
+}
+
+fn scalar(multiplier: u64) -> [u8; 32] {
+    Scalar::from(multiplier).to_bytes().into()
+}
+
+fn decode_response(bytes: &[u8]) -> ProviderRedeemResponseV2 {
+    ProviderRedeemResponseV2::decode(bytes).expect("decode canonical BAT V2 redeem response")
+}
+
+#[test]
+fn startup_rejects_missing_required_class_scalar() {
+    let fixture = Fixture::new();
+    let wrong_keyring = Arc::new(
+        K256CashuMintKeyringV1::from_secret_keys([scalar(BAT_KEY_MULTIPLIER + 1)])
+            .expect("construct wrong BAT V2 keyring"),
+    );
+
+    assert_eq!(
+        BatV2IssuerRedemptionServiceV2::new(
+            fixture.store,
+            wrong_keyring,
+            fixture.settlement_key,
+            NOW,
+        )
+        .unwrap_err(),
+        IssuerServiceErrorV1::InvalidRequest,
+        "a live redemption class must pin its exact Cashu scalar at startup"
+    );
+}
+
+#[test]
+fn fresh_success_and_all_same_proof_replays_are_terminal_across_restart() {
+    let fixture = Fixture::new();
+    let proof = fixture.proof(0x41);
+    let initial = fixture.envelope(&proof, 0x51, &fixture.clearing_key);
+    let initial_request = initial.request.clone();
+    let initial_wire = initial.encode().expect("encode initial BAT V2 redeem");
+    let service = fixture.service();
+
+    let success_wire = service
+        .redeem_v2(&initial_wire, NOW)
+        .expect("fresh BAT V2 redeem succeeds");
+    let success = decode_response(&success_wire);
+    success
+        .verify_for_exact_request(&initial_request, &fixture.settlement_key.verifying_key())
+        .expect("verify signed fresh success");
+    assert!(matches!(
+        success.outcome,
+        ProviderRedeemOutcomeV2::GrantableSuccess { .. }
+    ));
+    assert_eq!(
+        fixture
+            .store
+            .operational_inventory()
+            .expect("inventory after fresh redeem")
+            .bat_v2_redemption_rows,
+        1
+    );
+
+    let exact_replay_wire = service
+        .redeem_v2(&initial_wire, NOW)
+        .expect("exact attempt replay is classified");
+    let exact_replay = decode_response(&exact_replay_wire);
+    exact_replay
+        .verify_for_exact_request(&initial_request, &fixture.settlement_key.verifying_key())
+        .expect("verify signed exact-attempt terminal");
+    assert_eq!(
+        exact_replay.outcome,
+        ProviderRedeemOutcomeV2::TerminalInvalidOrSpent
+    );
+    assert_ne!(
+        exact_replay_wire, success_wire,
+        "the issuer must never replay the retained initial success"
+    );
+
+    let later = fixture.envelope(&proof, 0x52, &fixture.clearing_key);
+    let later_request = later.request.clone();
+    let later_wire = later.encode().expect("encode later BAT V2 attempt");
+    let later_response = decode_response(
+        &service
+            .redeem_v2(&later_wire, NOW)
+            .expect("same proof under a later attempt is classified"),
+    );
+    later_response
+        .verify_for_exact_request(&later_request, &fixture.settlement_key.verifying_key())
+        .expect("verify signed later-attempt terminal");
+    assert_eq!(
+        later_response.outcome,
+        ProviderRedeemOutcomeV2::TerminalInvalidOrSpent
+    );
+    assert_eq!(
+        fixture
+            .store
+            .operational_inventory()
+            .expect("inventory after replay classifications")
+            .bat_v2_redemption_rows,
+        1
+    );
+
+    drop(service);
+    let reopened = fixture.path.reopen_store(fixture.issuer_id);
+    let restarted = BatV2IssuerRedemptionServiceV2::new(
+        reopened,
+        Arc::clone(&fixture.keyring),
+        fixture.settlement_key.clone(),
+        NOW,
+    )
+    .expect("rebuild BAT V2 redemption service");
+    let restarted_replay_wire = restarted
+        .redeem_v2(&initial_wire, NOW)
+        .expect("restart replay is classified");
+    let restarted_replay = decode_response(&restarted_replay_wire);
+    restarted_replay
+        .verify_for_exact_request(&initial_request, &fixture.settlement_key.verifying_key())
+        .expect("verify restart terminal");
+    assert_eq!(
+        restarted_replay.outcome,
+        ProviderRedeemOutcomeV2::TerminalInvalidOrSpent
+    );
+    assert_eq!(
+        restarted_replay_wire, exact_replay_wire,
+        "service rebuild must preserve the same unified terminal result"
+    );
+}
+
+#[test]
+fn signed_retry_safe_is_zero_mutation_then_the_same_proof_can_succeed() {
+    let fixture = Fixture::new();
+    let foreign_provider_id = [0xe2; 32];
+    let foreign_operator = SigningKey::from_bytes(&[0xe3; 32]);
+    let foreign_clearing = SigningKey::from_bytes(&[0xe4; 32]);
+    let foreign_account_id = [0xe5; 32];
+    let foreign_authorization = ProviderAccountingAuthorizationV2::sign(
+        ProviderAccountingAuthorizationClaimsV2 {
+            authorization_id: [0xe6; 16],
+            authorization_epoch: 1,
+            provider_id: foreign_provider_id,
+            issuer_id: fixture.issuer_id,
+            redeem_endpoint: "https://issuer.invalid".to_owned(),
+            redeem_leaf_spki_sha256_pins: vec![[0xe7; 32]],
+            settlement_account_id: foreign_account_id,
+            clearing_verifying_key: foreign_clearing.verifying_key().to_bytes(),
+            not_before: 100,
+            not_after: 2_000,
+            rules: vec![ProviderAccountingRuleV2 {
+                class_id: fixture.class.class_id,
+                policy_digest: fixture.member.member.policy_digest,
+                scope_id: fixture.member.member.scope_id,
+                offer_id: fixture.member.member.offer_id,
+                unit: SettlementUnitV1::AuthCredit,
+                accepted_value: 10,
+                provider_credit: 7,
+                issuer_fee: 3,
+            }],
+        },
+        &foreign_operator,
+    )
+    .expect("sign foreign-provider accounting authorization");
+    let foreign_approval = IssuerAccountingApprovalV2::sign(
+        &foreign_authorization,
+        200,
+        2_000,
+        &fixture.settlement_key,
+    )
+    .expect("sign foreign-provider issuer approval");
+    let _ = fixture
+        .store
+        .register_bat_v2_accounting_authorization(
+            &foreign_authorization,
+            &foreign_approval,
+            &foreign_operator.verifying_key(),
+            &fixture.settlement_key.verifying_key(),
+            200,
+        )
+        .expect("register foreign-provider accounting authorization");
+    let service = fixture.service();
+    let proof = fixture.proof(0x61);
+    let wrong_clearing_key = SigningKey::from_bytes(&[0xe1; 32]);
+    let rejected = fixture.envelope(&proof, 0x62, &wrong_clearing_key);
+    let rejected_request = rejected.request.clone();
+    let baseline = fixture
+        .store
+        .identity()
+        .expect("identity before retry-safe rejection")
+        .commit_seq;
+
+    let rejection = decode_response(
+        &service
+            .redeem_v2(
+                &rejected.encode().expect("encode unauthenticated redeem"),
+                NOW,
+            )
+            .expect("pre-consumption rejection is signed"),
+    );
+    rejection
+        .verify_for_exact_request(&rejected_request, &fixture.settlement_key.verifying_key())
+        .expect("verify signed retry-safe response");
+    assert_eq!(
+        rejection.outcome,
+        ProviderRedeemOutcomeV2::RetrySafeNonConsuming {
+            reason: RetrySafeNonConsumingReasonV2::ProviderAuthentication,
+        }
+    );
+    assert_eq!(
+        fixture
+            .store
+            .identity()
+            .expect("identity after retry-safe rejection")
+            .commit_seq,
+        baseline,
+        "RetrySafeNonConsuming must not mutate the issuer store"
+    );
+    assert_eq!(
+        fixture
+            .store
+            .operational_inventory()
+            .expect("inventory after retry-safe rejection")
+            .bat_v2_redemption_rows,
+        0
+    );
+
+    let mut incompatible = fixture.envelope(&proof, 0x63, &fixture.clearing_key);
+    incompatible.request.provider_id = foreign_provider_id;
+    incompatible.request.accounting_authorization_digest = foreign_authorization
+        .authorization_digest()
+        .expect("foreign authorization digest");
+    incompatible.request.settlement_account_id = foreign_account_id;
+    incompatible.request_auth =
+        ProviderRedeemRequestAuthV2::sign(&incompatible.request, &foreign_clearing)
+            .expect("sign incompatible foreign-provider request");
+    let incompatible_request = incompatible.request.clone();
+    let class_rejection = decode_response(
+        &service
+            .redeem_v2(
+                &incompatible
+                    .encode()
+                    .expect("encode incompatible foreign-provider redeem"),
+                NOW,
+            )
+            .expect("class incompatibility is signed"),
+    );
+    class_rejection
+        .verify_for_exact_request(
+            &incompatible_request,
+            &fixture.settlement_key.verifying_key(),
+        )
+        .expect("verify signed class-compatibility response");
+    assert_eq!(
+        class_rejection.outcome,
+        ProviderRedeemOutcomeV2::RetrySafeNonConsuming {
+            reason: RetrySafeNonConsumingReasonV2::ClassCompatibility,
+        }
+    );
+    assert_eq!(
+        fixture
+            .store
+            .identity()
+            .expect("identity after class-compatibility rejection")
+            .commit_seq,
+        baseline,
+        "class compatibility rejection must not mutate the issuer store"
+    );
+    assert_eq!(
+        fixture
+            .store
+            .operational_inventory()
+            .expect("inventory after class-compatibility rejection")
+            .bat_v2_redemption_rows,
+        0
+    );
+
+    let accepted = fixture.envelope(&proof, 0x62, &fixture.clearing_key);
+    let accepted_request = accepted.request.clone();
+    let success = decode_response(
+        &service
+            .redeem_v2(
+                &accepted.encode().expect("encode authenticated redeem"),
+                NOW,
+            )
+            .expect("same proof succeeds after retry-safe rejection"),
+    );
+    success
+        .verify_for_exact_request(&accepted_request, &fixture.settlement_key.verifying_key())
+        .expect("verify signed success after retry-safe rejection");
+    assert!(matches!(
+        success.outcome,
+        ProviderRedeemOutcomeV2::GrantableSuccess { .. }
+    ));
+    assert_eq!(
+        fixture
+            .store
+            .operational_inventory()
+            .expect("inventory after successful redeem")
+            .bat_v2_redemption_rows,
+        1
+    );
+}

--- a/crates/protocol/service/src/bat_v2.rs
+++ b/crates/protocol/service/src/bat_v2.rs
@@ -12,10 +12,10 @@ use crate::codec::{put_bytes_u16, Decoder};
 use crate::{
     derive_issuer_id, is_canonical_service_https_origin_v1, AuthPaddingClassV1, AuthScheme,
     BackendId, DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1, PriceV1, PrivacyLeakageV1,
-    ProviderId, ScopeId, ServiceProtocolError, ServiceScopeV1, VerifiedCurrentPolicyV1, WorkloadId,
-    MAX_BITCOIN_MSAT_V1, MAX_BOLT11_CLAIM_WINDOW_SECONDS_V1,
-    MAX_BOLT11_CREDENTIAL_VALIDITY_SECONDS_V1, MAX_BOLT11_INVOICE_EXPIRY_SECONDS_V1,
-    MAX_CREDENTIALS_PER_ACQUISITION_V1, MAX_ENDPOINT_LEN,
+    ProviderId, ScopeId, ServicePolicyV1, ServiceProtocolError, ServiceScopeV1,
+    VerifiedCurrentPolicyV1, VerifiedServiceOfferV1, WorkloadId, MAX_BITCOIN_MSAT_V1,
+    MAX_BOLT11_CLAIM_WINDOW_SECONDS_V1, MAX_BOLT11_CREDENTIAL_VALIDITY_SECONDS_V1,
+    MAX_BOLT11_INVOICE_EXPIRY_SECONDS_V1, MAX_CREDENTIALS_PER_ACQUISITION_V1, MAX_ENDPOINT_LEN,
 };
 
 pub const BAT_ACCEPTANCE_CLASS_CODEC_MAGIC_V2: &[u8; 8] = b"BPIRBAT2";
@@ -125,6 +125,35 @@ pub fn bat_acceptance_member_from_verified_policy_v2(
     offer_id: u32,
 ) -> Result<VerifiedBatAcceptanceMemberV2, ServiceProtocolError> {
     let selected = verified.offer(expected_scope_id, offer_id)?;
+    bat_acceptance_member_from_verified_offer_v2(verified.policy(), selected)
+}
+
+/// Rebuild one exact member from an issuer-retained signed policy. Unlike the
+/// current-policy acquisition projection, this does not require the policy to
+/// remain current; the later redemption precheck enforces the retained member
+/// deadline and class validity.
+pub fn bat_acceptance_member_from_retained_policy_v2(
+    policy: &ServicePolicyV1,
+    expected_provider_id: &ProviderId,
+    expected_policy_digest: &[u8; 32],
+    expected_scope_id: &ScopeId,
+    offer_id: u32,
+    verifying_key: &VerifyingKey,
+) -> Result<VerifiedBatAcceptanceMemberV2, ServiceProtocolError> {
+    let selected = policy.verify_retained_bat_v2_offer(
+        expected_provider_id,
+        expected_policy_digest,
+        expected_scope_id,
+        offer_id,
+        verifying_key,
+    )?;
+    bat_acceptance_member_from_verified_offer_v2(policy, selected)
+}
+
+fn bat_acceptance_member_from_verified_offer_v2(
+    policy: &ServicePolicyV1,
+    selected: VerifiedServiceOfferV1<'_>,
+) -> Result<VerifiedBatAcceptanceMemberV2, ServiceProtocolError> {
     let scope = selected.scope();
     let offer = selected.offer();
     if offer.authorization != AuthScheme::BitcoinPirCashuBatV2
@@ -156,7 +185,7 @@ pub fn bat_acceptance_member_from_verified_policy_v2(
         });
     };
     let common_terms = BatAcceptanceTermsV2 {
-        auth_padding_class: verified.policy().auth_padding_class,
+        auth_padding_class: policy.auth_padding_class,
         backend: scope.backend,
         workload: scope.workload,
         protocol_version: scope.protocol_version,
@@ -182,13 +211,13 @@ pub fn bat_acceptance_member_from_verified_policy_v2(
         class_id,
         member: BatAcceptanceMemberV2 {
             provider_id: scope.provider_id,
-            policy_digest: verified.policy_digest(),
-            scope_id: *expected_scope_id,
-            offer_id,
+            policy_digest: selected.policy_digest(),
+            scope_id: scope.scope_id(),
+            offer_id: offer.offer_id,
         },
         common_terms,
-        policy_issued_at: verified.policy().issued_at,
-        policy_expires_at: verified.policy().expires_at,
+        policy_issued_at: policy.issued_at,
+        policy_expires_at: policy.expires_at,
         redemption_deadline: selected.redemption_deadline(),
     })
 }
@@ -902,6 +931,29 @@ mod tests {
         assert_eq!(projected.policy_issued_at, 100);
         assert_eq!(projected.policy_expires_at, 1_000);
         assert_eq!(projected.redemption_deadline, 1_480);
+
+        let retained = bat_acceptance_member_from_retained_policy_v2(
+            &policy,
+            &provider_scope.provider_id,
+            &policy.policy_digest().unwrap(),
+            &scope_id,
+            7,
+            &provider_key.verifying_key(),
+        )
+        .unwrap();
+        assert_eq!(retained, projected);
+
+        let mut wrong_digest = policy.policy_digest().unwrap();
+        wrong_digest[0] ^= 1;
+        assert!(bat_acceptance_member_from_retained_policy_v2(
+            &policy,
+            &provider_scope.provider_id,
+            &wrong_digest,
+            &scope_id,
+            7,
+            &provider_key.verifying_key(),
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/protocol/service/src/bat_v2_redemption.rs
+++ b/crates/protocol/service/src/bat_v2_redemption.rs
@@ -1592,7 +1592,6 @@ pub fn precheck_bat_v2_redeem_v2(
     class.verify_for(&expectation.issuer_id, &member.class_id)?;
 
     if member.issuer_id != expectation.issuer_id
-        || member.member.provider_id != expectation.provider_id
         || member.class_id != class.class_id
         || member.common_terms != class.common_terms
         || !class.members.contains(&member.member)
@@ -1634,6 +1633,23 @@ pub fn precheck_bat_v2_redeem_v2(
         ));
     }
 
+    if member.member.provider_id != expectation.provider_id
+        || request.policy_digest != member.member.policy_digest
+        || request.scope_id != member.member.scope_id
+        || request.offer_id != member.member.offer_id
+        || request.class_id != class.class_id
+        || request.class_digest != class.class_digest()?
+        || request.class_key_epoch != class.key_epoch
+        || request.bat_key_id != class.bat_key_id()
+    {
+        return Ok(BatV2RedeemPrecheckV2::RetrySafeNonConsuming(
+            VerifiedRetrySafeNonConsumingV2 {
+                request: request.clone(),
+                reason: RetrySafeNonConsumingReasonV2::ClassCompatibility,
+            },
+        ));
+    }
+
     let Some(rule) = authorization.rule_for_member(&member.member, &class.class_id) else {
         return Ok(BatV2RedeemPrecheckV2::RetrySafeNonConsuming(
             VerifiedRetrySafeNonConsumingV2 {
@@ -1650,22 +1666,6 @@ pub fn precheck_bat_v2_redeem_v2(
             VerifiedRetrySafeNonConsumingV2 {
                 request: request.clone(),
                 reason: RetrySafeNonConsumingReasonV2::AccountingTarget,
-            },
-        ));
-    }
-
-    if request.policy_digest != member.member.policy_digest
-        || request.scope_id != member.member.scope_id
-        || request.offer_id != member.member.offer_id
-        || request.class_id != class.class_id
-        || request.class_digest != class.class_digest()?
-        || request.class_key_epoch != class.key_epoch
-        || request.bat_key_id != class.bat_key_id()
-    {
-        return Ok(BatV2RedeemPrecheckV2::RetrySafeNonConsuming(
-            VerifiedRetrySafeNonConsumingV2 {
-                request: request.clone(),
-                reason: RetrySafeNonConsumingReasonV2::ClassCompatibility,
             },
         ));
     }

--- a/crates/protocol/service/src/lib.rs
+++ b/crates/protocol/service/src/lib.rs
@@ -43,14 +43,14 @@ pub use auth_verify::{
     bind_auth_begin_v1, BoundAuthAttemptV1, TrustedCatalogResolutionV1, TrustedServiceCatalogV1,
 };
 pub use bat_v2::{
-    bat_acceptance_member_from_verified_policy_v2, derive_bat_acceptance_key_id_v2,
-    validate_bat_acceptance_class_id_v2, BatAcceptanceClassIdV2, BatAcceptanceClassV2,
-    BatAcceptanceMemberV2, BatAcceptanceTermsV2, VerifiedBatAcceptanceMemberV2,
-    BAT_ACCEPTANCE_CLASS_CODEC_MAGIC_V2, BAT_ACCEPTANCE_CLASS_DIGEST_DOMAIN_V2,
-    BAT_ACCEPTANCE_CLASS_SIGNATURE_DOMAIN_V2, BAT_ACCEPTANCE_CLASS_WIRE_VERSION_V2,
-    BAT_ACCEPTANCE_KEY_ID_DOMAIN_V2, BAT_ACCEPTANCE_TERMS_DIGEST_DOMAIN_V2,
-    MAX_BAT_ACCEPTANCE_CLASS_LEN_V2, MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2,
-    MAX_BAT_ACCEPTANCE_TERMS_LEN_V2,
+    bat_acceptance_member_from_retained_policy_v2, bat_acceptance_member_from_verified_policy_v2,
+    derive_bat_acceptance_key_id_v2, validate_bat_acceptance_class_id_v2, BatAcceptanceClassIdV2,
+    BatAcceptanceClassV2, BatAcceptanceMemberV2, BatAcceptanceTermsV2,
+    VerifiedBatAcceptanceMemberV2, BAT_ACCEPTANCE_CLASS_CODEC_MAGIC_V2,
+    BAT_ACCEPTANCE_CLASS_DIGEST_DOMAIN_V2, BAT_ACCEPTANCE_CLASS_SIGNATURE_DOMAIN_V2,
+    BAT_ACCEPTANCE_CLASS_WIRE_VERSION_V2, BAT_ACCEPTANCE_KEY_ID_DOMAIN_V2,
+    BAT_ACCEPTANCE_TERMS_DIGEST_DOMAIN_V2, MAX_BAT_ACCEPTANCE_CLASS_LEN_V2,
+    MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2, MAX_BAT_ACCEPTANCE_TERMS_LEN_V2,
 };
 pub use bat_v2_acquisition::{
     BatV2IssuanceRequestV2, BatV2IssuanceResponseV2, Bolt11BatV2ClaimEnvelopeV2,

--- a/crates/protocol/service/src/policy.rs
+++ b/crates/protocol/service/src/policy.rs
@@ -1677,6 +1677,42 @@ impl ServicePolicyV1 {
         Ok(verified)
     }
 
+    /// Verify the signature and exact digest of one issuer-retained BAT V2
+    /// policy member without asserting that it is current. This does not grant
+    /// service and intentionally performs no wall-clock check; the signed BAT
+    /// class and redemption precheck apply the retained member deadline and
+    /// produce the terminal result for expired credentials.
+    pub fn verify_retained_bat_v2_offer<'a>(
+        &'a self,
+        expected_provider_id: &ProviderId,
+        expected_policy_digest: &[u8; 32],
+        expected_scope_id: &crate::ScopeId,
+        offer_id: u32,
+        verifying_key: &VerifyingKey,
+    ) -> Result<VerifiedServiceOfferV1<'a>, ServiceProtocolError> {
+        self.verify_signature_and_identity(expected_provider_id, verifying_key)?;
+        if &self.policy_digest()? != expected_policy_digest {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "ServicePolicyV1.retained_bat_v2_offer",
+                reason: "policy is not the exact issuer-retained digest",
+            });
+        }
+        let verified =
+            verified_offer_from_policy(self, *expected_policy_digest, expected_scope_id, offer_id)?;
+        if verified.offer.authorization != AuthScheme::BitcoinPirCashuBatV2
+            || verified.offer.acquisition != AcquisitionMethod::Bolt11V1
+            || verified.offer.verification != VerificationMode::SharedIssuerOnline
+            || verified.offer.credential_binding.is_some()
+            || verified.offer.cashu_mint_manifest.is_some()
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "ServicePolicyV1.retained_bat_v2_offer",
+                reason: "retained offer is not an issuer-wide BAT V2 member",
+            });
+        }
+        Ok(verified)
+    }
+
     /// Reconstruct the verified offer needed to recover an exact, already
     /// reserved BOLT11 quote after the provider has published a newer policy.
     ///

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -41,13 +41,25 @@ activated the path with real money.
       claim response. Focused tests cover protocol codecs, mixed V1/V2 store
       restart, class-key selection, claim-before-restart recovery and route
       isolation.
-- [ ] **Issuer-wide V2 redemption and provider path pending.** V1 redeem and
-      ProviderStore paths still deliberately reject scheme 6; no old
-      replayable V1 redeem success is reinterpreted. The V2 presentation,
-      issuer-global first-spend transaction, non-grantable redeem replay,
-      storeless provider commit, SDK/Web class wallet and render gates remain
-      to implement. Current `main` also retains the old Direct Mainnet issuer
-      unit and stateful V1 provider profiles. An old draft's fixed
+- [x] **Issuer-wide V2 redemption implemented at the issuer boundary.** A
+      separate V2 presentation, provider accounting authorization and
+      `/v2/redeems` route use issuer-store schema v8. The issuer transaction
+      races every provider on one global credential-spend key, credits only
+      the fresh winner, keeps the initial signed success private to integrity
+      checks and returns only a non-granting terminal for exact, later,
+      cross-provider and post-restart replays. Pre-spend provider-authentication,
+      accounting-target and class-compatibility failures are signed retry-safe
+      zero-mutation outcomes; storage/verification ambiguity uses a distinct
+      burn/no-retry HTTP error. V1 redeem remains isolated. Focused protocol,
+      store, service and route tests cover one-winner concurrency, retained
+      members, restart replay, real Cashu proof verification, zero-mutation
+      retry-safe rejection, exact media types and CLI trust inputs.
+- [ ] **Storeless provider, SDK/Web and render path pending.** ProviderStore
+      paths still deliberately reject scheme 6; no old replayable V1 success is
+      reinterpreted. The connection-local V2 provider committer, SDK/Web class
+      wallet, two-paid-leg selection and production render gates remain to
+      implement. Current `main` also retains the old Direct Mainnet issuer unit
+      and stateful V1 provider profiles. An old draft's fixed
       2-policy/12-key/2-clearing shape remains superseded and is not V2
       readiness evidence.
 - [ ] **Payment-storeless provider mode pending.** The current shared-BAT


### PR DESCRIPTION
## Summary
- add the transport-neutral issuer BAT V2 redemption service and exact retained-policy member verification
- expose isolated `/v2/redeems` media types and V2 accounting trust inputs without V1 ProviderStore or replay semantics
- enforce issuer-global first-spend, fresh-success-only grants, signed retry-safe pre-spend failures, and burn-on-ambiguity errors
- update implementation status while provider/runtime/SDK/Web/render work remains pending

## Tests
- `cargo test --locked --offline -p pir-service-protocol bat_v2_redemption_`
- `cargo test --locked --offline -p pir-issuer-service --test bat_v2_redemption`
- `cargo test --locked --offline -p payment-issuer bat_v2_`
- `cargo check --locked --offline -p pir-service-protocol -p pir-issuer-service -p payment-issuer --all-targets`
- `cargo clippy --locked --offline -p pir-service-protocol -p pir-issuer-service -p payment-issuer --all-targets --no-deps -- -D warnings`