### PR TITLE
Add storeless BAT V2 runtime admission

### DIFF
--- a/apps/server/src/bin/unified_server.rs
+++ b/apps/server/src/bin/unified_server.rs
@@ -4427,6 +4427,7 @@ impl StrictServiceAdmissionRuntimeV1 {
             | AdmissionMethodRouteV1::ArcSharedIssuerOnlineExperimental => {
                 self.provider_store.is_some() && self.shared_issuer.is_some()
             }
+            AdmissionMethodRouteV1::BitcoinPirCashuBatV2SharedIssuerOnline => false,
         }
     }
 }

--- a/crates/payment/issuer-store/src/bat_v2_ops.rs
+++ b/crates/payment/issuer-store/src/bat_v2_ops.rs
@@ -10,8 +10,8 @@ use crate::{
     IssuerStore, StoreError, StoreResult, WriteDisposition, MAX_EXACT_BAT_V2_CLASS_BYTES,
 };
 use pir_service_protocol::{
-    bat_verification_key_fingerprint_v1, BatAcceptanceClassV2, BatAcceptanceMemberV2,
-    VerifiedBatAcceptanceMemberV2,
+    bat_verification_key_fingerprint_v1, verify_bat_acceptance_class_member_projection_v2,
+    BatAcceptanceClassV2, BatAcceptanceMemberV2, VerifiedBatAcceptanceMemberV2,
 };
 use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
 
@@ -354,27 +354,8 @@ fn projection_matches_artifact(
     member: &BatAcceptanceMemberV2,
     projection: &VerifiedBatAcceptanceMemberV2,
 ) -> bool {
-    if projection.issuer_id != artifact.issuer_id
-        || projection.class_id != artifact.class_id
-        || projection.member != *member
-        || projection.common_terms != artifact.common_terms
-        || artifact.key_not_before > projection.policy_issued_at
-        || artifact.key_not_after > projection.redemption_deadline
-    {
-        return false;
-    }
-    projection
-        .policy_expires_at
-        .checked_add(u64::from(projection.common_terms.invoice_expiry_seconds))
-        .and_then(|value| {
-            value.checked_add(u64::from(projection.common_terms.claim_window_seconds))
-        })
-        .and_then(|value| {
-            value.checked_add(u64::from(
-                projection.common_terms.minimum_credential_validity_seconds,
-            ))
-        })
-        .is_some_and(|minimum_not_after| artifact.key_not_after >= minimum_not_after)
+    projection.member == *member
+        && verify_bat_acceptance_class_member_projection_v2(artifact, projection).is_ok()
 }
 
 fn encode_member_commitment_material(members: &[VerifiedBatAcceptanceMemberV2]) -> Vec<u8> {

--- a/crates/payment/provider-clearing-client/src/bat_v2.rs
+++ b/crates/payment/provider-clearing-client/src/bat_v2.rs
@@ -5,6 +5,7 @@ use pir_runtime_core::service_admission::{
     AdmissionCommitErrorV1, AdmissionMethodCommitterV1, AdmissionMethodRouteV1,
 };
 use pir_service_protocol::{
+    verify_bat_acceptance_class_member_projection_v2,
     verify_grantable_success_for_inflight_attempt_v2, BatAcceptanceClassV2,
     BitcoinPirCashuBatProofV2, IssuerAccountingApprovalV2, ProviderAccountingAuthorizationV2,
     ProviderId, ProviderRedeemEnvelopeV2, ProviderRedeemOutcomeV2, ProviderRedeemRequestAuthV2,
@@ -399,20 +400,7 @@ impl<'a> StorelessBatV2AdmissionCommitterV2<'a> {
         class: &'a BatAcceptanceClassV2,
         client: &'a StorelessBatV2ProviderRedeemClientV2<'a>,
     ) -> Result<Self, ServiceProtocolError> {
-        class.verify_for(&member.issuer_id, &member.class_id)?;
-        let expected_deadline = member
-            .policy_expires_at
-            .checked_add(class.common_terms.retired_policy_grace_seconds as u64);
-        if member.common_terms != class.common_terms
-            || !class.members.contains(&member.member)
-            || member.policy_issued_at > member.policy_expires_at
-            || expected_deadline != Some(member.redemption_deadline)
-        {
-            return Err(ServiceProtocolError::InvalidValue {
-                field: "StorelessBatV2AdmissionCommitterV2.member",
-                reason: "verified member is not an exact member of the signed BAT V2 class",
-            });
-        }
+        verify_bat_acceptance_class_member_projection_v2(class, member)?;
         Ok(Self {
             member,
             class,

--- a/crates/payment/provider-clearing-client/src/bat_v2.rs
+++ b/crates/payment/provider-clearing-client/src/bat_v2.rs
@@ -1,6 +1,9 @@
 use core::fmt;
 
 use ed25519_dalek::{SigningKey, VerifyingKey};
+use pir_runtime_core::service_admission::{
+    AdmissionCommitErrorV1, AdmissionMethodCommitterV1, AdmissionMethodRouteV1,
+};
 use pir_service_protocol::{
     verify_grantable_success_for_inflight_attempt_v2, BatAcceptanceClassV2,
     BitcoinPirCashuBatProofV2, IssuerAccountingApprovalV2, ProviderAccountingAuthorizationV2,
@@ -369,4 +372,174 @@ fn fresh_nonzero_attempt_id_v2() -> Result<[u8; 32], StorelessBatV2RedeemErrorV2
         }
     }
     Err(StorelessBatV2RedeemErrorV2::EntropyUnavailable)
+}
+
+/// Admission adapter bound to one exact verified policy member, its signed
+/// acceptance class, and the storeless issuer client. It owns no ProviderStore
+/// and cannot be used for a V1 shared-issuer route.
+pub struct StorelessBatV2AdmissionCommitterV2<'a> {
+    member: &'a VerifiedBatAcceptanceMemberV2,
+    class: &'a BatAcceptanceClassV2,
+    client: &'a StorelessBatV2ProviderRedeemClientV2<'a>,
+}
+
+impl fmt::Debug for StorelessBatV2AdmissionCommitterV2<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StorelessBatV2AdmissionCommitterV2")
+            .field("member", &self.member.member)
+            .field("class_id", &self.class.class_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> StorelessBatV2AdmissionCommitterV2<'a> {
+    pub fn new(
+        member: &'a VerifiedBatAcceptanceMemberV2,
+        class: &'a BatAcceptanceClassV2,
+        client: &'a StorelessBatV2ProviderRedeemClientV2<'a>,
+    ) -> Result<Self, ServiceProtocolError> {
+        class.verify_for(&member.issuer_id, &member.class_id)?;
+        let expected_deadline = member
+            .policy_expires_at
+            .checked_add(class.common_terms.retired_policy_grace_seconds as u64);
+        if member.common_terms != class.common_terms
+            || !class.members.contains(&member.member)
+            || member.policy_issued_at > member.policy_expires_at
+            || expected_deadline != Some(member.redemption_deadline)
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "StorelessBatV2AdmissionCommitterV2.member",
+                reason: "verified member is not an exact member of the signed BAT V2 class",
+            });
+        }
+        Ok(Self {
+            member,
+            class,
+            client,
+        })
+    }
+
+    fn attempt_matches_exact_member(
+        &self,
+        attempt: &pir_service_protocol::BoundAuthAttemptV1<'_>,
+    ) -> bool {
+        let offer = attempt.offer();
+        let scope = attempt.scope();
+        attempt.verified_offer().policy_digest() == self.member.member.policy_digest
+            && attempt.verified_offer().redemption_deadline() == self.member.redemption_deadline
+            && scope.provider_id == self.member.member.provider_id
+            && scope.scope_id() == self.member.member.scope_id
+            && offer.offer_id == self.member.member.offer_id
+            && offer.issuer_id == self.member.issuer_id
+            && offer.key_id.as_slice() == self.member.class_id
+    }
+}
+
+impl AdmissionMethodCommitterV1 for StorelessBatV2AdmissionCommitterV2<'_> {
+    fn verify_and_commit_v1(
+        &self,
+        route: AdmissionMethodRouteV1,
+        attempt: &pir_service_protocol::BoundAuthAttemptV1<'_>,
+        now_unix_seconds: u64,
+    ) -> Result<(), AdmissionCommitErrorV1> {
+        if route != AdmissionMethodRouteV1::BitcoinPirCashuBatV2SharedIssuerOnline {
+            return Err(AdmissionCommitErrorV1::UnsupportedScheme);
+        }
+        let pir_service_protocol::AuthorizationProofV1::BitcoinPirCashuBatV2(proof) =
+            attempt.proof()
+        else {
+            return Err(AdmissionCommitErrorV1::ScopeUnavailable);
+        };
+        if !self.attempt_matches_exact_member(attempt) {
+            return Err(AdmissionCommitErrorV1::ScopeUnavailable);
+        }
+
+        map_storeless_bat_v2_admission_result(self.client.redeem_once(
+            self.member,
+            self.class,
+            proof,
+            now_unix_seconds,
+        ))
+    }
+}
+
+fn map_storeless_bat_v2_admission_result(
+    result: Result<StorelessBatV2RedeemDecisionV2, StorelessBatV2RedeemErrorV2>,
+) -> Result<(), AdmissionCommitErrorV1> {
+    match result {
+        Ok(StorelessBatV2RedeemDecisionV2::FreshGrant(_)) => Ok(()),
+        Ok(StorelessBatV2RedeemDecisionV2::DefinitelyNotSent { retry_after_ms }) => {
+            Err(AdmissionCommitErrorV1::ServerBusy { retry_after_ms })
+        }
+        Ok(StorelessBatV2RedeemDecisionV2::RetrySafeNonConsuming(_)) => {
+            Err(AdmissionCommitErrorV1::ScopeUnavailable)
+        }
+        Ok(StorelessBatV2RedeemDecisionV2::TerminalInvalidOrSpent) => {
+            Err(AdmissionCommitErrorV1::InvalidOrSpent)
+        }
+        Err(StorelessBatV2RedeemErrorV2::PreSend(_)) => {
+            Err(AdmissionCommitErrorV1::ScopeUnavailable)
+        }
+        Err(StorelessBatV2RedeemErrorV2::EntropyUnavailable) => {
+            Err(AdmissionCommitErrorV1::ServerBusy {
+                retry_after_ms: 1_000,
+            })
+        }
+        Err(StorelessBatV2RedeemErrorV2::OutcomeUnknownCredentialBurned) => {
+            Err(AdmissionCommitErrorV1::InternalAfterSpend)
+        }
+    }
+}
+
+#[cfg(test)]
+mod admission_tests {
+    use super::*;
+
+    #[test]
+    fn admission_mapping_preserves_safe_vs_burned_outcomes() {
+        assert_eq!(
+            map_storeless_bat_v2_admission_result(Ok(
+                StorelessBatV2RedeemDecisionV2::DefinitelyNotSent { retry_after_ms: 17 }
+            )),
+            Err(AdmissionCommitErrorV1::ServerBusy { retry_after_ms: 17 })
+        );
+        assert_eq!(
+            map_storeless_bat_v2_admission_result(Ok(
+                StorelessBatV2RedeemDecisionV2::RetrySafeNonConsuming(
+                    RetrySafeNonConsumingReasonV2::ClassCompatibility,
+                )
+            )),
+            Err(AdmissionCommitErrorV1::ScopeUnavailable)
+        );
+        assert_eq!(
+            map_storeless_bat_v2_admission_result(Ok(
+                StorelessBatV2RedeemDecisionV2::TerminalInvalidOrSpent,
+            )),
+            Err(AdmissionCommitErrorV1::InvalidOrSpent)
+        );
+        assert_eq!(
+            map_storeless_bat_v2_admission_result(Err(
+                StorelessBatV2RedeemErrorV2::EntropyUnavailable,
+            )),
+            Err(AdmissionCommitErrorV1::ServerBusy {
+                retry_after_ms: 1_000,
+            })
+        );
+        assert_eq!(
+            map_storeless_bat_v2_admission_result(Err(StorelessBatV2RedeemErrorV2::PreSend(
+                ServiceProtocolError::InvalidValue {
+                    field: "test",
+                    reason: "not sent",
+                }
+            ),)),
+            Err(AdmissionCommitErrorV1::ScopeUnavailable)
+        );
+        assert_eq!(
+            map_storeless_bat_v2_admission_result(Err(
+                StorelessBatV2RedeemErrorV2::OutcomeUnknownCredentialBurned,
+            )),
+            Err(AdmissionCommitErrorV1::InternalAfterSpend)
+        );
+    }
 }

