### PR TITLE
Stabilize directory restart profile test

### DIFF
--- a/apps/directory-relay/src/server.rs
+++ b/apps/directory-relay/src/server.rs
@@ -878,8 +878,8 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     use pir_directory_nostr::{
-        catalog_req_json_v1, DirectoryEntryV1, DirectoryHealthClassV1, DirectoryHealthV1,
-        DirectoryPublisherKeyV1, NostrEventV1,
+        catalog_req_json_v1, verify_directory_entry_event_v1, DirectoryEntryV1,
+        DirectoryHealthClassV1, DirectoryHealthV1, DirectoryPublisherKeyV1, NostrEventV1,
     };
     use serde::Serialize;
     use serde_json::Value;
@@ -941,7 +941,7 @@ mod tests {
             now + 3_600,
             DirectoryHealthV1 {
                 class: DirectoryHealthClassV1::Unknown,
-                observed_bucket: now - (now % 300),
+                observed_bucket: created_at - (created_at % 300),
             },
             now,
         )
@@ -949,6 +949,20 @@ mod tests {
         publisher
             .sign_entry_event(&entry, created_at, &[randomness; 32])
             .unwrap()
+    }
+
+    #[test]
+    fn signed_entry_health_bucket_does_not_postdate_event() {
+        let publisher = DirectoryPublisherKeyV1::from_secret_bytes([62; 32]).unwrap();
+        let created_at = 599;
+        let event = signed_entry(&publisher, [0x32; 32], 1, created_at, 600, 1);
+
+        verify_directory_entry_event_v1(
+            &event.to_json_bytes().unwrap(),
+            publisher.public_key(),
+            created_at,
+        )
+        .unwrap();
     }
 
     async fn connect_public(handle: &RelayHandle) -> TestClient {


### PR DESCRIPTION
## Summary
- compute directory test health buckets from each EVENT's creation time
- add a deterministic five-minute-boundary regression test
- keep the production directory relay unchanged

## Root cause
The restart test created some EVENTs at `now - 4` but derived their health bucket from `now`. During the first four seconds after a five-minute boundary, the bucket postdated the EVENT. Initial ingestion accepted it at receipt time, while restart integrity validation correctly rejected it at the EVENT timestamp.

## Verification
- `cargo test --locked --offline -p bitcoinpir-directory-relay server::tests::signed_entry_health_bucket_does_not_postdate_event -- --exact --nocapture`
- `cargo check --locked --offline -p bitcoinpir-directory-relay --all-targets`
- `cargo clippy --locked --offline -p bitcoinpir-directory-relay --all-targets --no-deps -- -D warnings`
- `cargo fmt -p bitcoinpir-directory-relay -- --check`
- `git diff --check`

The full websocket test cannot bind its dedicated `127.0.0.2` publisher address on this macOS host; GitHub's Linux protocol lane is the intended dynamic verification.
