### PR TITLE
Add storeless BAT V2 provider redemption client

### DIFF
--- a/crates/payment/provider-clearing-client/README.md
+++ b/crates/payment/provider-clearing-client/README.md
@@ -5,6 +5,17 @@ settlement workflow persistence. It never accepts or stores a payer identity,
 Lightning invoice, payment hash, preimage, PIR query, result, or peer-provider
 identity.
 
+The issuer-wide BAT V2 path is deliberately payment-storeless. It creates one
+fresh public OS-random attempt ID per connection, sends the canonical request
+exactly once, and can produce an opaque connection grant only by consuming the
+protocol's non-clone in-flight witness for that exact issuer-signed fresh
+success. It has no `ProviderStore`, provider-secret idempotency HMAC, local
+delivery claim, payment rollback client, automatic retry, or saved-response
+grant recovery. Only a transport-proven `DefinitelyNotSent` result or one of
+the three issuer-signed non-consuming rejections leaves the BAT eligible for a
+later caller-initiated presentation; every unsigned HTTP status, malformed or
+misbound response, timeout, and otherwise ambiguous outcome burns it.
+
 `StrictHttpsProviderSettlementTransportV1` accepts HTTP 200 as the only
 transport success status and requires the route-specific success media type.
 Every other status must use the bounded problem media type and remains an