--- a/crates/payment/provider-clearing-client/src/bat_v2_tests.rs
+++ b/crates/payment/provider-clearing-client/src/bat_v2_tests.rs
@@ -19,7 +19,8 @@ use pir_service_protocol::{
 
 use crate::{
     BatV2ProviderRedeemTrustV2, BatV2RedeemHttpRequestV2, BatV2RedeemTransportErrorV2,
-    BatV2RedeemTransportV2, StorelessBatV2ProviderRedeemClientV2, StorelessBatV2RedeemDecisionV2,
+    BatV2RedeemTransportV2, StorelessBatV2AdmissionCommitterV2,
+    StorelessBatV2ProviderRedeemClientV2, StorelessBatV2RedeemDecisionV2,
     StorelessBatV2RedeemErrorV2, BAT_V2_REDEEM_ENDPOINT_V2, BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2,
     BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
 };
@@ -622,6 +623,28 @@ fn bat_v2_storeless_constructor_and_presend_checks_fail_closed() {
     .is_err());
 
     let client = client(&transport);
+    assert!(StorelessBatV2AdmissionCommitterV2::new(
+        &transport.fixture.selected,
+        &transport.fixture.class,
+        &client,
+    )
+    .is_ok());
+    let mut wrong_member = transport.fixture.selected.clone();
+    wrong_member.member.offer_id += 1;
+    assert!(StorelessBatV2AdmissionCommitterV2::new(
+        &wrong_member,
+        &transport.fixture.class,
+        &client,
+    )
+    .is_err());
+    let mut extended_deadline = transport.fixture.selected.clone();
+    extended_deadline.redemption_deadline += 1;
+    assert!(StorelessBatV2AdmissionCommitterV2::new(
+        &extended_deadline,
+        &transport.fixture.class,
+        &client,
+    )
+    .is_err());
     assert!(matches!(
         client.redeem_once(
             &transport.fixture.selected,

--- a/crates/payment/provider-clearing-client/src/bat_v2_tests.rs
+++ b/crates/payment/provider-clearing-client/src/bat_v2_tests.rs
@@ -12,8 +12,8 @@ use pir_service_protocol::{
     DeploymentStatus, EntitlementLimitsV1, IssuerAccountingApprovalV2, PrivacyLeakageV1,
     ProviderAccountingAuthorizationClaimsV2, ProviderAccountingAuthorizationV2,
     ProviderAccountingExpectationV2, ProviderAccountingRuleV2, ProviderRedeemEnvelopeV2,
-    ProviderRedeemResponseV2, RetrySafeNonConsumingReasonV2, SettlementUnitV1,
-    VerifiedBatAcceptanceMemberV2, VerifiedBatV2RedeemCommitV2, WorkloadId,
+    ProviderRedeemResponseV2, RetrySafeNonConsumingReasonV2, ServiceProtocolError,
+    SettlementUnitV1, VerifiedBatAcceptanceMemberV2, VerifiedBatV2RedeemCommitV2, WorkloadId,
     MAX_BAT_V2_PROVIDER_REDEEM_RESPONSE_LEN_V2,
 };
 
@@ -101,7 +101,7 @@ impl Fixture {
             [7; 32],
             13,
             100,
-            2_000,
+            1_480,
             SECP_GENERATOR,
             terms(),
             members.clone(),
@@ -186,6 +186,20 @@ impl Fixture {
             issuer_settlement_verifying_key: self.settlement_key.verifying_key(),
             minimum_authorization_epoch: 7,
         }
+    }
+
+    fn class_with_validity(&self, key_not_before: u64, key_not_after: u64) -> BatAcceptanceClassV2 {
+        BatAcceptanceClassV2::sign(
+            self.class.class_id,
+            self.class.key_epoch,
+            key_not_before,
+            key_not_after,
+            self.class.bat_verification_key,
+            self.class.common_terms.clone(),
+            self.class.members.clone(),
+            &SigningKey::from_bytes(&[8; 32]),
+        )
+        .unwrap()
     }
 }
 
@@ -645,6 +659,38 @@ fn bat_v2_storeless_constructor_and_presend_checks_fail_closed() {
         &client,
     )
     .is_err());
+    let starts_after_policy = transport.fixture.class_with_validity(101, 1_480);
+    assert!(StorelessBatV2AdmissionCommitterV2::new(
+        &transport.fixture.selected,
+        &starts_after_policy,
+        &client,
+    )
+    .is_err());
+    let short_by_one = transport.fixture.class_with_validity(100, 1_479);
+    assert!(StorelessBatV2AdmissionCommitterV2::new(
+        &transport.fixture.selected,
+        &short_by_one,
+        &client,
+    )
+    .is_err());
+    let extends_past_redemption = transport.fixture.class_with_validity(100, 1_481);
+    assert!(StorelessBatV2AdmissionCommitterV2::new(
+        &transport.fixture.selected,
+        &extends_past_redemption,
+        &client,
+    )
+    .is_err());
+    let overflow_class = transport.fixture.class_with_validity(100, u64::MAX);
+    let mut overflow_member = transport.fixture.selected.clone();
+    overflow_member.policy_expires_at = u64::MAX - 100;
+    overflow_member.redemption_deadline = u64::MAX;
+    assert!(matches!(
+        StorelessBatV2AdmissionCommitterV2::new(&overflow_member, &overflow_class, &client),
+        Err(ServiceProtocolError::InvalidValue {
+            field: "VerifiedBatAcceptanceMemberV2.class_projection",
+            reason: "minimum class validity horizon overflows",
+        })
+    ));
     assert!(matches!(
         client.redeem_once(
             &transport.fixture.selected,

--- a/crates/payment/provider-clearing-client/src/lib.rs
+++ b/crates/payment/provider-clearing-client/src/lib.rs
@@ -18,9 +18,10 @@ mod sqlite_store;
 
 pub use bat_v2::{
     BatV2ProviderRedeemTrustV2, BatV2RedeemHttpRequestV2, BatV2RedeemTransportErrorV2,
-    BatV2RedeemTransportV2, FreshBatV2ConnectionGrantV2, StorelessBatV2ProviderRedeemClientV2,
-    StorelessBatV2RedeemDecisionV2, StorelessBatV2RedeemErrorV2, BAT_V2_REDEEM_ENDPOINT_V2,
-    BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2, BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
+    BatV2RedeemTransportV2, FreshBatV2ConnectionGrantV2, StorelessBatV2AdmissionCommitterV2,
+    StorelessBatV2ProviderRedeemClientV2, StorelessBatV2RedeemDecisionV2,
+    StorelessBatV2RedeemErrorV2, BAT_V2_REDEEM_ENDPOINT_V2, BAT_V2_REDEEM_REQUEST_CONTENT_TYPE_V2,
+    BAT_V2_REDEEM_RESPONSE_CONTENT_TYPE_V2,
 };
 pub use bat_v2_https_transport::StrictHttpsBatV2RedeemTransportV2;
 pub use https_transport::StrictHttpsProviderSettlementTransportV1;

--- a/crates/protocol/runtime/src/service_admission.rs
+++ b/crates/protocol/runtime/src/service_admission.rs
@@ -169,6 +169,7 @@ pub enum AdmissionMethodRouteV1 {
     StandardCashuMintOnline,
     BitcoinPirCashuBatProviderLocal,
     BitcoinPirCashuBatSharedIssuerOnline,
+    BitcoinPirCashuBatV2SharedIssuerOnline,
     ArcProviderLocalExperimental,
     ArcSharedIssuerOnlineExperimental,
 }
@@ -222,6 +223,7 @@ pub struct CompositeAdmissionMethodCommitterV1<'a> {
     provider_local: Option<&'a dyn AdmissionMethodCommitterV1>,
     standard_cashu: Option<&'a dyn AdmissionMethodCommitterV1>,
     shared_issuer: Option<&'a dyn AdmissionMethodCommitterV1>,
+    bat_v2_shared_issuer_online: Option<&'a dyn AdmissionMethodCommitterV1>,
 }
 
 impl fmt::Debug for CompositeAdmissionMethodCommitterV1<'_> {
@@ -232,6 +234,10 @@ impl fmt::Debug for CompositeAdmissionMethodCommitterV1<'_> {
             .field("provider_local", &self.provider_local.is_some())
             .field("standard_cashu", &self.standard_cashu.is_some())
             .field("shared_issuer", &self.shared_issuer.is_some())
+            .field(
+                "bat_v2_shared_issuer_online",
+                &self.bat_v2_shared_issuer_online.is_some(),
+            )
             .finish()
     }
 }
@@ -243,6 +249,7 @@ impl<'a> CompositeAdmissionMethodCommitterV1<'a> {
             provider_local: None,
             standard_cashu: None,
             shared_issuer: None,
+            bat_v2_shared_issuer_online: None,
         }
     }
 
@@ -275,6 +282,17 @@ impl<'a> CompositeAdmissionMethodCommitterV1<'a> {
         self
     }
 
+    /// Install only the issuer-wide, payment-storeless BAT V2 adapter. This
+    /// slot is deliberately separate from every replayable V1 shared-issuer
+    /// method so enabling scheme 6 cannot widen legacy routing.
+    pub const fn with_bat_v2_shared_issuer_online(
+        mut self,
+        committer: &'a dyn AdmissionMethodCommitterV1,
+    ) -> Self {
+        self.bat_v2_shared_issuer_online = Some(committer);
+        self
+    }
+
     fn committer_for(
         &self,
         route: AdmissionMethodRouteV1,
@@ -291,6 +309,9 @@ impl<'a> CompositeAdmissionMethodCommitterV1<'a> {
             AdmissionMethodRouteV1::FreeAnonymousTicketSharedIssuerOnline
             | AdmissionMethodRouteV1::BitcoinPirCashuBatSharedIssuerOnline
             | AdmissionMethodRouteV1::ArcSharedIssuerOnlineExperimental => self.shared_issuer,
+            AdmissionMethodRouteV1::BitcoinPirCashuBatV2SharedIssuerOnline => {
+                self.bat_v2_shared_issuer_online
+            }
         }
     }
 }
@@ -392,7 +413,8 @@ impl AdmissionMethodCommitterV1 for ProviderStoreBearerCommitterV1<'_> {
             | AdmissionMethodRouteV1::FreeProofOfWork
             | AdmissionMethodRouteV1::FreeAnonymousTicketSharedIssuerOnline
             | AdmissionMethodRouteV1::StandardCashuMintOnline
-            | AdmissionMethodRouteV1::BitcoinPirCashuBatSharedIssuerOnline => {
+            | AdmissionMethodRouteV1::BitcoinPirCashuBatSharedIssuerOnline
+            | AdmissionMethodRouteV1::BitcoinPirCashuBatV2SharedIssuerOnline => {
                 Err(AdmissionCommitErrorV1::UnsupportedScheme)
             }
         }
@@ -485,6 +507,7 @@ impl AdmissionMethodCommitterV1 for RejectAllAdmissionMethodsV1 {
             | AdmissionMethodRouteV1::StandardCashuMintOnline
             | AdmissionMethodRouteV1::BitcoinPirCashuBatProviderLocal
             | AdmissionMethodRouteV1::BitcoinPirCashuBatSharedIssuerOnline
+            | AdmissionMethodRouteV1::BitcoinPirCashuBatV2SharedIssuerOnline
             | AdmissionMethodRouteV1::ArcProviderLocalExperimental
             | AdmissionMethodRouteV1::ArcSharedIssuerOnlineExperimental => {
                 Err(AdmissionCommitErrorV1::UnsupportedScheme)
@@ -1436,6 +1459,12 @@ fn admission_route_v1(
             AuthorizationProofV1::BitcoinPirCashuBat(_),
         ) => AdmissionMethodRouteV1::BitcoinPirCashuBatSharedIssuerOnline,
         (
+            AuthScheme::BitcoinPirCashuBatV2,
+            FreeModeV1::NotFree,
+            VerificationMode::SharedIssuerOnline,
+            AuthorizationProofV1::BitcoinPirCashuBatV2(_),
+        ) => AdmissionMethodRouteV1::BitcoinPirCashuBatV2SharedIssuerOnline,
+        (
             AuthScheme::ArcV1Experimental,
             FreeModeV1::NotFree,
             VerificationMode::ProviderLocal,
@@ -2044,11 +2073,15 @@ mod tests {
         let shared = AcceptingTestCommitter {
             routes: Mutex::new(Vec::new()),
         };
+        let bat_v2 = AcceptingTestCommitter {
+            routes: Mutex::new(Vec::new()),
+        };
         let composite = CompositeAdmissionMethodCommitterV1::new()
             .with_free(&free)
             .with_provider_local(&local)
             .with_standard_cashu(&cashu)
-            .with_shared_issuer(&shared);
+            .with_shared_issuer(&shared)
+            .with_bat_v2_shared_issuer_online(&bat_v2);
 
         for route in [
             AdmissionMethodRouteV1::FreeOpenBestEffort,
@@ -2087,6 +2120,12 @@ mod tests {
                 &shared as &dyn AdmissionMethodCommitterV1,
             ));
         }
+        assert!(core::ptr::eq(
+            composite
+                .committer_for(AdmissionMethodRouteV1::BitcoinPirCashuBatV2SharedIssuerOnline)
+                .unwrap(),
+            &bat_v2 as &dyn AdmissionMethodCommitterV1,
+        ));
 
         let only_free = CompositeAdmissionMethodCommitterV1::new().with_free(&free);
         assert!(only_free
@@ -2097,6 +2136,11 @@ mod tests {
             .is_none());
         assert!(only_free
             .committer_for(AdmissionMethodRouteV1::StandardCashuMintOnline)
+            .is_none());
+        let only_legacy_shared =
+            CompositeAdmissionMethodCommitterV1::new().with_shared_issuer(&shared);
+        assert!(only_legacy_shared
+            .committer_for(AdmissionMethodRouteV1::BitcoinPirCashuBatV2SharedIssuerOnline)
             .is_none());
     }
 

--- a/crates/protocol/runtime/src/service_policy_runtime.rs
+++ b/crates/protocol/runtime/src/service_policy_runtime.rs
@@ -11,10 +11,12 @@ use std::fmt;
 
 use ed25519_dalek::VerifyingKey;
 use pir_service_protocol::{
+    bat_acceptance_member_from_retained_policy_v2, bat_acceptance_member_from_verified_policy_v2,
     AcquisitionMethod, AuthScheme, CashuManifestEpochFloorV1, CredentialKeysetEpochFloorV1,
     FreeModeV1, PolicyRollbackGuardV1, PriceV1, ProviderId, ServiceOfferV1,
     ServicePolicyEpochFloorsV1, ServicePolicyResponseV1, ServicePolicyV1, ServiceProtocolError,
-    VerificationMode, VerifiedCurrentPolicyV1, VerifiedRetiredOfferV1, VerifiedServiceOfferV1,
+    VerificationMode, VerifiedBatAcceptanceMemberV2, VerifiedCurrentPolicyV1,
+    VerifiedRetiredOfferV1, VerifiedServiceOfferV1,
 };
 use pir_service_store::{
     ArcExclusiveKeyLineageVerifierV1, ProviderStore, StoreError,
@@ -36,6 +38,8 @@ pub enum ServicePolicyActivationErrorV1 {
     RetainedPolicyHasNoCredentialOffers,
     ExactPolicyDigestMismatch,
     StorelessPolicyIsNotFreeProofOfWorkOnly,
+    StorelessBatV2PolicyShape,
+    StorelessRetainedBatV2PolicyExpired,
     MissingMethodAdapter(AdmissionMethodRouteV1),
 }
 
@@ -70,6 +74,12 @@ impl fmt::Display for ServicePolicyActivationErrorV1 {
             Self::StorelessPolicyIsNotFreeProofOfWorkOnly => formatter.write_str(
                 "storeless service policy must contain only provider-local Free proof-of-work offers",
             ),
+            Self::StorelessBatV2PolicyShape => formatter.write_str(
+                "payment-storeless BAT V2 policy must contain scheme 6 and only provider-local Free proof-of-work or shared-issuer BAT V2 offers",
+            ),
+            Self::StorelessRetainedBatV2PolicyExpired => formatter.write_str(
+                "retained payment-storeless BAT V2 policy has no member inside its redemption horizon",
+            ),
             Self::MissingMethodAdapter(route) => {
                 write!(
                     formatter,
@@ -94,6 +104,8 @@ impl std::error::Error for ServicePolicyActivationErrorV1 {
             | Self::RetainedPolicyHasNoCredentialOffers
             | Self::ExactPolicyDigestMismatch
             | Self::StorelessPolicyIsNotFreeProofOfWorkOnly
+            | Self::StorelessBatV2PolicyShape
+            | Self::StorelessRetainedBatV2PolicyExpired
             | Self::MissingMethodAdapter(_) => None,
         }
     }
@@ -122,7 +134,9 @@ pub fn required_retained_redemption_routes_v1(
     let mut routes = BTreeSet::new();
     for scope_policy in &policy.scopes {
         for offer in &scope_policy.offers {
-            if offer.credential_binding.is_none() {
+            if offer.credential_binding.is_none()
+                && offer.authorization != AuthScheme::BitcoinPirCashuBatV2
+            {
                 continue;
             }
             if let Some(route) = admission_method_route_v1(offer) {
@@ -166,6 +180,11 @@ fn admission_method_route_v1(offer: &ServiceOfferV1) -> Option<AdmissionMethodRo
             _,
             pir_service_protocol::VerificationMode::SharedIssuerOnline,
         ) => AdmissionMethodRouteV1::BitcoinPirCashuBatSharedIssuerOnline,
+        (
+            AuthScheme::BitcoinPirCashuBatV2,
+            _,
+            pir_service_protocol::VerificationMode::SharedIssuerOnline,
+        ) => AdmissionMethodRouteV1::BitcoinPirCashuBatV2SharedIssuerOnline,
         (
             AuthScheme::ArcV1Experimental,
             _,
@@ -268,6 +287,16 @@ impl ActivatedServicePolicyV1 {
     ) -> Result<VerifiedServiceOfferV1<'_>, ServiceProtocolError> {
         self.verify_current(now_unix)?.offer(scope_id, offer_id)
     }
+
+    pub fn verified_bat_v2_member_for_admission(
+        &self,
+        scope_id: &[u8; 32],
+        offer_id: u32,
+        now_unix: u64,
+    ) -> Result<VerifiedBatAcceptanceMemberV2, ServiceProtocolError> {
+        let verified = self.verify_current(now_unix)?;
+        bat_acceptance_member_from_verified_policy_v2(&verified, scope_id, offer_id)
+    }
 }
 
 /// One exact, operator-configured historical policy.  This type deliberately
@@ -321,6 +350,61 @@ impl ActivatedRetainedServicePolicyV1 {
                 }) && self
                     .verified_offer_for_redemption(&scope_id, offer.offer_id, now_unix)
                     .is_ok()
+            })
+        })
+    }
+
+    pub fn verified_bat_v2_member_for_redemption(
+        &self,
+        scope_id: &[u8; 32],
+        offer_id: u32,
+        now_unix: u64,
+    ) -> Result<VerifiedBatAcceptanceMemberV2, ServiceProtocolError> {
+        self.verified_bat_v2_offer_for_redemption(scope_id, offer_id, now_unix)?;
+        let member = bat_acceptance_member_from_retained_policy_v2(
+            &self.policy,
+            &self.provider_id,
+            &self.policy_digest,
+            scope_id,
+            offer_id,
+            &self.verifying_key,
+        )?;
+        Ok(member)
+    }
+
+    /// Exact verified offer for binding a retained scheme-6 `AuthBeginV1`.
+    /// Unlike the provider-bound V1 accessor, this accepts no credential
+    /// binding and closes validity at the signed BAT V2 redemption deadline.
+    pub fn verified_bat_v2_offer_for_redemption(
+        &self,
+        scope_id: &[u8; 32],
+        offer_id: u32,
+        now_unix: u64,
+    ) -> Result<VerifiedServiceOfferV1<'_>, ServiceProtocolError> {
+        let verified = self.policy.verify_retained_bat_v2_offer(
+            &self.provider_id,
+            &self.policy_digest,
+            scope_id,
+            offer_id,
+            &self.verifying_key,
+        )?;
+        if now_unix < self.policy.issued_at || now_unix > verified.redemption_deadline() {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "ActivatedRetainedServicePolicyV1.bat_v2_offer",
+                reason: "retained BAT V2 member is outside its signed redemption horizon",
+            });
+        }
+        Ok(verified)
+    }
+
+    pub fn has_live_bat_v2_redemption(&self, now_unix: u64) -> bool {
+        self.policy.scopes.iter().any(|scope_policy| {
+            let scope_id = scope_policy.scope.scope_id();
+            scope_policy.offers.iter().any(|offer| {
+                offer.authorization == AuthScheme::BitcoinPirCashuBatV2
+                    && self
+                        .verified_bat_v2_member_for_redemption(&scope_id, offer.offer_id, now_unix)
+                        .is_ok()
             })
         })
     }