--- a/crates/payment/provider-clearing-client/src/bat_v2.rs
+++ b/crates/payment/provider-clearing-client/src/bat_v2.rs
@@ -1,0 +1,372 @@
+use core::fmt;
+
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use pir_service_protocol::{
+    verify_grantable_success_for_inflight_attempt_v2, BatAcceptanceClassV2,
+    BitcoinPirCashuBatProofV2, IssuerAccountingApprovalV2, ProviderAccountingAuthorizationV2,
+    ProviderId, ProviderRedeemEnvelopeV2, ProviderRedeemOutcomeV2, ProviderRedeemRequestAuthV2,
+    ProviderRedeemRequestV2, ProviderRedeemResponseV2, RetrySafeNonConsumingReasonV2,
+    ServiceProtocolError, VerifiedBatAcceptanceMemberV2, VerifiedGrantableProviderRedeemSuccessV2,
+    MAX_BAT_V2_PROVIDER_REDEEM_RESPONSE_LEN_V2,
+};
+use zeroize::Zeroizing;
+
+pub const BAT_V2_REDEEM_ENDPOINT_V2: &str = "/v2/redeems";
+pub const BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2: &str =
+    "application/vnd.bitcoinpir.bat-v2-provider-redeem-envelope-v2";
+pub const BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2: &str =
+    "application/vnd.bitcoinpir.bat-v2-provider-redeem-response-v2";
+
+/// Exact canonical request handed to a concrete HTTPS adapter. The origin and
+/// leaf pins come only from the signed accounting authorization; adapters must
+/// require WebPKI in addition to the pins, disable redirects, and never log the
+/// body.
+pub struct BatV2RedeemHttpRequestV2<'a> {
+    pub issuer_origin: &'a str,
+    pub leaf_spki_sha256_pins: &'a [[u8; 32]],
+    pub endpoint: &'static str,
+    pub request_content_type: &'static str,
+    pub response_content_type: &'static str,
+    pub canonical_envelope: &'a [u8],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BatV2RedeemTransportErrorV2 {
+    /// The adapter proves that no HTTP application byte reached the issuer.
+    DefinitelyNotSent { retry_after_ms: u32 },
+    /// Request delivery or issuer commit may have occurred. This burns the BAT.
+    OutcomeUnknown,
+}
+
+/// Transport-neutral, single-attempt BAT V2 redemption boundary.
+pub trait BatV2RedeemTransportV2: Send + Sync {
+    fn redeem_v2(
+        &self,
+        request: BatV2RedeemHttpRequestV2<'_>,
+        max_response_bytes: usize,
+    ) -> Result<Vec<u8>, BatV2RedeemTransportErrorV2>;
+}
+
+pub struct BatV2ProviderRedeemTrustV2 {
+    pub expected_provider_id: ProviderId,
+    pub expected_issuer_id: [u8; 32],
+    pub authorization: ProviderAccountingAuthorizationV2,
+    pub issuer_approval: IssuerAccountingApprovalV2,
+    pub operator_verifying_key: VerifyingKey,
+    pub issuer_settlement_verifying_key: VerifyingKey,
+    pub minimum_authorization_epoch: u64,
+}
+
+impl fmt::Debug for BatV2ProviderRedeemTrustV2 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BatV2ProviderRedeemTrustV2")
+            .field("expected_provider_id", &self.expected_provider_id)
+            .field("expected_issuer_id", &self.expected_issuer_id)
+            .field(
+                "authorization_epoch",
+                &self.authorization.claims.authorization_epoch,
+            )
+            .field(
+                "minimum_authorization_epoch",
+                &self.minimum_authorization_epoch,
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+/// Opaque, non-clone proof that the issuer freshly committed this exact
+/// in-flight attempt. It intentionally exposes neither response bytes nor a
+/// recovery constructor.
+pub struct FreshBatV2ConnectionGrantV2 {
+    _verified: VerifiedGrantableProviderRedeemSuccessV2,
+}
+
+impl fmt::Debug for FreshBatV2ConnectionGrantV2 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("FreshBatV2ConnectionGrantV2")
+            .finish_non_exhaustive()
+    }
+}
+
+pub enum StorelessBatV2RedeemDecisionV2 {
+    FreshGrant(Box<FreshBatV2ConnectionGrantV2>),
+    RetrySafeNonConsuming(RetrySafeNonConsumingReasonV2),
+    DefinitelyNotSent { retry_after_ms: u32 },
+    TerminalInvalidOrSpent,
+}
+
+impl fmt::Debug for StorelessBatV2RedeemDecisionV2 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FreshGrant(_) => formatter.write_str("FreshGrant([VERIFIED])"),
+            Self::RetrySafeNonConsuming(reason) => formatter
+                .debug_tuple("RetrySafeNonConsuming")
+                .field(reason)
+                .finish(),
+            Self::DefinitelyNotSent { retry_after_ms } => formatter
+                .debug_struct("DefinitelyNotSent")
+                .field("retry_after_ms", retry_after_ms)
+                .finish(),
+            Self::TerminalInvalidOrSpent => formatter.write_str("TerminalInvalidOrSpent"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum StorelessBatV2RedeemErrorV2 {
+    /// Local validation or encoding failed before any request byte was sent.
+    PreSend(ServiceProtocolError),
+    /// OS randomness failed before any request byte was sent.
+    EntropyUnavailable,
+    /// Delivery, response validity, or issuer commit is uncertain. The caller
+    /// must burn the credential and must not automatically retry it.
+    OutcomeUnknownCredentialBurned,
+}
+
+impl fmt::Display for StorelessBatV2RedeemErrorV2 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PreSend(error) => write!(formatter, "BAT V2 pre-send validation failed: {error}"),
+            Self::EntropyUnavailable => {
+                formatter.write_str("BAT V2 attempt entropy is unavailable before send")
+            }
+            Self::OutcomeUnknownCredentialBurned => formatter.write_str(
+                "BAT V2 outcome is unknown; the credential is burned and must not be retried",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for StorelessBatV2RedeemErrorV2 {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::PreSend(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+/// Stateless provider client for issuer-wide BAT V2 admission. It owns no
+/// ProviderStore, idempotency/HMAC secret, rollback client, or replay state.
+pub struct StorelessBatV2ProviderRedeemClientV2<'a> {
+    trust: BatV2ProviderRedeemTrustV2,
+    clearing_signing_key: SigningKey,
+    transport: &'a dyn BatV2RedeemTransportV2,
+}
+
+impl fmt::Debug for StorelessBatV2ProviderRedeemClientV2<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorelessBatV2ProviderRedeemClientV2")
+            .field("trust", &self.trust)
+            .field("clearing_signing_key", &"[REDACTED]")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> StorelessBatV2ProviderRedeemClientV2<'a> {
+    pub fn new(
+        trust: BatV2ProviderRedeemTrustV2,
+        clearing_signing_key: SigningKey,
+        transport: &'a dyn BatV2RedeemTransportV2,
+    ) -> Result<Self, ServiceProtocolError> {
+        if trust.minimum_authorization_epoch == 0
+            || trust.authorization.claims.provider_id != trust.expected_provider_id
+            || trust.authorization.claims.issuer_id != trust.expected_issuer_id
+            || trust.authorization.claims.authorization_epoch < trust.minimum_authorization_epoch
+            || trust.authorization.claims.clearing_verifying_key
+                != clearing_signing_key.verifying_key().to_bytes()
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "StorelessBatV2ProviderRedeemClientV2.trust",
+                reason: "provider, issuer, epoch, or clearing key does not match pinned trust",
+            });
+        }
+        let operator = trust.operator_verifying_key.to_bytes();
+        let settlement = trust.issuer_settlement_verifying_key.to_bytes();
+        let clearing = clearing_signing_key.verifying_key().to_bytes();
+        if operator == settlement || operator == clearing || settlement == clearing {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "StorelessBatV2ProviderRedeemClientV2.role_keys",
+                reason: "operator, issuer settlement, and provider clearing keys must be distinct",
+            });
+        }
+        // Prove that the two public artifacts share at least one valid instant
+        // before accepting them as a durable trust configuration. Current-time
+        // validity is checked again for every attempt.
+        let overlap_start = trust
+            .authorization
+            .claims
+            .not_before
+            .max(trust.issuer_approval.approved_at);
+        let overlap_end = trust
+            .authorization
+            .claims
+            .not_after
+            .min(trust.issuer_approval.not_after);
+        if overlap_start > overlap_end {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "StorelessBatV2ProviderRedeemClientV2.validity",
+                reason: "authorization and issuer approval have no common validity instant",
+            });
+        }
+        trust.authorization.verify_for(
+            &trust.expected_provider_id,
+            &trust.expected_issuer_id,
+            &trust.operator_verifying_key,
+            overlap_start,
+            trust.minimum_authorization_epoch,
+        )?;
+        trust.issuer_approval.verify_for(
+            &trust.authorization,
+            &trust.issuer_settlement_verifying_key,
+            overlap_start,
+            trust.minimum_authorization_epoch,
+        )?;
+        Ok(Self {
+            trust,
+            clearing_signing_key,
+            transport,
+        })
+    }
+
+    pub fn redeem_once(
+        &self,
+        member: &VerifiedBatAcceptanceMemberV2,
+        class: &BatAcceptanceClassV2,
+        proof: &BitcoinPirCashuBatProofV2,
+        now_unix: u64,
+    ) -> Result<StorelessBatV2RedeemDecisionV2, StorelessBatV2RedeemErrorV2> {
+        self.verify_attempt_inputs(member, class, now_unix)
+            .map_err(StorelessBatV2RedeemErrorV2::PreSend)?;
+        let attempt_id = fresh_nonzero_attempt_id_v2()?;
+        let prepared = ProviderRedeemRequestV2::prepare(
+            &self.trust.authorization,
+            member,
+            class,
+            proof,
+            attempt_id,
+        )
+        .map_err(StorelessBatV2RedeemErrorV2::PreSend)?;
+        let (request, in_flight) = prepared.into_parts();
+        let request_auth = ProviderRedeemRequestAuthV2::sign(&request, &self.clearing_signing_key)
+            .map_err(StorelessBatV2RedeemErrorV2::PreSend)?;
+        let canonical_envelope = Zeroizing::new(
+            ProviderRedeemEnvelopeV2 {
+                request: request.clone(),
+                request_auth,
+                credential: proof.clone(),
+            }
+            .encode()
+            .map_err(StorelessBatV2RedeemErrorV2::PreSend)?,
+        );
+
+        let response_bytes = match self.transport.redeem_v2(
+            BatV2RedeemHttpRequestV2 {
+                issuer_origin: &self.trust.authorization.claims.redeem_endpoint,
+                leaf_spki_sha256_pins: &self
+                    .trust
+                    .authorization
+                    .claims
+                    .redeem_leaf_spki_sha256_pins,
+                endpoint: BAT_V2_REDEEM_ENDPOINT_V2,
+                request_content_type: BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2,
+                response_content_type: BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
+                canonical_envelope: canonical_envelope.as_slice(),
+            },
+            MAX_BAT_V2_PROVIDER_REDEEM_RESPONSE_LEN_V2,
+        ) {
+            Ok(bytes) => Zeroizing::new(bytes),
+            Err(BatV2RedeemTransportErrorV2::DefinitelyNotSent { retry_after_ms }) => {
+                return Ok(StorelessBatV2RedeemDecisionV2::DefinitelyNotSent { retry_after_ms });
+            }
+            Err(BatV2RedeemTransportErrorV2::OutcomeUnknown) => {
+                return Err(StorelessBatV2RedeemErrorV2::OutcomeUnknownCredentialBurned);
+            }
+        };
+        if response_bytes.len() > MAX_BAT_V2_PROVIDER_REDEEM_RESPONSE_LEN_V2 {
+            return Err(StorelessBatV2RedeemErrorV2::OutcomeUnknownCredentialBurned);
+        }
+        let response = ProviderRedeemResponseV2::decode(&response_bytes)
+            .map_err(|_| StorelessBatV2RedeemErrorV2::OutcomeUnknownCredentialBurned)?;
+        if response
+            .encode()
+            .map_err(|_| StorelessBatV2RedeemErrorV2::OutcomeUnknownCredentialBurned)?
+            != response_bytes.as_slice()
+        {
+            return Err(StorelessBatV2RedeemErrorV2::OutcomeUnknownCredentialBurned);
+        }
+        response
+            .verify_for_exact_request(&request, &self.trust.issuer_settlement_verifying_key)
+            .map_err(|_| StorelessBatV2RedeemErrorV2::OutcomeUnknownCredentialBurned)?;
+
+        match response.outcome {
+            ProviderRedeemOutcomeV2::GrantableSuccess { .. } => {
+                let verified = verify_grantable_success_for_inflight_attempt_v2(
+                    response,
+                    &request,
+                    in_flight,
+                    &self.trust.issuer_settlement_verifying_key,
+                )
+                .map_err(|_| StorelessBatV2RedeemErrorV2::OutcomeUnknownCredentialBurned)?;
+                Ok(StorelessBatV2RedeemDecisionV2::FreshGrant(Box::new(
+                    FreshBatV2ConnectionGrantV2 {
+                        _verified: verified,
+                    },
+                )))
+            }
+            ProviderRedeemOutcomeV2::RetrySafeNonConsuming { reason } => Ok(
+                StorelessBatV2RedeemDecisionV2::RetrySafeNonConsuming(reason),
+            ),
+            ProviderRedeemOutcomeV2::TerminalInvalidOrSpent => {
+                Ok(StorelessBatV2RedeemDecisionV2::TerminalInvalidOrSpent)
+            }
+        }
+    }
+
+    fn verify_attempt_inputs(
+        &self,
+        member: &VerifiedBatAcceptanceMemberV2,
+        class: &BatAcceptanceClassV2,
+        now_unix: u64,
+    ) -> Result<(), ServiceProtocolError> {
+        self.trust.authorization.verify_for(
+            &self.trust.expected_provider_id,
+            &self.trust.expected_issuer_id,
+            &self.trust.operator_verifying_key,
+            now_unix,
+            self.trust.minimum_authorization_epoch,
+        )?;
+        self.trust.issuer_approval.verify_for(
+            &self.trust.authorization,
+            &self.trust.issuer_settlement_verifying_key,
+            now_unix,
+            self.trust.minimum_authorization_epoch,
+        )?;
+        if now_unix < class.key_not_before
+            || now_unix > class.key_not_after
+            || now_unix < member.policy_issued_at
+            || now_unix > member.redemption_deadline
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "StorelessBatV2ProviderRedeemClientV2.member_validity",
+                reason: "class key or exact policy member is outside its redemption window",
+            });
+        }
+        Ok(())
+    }
+}
+
+fn fresh_nonzero_attempt_id_v2() -> Result<[u8; 32], StorelessBatV2RedeemErrorV2> {
+    for _ in 0..2 {
+        let mut attempt_id = [0u8; 32];
+        getrandom::getrandom(&mut attempt_id)
+            .map_err(|_| StorelessBatV2RedeemErrorV2::EntropyUnavailable)?;
+        if attempt_id.iter().any(|byte| *byte != 0) {
+            return Ok(attempt_id);
+        }
+    }
+    Err(StorelessBatV2RedeemErrorV2::EntropyUnavailable)
+}