@@ -459,6 +543,172 @@ pub fn activate_exact_storeless_free_pow_policy_v1(
         epoch_floors,
         policy_digest,
     })
+}
+
+/// Activate one exact, payment-storeless policy whose only admission methods
+/// are provider-local Free-PoW and issuer-wide BAT V2. The exact digest is the
+/// immutable rollback/fork boundary; no ProviderStore or payment rollback
+/// authority participates in this mode.
+pub fn activate_exact_storeless_bat_v2_policy_v1(
+    canonical_signed_policy: &[u8],
+    expected_provider_id: ProviderId,
+    verifying_key: VerifyingKey,
+    expected_policy_digest: [u8; 32],
+    now_unix: u64,
+) -> Result<ActivatedServicePolicyV1, ServicePolicyActivationErrorV1> {
+    let policy = decode_exact_storeless_policy_v1(canonical_signed_policy, expected_policy_digest)?;
+    if !is_closed_storeless_bat_v2_policy_v1(&policy) {
+        return Err(ServicePolicyActivationErrorV1::StorelessBatV2PolicyShape);
+    }
+
+    let rollback_guard = PolicyRollbackGuardV1 {
+        highest_epoch: policy.policy_epoch,
+        digest_at_highest_epoch: expected_policy_digest,
+    };
+    let epoch_floors = ServicePolicyEpochFloorsV1::initial();
+    let verified = policy.verify_current_for_acquisition(
+        &expected_provider_id,
+        now_unix,
+        &rollback_guard,
+        &epoch_floors,
+        &verifying_key,
+    )?;
+    for scope_policy in &policy.scopes {
+        let scope_id = scope_policy.scope.scope_id();
+        for offer in &scope_policy.offers {
+            if offer.authorization == AuthScheme::BitcoinPirCashuBatV2 {
+                bat_acceptance_member_from_verified_policy_v2(
+                    &verified,
+                    &scope_id,
+                    offer.offer_id,
+                )?;
+            }
+        }
+    }
+
+    Ok(ActivatedServicePolicyV1 {
+        policy,
+        provider_id: expected_provider_id,
+        verifying_key,
+        rollback_guard,
+        epoch_floors,
+        policy_digest: expected_policy_digest,
+    })
+}
+
+/// Activate one exact older payment-storeless BAT V2 policy only while at
+/// least one of its scheme-6 members remains inside the signed redemption
+/// horizon. Free-PoW offers in the immutable bytes are never redemption
+/// methods. The caller must pin each retained digest explicitly.
+pub fn activate_exact_storeless_retained_bat_v2_policy_v1(
+    canonical_signed_policy: &[u8],
+    expected_policy_digest: [u8; 32],
+    current: &ActivatedServicePolicyV1,
+    now_unix: u64,
+) -> Result<ActivatedRetainedServicePolicyV1, ServicePolicyActivationErrorV1> {
+    let policy = decode_exact_storeless_policy_v1(canonical_signed_policy, expected_policy_digest)?;
+    policy.verify_signature_and_identity(&current.provider_id, &current.verifying_key)?;
+    if expected_policy_digest == current.policy_digest {
+        return Err(ServicePolicyActivationErrorV1::RetainedPolicyIsCurrent);
+    }
+    if policy.policy_epoch >= current.policy.policy_epoch {
+        return Err(ServicePolicyActivationErrorV1::RetainedPolicyIsNotOlder);
+    }
+    if !is_closed_storeless_bat_v2_policy_v1(&policy) {
+        return Err(ServicePolicyActivationErrorV1::StorelessBatV2PolicyShape);
+    }
+
+    let retained = ActivatedRetainedServicePolicyV1 {
+        policy,
+        provider_id: current.provider_id,
+        verifying_key: current.verifying_key,
+        policy_digest: expected_policy_digest,
+    };
+    if !retained.has_live_bat_v2_redemption(now_unix) {
+        return Err(ServicePolicyActivationErrorV1::StorelessRetainedBatV2PolicyExpired);
+    }
+    Ok(retained)
+}
+
+fn decode_exact_storeless_policy_v1(
+    canonical_signed_policy: &[u8],
+    expected_policy_digest: [u8; 32],
+) -> Result<ServicePolicyV1, ServicePolicyActivationErrorV1> {
+    if canonical_signed_policy.is_empty() {
+        return Err(ServicePolicyActivationErrorV1::EmptyPolicy);
+    }
+    if canonical_signed_policy.len() > MAX_SIGNED_POLICY_BYTES {
+        return Err(ServicePolicyActivationErrorV1::PolicyTooLarge {
+            len: canonical_signed_policy.len(),
+        });
+    }
+    let policy = ServicePolicyV1::decode(canonical_signed_policy)?;
+    if policy.encode()?.as_slice() != canonical_signed_policy {
+        return Err(ServicePolicyActivationErrorV1::NonCanonicalPolicy);
+    }
+    let policy_digest = policy.policy_digest()?;
+    if expected_policy_digest.iter().all(|byte| *byte == 0)
+        || policy_digest != expected_policy_digest
+    {
+        return Err(ServicePolicyActivationErrorV1::ExactPolicyDigestMismatch);
+    }
+    Ok(policy)
+}
+
+fn is_closed_storeless_bat_v2_policy_v1(policy: &ServicePolicyV1) -> bool {
+    if policy.scopes.is_empty() {
+        return false;
+    }
+    for scope in &policy.scopes {
+        if scope.offers.len() != 2 {
+            return false;
+        }
+        let mut free_pow_count = 0;
+        let mut bat_v2_count = 0;
+        for offer in &scope.offers {
+            if offer.authorization == AuthScheme::BitcoinPirCashuBatV2 {
+                bat_v2_count += 1;
+                if offer.acquisition != AcquisitionMethod::Bolt11V1
+                    || offer.free_mode != FreeModeV1::NotFree
+                    || offer.verification != VerificationMode::SharedIssuerOnline
+                    || !matches!(offer.price, PriceV1::MilliSatoshi(_))
+                    || offer.issuer_id.iter().all(|byte| *byte == 0)
+                    || offer.key_id.len() != 32
+                    || offer.key_id.iter().all(|byte| *byte == 0)
+                    || offer.credential_binding.is_some()
+                    || offer.cashu_mint_manifest.is_some()
+                {
+                    return false;
+                }
+            } else {
+                free_pow_count += 1;
+                if offer.acquisition != AcquisitionMethod::FreeV1
+                    || offer.authorization != AuthScheme::FreeV1
+                    || offer.free_mode != FreeModeV1::ProofOfWork
+                    || offer.verification != VerificationMode::ProviderLocal
+                    || offer.price != PriceV1::Free
+                    || offer.issuer_id != [0; 32]
+                    || !offer.key_id.is_empty()
+                    || offer.credential_binding.is_some()
+                    || offer.cashu_mint_manifest.is_some()
+                    || !offer.endpoint.is_empty()
+                    || offer.invoice_expiry_seconds != 0
+                    || offer.claim_window_seconds != 0
+                    || offer.minimum_credential_validity_seconds != 1
+                    || offer.retired_policy_grace_seconds != 0
+                    || offer.credential_count != 1
+                    || offer.credential_presentation_limit != 1
+                    || offer.privacy_leakage != pir_service_protocol::PrivacyLeakageV1::NONE
+                {
+                    return false;
+                }
+            }
+        }
+        if free_pow_count != 1 || bat_v2_count != 1 {
+            return false;
+        }
+    }
+    true
 }
 
 /// Decode, verify, durably advance rollback state, install provider-local
@@ -743,6 +993,59 @@ mod tests {
             signing,
         )
         .unwrap()
+    }
+
+    fn storeless_bat_v2_policy(
+        signing: &SigningKey,
+        provider_id: ProviderId,
+        epoch: u64,
+    ) -> (ServicePolicyV1, [u8; 32]) {
+        let template = free_pow_policy(signing, provider_id, epoch);
+        let mut scopes = template.scopes;
+        let scope_id = scopes[0].scope.scope_id();
+        scopes[0].offers.push(ServiceOfferV1 {
+            offer_id: 2,
+            acquisition: AcquisitionMethod::Bolt11V1,
+            free_mode: FreeModeV1::NotFree,
+            free_quota: 0,
+            free_window_seconds: 0,
+            free_pow_difficulty_bits: 0,
+            priority_class: 1,
+            authorization: AuthScheme::BitcoinPirCashuBatV2,
+            verification: VerificationMode::SharedIssuerOnline,
+            deployment_status: DeploymentStatus::Stable,
+            price: PriceV1::MilliSatoshi(1_000),
+            issuer_id: [7; 32],
+            key_id: vec![8; 32],
+            credential_binding: None,
+            cashu_mint_manifest: None,
+            endpoint: "https://issuer.invalid".into(),
+            invoice_expiry_seconds: 10,
+            claim_window_seconds: 10,
+            minimum_credential_validity_seconds: 100,
+            retired_policy_grace_seconds: 120,
+            credential_count: 1,
+            credential_presentation_limit: 1,
+            privacy_leakage: PrivacyLeakageV1::from_bits(
+                PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                    | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                    | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+            )
+            .unwrap(),
+        });
+        (
+            ServicePolicyV1::sign(
+                provider_id,
+                epoch,
+                template.issued_at,
+                template.expires_at,
+                template.auth_padding_class,
+                scopes,
+                signing,
+            )
+            .unwrap(),
+            scope_id,
+        )
     }
 
     fn retained_receipt_policy(
@@ -1068,6 +1371,168 @@ mod tests {
                 Err(ServicePolicyActivationErrorV1::StorelessPolicyIsNotFreeProofOfWorkOnly)
             ));
         }