--- a/crates/payment/provider-clearing-client/src/bat_v2_https_transport.rs
+++ b/crates/payment/provider-clearing-client/src/bat_v2_https_transport.rs
@@ -1,0 +1,218 @@
+use std::time::Duration;
+
+use pir_strict_https::{HttpsPostErrorV1, StrictHttpsClientV1};
+
+use crate::{
+    BatV2RedeemHttpRequestV2, BatV2RedeemTransportErrorV2, BatV2RedeemTransportV2,
+    BAT_V2_REDEEM_ENDPOINT_V2, BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2,
+    BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
+};
+
+/// Strict production HTTPS adapter for the storeless BAT V2 redeem client.
+/// WebPKI is always required in addition to the signed leaf-SPKI pins.
+#[derive(Clone, Debug)]
+pub struct StrictHttpsBatV2RedeemTransportV2 {
+    issuer_origin: String,
+    leaf_spki_sha256_pins: Vec<[u8; 32]>,
+    client: StrictHttpsClientV1,
+}
+
+impl StrictHttpsBatV2RedeemTransportV2 {
+    pub fn new(
+        issuer_origin: String,
+        connect_timeout: Duration,
+        io_timeout: Duration,
+        leaf_spki_sha256_pins: &[[u8; 32]],
+    ) -> Result<Self, String> {
+        StrictHttpsClientV1::validate_base_endpoint(&issuer_origin)?;
+        let client = StrictHttpsClientV1::new_with_leaf_spki_sha256_pins(
+            connect_timeout,
+            io_timeout,
+            leaf_spki_sha256_pins,
+        )?;
+        Ok(Self {
+            issuer_origin,
+            leaf_spki_sha256_pins: leaf_spki_sha256_pins.to_vec(),
+            client,
+        })
+    }
+
+    #[cfg(feature = "test-only-webpki-root")]
+    pub fn new_with_test_only_webpki_root_pem(
+        issuer_origin: String,
+        connect_timeout: Duration,
+        io_timeout: Duration,
+        leaf_spki_sha256_pins: &[[u8; 32]],
+        test_only_root_pem: &[u8],
+    ) -> Result<Self, String> {
+        StrictHttpsClientV1::validate_base_endpoint(&issuer_origin)?;
+        let client =
+            StrictHttpsClientV1::new_with_leaf_spki_sha256_pins_and_test_only_webpki_root_pem(
+                connect_timeout,
+                io_timeout,
+                leaf_spki_sha256_pins,
+                test_only_root_pem,
+            )?;
+        Ok(Self {
+            issuer_origin,
+            leaf_spki_sha256_pins: leaf_spki_sha256_pins.to_vec(),
+            client,
+        })
+    }
+
+    pub fn issuer_origin(&self) -> &str {
+        &self.issuer_origin
+    }
+}
+
+impl BatV2RedeemTransportV2 for StrictHttpsBatV2RedeemTransportV2 {
+    fn redeem_v2(
+        &self,
+        request: BatV2RedeemHttpRequestV2<'_>,
+        max_response_bytes: usize,
+    ) -> Result<Vec<u8>, BatV2RedeemTransportErrorV2> {
+        if request.issuer_origin != self.issuer_origin
+            || request.leaf_spki_sha256_pins != self.leaf_spki_sha256_pins
+            || request.endpoint != BAT_V2_REDEEM_ENDPOINT_V2
+            || request.request_content_type != BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2
+            || request.response_content_type != BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2
+        {
+            return Err(BatV2RedeemTransportErrorV2::DefinitelyNotSent { retry_after_ms: 0 });
+        }
+        self.client
+            .post_with_error_content_type(
+                &self.issuer_origin,
+                BAT_V2_REDEEM_ENDPOINT_V2,
+                BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2,
+                BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
+                "application/problem+json",
+                request.canonical_envelope,
+                max_response_bytes,
+            )
+            .map_err(map_bat_v2_https_error)
+    }
+}
+
+fn map_bat_v2_https_error(error: HttpsPostErrorV1) -> BatV2RedeemTransportErrorV2 {
+    match error {
+        HttpsPostErrorV1::DefinitelyNotSent => {
+            BatV2RedeemTransportErrorV2::DefinitelyNotSent { retry_after_ms: 0 }
+        }
+        HttpsPostErrorV1::OutcomeUnknown
+        | HttpsPostErrorV1::InvalidResponse
+        | HttpsPostErrorV1::HttpStatus { .. } => BatV2RedeemTransportErrorV2::OutcomeUnknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeroize::Zeroizing;
+
+    #[test]
+    fn bat_v2_https_only_definitely_not_sent_is_retry_safe() {
+        assert_eq!(
+            map_bat_v2_https_error(HttpsPostErrorV1::DefinitelyNotSent),
+            BatV2RedeemTransportErrorV2::DefinitelyNotSent { retry_after_ms: 0 }
+        );
+        assert_eq!(
+            map_bat_v2_https_error(HttpsPostErrorV1::OutcomeUnknown),
+            BatV2RedeemTransportErrorV2::OutcomeUnknown
+        );
+        assert_eq!(
+            map_bat_v2_https_error(HttpsPostErrorV1::InvalidResponse),
+            BatV2RedeemTransportErrorV2::OutcomeUnknown
+        );
+        for status in 0..=u16::MAX {
+            assert_eq!(
+                map_bat_v2_https_error(HttpsPostErrorV1::HttpStatus {
+                    status,
+                    body: Zeroizing::new(Vec::new()),
+                }),
+                BatV2RedeemTransportErrorV2::OutcomeUnknown
+            );
+        }
+    }
+
+    #[test]
+    fn bat_v2_https_constructor_rejects_unsafe_origin_or_pins() {
+        for origin in [
+            "http://issuer.example",
+            "https://issuer.example/",
+            "https://user@issuer.example",
+            "https://issuer.example?query",
+        ] {
+            assert!(StrictHttpsBatV2RedeemTransportV2::new(
+                origin.to_owned(),
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+                &[[1; 32]],
+            )
+            .is_err());
+        }
+        assert!(StrictHttpsBatV2RedeemTransportV2::new(
+            "https://issuer.example/api".to_owned(),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            &[[1; 32]],
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn bat_v2_https_rejects_misbound_signed_transport_inputs_before_send() {
+        let transport = StrictHttpsBatV2RedeemTransportV2::new(
+            "https://issuer.example/api".to_owned(),
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            &[[1; 32]],
+        )
+        .unwrap();
+        let assert_not_sent = |request| {
+            assert_eq!(
+                transport.redeem_v2(request, 339),
+                Err(BatV2RedeemTransportErrorV2::DefinitelyNotSent { retry_after_ms: 0 })
+            );
+        };
+        assert_not_sent(BatV2RedeemHttpRequestV2 {
+            issuer_origin: "https://other.example/api",
+            leaf_spki_sha256_pins: &[[1; 32]],
+            endpoint: BAT_V2_REDEEM_ENDPOINT_V2,
+            request_content_type: BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2,
+            response_content_type: BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
+            canonical_envelope: &[],
+        });
+        assert_not_sent(BatV2RedeemHttpRequestV2 {
+            issuer_origin: "https://issuer.example/api",
+            leaf_spki_sha256_pins: &[[2; 32]],
+            endpoint: BAT_V2_REDEEM_ENDPOINT_V2,
+            request_content_type: BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2,
+            response_content_type: BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
+            canonical_envelope: &[],
+        });
+        assert_not_sent(BatV2RedeemHttpRequestV2 {
+            issuer_origin: "https://issuer.example/api",
+            leaf_spki_sha256_pins: &[[1; 32]],
+            endpoint: "/v2/redeems/",
+            request_content_type: BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2,
+            response_content_type: BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
+            canonical_envelope: &[],
+        });
+        assert_not_sent(BatV2RedeemHttpRequestV2 {
+            issuer_origin: "https://issuer.example/api",
+            leaf_spki_sha256_pins: &[[1; 32]],
+            endpoint: BAT_V2_REDEEM_ENDPOINT_V2,
+            request_content_type: "application/octet-stream",
+            response_content_type: BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
+            canonical_envelope: &[],
+        });
+        assert_not_sent(BatV2RedeemHttpRequestV2 {
+            issuer_origin: "https://issuer.example/api",
+            leaf_spki_sha256_pins: &[[1; 32]],
+            endpoint: BAT_V2_REDEEM_ENDPOINT_V2,
+            request_content_type: BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2,
+            response_content_type: "application/octet-stream",
+            canonical_envelope: &[],
+        });
+    }
+}

--- a/crates/payment/provider-clearing-client/src/bat_v2_tests.rs
+++ b/crates/payment/provider-clearing-client/src/bat_v2_tests.rs
@@ -1,0 +1,638 @@
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use ed25519_dalek::SigningKey;
+use pir_service_protocol::{
+    precheck_bat_v2_redeem_v2, sign_and_commit_grantable_success_v2,
+    sign_retry_safe_non_consuming_v2, sign_terminal_invalid_or_spent_v2,
+    verify_bat_v2_credential_for_commit_v2, AuthPaddingClassV1, BackendId, BatAcceptanceClassV2,
+    BatAcceptanceMemberV2, BatAcceptanceTermsV2, BatV2CredentialCheckV2,
+    BatV2ProofVerificationInputV2, BatV2ProofVerifierV2, BatV2RedeemCommitResultV2,
+    BatV2RedeemCommitStoreV2, BatV2RedeemPrecheckV2, BitcoinPirCashuBatProofV2, DatasetBindingV1,
+    DeploymentStatus, EntitlementLimitsV1, IssuerAccountingApprovalV2, PrivacyLeakageV1,
+    ProviderAccountingAuthorizationClaimsV2, ProviderAccountingAuthorizationV2,
+    ProviderAccountingExpectationV2, ProviderAccountingRuleV2, ProviderRedeemEnvelopeV2,
+    ProviderRedeemResponseV2, RetrySafeNonConsumingReasonV2, SettlementUnitV1,
+    VerifiedBatAcceptanceMemberV2, VerifiedBatV2RedeemCommitV2, WorkloadId,
+    MAX_BAT_V2_PROVIDER_REDEEM_RESPONSE_LEN_V2,
+};
+
+use crate::{
+    BatV2ProviderRedeemTrustV2, BatV2RedeemHttpRequestV2, BatV2RedeemTransportErrorV2,
+    BatV2RedeemTransportV2, StorelessBatV2ProviderRedeemClientV2, StorelessBatV2RedeemDecisionV2,
+    StorelessBatV2RedeemErrorV2, BAT_V2_REDEEM_ENDPOINT_V2, BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2,
+    BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
+};
+
+const NOW: u64 = 200;
+const SECP_GENERATOR: [u8; 33] = [
+    0x02, 0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce, 0x87, 0x0b,
+    0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81, 0x5b, 0x16, 0xf8, 0x17,
+    0x98,
+];
+
+fn terms() -> BatAcceptanceTermsV2 {
+    BatAcceptanceTermsV2 {
+        auth_padding_class: AuthPaddingClassV1::Class16KiB,
+        backend: BackendId::DpfPirV1,
+        workload: WorkloadId::DpfEvaluateJobV1,
+        protocol_version: 1,
+        dataset: DatasetBindingV1::Class { class_id: 1 },
+        operation_profile: 1,
+        entitlement_profile: 2,
+        limits: EntitlementLimitsV1 {
+            max_logical_inputs: 4,
+            max_frames: 200,
+            max_request_bytes: 1_000_000,
+            max_response_bytes: 2_000_000,
+            max_wall_time_ms: 60_000,
+            max_concurrent_sockets: 1,
+            max_hint_groups: 0,
+            max_work_units: 9_000,
+        },
+        priority_class: 1,
+        deployment_status: DeploymentStatus::Stable,
+        price_msat: 2_000,
+        issuer_endpoint: "https://issuer.invalid".into(),
+        invoice_expiry_seconds: 60,
+        claim_window_seconds: 120,
+        minimum_credential_validity_seconds: 300,
+        retired_policy_grace_seconds: 480,
+        credential_count: 2,
+        credential_presentation_limit: 1,
+        privacy_leakage: PrivacyLeakageV1::from_bits(
+            PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+        )
+        .unwrap(),
+    }
+}
+
+fn member(policy_byte: u8, scope_byte: u8, offer_id: u32) -> BatAcceptanceMemberV2 {
+    BatAcceptanceMemberV2 {
+        provider_id: [2; 32],
+        policy_digest: [policy_byte; 32],
+        scope_id: [scope_byte; 32],
+        offer_id,
+    }
+}
+
+struct Fixture {
+    class: BatAcceptanceClassV2,
+    selected: VerifiedBatAcceptanceMemberV2,
+    class_only: VerifiedBatAcceptanceMemberV2,
+    authorization: ProviderAccountingAuthorizationV2,
+    approval: IssuerAccountingApprovalV2,
+    operator_key: SigningKey,
+    settlement_key: SigningKey,
+    clearing_key: SigningKey,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let class_signing_key = SigningKey::from_bytes(&[8; 32]);
+        let operator_key = SigningKey::from_bytes(&[11; 32]);
+        let settlement_key = SigningKey::from_bytes(&[24; 32]);
+        let clearing_key = SigningKey::from_bytes(&[6; 32]);
+        let members = vec![member(8, 9, 10), member(18, 19, 20)];
+        let class = BatAcceptanceClassV2::sign(
+            [7; 32],
+            13,
+            100,
+            2_000,
+            SECP_GENERATOR,
+            terms(),
+            members.clone(),
+            &class_signing_key,
+        )
+        .unwrap();
+        let issuer_id = class.issuer_id;
+        let class_id = class.class_id;
+        let common_terms = class.common_terms.clone();
+        let verified = |member: BatAcceptanceMemberV2| VerifiedBatAcceptanceMemberV2 {
+            issuer_id,
+            class_id,
+            member,
+            common_terms: common_terms.clone(),
+            policy_issued_at: 100,
+            policy_expires_at: 1_000,
+            redemption_deadline: 1_480,
+        };
+        let authorization = ProviderAccountingAuthorizationV2::sign(
+            ProviderAccountingAuthorizationClaimsV2 {
+                authorization_id: [1; 16],
+                authorization_epoch: 7,
+                provider_id: [2; 32],
+                issuer_id: class.issuer_id,
+                redeem_endpoint: "https://issuer.invalid".into(),
+                redeem_leaf_spki_sha256_pins: vec![[4; 32]],
+                settlement_account_id: [5; 32],
+                clearing_verifying_key: clearing_key.verifying_key().to_bytes(),
+                not_before: 100,
+                not_after: 1_000,
+                rules: vec![
+                    ProviderAccountingRuleV2 {
+                        class_id: class.class_id,
+                        policy_digest: members[0].policy_digest,
+                        scope_id: members[0].scope_id,
+                        offer_id: members[0].offer_id,
+                        unit: SettlementUnitV1::AuthCredit,
+                        accepted_value: 10,
+                        provider_credit: 8,
+                        issuer_fee: 2,
+                    },
+                    ProviderAccountingRuleV2 {
+                        class_id: class.class_id,
+                        policy_digest: members[1].policy_digest,
+                        scope_id: members[1].scope_id,
+                        offer_id: members[1].offer_id,
+                        unit: SettlementUnitV1::AuthCredit,
+                        accepted_value: 10,
+                        provider_credit: 8,
+                        issuer_fee: 2,
+                    },
+                ],
+            },
+            &operator_key,
+        )
+        .unwrap();
+        let approval =
+            IssuerAccountingApprovalV2::sign(&authorization, 150, 900, &settlement_key).unwrap();
+        Self {
+            class,
+            selected: verified(members[0].clone()),
+            class_only: verified(members[1].clone()),
+            authorization,
+            approval,
+            operator_key,
+            settlement_key,
+            clearing_key,
+        }
+    }
+
+    fn proof(&self) -> BitcoinPirCashuBatProofV2 {
+        BitcoinPirCashuBatProofV2::from_class(&self.class, [15; 32], SECP_GENERATOR).unwrap()
+    }
+
+    fn trust(&self) -> BatV2ProviderRedeemTrustV2 {
+        BatV2ProviderRedeemTrustV2 {
+            expected_provider_id: [2; 32],
+            expected_issuer_id: self.class.issuer_id,
+            authorization: self.authorization.clone(),
+            issuer_approval: self.approval.clone(),
+            operator_verifying_key: self.operator_key.verifying_key(),
+            issuer_settlement_verifying_key: self.settlement_key.verifying_key(),
+            minimum_authorization_epoch: 7,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Mode {
+    Normal,
+    DefinitelyNotSent,
+    OutcomeUnknown,
+    InvalidBody,
+    Oversize,
+    ReplayPrevious,
+    BadSignature,
+    RetryProviderAuthentication,
+    RetryClassCompatibility,
+}
+
+#[derive(Debug)]
+struct Observation {
+    attempt_id: [u8; 32],
+    endpoint: &'static str,
+    request_content_type: &'static str,
+    response_content_type: &'static str,
+    max_response_bytes: usize,
+}
+
+#[derive(Default)]
+struct MemoryCommitStore {
+    attempts: HashSet<([u8; 32], [u8; 32])>,
+    spends: HashSet<[u8; 32]>,
+}
+
+impl BatV2RedeemCommitStoreV2 for MemoryCommitStore {
+    type Error = ();
+
+    fn attempt_is_committed(
+        &self,
+        request: &pir_service_protocol::ProviderRedeemRequestV2,
+    ) -> Result<bool, Self::Error> {
+        Ok(self
+            .attempts
+            .contains(&(request.provider_id, request.attempt_id)))
+    }
+
+    fn commit_fresh(
+        &mut self,
+        verified: &VerifiedBatV2RedeemCommitV2,
+        _signed_initial_success: &ProviderRedeemResponseV2,
+    ) -> Result<bool, Self::Error> {
+        let attempt = (
+            verified.request().provider_id,
+            verified.request().attempt_id,
+        );
+        if self.attempts.contains(&attempt) || self.spends.contains(verified.global_spend_key()) {
+            return Ok(false);
+        }
+        self.attempts.insert(attempt);
+        self.spends.insert(*verified.global_spend_key());
+        Ok(true)
+    }
+}
+
+struct TestIssuerTransport {
+    fixture: Fixture,
+    mode: Mutex<Mode>,
+    store: Mutex<MemoryCommitStore>,
+    observations: Mutex<Vec<Observation>>,
+    previous_response: Mutex<Option<Vec<u8>>>,
+}
+
+struct AlwaysValidProof;
+
+impl BatV2ProofVerifierV2 for AlwaysValidProof {
+    type Error = ();
+
+    fn verify_bat_v2_proof(
+        &self,
+        _input: BatV2ProofVerificationInputV2<'_>,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+impl TestIssuerTransport {
+    fn new() -> Self {
+        Self {
+            fixture: Fixture::new(),
+            mode: Mutex::new(Mode::Normal),
+            store: Mutex::new(MemoryCommitStore::default()),
+            observations: Mutex::new(Vec::new()),
+            previous_response: Mutex::new(None),
+        }
+    }
+
+    fn set_mode(&self, mode: Mode) {
+        *self.mode.lock().unwrap() = mode;
+    }
+
+    fn response_for(
+        &self,
+        envelope: ProviderRedeemEnvelopeV2,
+        mode: Mode,
+    ) -> ProviderRedeemResponseV2 {
+        let (member, now_unix) = match mode {
+            Mode::RetryProviderAuthentication => (&self.fixture.selected, 1_001),
+            Mode::RetryClassCompatibility => (&self.fixture.class_only, NOW),
+            _ => (&self.fixture.selected, NOW),
+        };
+        let precheck = precheck_bat_v2_redeem_v2(
+            envelope,
+            &self.fixture.authorization,
+            &self.fixture.approval,
+            &self.fixture.class,
+            member,
+            ProviderAccountingExpectationV2 {
+                provider_id: [2; 32],
+                issuer_id: self.fixture.class.issuer_id,
+                operator_verifying_key: &self.fixture.operator_key.verifying_key(),
+                issuer_settlement_verifying_key: &self.fixture.settlement_key.verifying_key(),
+                now_unix,
+                minimum_authorization_epoch: 7,
+            },
+        )
+        .unwrap();
+        match precheck {
+            BatV2RedeemPrecheckV2::RetrySafeNonConsuming(retry) => {
+                sign_retry_safe_non_consuming_v2(retry, &self.fixture.settlement_key).unwrap()
+            }
+            BatV2RedeemPrecheckV2::TerminalInvalidOrSpent(terminal) => {
+                sign_terminal_invalid_or_spent_v2(terminal, &self.fixture.settlement_key).unwrap()
+            }
+            BatV2RedeemPrecheckV2::Authorized(authorized) => {
+                let checked =
+                    verify_bat_v2_credential_for_commit_v2(*authorized, &AlwaysValidProof).unwrap();
+                match checked {
+                    BatV2CredentialCheckV2::Verified(verified) => {
+                        let mut store = self.store.lock().unwrap();
+                        match sign_and_commit_grantable_success_v2(
+                            verified,
+                            &self.fixture.settlement_key,
+                            &mut *store,
+                        )
+                        .unwrap()
+                        {
+                            BatV2RedeemCommitResultV2::FreshCommitted(fresh) => {
+                                fresh.into_response()
+                            }
+                            BatV2RedeemCommitResultV2::TerminalInvalidOrSpent(response) => response,
+                        }
+                    }
+                    BatV2CredentialCheckV2::TerminalInvalidOrSpent(terminal) => {
+                        sign_terminal_invalid_or_spent_v2(terminal, &self.fixture.settlement_key)
+                            .unwrap()
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl BatV2RedeemTransportV2 for TestIssuerTransport {
+    fn redeem_v2(
+        &self,
+        request: BatV2RedeemHttpRequestV2<'_>,
+        max_response_bytes: usize,
+    ) -> Result<Vec<u8>, BatV2RedeemTransportErrorV2> {
+        assert_eq!(request.issuer_origin, "https://issuer.invalid");
+        assert_eq!(request.leaf_spki_sha256_pins, &[[4; 32]]);
+        let envelope = ProviderRedeemEnvelopeV2::decode(request.canonical_envelope).unwrap();
+        self.observations.lock().unwrap().push(Observation {
+            attempt_id: envelope.request.attempt_id,
+            endpoint: request.endpoint,
+            request_content_type: request.request_content_type,
+            response_content_type: request.response_content_type,
+            max_response_bytes,
+        });
+        let mode = *self.mode.lock().unwrap();
+        match mode {
+            Mode::DefinitelyNotSent => {
+                return Err(BatV2RedeemTransportErrorV2::DefinitelyNotSent { retry_after_ms: 17 })
+            }
+            Mode::OutcomeUnknown => return Err(BatV2RedeemTransportErrorV2::OutcomeUnknown),
+            Mode::InvalidBody => return Ok(vec![0x55; 32]),
+            Mode::Oversize => return Ok(vec![0; max_response_bytes + 1]),
+            Mode::ReplayPrevious => {
+                return Ok(self
+                    .previous_response
+                    .lock()
+                    .unwrap()
+                    .clone()
+                    .expect("previous signed response"))
+            }
+            _ => {}
+        }
+        envelope
+            .request_auth
+            .verify_for(
+                &envelope.request,
+                &self.fixture.clearing_key.verifying_key(),
+            )
+            .unwrap();
+        let response = self.response_for(envelope, mode);
+        let mut encoded = response.encode().unwrap();
+        if mode == Mode::BadSignature {
+            *encoded.last_mut().unwrap() ^= 1;
+        } else {
+            *self.previous_response.lock().unwrap() = Some(encoded.clone());
+        }
+        Ok(encoded)
+    }
+}
+
+fn client<'a>(transport: &'a TestIssuerTransport) -> StorelessBatV2ProviderRedeemClientV2<'a> {
+    StorelessBatV2ProviderRedeemClientV2::new(
+        transport.fixture.trust(),
+        transport.fixture.clearing_key.clone(),
+        transport,
+    )
+    .unwrap()
+}
+
+#[test]
+fn bat_v2_storeless_fresh_grant_once_then_global_spend_is_terminal() {
+    let transport = TestIssuerTransport::new();
+    let client = client(&transport);
+    let proof = transport.fixture.proof();
+    assert!(matches!(
+        client
+            .redeem_once(
+                &transport.fixture.selected,
+                &transport.fixture.class,
+                &proof,
+                NOW,
+            )
+            .unwrap(),
+        StorelessBatV2RedeemDecisionV2::FreshGrant(_)
+    ));
+    assert!(matches!(
+        client
+            .redeem_once(
+                &transport.fixture.selected,
+                &transport.fixture.class,
+                &proof,
+                NOW,
+            )
+            .unwrap(),
+        StorelessBatV2RedeemDecisionV2::TerminalInvalidOrSpent
+    ));
+    let observations = transport.observations.lock().unwrap();
+    assert_eq!(observations.len(), 2);
+    assert_ne!(observations[0].attempt_id, [0; 32]);
+    assert_ne!(observations[0].attempt_id, observations[1].attempt_id);
+    for observation in observations.iter() {
+        assert_eq!(observation.endpoint, BAT_V2_REDEEM_ENDPOINT_V2);
+        assert_eq!(
+            observation.request_content_type,
+            BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2
+        );
+        assert_eq!(
+            observation.response_content_type,
+            BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2
+        );
+        assert_eq!(
+            observation.max_response_bytes,
+            MAX_BAT_V2_PROVIDER_REDEEM_RESPONSE_LEN_V2
+        );
+    }
+}
+
+#[test]
+fn bat_v2_storeless_definitely_not_sent_never_retries_automatically() {
+    let transport = TestIssuerTransport::new();
+    let client = client(&transport);
+    let proof = transport.fixture.proof();
+    transport.set_mode(Mode::DefinitelyNotSent);
+    assert!(matches!(
+        client
+            .redeem_once(
+                &transport.fixture.selected,
+                &transport.fixture.class,
+                &proof,
+                NOW,
+            )
+            .unwrap(),
+        StorelessBatV2RedeemDecisionV2::DefinitelyNotSent { retry_after_ms: 17 }
+    ));
+    assert_eq!(transport.observations.lock().unwrap().len(), 1);
+    transport.set_mode(Mode::Normal);
+    assert!(matches!(
+        client
+            .redeem_once(
+                &transport.fixture.selected,
+                &transport.fixture.class,
+                &proof,
+                NOW,
+            )
+            .unwrap(),
+        StorelessBatV2RedeemDecisionV2::FreshGrant(_)
+    ));
+    let observations = transport.observations.lock().unwrap();
+    assert_ne!(observations[0].attempt_id, observations[1].attempt_id);
+}
+
+#[test]
+fn bat_v2_storeless_signed_retry_safe_reasons_preserve_the_proof() {
+    for (mode, expected) in [
+        (
+            Mode::RetryProviderAuthentication,
+            RetrySafeNonConsumingReasonV2::ProviderAuthentication,
+        ),
+        (
+            Mode::RetryClassCompatibility,
+            RetrySafeNonConsumingReasonV2::ClassCompatibility,
+        ),
+    ] {
+        let transport = TestIssuerTransport::new();
+        let client = client(&transport);
+        let proof = transport.fixture.proof();
+        transport.set_mode(mode);
+        let decision = client
+            .redeem_once(
+                &transport.fixture.selected,
+                &transport.fixture.class,
+                &proof,
+                NOW,
+            )
+            .unwrap();
+        assert!(
+            matches!(
+                &decision,
+                StorelessBatV2RedeemDecisionV2::RetrySafeNonConsuming(reason)
+                    if *reason == expected
+            ),
+            "mode {mode:?} returned {decision:?}"
+        );
+        assert_eq!(transport.observations.lock().unwrap().len(), 1);
+        transport.set_mode(Mode::Normal);
+        assert!(matches!(
+            client
+                .redeem_once(
+                    &transport.fixture.selected,
+                    &transport.fixture.class,
+                    &proof,
+                    NOW,
+                )
+                .unwrap(),
+            StorelessBatV2RedeemDecisionV2::FreshGrant(_)
+        ));
+    }
+}
+
+#[test]
+fn bat_v2_storeless_unsigned_or_stale_responses_burn_and_never_grant() {
+    for mode in [
+        Mode::OutcomeUnknown,
+        Mode::InvalidBody,
+        Mode::Oversize,
+        Mode::BadSignature,
+    ] {
+        let transport = TestIssuerTransport::new();
+        let client = client(&transport);
+        transport.set_mode(mode);
+        assert!(matches!(
+            client.redeem_once(
+                &transport.fixture.selected,
+                &transport.fixture.class,
+                &transport.fixture.proof(),
+                NOW,
+            ),
+            Err(StorelessBatV2RedeemErrorV2::OutcomeUnknownCredentialBurned)
+        ));
+        assert_eq!(transport.observations.lock().unwrap().len(), 1);
+    }
+
+    let transport = TestIssuerTransport::new();
+    let client = client(&transport);
+    let first_proof = transport.fixture.proof();
+    assert!(matches!(
+        client
+            .redeem_once(
+                &transport.fixture.selected,
+                &transport.fixture.class,
+                &first_proof,
+                NOW,
+            )
+            .unwrap(),
+        StorelessBatV2RedeemDecisionV2::FreshGrant(_)
+    ));
+    transport.set_mode(Mode::ReplayPrevious);
+    assert!(matches!(
+        client.redeem_once(
+            &transport.fixture.selected,
+            &transport.fixture.class,
+            &transport.fixture.proof(),
+            NOW,
+        ),
+        Err(StorelessBatV2RedeemErrorV2::OutcomeUnknownCredentialBurned)
+    ));
+}
+
+#[test]
+fn bat_v2_storeless_constructor_and_presend_checks_fail_closed() {
+    let transport = TestIssuerTransport::new();
+    let mut wrong_provider = transport.fixture.trust();
+    wrong_provider.expected_provider_id = [99; 32];
+    assert!(StorelessBatV2ProviderRedeemClientV2::new(
+        wrong_provider,
+        transport.fixture.clearing_key.clone(),
+        &transport,
+    )
+    .is_err());
+
+    let mut rollback = transport.fixture.trust();
+    rollback.minimum_authorization_epoch = 8;
+    assert!(StorelessBatV2ProviderRedeemClientV2::new(
+        rollback,
+        transport.fixture.clearing_key.clone(),
+        &transport,
+    )
+    .is_err());
+
+    assert!(StorelessBatV2ProviderRedeemClientV2::new(
+        transport.fixture.trust(),
+        SigningKey::from_bytes(&[77; 32]),
+        &transport,
+    )
+    .is_err());
+
+    let mut reused_role = transport.fixture.trust();
+    reused_role.issuer_settlement_verifying_key = transport.fixture.clearing_key.verifying_key();
+    assert!(StorelessBatV2ProviderRedeemClientV2::new(
+        reused_role,
+        transport.fixture.clearing_key.clone(),
+        &transport,
+    )
+    .is_err());
+
+    let client = client(&transport);
+    assert!(matches!(
+        client.redeem_once(
+            &transport.fixture.selected,
+            &transport.fixture.class,
+            &transport.fixture.proof(),
+            1_001,
+        ),
+        Err(StorelessBatV2RedeemErrorV2::PreSend(_))
+    ));
+    assert!(transport.observations.lock().unwrap().is_empty());
+    let debug = format!("{client:?}");
+    assert!(debug.contains("[REDACTED]"));
+    assert!(!debug.contains(&format!("{:?}", [6u8; 32])));
+}

--- a/crates/payment/provider-clearing-client/src/lib.rs
+++ b/crates/payment/provider-clearing-client/src/lib.rs
@@ -8,10 +8,21 @@
 
 #![forbid(unsafe_code)]
 
+mod bat_v2;
+mod bat_v2_https_transport;
+#[cfg(test)]
+mod bat_v2_tests;
 mod https_transport;
 mod remote_floor;
 mod sqlite_store;
 
+pub use bat_v2::{
+    BatV2ProviderRedeemTrustV2, BatV2RedeemHttpRequestV2, BatV2RedeemTransportErrorV2,
+    BatV2RedeemTransportV2, FreshBatV2ConnectionGrantV2, StorelessBatV2ProviderRedeemClientV2,
+    StorelessBatV2RedeemDecisionV2, StorelessBatV2RedeemErrorV2, BAT_V2_REDEEM_ENDPOINT_V2,
+    BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2, BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
+};
+pub use bat_v2_https_transport::StrictHttpsBatV2RedeemTransportV2;
 pub use https_transport::StrictHttpsProviderSettlementTransportV1;
 pub use remote_floor::RemoteProviderSettlementFloorAuthorityV1;
 pub use sqlite_store::{

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -54,12 +54,26 @@ activated the path with real money.
       store, service and route tests cover one-winner concurrency, retained
       members, restart replay, real Cashu proof verification, zero-mutation
       retry-safe rejection, exact media types and CLI trust inputs.
-- [ ] **Storeless provider, SDK/Web and render path pending.** ProviderStore
-      paths still deliberately reject scheme 6; no old replayable V1 success is
-      reinterpreted. The connection-local V2 provider committer, SDK/Web class
-      wallet, two-paid-leg selection and production render gates remain to
-      implement. Current `main` also retains the old Direct Mainnet issuer unit
-      and stateful V1 provider profiles. An old draft's fixed
+- [x] **Storeless provider redemption client core implemented.** The provider
+      creates one fresh public OS-random attempt per call, sends the canonical
+      V2 envelope exactly once through strict WebPKI-plus-pin HTTPS, and can
+      create an opaque connection grant only by consuming the protocol's exact
+      in-flight witness for a freshly committed issuer success. It has no
+      ProviderStore, idempotency/HMAC secret, local delivery claim, payment
+      rollback client, automatic retry or saved-response recovery. Only
+      transport-proven `DefinitelyNotSent` and issuer-signed non-consuming
+      rejection leave the proof eligible for a later caller-initiated attempt;
+      every unsigned HTTP status, malformed/misbound response and ambiguous
+      outcome burns it. Focused tests cover fresh success, issuer-global replay,
+      signed retry-safe decisions, stale/invalid response rejection, transport
+      ambiguity, trust/role-key checks and exact route/media bindings.
+- [ ] **Runtime provider, SDK/Web and render path pending.** Legacy
+      ProviderStore/admission paths still deliberately reject scheme 6; no old
+      replayable V1 success is reinterpreted. The exact-policy runtime adapter,
+      unified-server closed profile, SDK/Web class wallet, two-paid-leg
+      selection and production render gates remain to implement. Current
+      `main` also retains the old Direct Mainnet issuer unit and stateful V1
+      provider profiles. An old draft's fixed
       2-policy/12-key/2-clearing shape remains superseded and is not V2
       readiness evidence.
 - [ ] **Payment-storeless provider mode pending.** The current shared-BAT


### PR DESCRIPTION
## Summary
- add a transport-neutral, payment-storeless BAT V2 provider redemption client
- generate one fresh OS-random attempt per explicit call and send the canonical envelope exactly once
- require an exact issuer-signed fresh success plus the non-clone in-flight witness before producing an opaque connection grant
- add strict WebPKI-plus-SPKI-pin HTTPS transport; unsigned HTTP errors and ambiguous outcomes burn the credential
- keep ProviderStore, idempotency HMAC, local delivery claims, payment rollback, automatic retry, and V1 admission routing out of the V2 path

## Tests
- `cargo test --locked --offline -p pir-provider-clearing-client bat_v2 -- --nocapture` (8 passed)
- `cargo check --locked --offline -p pir-provider-clearing-client --all-targets`
- `cargo clippy --locked --offline -p pir-provider-clearing-client --all-targets --no-deps -- -D warnings`
- scoped rustfmt and `git diff --check`