+    }
+
+    #[test]
+    fn exact_storeless_bat_v2_activation_is_closed_and_uses_its_own_route() {
+        let provider_id = [9; 32];
+        let signing = SigningKey::from_bytes(&[3; 32]);
+        let (policy, scope_id) = storeless_bat_v2_policy(&signing, provider_id, 2);
+        let bytes = policy.encode().unwrap();
+        let digest = policy.policy_digest().unwrap();
+
+        let activated = activate_exact_storeless_bat_v2_policy_v1(
+            &bytes,
+            provider_id,
+            signing.verifying_key(),
+            digest,
+            150,
+        )
+        .unwrap();
+        let member = activated
+            .verified_bat_v2_member_for_admission(&scope_id, 2, 150)
+            .unwrap();
+        assert_eq!(member.member.policy_digest, digest);
+        assert_eq!(member.member.scope_id, scope_id);
+        assert_eq!(member.class_id, [8; 32]);
+        assert_eq!(
+            required_admission_routes_v1(activated.policy()),
+            BTreeSet::from([
+                AdmissionMethodRouteV1::FreeProofOfWork,
+                AdmissionMethodRouteV1::BitcoinPirCashuBatV2SharedIssuerOnline,
+            ])
+        );
+
+        assert!(matches!(
+            activate_exact_storeless_free_pow_policy_v1(
+                &bytes,
+                provider_id,
+                signing.verifying_key(),
+                digest,
+                150,
+            ),
+            Err(ServicePolicyActivationErrorV1::StorelessPolicyIsNotFreeProofOfWorkOnly)
+        ));
+        let free_only = free_pow_policy(&signing, provider_id, 2);
+        assert!(matches!(
+            activate_exact_storeless_bat_v2_policy_v1(
+                &free_only.encode().unwrap(),
+                provider_id,
+                signing.verifying_key(),
+                free_only.policy_digest().unwrap(),
+                150,
+            ),
+            Err(ServicePolicyActivationErrorV1::StorelessBatV2PolicyShape)
+        ));
+
+        let resign = |template: &ServicePolicyV1, scopes: Vec<ServiceScopePolicyV1>| {
+            ServicePolicyV1::sign(
+                provider_id,
+                template.policy_epoch,
+                template.issued_at,
+                template.expires_at,
+                template.auth_padding_class,
+                scopes,
+                &signing,
+            )
+            .unwrap()
+        };
+        let rejects_closed_shape = |candidate: &ServicePolicyV1| {
+            matches!(
+                activate_exact_storeless_bat_v2_policy_v1(
+                    &candidate.encode().unwrap(),
+                    provider_id,
+                    signing.verifying_key(),
+                    candidate.policy_digest().unwrap(),
+                    150,
+                ),
+                Err(ServicePolicyActivationErrorV1::StorelessBatV2PolicyShape)
+            )
+        };
+
+        let (template, _) = storeless_bat_v2_policy(&signing, provider_id, 2);
+        let free_offer = template.scopes[0].offers[0].clone();
+        let bat_offer = template.scopes[0].offers[1].clone();
+
+        let mut only_bat_scopes = template.scopes.clone();
+        only_bat_scopes[0].offers = vec![bat_offer.clone()];
+        assert!(rejects_closed_shape(&resign(&template, only_bat_scopes)));
+
+        let mut duplicate_bat = bat_offer.clone();
+        duplicate_bat.offer_id = 3;
+        let mut duplicate_bat_scopes = template.scopes.clone();
+        duplicate_bat_scopes[0].offers = vec![bat_offer.clone(), duplicate_bat];
+        assert!(rejects_closed_shape(&resign(
+            &template,
+            duplicate_bat_scopes,
+        )));
+
+        let mut duplicate_free = free_offer.clone();
+        duplicate_free.offer_id = 3;
+        let mut duplicate_free_scopes = template.scopes.clone();
+        duplicate_free_scopes[0].offers = vec![free_offer.clone(), duplicate_free];
+        assert!(rejects_closed_shape(&resign(
+            &template,
+            duplicate_free_scopes,
+        )));
+
+        let mut bat_only_scope = template.scopes[0].clone();
+        bat_only_scope.offers = vec![bat_offer];
+        let mut free_only_scope = template.scopes[0].clone();
+        free_only_scope.scope.dataset = DatasetBindingV1::Class { class_id: 12 };
+        free_only_scope.offers = vec![free_offer];
+        let mut split_method_scopes = vec![bat_only_scope, free_only_scope];
+        split_method_scopes.sort_by_key(|scope| scope.scope.scope_id());
+        assert!(rejects_closed_shape(&resign(
+            &template,
+            split_method_scopes,
+        )));
+    }
+
+    #[test]
+    fn exact_storeless_retained_bat_v2_is_digest_pinned_and_horizon_closed() {
+        let provider_id = [9; 32];
+        let signing = SigningKey::from_bytes(&[3; 32]);
+        let (current_policy, _) = storeless_bat_v2_policy(&signing, provider_id, 2);
+        let current = activate_exact_storeless_bat_v2_policy_v1(
+            &current_policy.encode().unwrap(),
+            provider_id,
+            signing.verifying_key(),
+            current_policy.policy_digest().unwrap(),
+            150,
+        )
+        .unwrap();
+        let (old_policy, old_scope_id) = storeless_bat_v2_policy(&signing, provider_id, 1);
+        let old_bytes = old_policy.encode().unwrap();
+        let old_digest = old_policy.policy_digest().unwrap();
+
+        let retained = activate_exact_storeless_retained_bat_v2_policy_v1(
+            &old_bytes, old_digest, &current, 250,
+        )
+        .unwrap();
+        assert!(retained.has_live_bat_v2_redemption(320));
+        assert!(retained
+            .verified_bat_v2_member_for_redemption(&old_scope_id, 2, 320)
+            .is_ok());
+        assert!(retained
+            .verified_bat_v2_offer_for_redemption(&old_scope_id, 2, 320)
+            .is_ok());
+        assert!(retained
+            .verified_bat_v2_member_for_redemption(&old_scope_id, 2, 321)
+            .is_err());
+        assert!(retained
+            .verified_bat_v2_offer_for_redemption(&old_scope_id, 2, 321)
+            .is_err());
+        assert!(matches!(
+            activate_exact_storeless_retained_bat_v2_policy_v1(
+                &old_bytes, old_digest, &current, 321,
+            ),
+            Err(ServicePolicyActivationErrorV1::StorelessRetainedBatV2PolicyExpired)
+        ));
+        assert!(matches!(
+            activate_exact_storeless_retained_bat_v2_policy_v1(&old_bytes, [42; 32], &current, 250,),
+            Err(ServicePolicyActivationErrorV1::ExactPolicyDigestMismatch)
+        ));
     }
 
     #[test]

--- a/crates/protocol/service/src/bat_v2.rs
+++ b/crates/protocol/service/src/bat_v2.rs
@@ -91,6 +91,62 @@ pub struct BatAcceptanceClassV2 {
     pub signature: [u8; 64],
 }
 
+/// Verifies that one signed BAT V2 class safely covers the exact provider
+/// policy projection from policy issuance through its retained redemption
+/// horizon. Issuer registration and storeless provider admission share this
+/// predicate so their class-validity contracts cannot drift apart.
+pub fn verify_bat_acceptance_class_member_projection_v2(
+    class: &BatAcceptanceClassV2,
+    projection: &VerifiedBatAcceptanceMemberV2,
+) -> Result<(), ServiceProtocolError> {
+    class.verify_for(&projection.issuer_id, &projection.class_id)?;
+    if projection.common_terms != class.common_terms
+        || !class.members.contains(&projection.member)
+        || projection.policy_issued_at > projection.policy_expires_at
+    {
+        return Err(ServiceProtocolError::InvalidValue {
+            field: "VerifiedBatAcceptanceMemberV2.class_projection",
+            reason: "projection is not an exact member of the signed BAT V2 class",
+        });
+    }
+
+    let minimum_not_after = projection
+        .policy_expires_at
+        .checked_add(u64::from(projection.common_terms.invoice_expiry_seconds))
+        .and_then(|value| {
+            value.checked_add(u64::from(projection.common_terms.claim_window_seconds))
+        })
+        .and_then(|value| {
+            value.checked_add(u64::from(
+                projection.common_terms.minimum_credential_validity_seconds,
+            ))
+        })
+        .ok_or(ServiceProtocolError::InvalidValue {
+            field: "VerifiedBatAcceptanceMemberV2.class_projection",
+            reason: "minimum class validity horizon overflows",
+        })?;
+    let expected_deadline = projection
+        .policy_expires_at
+        .checked_add(u64::from(
+            projection.common_terms.retired_policy_grace_seconds,
+        ))
+        .ok_or(ServiceProtocolError::InvalidValue {
+            field: "VerifiedBatAcceptanceMemberV2.class_projection",
+            reason: "retained policy redemption deadline overflows",
+        })?;
+    if expected_deadline != projection.redemption_deadline
+        || class.key_not_before > projection.policy_issued_at
+        || class.key_not_after > projection.redemption_deadline
+        || class.key_not_after < minimum_not_after
+    {
+        return Err(ServiceProtocolError::InvalidValue {
+            field: "VerifiedBatAcceptanceMemberV2.class_projection",
+            reason: "signed class key validity does not cover the exact policy horizons",
+        });
+    }
+    Ok(())
+}
+
 pub fn validate_bat_acceptance_class_id_v2(
     class_id: &BatAcceptanceClassIdV2,
 ) -> Result<(), ServiceProtocolError> {

--- a/crates/protocol/service/src/lib.rs
+++ b/crates/protocol/service/src/lib.rs
@@ -44,13 +44,14 @@ pub use auth_verify::{
 };
 pub use bat_v2::{
     bat_acceptance_member_from_retained_policy_v2, bat_acceptance_member_from_verified_policy_v2,
-    derive_bat_acceptance_key_id_v2, validate_bat_acceptance_class_id_v2, BatAcceptanceClassIdV2,
-    BatAcceptanceClassV2, BatAcceptanceMemberV2, BatAcceptanceTermsV2,
-    VerifiedBatAcceptanceMemberV2, BAT_ACCEPTANCE_CLASS_CODEC_MAGIC_V2,
-    BAT_ACCEPTANCE_CLASS_DIGEST_DOMAIN_V2, BAT_ACCEPTANCE_CLASS_SIGNATURE_DOMAIN_V2,
-    BAT_ACCEPTANCE_CLASS_WIRE_VERSION_V2, BAT_ACCEPTANCE_KEY_ID_DOMAIN_V2,
-    BAT_ACCEPTANCE_TERMS_DIGEST_DOMAIN_V2, MAX_BAT_ACCEPTANCE_CLASS_LEN_V2,
-    MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2, MAX_BAT_ACCEPTANCE_TERMS_LEN_V2,
+    derive_bat_acceptance_key_id_v2, validate_bat_acceptance_class_id_v2,
+    verify_bat_acceptance_class_member_projection_v2, BatAcceptanceClassIdV2, BatAcceptanceClassV2,
+    BatAcceptanceMemberV2, BatAcceptanceTermsV2, VerifiedBatAcceptanceMemberV2,
+    BAT_ACCEPTANCE_CLASS_CODEC_MAGIC_V2, BAT_ACCEPTANCE_CLASS_DIGEST_DOMAIN_V2,
+    BAT_ACCEPTANCE_CLASS_SIGNATURE_DOMAIN_V2, BAT_ACCEPTANCE_CLASS_WIRE_VERSION_V2,
+    BAT_ACCEPTANCE_KEY_ID_DOMAIN_V2, BAT_ACCEPTANCE_TERMS_DIGEST_DOMAIN_V2,
+    MAX_BAT_ACCEPTANCE_CLASS_LEN_V2, MAX_BAT_ACCEPTANCE_CLASS_MEMBERS_V2,
+    MAX_BAT_ACCEPTANCE_TERMS_LEN_V2,
 };
 pub use bat_v2_acquisition::{
     BatV2IssuanceRequestV2, BatV2IssuanceResponseV2, Bolt11BatV2ClaimEnvelopeV2,

--- a/crates/protocol/service/src/proof.rs
+++ b/crates/protocol/service/src/proof.rs
@@ -15,9 +15,10 @@ use zeroize::{Zeroize, Zeroizing};
 use crate::cashu_manifest::is_valid_compressed_point;
 use crate::codec::{expect_v1, put_bytes_u16, put_bytes_u32, Decoder};
 use crate::{
-    is_canonical_cashu_keyset_id_v2, AcquisitionMethod, AuthScheme, FreeModeV1, PaidReceiptV1,
-    PriceV1, ProviderId, ScopeId, ServiceProtocolError, VerificationMode, VerifiedServiceOfferV1,
-    CASHU_KEYSET_ID_V2_LEN, MAX_AUTH_PROOF_LEN, MAX_SERVICE_VALUE_V1, SERVICE_PROTOCOL_VERSION,
+    is_canonical_cashu_keyset_id_v2, AcquisitionMethod, AuthScheme, BitcoinPirCashuBatProofV2,
+    FreeModeV1, PaidReceiptV1, PriceV1, ProviderId, ScopeId, ServiceProtocolError,
+    VerificationMode, VerifiedServiceOfferV1, BAT_V2_PROOF_LEN_V2, CASHU_KEYSET_ID_V2_LEN,
+    MAX_AUTH_PROOF_LEN, MAX_SERVICE_VALUE_V1, SERVICE_PROTOCOL_VERSION,
 };
 
 pub const FREE_POW_PROOF_LEN_V1: usize = 1 + 32 + 8;
@@ -1077,6 +1078,7 @@ pub enum AuthorizationProofV1 {
     Bolt11DirectReceipt(Box<PaidReceiptV1>),
     StandardCashu(StandardCashuSpendV1),
     BitcoinPirCashuBat(BitcoinPirCashuBatProofV1),
+    BitcoinPirCashuBatV2(BitcoinPirCashuBatProofV2),
     ArcExperimental(ArcPresentationV1),
 }
 
@@ -1107,6 +1109,10 @@ impl fmt::Debug for AuthorizationProofV1 {
                 .finish(),
             Self::BitcoinPirCashuBat(_) => formatter
                 .debug_tuple("AuthorizationProofV1::BitcoinPirCashuBat")
+                .field(&"[REDACTED]")
+                .finish(),
+            Self::BitcoinPirCashuBatV2(_) => formatter
+                .debug_tuple("AuthorizationProofV1::BitcoinPirCashuBatV2")
                 .field(&"[REDACTED]")
                 .finish(),
             Self::ArcExperimental(_) => formatter
@@ -1159,6 +1165,11 @@ impl AuthorizationProofV1 {
                 FreeModeV1::NotFree,
                 Self::BitcoinPirCashuBat(proof),
             ) => Ok(proof.encode_zeroizing()?.to_vec()),
+            (
+                AuthScheme::BitcoinPirCashuBatV2,
+                FreeModeV1::NotFree,
+                Self::BitcoinPirCashuBatV2(proof),
+            ) => Ok(proof.encode()?.to_vec()),
             (
                 AuthScheme::ArcV1Experimental,
                 FreeModeV1::NotFree,
@@ -1230,6 +1241,17 @@ pub(crate) fn decode_authorization_proof_v1(
         (AuthScheme::BitcoinPirCashuBatV1, FreeModeV1::NotFree) => Ok(
             AuthorizationProofV1::BitcoinPirCashuBat(BitcoinPirCashuBatProofV1::decode(bytes)?),
         ),
+        (AuthScheme::BitcoinPirCashuBatV2, FreeModeV1::NotFree) => {
+            if bytes.len() != BAT_V2_PROOF_LEN_V2 {
+                return Err(ServiceProtocolError::InvalidValue {
+                    field: "BitcoinPirCashuBatProofV2",
+                    reason: "scheme 6 proof must use the fixed 210-byte V2 codec",
+                });
+            }
+            Ok(AuthorizationProofV1::BitcoinPirCashuBatV2(
+                BitcoinPirCashuBatProofV2::decode(bytes)?,
+            ))
+        }
         (AuthScheme::ArcV1Experimental, FreeModeV1::NotFree) => {
             let canonicalizer = arc_canonicalizer.ok_or(ServiceProtocolError::InvalidValue {
                 field: "ArcPresentationV1.presentation",
@@ -2177,5 +2199,46 @@ mod tests {
             None,
         )
         .is_err());
+
+        let bat_v2 = AuthorizationProofV1::BitcoinPirCashuBatV2(BitcoinPirCashuBatProofV2 {
+            issuer_id: [2; 32],
+            class_id: [3; 32],
+            class_digest: [4; 32],
+            class_key_epoch: 5,
+            bat_key_id: [6; 32],
+            secret_raw: [7; 32],
+            c: point(2),
+        });
+        let encoded_v2 = bat_v2
+            .encode_for(AuthScheme::BitcoinPirCashuBatV2, FreeModeV1::NotFree)
+            .unwrap();
+        assert_eq!(encoded_v2.len(), BAT_V2_PROOF_LEN_V2);
+        assert!(matches!(
+            decode_authorization_proof_v1(
+                AuthScheme::BitcoinPirCashuBatV2,
+                FreeModeV1::NotFree,
+                &encoded_v2,
+                None,
+            )
+            .unwrap(),
+            AuthorizationProofV1::BitcoinPirCashuBatV2(_)
+        ));
+        assert!(decode_authorization_proof_v1(
+            AuthScheme::BitcoinPirCashuBatV1,
+            FreeModeV1::NotFree,
+            &encoded_v2,
+            None,
+        )
+        .is_err());
+        assert!(decode_authorization_proof_v1(
+            AuthScheme::BitcoinPirCashuBatV2,
+            FreeModeV1::NotFree,
+            &encoded,
+            None,
+        )
+        .is_err());
+        assert!(bat_v2
+            .encode_for(AuthScheme::BitcoinPirCashuBatV1, FreeModeV1::NotFree)
+            .is_err());
     }
 }

--- a/docs/payment/IMPLEMENTATION_STATUS.md
+++ b/docs/payment/IMPLEMENTATION_STATUS.md
@@ -67,20 +67,31 @@ activated the path with real money.
       outcome burns it. Focused tests cover fresh success, issuer-global replay,
       signed retry-safe decisions, stale/invalid response rejection, transport
       ambiguity, trust/role-key checks and exact route/media bindings.
-- [ ] **Runtime provider, SDK/Web and render path pending.** Legacy
-      ProviderStore/admission paths still deliberately reject scheme 6; no old
-      replayable V1 success is reinterpreted. The exact-policy runtime adapter,
-      unified-server closed profile, SDK/Web class wallet, two-paid-leg
-      selection and production render gates remain to implement. Current
+- [x] **Runtime protocol/provider adapter implemented.** Scheme 6 has an
+      independent fixed-size proof variant, admission route and composite
+      committer slot; it is not interpreted as V1 and the ProviderStore adapter
+      explicitly rejects it. Separate exact-digest current/retained policy
+      activation accepts only the closed per-scope Free-PoW plus shared-issuer
+      BAT V2 shape, and the storeless committer binds the exact verified member,
+      signed class and provider client before one issuer-online attempt.
+      Focused protocol, runtime and provider-client tests cover route isolation,
+      closed policy shape, retained deadlines and fail-closed outcome mapping.
+- [ ] **Unified-server, SDK/Web and render integration pending.** The new
+      runtime/provider libraries are not yet selected by `unified_server`; no
+      SDK/Web class wallet, two-paid-leg selection or production render gate
+      exists. Legacy ProviderStore/admission paths still deliberately reject
+      scheme 6, and no old replayable V1 success is reinterpreted. Current
       `main` also retains the old Direct Mainnet issuer unit and stateful V1
       provider profiles. An old draft's fixed
       2-policy/12-key/2-clearing shape remains superseded and is not V2
       readiness evidence.
-- [ ] **Payment-storeless provider mode pending.** The current shared-BAT
-      committer still uses ProviderStore for a local delivery claim and the
-      existing storeless mode accepts only Free-PoW. The V2 path must make the
-      issuer the only durable spend/replay authority and must not return a
-      grantable success after first commit.
+- [x] **Payment-storeless provider library mode implemented.** The independent
+      BAT V2 path has no ProviderStore, local delivery claim, HMAC/idempotency
+      secret or payment rollback client. The issuer remains the only durable
+      spend/replay authority; only a freshly committed issuer response can
+      grant, while terminal/replay and ambiguous outcomes cannot grant. This
+      checkbox covers library/runtime behavior only, not the pending
+      `unified_server`, SDK/Web, render or production activation work above.
 - [ ] **Old Direct transition pending.** Before replacing the old Mainnet
       source profile, an owner must inventory every private plan, installed
       bundle, store/floor, identity/key lineage, backup and outstanding quote/
@@ -1505,13 +1516,13 @@ findings and must not be collapsed into that count.
    attestation/binary/client-pin acceptance. Policy expiry/renewal, difficulty,
    scope, limit or dataset changes all require another UKI; host-side edits fail
    closed.
-   The current storeless exception cannot implement issuer-wide V2 BAT either,
-   because its runtime contract accepts only Free-PoW. V2 must add an
-   exact-policy, issuer-online BAT mode with no payment ProviderStore,
-   shared-idempotency material or provider payment rollback client. pir2's
-   selected sealed identity/clearing implementation and capability canary are
-   tracked separately above. Until that code and evidence exist, no pir2 V2
-   plan or UKI is source-ready.
+   The original Free-PoW-only storeless contract remains unchanged. A separate
+   exact-policy, issuer-online BAT V2 library/runtime path now exists without a
+   payment ProviderStore, shared-idempotency material or provider payment
+   rollback client, but it is not yet wired into `unified_server` or a rendered
+   provider plan. pir2's selected sealed identity/clearing implementation and
+   capability canary are tracked separately above. Until those integration and
+   sealed-state artifacts exist, no pir2 V2 plan or UKI is source-ready.
 5. **Reproducible network E2E.** A committed deterministic no-funds fixture
    assembles two independent providers, all five workloads/methods and issuer
    artifacts. The current acceptance additionally launches two independent


### PR DESCRIPTION
## Summary
- add the independent 210-byte BAT V2 authorization proof and runtime route
- add a dedicated composite slot and a storeless provider admission committer
- activate exact current and retained policies only when every scope has exactly one Free-PoW offer and one shared-issuer BAT V2 offer
- share the signed-class/member horizon verifier between issuer registration and provider admission
- keep ProviderStore, V1 replay semantics, idempotency material, and payment rollback out of the V2 path

## Contract
Only a freshly verified issuer success for the exact in-flight attempt can authorize the connection. Definitely-not-sent and signed non-consuming rejections remain non-terminal; terminal/spent and ambiguous outcomes cannot grant. Retained policy use is exact-digest and bounded by the signed redemption deadline.

This PR is library/runtime wiring only. unified_server, SDK/Web, render profiles, and pir2 sealed-key handoff remain explicitly pending.

## Verification
- three-package all-target check
- BAT V2 focused tests: protocol 13, provider-clearing client 9, issuer-store 11
- runtime storeless tests 4/4
- composite route test 1/1
- complete package tests previously passed: protocol 44 plus integrations, runtime 175 plus integrations, provider client 150
- scoped rustfmt and diff check
- strict Clippy passed after allowing the repository's pre-existing Rust 1.94 baseline lints
