### PR TITLE
feat: add class-bound BAT V2 SDK acquisition

### DIFF
--- a/crates/protocol/service/src/quote.rs
+++ b/crates/protocol/service/src/quote.rs
@@ -2017,6 +2017,56 @@ impl Bolt11QuoteV1 {
         Ok(verified)
     }
 
+    /// BAT V2 counterpart of [`Self::verify_latest_after`]. Both snapshots
+    /// must remain bound to the exact issuer-signed acceptance class before
+    /// lifecycle monotonicity is considered.
+    pub fn verify_latest_bat_v2_after<'a>(
+        &'a self,
+        previous: &Bolt11QuoteV1,
+        intent: &'a Bolt11BatV2QuoteIntentV2,
+        class: &'a BatAcceptanceClassV2,
+        delegation: &Bolt11QuoteKeyDelegationV1,
+        parsed_invoice: &ParsedBolt11InvoiceV1,
+        now_unix: u64,
+    ) -> Result<VerifiedBolt11BatV2QuoteV2<'a>, ServiceProtocolError> {
+        previous.verify_bat_v2_snapshot(intent, class, delegation, parsed_invoice, now_unix)?;
+        let verified =
+            self.verify_bat_v2_snapshot(intent, class, delegation, parsed_invoice, now_unix)?;
+        let prior = previous;
+        if self.quote_id != prior.quote_id {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.quote_id",
+                reason: "status polling cannot replace the original quote",
+            });
+        }
+        if self.state_version < prior.state_version {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.state_version",
+                reason: "status snapshot rolls back the locally accepted version",
+            });
+        }
+        if self.state_version == prior.state_version {
+            let current = Zeroizing::new(self.encode()?);
+            let previous = Zeroizing::new(prior.encode()?);
+            if current.as_slice() != previous.as_slice() {
+                return Err(ServiceProtocolError::InvalidValue {
+                    field: "Bolt11QuoteV1.state_version",
+                    reason: "different signed snapshots exist at the same state version",
+                });
+            }
+            return Ok(verified);
+        }
+        if self.status_updated_at <= prior.status_updated_at
+            || !is_observable_quote_successor_v1(prior, self)
+        {
+            return Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.status",
+                reason: "status snapshot is not a reachable monotonic successor",
+            });
+        }
+        Ok(verified)
+    }
+
     fn signing_preimage(&self) -> Result<Zeroizing<Vec<u8>>, ServiceProtocolError> {
         let unsigned = self.encode_unsigned()?;
         let mut out = Zeroizing::new(Vec::with_capacity(
@@ -2962,11 +3012,12 @@ pub(crate) fn ensure_quote_claim_submission_at(
 mod tests {
     use super::*;
     use crate::{
-        derive_bat_key_id_v1, AuthPaddingClassV1, BackendId, CredentialKeyBindingClaimsV1,
-        CredentialKeyBindingV1, CredentialUnitV1, DatasetBindingV1, DeploymentStatus,
-        EntitlementLimitsV1, FreeModeV1, PolicyRollbackGuardV1, PrivacyLeakageV1, ServiceOfferV1,
-        ServicePolicyEpochFloorsV1, ServicePolicyV1, ServiceScopePolicyV1, ServiceScopeV1,
-        VerificationMode, WorkloadId,
+        derive_bat_key_id_v1, AuthPaddingClassV1, BackendId, BatAcceptanceMemberV2,
+        BatAcceptanceTermsV2, CredentialKeyBindingClaimsV1, CredentialKeyBindingV1,
+        CredentialUnitV1, DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1, FreeModeV1,
+        PolicyRollbackGuardV1, PrivacyLeakageV1, ServiceOfferV1, ServicePolicyEpochFloorsV1,
+        ServicePolicyV1, ServiceScopePolicyV1, ServiceScopeV1, VerificationMode,
+        VerifiedBatAcceptanceMemberV2, WorkloadId,
     };
     #[cfg(not(target_family = "wasm"))]
     use bitcoin::hashes::{sha256, Hash};
@@ -3103,6 +3154,168 @@ mod tests {
             CREATED_AT,
             delegation,
             quote_key,
+        )
+        .unwrap()
+    }
+
+    struct BatV2QuoteFixture {
+        quote_key: SigningKey,
+        delegation: Bolt11QuoteKeyDelegationV1,
+        class: BatAcceptanceClassV2,
+        member: VerifiedBatAcceptanceMemberV2,
+        guard: Bolt11QuoteKeyRollbackGuardV1,
+        intent: Bolt11BatV2QuoteIntentV2,
+        parsed_invoice: ParsedBolt11InvoiceV1,
+        open: Bolt11QuoteV1,
+    }
+
+    fn bat_v2_quote_fixture() -> BatV2QuoteFixture {
+        let issuer_key = SigningKey::from_bytes(&[17; 32]);
+        let quote_key = SigningKey::from_bytes(&[18; 32]);
+        let member_coordinates = BatAcceptanceMemberV2 {
+            provider_id: [0x21; 32],
+            policy_digest: [0x22; 32],
+            scope_id: [0x23; 32],
+            offer_id: 24,
+        };
+        let common_terms = BatAcceptanceTermsV2 {
+            auth_padding_class: AuthPaddingClassV1::Class16KiB,
+            backend: BackendId::DpfPirV1,
+            workload: WorkloadId::DpfEvaluateJobV1,
+            protocol_version: 1,
+            dataset: DatasetBindingV1::Class { class_id: 1 },
+            operation_profile: 2,
+            entitlement_profile: 3,
+            limits: EntitlementLimitsV1 {
+                max_logical_inputs: 1,
+                max_frames: 10,
+                max_request_bytes: 10_000,
+                max_response_bytes: 20_000,
+                max_wall_time_ms: 1_000,
+                max_concurrent_sockets: 1,
+                max_hint_groups: 0,
+                max_work_units: 100,
+            },
+            priority_class: 1,
+            deployment_status: DeploymentStatus::Stable,
+            price_msat: 1_000_000,
+            issuer_endpoint: "https://issuer.invalid".into(),
+            invoice_expiry_seconds: INVOICE_EXPIRY,
+            claim_window_seconds: CLAIM_WINDOW,
+            minimum_credential_validity_seconds: CREDENTIAL_VALIDITY,
+            retired_policy_grace_seconds: 5_500,
+            credential_count: 8,
+            credential_presentation_limit: 1,
+            privacy_leakage: PrivacyLeakageV1::from_bits(
+                PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                    | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                    | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+            )
+            .unwrap(),
+        };
+        let class = BatAcceptanceClassV2::sign(
+            [0x24; 32],
+            3,
+            100,
+            20_000,
+            compressed_point(11),
+            common_terms.clone(),
+            vec![member_coordinates.clone()],
+            &issuer_key,
+        )
+        .unwrap();
+        let member = VerifiedBatAcceptanceMemberV2 {
+            issuer_id: class.issuer_id,
+            class_id: class.class_id,
+            member: member_coordinates,
+            common_terms: common_terms.clone(),
+            policy_issued_at: 100,
+            policy_expires_at: 20_000,
+            redemption_deadline: 20_000,
+        };
+        let payee = compressed_point(3);
+        let delegation = Bolt11QuoteKeyDelegationV1::sign(
+            LightningNetworkV1::Bitcoin,
+            payee,
+            4,
+            100,
+            20_000,
+            quote_key.verifying_key().to_bytes(),
+            &issuer_key,
+        )
+        .unwrap();
+        let guard = Bolt11QuoteKeyRollbackGuardV1::initial(
+            class.issuer_id,
+            LightningNetworkV1::Bitcoin,
+            payee,
+        )
+        .unwrap();
+        let intent = Bolt11BatV2QuoteIntentV2::from_verified_class_member_guarded(
+            &member,
+            &class,
+            &delegation,
+            &guard,
+            CREATED_AT,
+            xonly_point(5),
+            [0x25; 32],
+        )
+        .unwrap()
+        .0;
+        let parsed_invoice = ParsedBolt11InvoiceV1::from_signature_verified_invoice(
+            INVOICE,
+            LightningNetworkV1::Bitcoin,
+            payee,
+            common_terms.price_msat,
+            CREATED_AT,
+            INVOICE_EXPIRY,
+        )
+        .unwrap();
+        let verified_intent = intent
+            .verify_for_class_member_guarded(&member, &class, &delegation, &guard, CREATED_AT)
+            .unwrap();
+        let open = Bolt11QuoteV1::sign_for_verified_bat_v2_intent(
+            &verified_intent,
+            [0x26; 32],
+            INVOICE.into(),
+            &parsed_invoice,
+            Bolt11QuoteStatusV1::InvoiceOpen,
+            CREATED_AT,
+            &quote_key,
+        )
+        .unwrap();
+        BatV2QuoteFixture {
+            quote_key,
+            delegation,
+            class,
+            member,
+            guard,
+            intent,
+            parsed_invoice,
+            open,
+        }
+    }
+
+    fn bat_v2_successor(
+        fixture: &BatV2QuoteFixture,
+        previous: &Bolt11QuoteV1,
+        status: Bolt11QuoteStatusV1,
+        status_updated_at: u64,
+    ) -> Bolt11QuoteV1 {
+        let verified = previous
+            .verify_bat_v2_snapshot(
+                &fixture.intent,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.parsed_invoice,
+                status_updated_at,
+            )
+            .unwrap();
+        Bolt11QuoteV1::with_status_from_verified_bat_v2_snapshot(
+            &verified,
+            status,
+            status_updated_at,
+            &fixture.delegation,
+            &fixture.quote_key,
         )
         .unwrap()
     }
@@ -3880,6 +4093,171 @@ mod tests {
         claimed
             .verify_latest_after(&open, &intent, &delegation, &parsed_invoice, 1_500)
             .unwrap();
+    }
+
+    #[test]
+    fn latest_bat_v2_snapshot_guard_accepts_reachable_monotonic_successor() {
+        let fixture = bat_v2_quote_fixture();
+        let settled = bat_v2_successor(
+            &fixture,
+            &fixture.open,
+            Bolt11QuoteStatusV1::PaymentSettled,
+            1_400,
+        );
+
+        settled
+            .verify_latest_bat_v2_after(
+                &fixture.open,
+                &fixture.intent,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.parsed_invoice,
+                1_500,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn latest_bat_v2_snapshot_guard_rejects_quote_replacement() {
+        let fixture = bat_v2_quote_fixture();
+        let verified_intent = fixture
+            .intent
+            .verify_for_class_member_guarded(
+                &fixture.member,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.guard,
+                CREATED_AT,
+            )
+            .unwrap();
+        let replacement = Bolt11QuoteV1::sign_for_verified_bat_v2_intent(
+            &verified_intent,
+            [0x27; 32],
+            INVOICE.into(),
+            &fixture.parsed_invoice,
+            Bolt11QuoteStatusV1::InvoiceOpen,
+            CREATED_AT,
+            &fixture.quote_key,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            replacement.verify_latest_bat_v2_after(
+                &fixture.open,
+                &fixture.intent,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.parsed_invoice,
+                1_500,
+            ),
+            Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.quote_id",
+                reason: "status polling cannot replace the original quote",
+            })
+        ));
+    }
+
+    #[test]
+    fn latest_bat_v2_snapshot_guard_rejects_version_rollback() {
+        let fixture = bat_v2_quote_fixture();
+        let settled = bat_v2_successor(
+            &fixture,
+            &fixture.open,
+            Bolt11QuoteStatusV1::PaymentSettled,
+            1_400,
+        );
+
+        assert!(matches!(
+            fixture.open.verify_latest_bat_v2_after(
+                &settled,
+                &fixture.intent,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.parsed_invoice,
+                1_500,
+            ),
+            Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.state_version",
+                reason: "status snapshot rolls back the locally accepted version",
+            })
+        ));
+    }
+
+    #[test]
+    fn latest_bat_v2_snapshot_guard_rejects_same_version_equivocation() {
+        let fixture = bat_v2_quote_fixture();
+        let settled = bat_v2_successor(
+            &fixture,
+            &fixture.open,
+            Bolt11QuoteStatusV1::PaymentSettled,
+            1_400,
+        );
+        let expired = bat_v2_successor(
+            &fixture,
+            &fixture.open,
+            Bolt11QuoteStatusV1::InvoiceExpiredPendingReconcile,
+            fixture.open.invoice_expires_at,
+        );
+        assert_eq!(settled.state_version, expired.state_version);
+
+        assert!(matches!(
+            expired.verify_latest_bat_v2_after(
+                &settled,
+                &fixture.intent,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.parsed_invoice,
+                1_700,
+            ),
+            Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.state_version",
+                reason: "different signed snapshots exist at the same state version",
+            })
+        ));
+    }
+
+    #[test]
+    fn latest_bat_v2_snapshot_guard_rejects_unreachable_successor() {
+        let fixture = bat_v2_quote_fixture();
+        let settled = bat_v2_successor(
+            &fixture,
+            &fixture.open,
+            Bolt11QuoteStatusV1::PaymentSettled,
+            1_400,
+        );
+        let expired = bat_v2_successor(
+            &fixture,
+            &fixture.open,
+            Bolt11QuoteStatusV1::InvoiceExpiredPendingReconcile,
+            fixture.open.invoice_expires_at,
+        );
+        let late = bat_v2_successor(
+            &fixture,
+            &expired,
+            Bolt11QuoteStatusV1::LateSettledReconcile,
+            1_700,
+        );
+        let claimed = bat_v2_successor(
+            &fixture,
+            &late,
+            Bolt11QuoteStatusV1::CredentialClaimed,
+            1_800,
+        );
+
+        assert!(matches!(
+            claimed.verify_latest_bat_v2_after(
+                &settled,
+                &fixture.intent,
+                &fixture.class,
+                &fixture.delegation,
+                &fixture.parsed_invoice,
+                1_900,
+            ),
+            Err(ServiceProtocolError::InvalidValue {
+                field: "Bolt11QuoteV1.status",
+                reason: "status snapshot is not a reachable monotonic successor",
+            })
+        ));
     }
 
     #[test]

--- a/crates/sdk/client/src/bat_v2.rs
+++ b/crates/sdk/client/src/bat_v2.rs
@@ -1,0 +1,701 @@
+//! Class-bound, restart-safe BOLT11 acquisition for issuer-wide BAT V2.
+//!
+//! HTTP remains caller-owned.  This module accepts a provider offer only long
+//! enough to prove membership in one exact issuer-signed class; every durable
+//! acquisition object thereafter contains class coordinates, never provider,
+//! policy, scope, or offer coordinates.
+
+use core::fmt;
+
+use pir_payment_crypto::{sign_bip340_prehash_v1, verify_quote_claim_v1};
+use pir_sdk::{PirError, PirResult};
+use pir_service_protocol::{
+    BatAcceptanceClassV2, BatV2IssuanceRequestV2, BatV2IssuanceResponseV2,
+    BitcoinPirCashuBatIssuanceRequestItemV1, Bolt11BatV2ClaimEnvelopeV2, Bolt11BatV2QuoteIntentV2,
+    Bolt11QuoteClaimV1, Bolt11QuoteKeyDelegationV1, Bolt11QuoteStatusRequestV1,
+    Bolt11QuoteStatusV1, Bolt11QuoteV1, CheckedBatV2IssuanceResponseV2, ParsedBolt11InvoiceV1,
+    VerifiedBatAcceptanceMemberV2,
+};
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::bolt11::Bolt11QuoteKeyCheckpointV1;
+
+/// A current provider policy offer proven to be an exact member of one
+/// issuer-signed BAT V2 acceptance class.
+///
+/// The member is retained only until the class-only quote intent is prepared;
+/// it is intentionally absent from [`PreparedBolt11BatV2QuoteV2`] and every
+/// recovery record derived from that type.
+#[derive(Clone, Debug)]
+pub struct VerifiedCurrentBatV2OfferV2 {
+    class: BatAcceptanceClassV2,
+    member: VerifiedBatAcceptanceMemberV2,
+}
+
+impl VerifiedCurrentBatV2OfferV2 {
+    pub(crate) const fn new(
+        class: BatAcceptanceClassV2,
+        member: VerifiedBatAcceptanceMemberV2,
+    ) -> Self {
+        Self { class, member }
+    }
+
+    pub const fn class(&self) -> &BatAcceptanceClassV2 {
+        &self.class
+    }
+
+    pub const fn member(&self) -> &VerifiedBatAcceptanceMemberV2 {
+        &self.member
+    }
+
+    pub fn class_bytes(&self) -> PirResult<Vec<u8>> {
+        self.class.encode().map_err(protocol_encode_error)
+    }
+
+    pub fn class_digest(&self) -> PirResult<[u8; 32]> {
+        self.class
+            .class_digest()
+            .map_err(protocol_verification_error)
+    }
+
+    pub const fn class_id(&self) -> [u8; 32] {
+        self.class.class_id
+    }
+
+    pub const fn class_key_epoch(&self) -> u64 {
+        self.class.key_epoch
+    }
+
+    pub fn bat_key_id(&self) -> [u8; 32] {
+        self.class.bat_key_id()
+    }
+}
+
+/// A class-only quote intent whose signed class, selected current member,
+/// quote-key delegation, and durable rollback stream have all been checked.
+#[derive(Clone, Debug)]
+pub struct PreparedBolt11BatV2QuoteV2 {
+    intent: Bolt11BatV2QuoteIntentV2,
+    class: BatAcceptanceClassV2,
+    delegation: Bolt11QuoteKeyDelegationV1,
+    advanced_checkpoint: Bolt11QuoteKeyCheckpointV1,
+}
+
+impl PreparedBolt11BatV2QuoteV2 {
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_verified_current_offer(
+        verified: &VerifiedCurrentBatV2OfferV2,
+        delegation_bytes: &[u8],
+        checkpoint: &Bolt11QuoteKeyCheckpointV1,
+        now_unix: u64,
+        claim_pubkey_xonly: [u8; 32],
+        idempotency_key: [u8; 32],
+    ) -> PirResult<Self> {
+        let delegation =
+            Bolt11QuoteKeyDelegationV1::decode(delegation_bytes).map_err(protocol_decode_error)?;
+        let (intent, advanced_guard) =
+            Bolt11BatV2QuoteIntentV2::from_verified_class_member_guarded(
+                verified.member(),
+                verified.class(),
+                &delegation,
+                checkpoint.rollback_guard_v1(),
+                now_unix,
+                claim_pubkey_xonly,
+                idempotency_key,
+            )
+            .map_err(protocol_verification_error)?;
+        Ok(Self {
+            intent,
+            class: verified.class.clone(),
+            delegation,
+            advanced_checkpoint: Bolt11QuoteKeyCheckpointV1::from_rollback_guard_v1(advanced_guard),
+        })
+    }
+
+    pub fn restore(
+        intent_bytes: &[u8],
+        class_bytes: &[u8],
+        delegation_bytes: &[u8],
+        checkpoint_bytes: &[u8],
+        now_unix: u64,
+    ) -> PirResult<Self> {
+        let intent =
+            Bolt11BatV2QuoteIntentV2::decode(intent_bytes).map_err(protocol_decode_error)?;
+        let class = BatAcceptanceClassV2::decode(class_bytes).map_err(protocol_decode_error)?;
+        let delegation =
+            Bolt11QuoteKeyDelegationV1::decode(delegation_bytes).map_err(protocol_decode_error)?;
+        let advanced_checkpoint = Bolt11QuoteKeyCheckpointV1::decode(checkpoint_bytes)?;
+        let verified = intent
+            .verify_for_class_guarded(
+                &class,
+                &delegation,
+                advanced_checkpoint.rollback_guard_v1(),
+                now_unix,
+            )
+            .map_err(protocol_verification_error)?;
+        if verified.advanced_guard() != *advanced_checkpoint.rollback_guard_v1() {
+            return Err(PirError::VerificationFailed(
+                "restored BAT V2 quote-key checkpoint differs from the intent".into(),
+            ));
+        }
+        Ok(Self {
+            intent,
+            class,
+            delegation,
+            advanced_checkpoint,
+        })
+    }
+
+    pub const fn intent(&self) -> &Bolt11BatV2QuoteIntentV2 {
+        &self.intent
+    }
+
+    pub const fn class(&self) -> &BatAcceptanceClassV2 {
+        &self.class
+    }
+
+    pub const fn delegation(&self) -> &Bolt11QuoteKeyDelegationV1 {
+        &self.delegation
+    }
+
+    pub fn intent_bytes(&self) -> PirResult<Vec<u8>> {
+        self.intent.encode().map_err(protocol_encode_error)
+    }
+
+    pub fn class_bytes(&self) -> PirResult<Vec<u8>> {
+        self.class.encode().map_err(protocol_encode_error)
+    }
+
+    pub fn delegation_bytes(&self) -> PirResult<Vec<u8>> {
+        self.delegation.encode().map_err(protocol_encode_error)
+    }
+
+    pub fn quote_key_checkpoint_bytes(&self) -> Vec<u8> {
+        self.advanced_checkpoint.encode()
+    }
+
+    pub fn accept_initial_quote_for_payment(
+        &self,
+        quote_bytes: &[u8],
+        now_unix: u64,
+    ) -> PirResult<AcceptedBolt11BatV2QuoteV2> {
+        let quote = Bolt11QuoteV1::decode(quote_bytes).map_err(protocol_decode_error)?;
+        let parsed =
+            ParsedBolt11InvoiceV1::parse(&quote.invoice).map_err(protocol_verification_error)?;
+        quote
+            .verify_bat_v2_for_payment(
+                &self.intent,
+                &self.class,
+                &self.delegation,
+                &parsed,
+                now_unix,
+            )
+            .map_err(protocol_verification_error)?;
+        Ok(AcceptedBolt11BatV2QuoteV2 { quote })
+    }
+
+    pub fn restore_quote_snapshot(
+        &self,
+        quote_bytes: &[u8],
+        now_unix: u64,
+    ) -> PirResult<AcceptedBolt11BatV2QuoteV2> {
+        let quote = Bolt11QuoteV1::decode(quote_bytes).map_err(protocol_decode_error)?;
+        let parsed =
+            ParsedBolt11InvoiceV1::parse(&quote.invoice).map_err(protocol_verification_error)?;
+        quote
+            .verify_bat_v2_snapshot(
+                &self.intent,
+                &self.class,
+                &self.delegation,
+                &parsed,
+                now_unix,
+            )
+            .map_err(protocol_verification_error)?;
+        Ok(AcceptedBolt11BatV2QuoteV2 { quote })
+    }
+
+    pub fn build_status_request(
+        &self,
+        quote: &AcceptedBolt11BatV2QuoteV2,
+        claim_secret_key: &[u8; 32],
+        requested_at: u64,
+        request_nonce: [u8; 32],
+        auxiliary_randomness: [u8; 32],
+    ) -> PirResult<Vec<u8>> {
+        let mut request = Bolt11QuoteStatusRequestV1 {
+            issuer_id: self.intent.issuer_id,
+            quote_id: quote.quote.quote_id,
+            quote_request_digest: self
+                .intent
+                .request_digest()
+                .map_err(protocol_encode_error)?,
+            claim_pubkey_xonly: self.intent.claim_pubkey_xonly,
+            requested_at,
+            request_nonce,
+            signature: [1; 64],
+        };
+        let digest = request
+            .bip340_signing_digest()
+            .map_err(protocol_encode_error)?;
+        let (public_key, signature) =
+            sign_bip340_prehash_v1(claim_secret_key, &digest, &auxiliary_randomness)
+                .map_err(payment_crypto_error)?;
+        if public_key != self.intent.claim_pubkey_xonly {
+            return Err(PirError::VerificationFailed(
+                "claim secret does not match the BAT V2 quote intent".into(),
+            ));
+        }
+        request.signature = signature;
+        request.encode().map_err(protocol_encode_error)
+    }
+
+    pub fn prepare_claim(
+        &self,
+        quote: &AcceptedBolt11BatV2QuoteV2,
+        items: Vec<BitcoinPirCashuBatIssuanceRequestItemV1>,
+        claim_secret_key: &[u8; 32],
+        auxiliary_randomness: [u8; 32],
+        now_unix: u64,
+    ) -> PirResult<PreparedBolt11BatV2ClaimV2> {
+        let parsed = ParsedBolt11InvoiceV1::parse(&quote.quote.invoice)
+            .map_err(protocol_verification_error)?;
+        let verified_quote = quote
+            .quote
+            .verify_bat_v2_for_claim_submission(
+                &self.intent,
+                &self.class,
+                &self.delegation,
+                &parsed,
+                now_unix,
+            )
+            .map_err(protocol_verification_error)?;
+        let request = BatV2IssuanceRequestV2 {
+            issuer_id: self.intent.issuer_id,
+            quote_id: quote.quote.quote_id,
+            quote_request_digest: quote.quote.request_digest,
+            class_id: self.intent.class_id,
+            class_digest: self.intent.class_digest,
+            class_key_epoch: self.intent.class_key_epoch,
+            bat_key_id: self.intent.bat_key_id,
+            items,
+        };
+        let credential_request_digest = request.request_digest().map_err(protocol_encode_error)?;
+        let mut claim = Bolt11QuoteClaimV1 {
+            issuer_id: self.intent.issuer_id,
+            quote_id: quote.quote.quote_id,
+            quote_request_digest: quote.quote.request_digest,
+            credential_request_digest,
+            claim_pubkey_xonly: self.intent.claim_pubkey_xonly,
+            idempotency_key: self.intent.idempotency_key,
+            signature: [1; 64],
+        };
+        let digest = claim
+            .bip340_signing_digest()
+            .map_err(protocol_encode_error)?;
+        let (public_key, signature) =
+            sign_bip340_prehash_v1(claim_secret_key, &digest, &auxiliary_randomness)
+                .map_err(payment_crypto_error)?;
+        if public_key != self.intent.claim_pubkey_xonly {
+            return Err(PirError::VerificationFailed(
+                "claim secret does not match the BAT V2 quote intent".into(),
+            ));
+        }
+        claim.signature = signature;
+        let unverified = request
+            .verify_for_verified_quote(&claim, &verified_quote, now_unix)
+            .map_err(protocol_verification_error)?;
+        verify_quote_claim_v1(&unverified).map_err(payment_crypto_error)?;
+        let envelope = Bolt11BatV2ClaimEnvelopeV2 {
+            quote_intent: self.intent.clone(),
+            claim,
+            credential_request: request.clone(),
+        };
+        let mut envelope_bytes = Zeroizing::new(envelope.encode().map_err(protocol_encode_error)?);
+        Ok(PreparedBolt11BatV2ClaimV2 {
+            request,
+            envelope_bytes: core::mem::take(&mut *envelope_bytes),
+        })
+    }
+
+    pub fn restore_claim(&self, envelope_bytes: &[u8]) -> PirResult<PreparedBolt11BatV2ClaimV2> {
+        let envelope =
+            Bolt11BatV2ClaimEnvelopeV2::decode(envelope_bytes).map_err(protocol_decode_error)?;
+        if envelope.quote_intent != self.intent
+            || envelope.claim.issuer_id != self.intent.issuer_id
+            || envelope.claim.quote_request_digest
+                != self
+                    .intent
+                    .request_digest()
+                    .map_err(protocol_encode_error)?
+            || envelope.claim.claim_pubkey_xonly != self.intent.claim_pubkey_xonly
+            || envelope.claim.idempotency_key != self.intent.idempotency_key
+        {
+            return Err(PirError::VerificationFailed(
+                "restored BAT V2 claim differs from the verified class-only intent".into(),
+            ));
+        }
+        let mut canonical = Zeroizing::new(envelope.encode().map_err(protocol_encode_error)?);
+        if canonical.as_slice() != envelope_bytes {
+            return Err(PirError::Decode(
+                "restored BAT V2 claim envelope is non-canonical".into(),
+            ));
+        }
+        Ok(PreparedBolt11BatV2ClaimV2 {
+            request: envelope.credential_request,
+            envelope_bytes: core::mem::take(&mut *canonical),
+        })
+    }
+
+    pub fn verify_issuance_response(
+        &self,
+        quote: &AcceptedBolt11BatV2QuoteV2,
+        claim: &PreparedBolt11BatV2ClaimV2,
+        response_bytes: &[u8],
+        now_unix: u64,
+    ) -> PirResult<CheckedBatV2IssuanceResponseV2> {
+        let parsed = ParsedBolt11InvoiceV1::parse(&quote.quote.invoice)
+            .map_err(protocol_verification_error)?;
+        let verified_quote = quote
+            .quote
+            .verify_bat_v2_snapshot(
+                &self.intent,
+                &self.class,
+                &self.delegation,
+                &parsed,
+                now_unix,
+            )
+            .map_err(protocol_verification_error)?;
+        let response =
+            BatV2IssuanceResponseV2::decode(response_bytes).map_err(protocol_decode_error)?;
+        response
+            .verify_for_verified_quote(&claim.request, &verified_quote)
+            .map_err(protocol_verification_error)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AcceptedBolt11BatV2QuoteV2 {
+    quote: Bolt11QuoteV1,
+}
+
+impl AcceptedBolt11BatV2QuoteV2 {
+    pub fn bytes(&self) -> PirResult<Vec<u8>> {
+        self.quote.encode().map_err(protocol_encode_error)
+    }
+
+    pub fn invoice(&self) -> &str {
+        &self.quote.invoice
+    }
+
+    pub const fn quote_id(&self) -> [u8; 32] {
+        self.quote.quote_id
+    }
+
+    pub const fn status(&self) -> Bolt11QuoteStatusV1 {
+        self.quote.status
+    }
+
+    pub const fn state_version(&self) -> u64 {
+        self.quote.state_version
+    }
+
+    pub const fn invoice_expires_at(&self) -> u64 {
+        self.quote.invoice_expires_at
+    }
+
+    pub const fn invoice_created_at(&self) -> u64 {
+        self.quote.invoice_created_at
+    }
+
+    pub const fn claim_deadline(&self) -> u64 {
+        self.quote.claim_deadline
+    }
+
+    pub fn accept_latest_after(
+        &self,
+        prepared: &PreparedBolt11BatV2QuoteV2,
+        response_bytes: &[u8],
+        now_unix: u64,
+    ) -> PirResult<Self> {
+        let next = Bolt11QuoteV1::decode(response_bytes).map_err(protocol_decode_error)?;
+        let parsed =
+            ParsedBolt11InvoiceV1::parse(&next.invoice).map_err(protocol_verification_error)?;
+        next.verify_latest_bat_v2_after(
+            &self.quote,
+            &prepared.intent,
+            &prepared.class,
+            &prepared.delegation,
+            &parsed,
+            now_unix,
+        )
+        .map_err(protocol_verification_error)?;
+        Ok(Self { quote: next })
+    }
+}
+
+#[derive(Clone)]
+pub struct PreparedBolt11BatV2ClaimV2 {
+    request: BatV2IssuanceRequestV2,
+    envelope_bytes: Vec<u8>,
+}
+
+impl fmt::Debug for PreparedBolt11BatV2ClaimV2 {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PreparedBolt11BatV2ClaimV2")
+            .field("claim_envelope", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl Drop for PreparedBolt11BatV2ClaimV2 {
+    fn drop(&mut self) {
+        self.envelope_bytes.zeroize();
+    }
+}
+
+impl PreparedBolt11BatV2ClaimV2 {
+    pub fn envelope_bytes(&self) -> &[u8] {
+        &self.envelope_bytes
+    }
+
+    pub fn credential_request_bytes(&self) -> PirResult<Vec<u8>> {
+        self.request.encode().map_err(protocol_encode_error)
+    }
+
+    pub const fn credential_request(&self) -> &BatV2IssuanceRequestV2 {
+        &self.request
+    }
+}
+
+fn protocol_decode_error(error: impl core::fmt::Display) -> PirError {
+    PirError::Decode(format!("BAT V2 protocol decode failed: {error}"))
+}
+
+fn protocol_encode_error(error: impl core::fmt::Display) -> PirError {
+    PirError::Encode(format!("BAT V2 protocol encode failed: {error}"))
+}
+
+fn protocol_verification_error(error: impl core::fmt::Display) -> PirError {
+    PirError::VerificationFailed(format!("BAT V2 verification failed: {error}"))
+}
+
+fn payment_crypto_error(error: impl core::fmt::Display) -> PirError {
+    PirError::VerificationFailed(format!("BAT V2 client cryptography failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use pir_service_protocol::{
+        AuthPaddingClassV1, BackendId, BatAcceptanceMemberV2, BatAcceptanceTermsV2,
+        DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1, LightningNetworkV1,
+        PrivacyLeakageV1, VerifiedBatAcceptanceMemberV2, WorkloadId,
+    };
+
+    const GENERATOR_COMPRESSED: [u8; 33] = [
+        0x02, 0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce, 0x87,
+        0x0b, 0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81, 0x5b, 0x16,
+        0xf8, 0x17, 0x98,
+    ];
+    const GENERATOR_XONLY: [u8; 32] = [
+        0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce, 0x87, 0x0b,
+        0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81, 0x5b, 0x16, 0xf8,
+        0x17, 0x98,
+    ];
+
+    fn terms() -> BatAcceptanceTermsV2 {
+        BatAcceptanceTermsV2 {
+            auth_padding_class: AuthPaddingClassV1::Class16KiB,
+            backend: BackendId::DpfPirV1,
+            workload: WorkloadId::DpfEvaluateJobV1,
+            protocol_version: 1,
+            dataset: DatasetBindingV1::Class { class_id: 1 },
+            operation_profile: 2,
+            entitlement_profile: 3,
+            limits: EntitlementLimitsV1 {
+                max_logical_inputs: 1,
+                max_frames: 10,
+                max_request_bytes: 10_000,
+                max_response_bytes: 20_000,
+                max_wall_time_ms: 1_000,
+                max_concurrent_sockets: 1,
+                max_hint_groups: 0,
+                max_work_units: 100,
+            },
+            priority_class: 1,
+            deployment_status: DeploymentStatus::Stable,
+            price_msat: 1_000,
+            issuer_endpoint: "https://issuer.invalid".into(),
+            invoice_expiry_seconds: 10,
+            claim_window_seconds: 10,
+            minimum_credential_validity_seconds: 10,
+            retired_policy_grace_seconds: 30,
+            credential_count: 2,
+            credential_presentation_limit: 1,
+            privacy_leakage: PrivacyLeakageV1::from_bits(
+                PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                    | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                    | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+            )
+            .unwrap(),
+        }
+    }
+
+    fn class_and_members() -> (
+        BatAcceptanceClassV2,
+        VerifiedBatAcceptanceMemberV2,
+        VerifiedBatAcceptanceMemberV2,
+        SigningKey,
+    ) {
+        let issuer_key = SigningKey::from_bytes(&[31; 32]);
+        let first = BatAcceptanceMemberV2 {
+            provider_id: [0xa1; 32],
+            policy_digest: [0xa2; 32],
+            scope_id: [0xa3; 32],
+            offer_id: 0xa4a4_a4a4,
+        };
+        let second = BatAcceptanceMemberV2 {
+            provider_id: [0xb1; 32],
+            policy_digest: [0xb2; 32],
+            scope_id: [0xb3; 32],
+            offer_id: 0xb4b4_b4b4,
+        };
+        let common_terms = terms();
+        let class = BatAcceptanceClassV2::sign(
+            [0xc1; 32],
+            7,
+            100,
+            10_030,
+            GENERATOR_COMPRESSED,
+            common_terms.clone(),
+            vec![first.clone(), second.clone()],
+            &issuer_key,
+        )
+        .unwrap();
+        let issuer_id = class.issuer_id;
+        let class_id = class.class_id;
+        let project = |member| VerifiedBatAcceptanceMemberV2 {
+            issuer_id,
+            class_id,
+            member,
+            common_terms: common_terms.clone(),
+            policy_issued_at: 100,
+            policy_expires_at: 10_000,
+            redemption_deadline: 10_030,
+        };
+        (class, project(first), project(second), issuer_key)
+    }
+
+    #[test]
+    fn recovery_domains_do_not_accept_v1_intents_as_v2() {
+        assert!(Bolt11BatV2QuoteIntentV2::decode(&[1; 64]).is_err());
+    }
+
+    #[test]
+    fn prepared_claim_debug_redacts_envelope() {
+        let claim = PreparedBolt11BatV2ClaimV2 {
+            request: BatV2IssuanceRequestV2 {
+                issuer_id: [1; 32],
+                quote_id: [2; 32],
+                quote_request_digest: [3; 32],
+                class_id: [4; 32],
+                class_digest: [5; 32],
+                class_key_epoch: 6,
+                bat_key_id: [7; 32],
+                items: Vec::new(),
+            },
+            envelope_bytes: b"secret-canary".to_vec(),
+        };
+        let rendered = format!("{claim:?}");
+        assert!(rendered.contains("[REDACTED]"));
+        assert!(!rendered.contains("secret-canary"));
+    }
+
+    #[test]
+    fn two_provider_members_produce_identical_class_only_intent() {
+        let (class, first_member, second_member, issuer_key) = class_and_members();
+        let quote_key = SigningKey::from_bytes(&[32; 32]);
+        let delegation = Bolt11QuoteKeyDelegationV1::sign(
+            LightningNetworkV1::Bitcoin,
+            GENERATOR_COMPRESSED,
+            9,
+            100,
+            10_030,
+            quote_key.verifying_key().to_bytes(),
+            &issuer_key,
+        )
+        .unwrap();
+        let checkpoint = Bolt11QuoteKeyCheckpointV1::initial(
+            class.issuer_id,
+            LightningNetworkV1::Bitcoin,
+            GENERATOR_COMPRESSED,
+        )
+        .unwrap();
+        let prepare = |member| {
+            PreparedBolt11BatV2QuoteV2::from_verified_current_offer(
+                &VerifiedCurrentBatV2OfferV2::new(class.clone(), member),
+                &delegation.encode().unwrap(),
+                &checkpoint,
+                1_000,
+                GENERATOR_XONLY,
+                [0xd1; 32],
+            )
+            .unwrap()
+        };
+        let first = prepare(first_member);
+        let second = prepare(second_member);
+        let first_bytes = first.intent_bytes().unwrap();
+        assert_eq!(first_bytes, second.intent_bytes().unwrap());
+        for provider_bound_canary in [
+            [0xa1; 32], [0xa2; 32], [0xa3; 32], [0xb1; 32], [0xb2; 32], [0xb3; 32],
+        ] {
+            assert!(!first_bytes
+                .windows(provider_bound_canary.len())
+                .any(|window| window == provider_bound_canary));
+        }
+
+        let restored = PreparedBolt11BatV2QuoteV2::restore(
+            &first.intent_bytes().unwrap(),
+            &first.class_bytes().unwrap(),
+            &first.delegation_bytes().unwrap(),
+            &first.quote_key_checkpoint_bytes(),
+            1_000,
+        )
+        .unwrap();
+        assert_eq!(restored.intent_bytes().unwrap(), first_bytes);
+    }
+
+    #[test]
+    fn nonmember_cannot_prepare_a_class_only_intent() {
+        let (class, mut member, _, issuer_key) = class_and_members();
+        member.member.provider_id = [0xee; 32];
+        let quote_key = SigningKey::from_bytes(&[33; 32]);
+        let delegation = Bolt11QuoteKeyDelegationV1::sign(
+            LightningNetworkV1::Bitcoin,
+            GENERATOR_COMPRESSED,
+            9,
+            100,
+            10_030,
+            quote_key.verifying_key().to_bytes(),
+            &issuer_key,
+        )
+        .unwrap();
+        let checkpoint = Bolt11QuoteKeyCheckpointV1::initial(
+            class.issuer_id,
+            LightningNetworkV1::Bitcoin,
+            GENERATOR_COMPRESSED,
+        )
+        .unwrap();
+        assert!(PreparedBolt11BatV2QuoteV2::from_verified_current_offer(
+            &VerifiedCurrentBatV2OfferV2::new(class, member),
+            &delegation.encode().unwrap(),
+            &checkpoint,
+            1_000,
+            GENERATOR_XONLY,
+            [0xd1; 32],
+        )
+        .is_err());
+    }
+}

--- a/crates/sdk/client/src/bolt11.rs
+++ b/crates/sdk/client/src/bolt11.rs
@@ -96,6 +96,14 @@ impl Bolt11QuoteKeyCheckpointV1 {
         self.guard.highest_epoch()
     }
 
+    pub(crate) const fn rollback_guard_v1(&self) -> &Bolt11QuoteKeyRollbackGuardV1 {
+        &self.guard
+    }
+
+    pub(crate) const fn from_rollback_guard_v1(guard: Bolt11QuoteKeyRollbackGuardV1) -> Self {
+        Self { guard }
+    }
+
     /// Validate one exact issuer delegation against this durable stream
     /// without constructing an invoice intent. Strict two-provider callers
     /// use this to freeze the payee and delegation before either payment leg

--- a/crates/sdk/client/src/lib.rs
+++ b/crates/sdk/client/src/lib.rs
@@ -58,6 +58,7 @@
 pub mod admin;
 pub mod announce;
 pub mod attest;
+pub mod bat_v2;
 pub mod bolt11;
 pub mod channel;
 #[cfg(not(target_arch = "wasm32"))]
@@ -84,6 +85,10 @@ mod wasm_chunk;
 #[cfg(target_arch = "wasm32")]
 mod wasm_transport;
 
+pub use bat_v2::{
+    AcceptedBolt11BatV2QuoteV2, PreparedBolt11BatV2ClaimV2, PreparedBolt11BatV2QuoteV2,
+    VerifiedCurrentBatV2OfferV2,
+};
 pub use bolt11::{
     AcceptedBolt11QuoteV1, Bolt11QuoteKeyCheckpointV1, PreparedBolt11ClaimV1, PreparedBolt11QuoteV1,
 };
@@ -102,14 +107,15 @@ pub use harmony::{HarmonyClient, HintProgress, PRP_FASTPRP, PRP_HMR12};
 pub use onion::OnionClient;
 pub use oram::{OramClient, OramLookupItem, OramLookupResult, OramLookupSlot};
 pub use query_plan::{
-    plan_dpf_service_query_v1, plan_harmony_service_hint_v1,
-    plan_harmony_service_query_v1, ProductBackendV1, ProductQueryLowerBoundsV1,
-    ProductQueryOmissionsV1, ProductQueryShapeV1, ProductWorkloadV1,
+    plan_dpf_service_query_v1, plan_harmony_service_hint_v1, plan_harmony_service_query_v1,
+    ProductBackendV1, ProductQueryLowerBoundsV1, ProductQueryOmissionsV1, ProductQueryShapeV1,
+    ProductWorkloadV1,
 };
 pub use service::{
-    accept_pow_challenge_response_v1, accept_retained_service_policy_response_v1,
-    accept_service_policy_response_v1, build_pow_challenge_request_v1,
-    build_retained_service_policy_request_v1, build_service_policy_request_v1,
+    accept_bat_v2_authorization_response_v2, accept_pow_challenge_response_v1,
+    accept_retained_service_policy_response_v1, accept_service_policy_response_v1,
+    build_pow_challenge_request_v1, build_retained_service_policy_request_v1,
+    build_service_policy_request_v1,
     dangerous_unpaired_accept_retained_service_authorization_response_v1,
     dangerous_unpaired_accept_service_authorization_response_v1,
     dangerous_unpaired_authorize_retained_service_redemption_v1,
@@ -120,13 +126,15 @@ pub use service::{
     dangerous_unpaired_build_service_authorization_request_v1,
     fetch_retained_service_redemption_v1, fetch_verified_service_policy_v1,
     request_pow_challenge_v1, verify_service_policy_session_v1, AcceptedRetiredServiceRedemptionV1,
-    AcceptedServicePolicyV1, ServicePolicyCheckpointV1,
+    AcceptedServicePolicyV1, BatV2AdmissionOutcomeV2, ServicePolicyCheckpointV1,
 };
 pub use strict_pair::{
-    select_strict_provider_offer_v1, verify_strict_two_provider_offer_pair_v1,
-    StrictProviderOfferSelectionV1, StrictProviderPairOptionsV1,
-    StrictProviderPaymentContextInputV1,
-    VerifiedStrictTwoProviderOfferPairV1, VerifiedStrictTwoProviderPaymentContextV1,
+    select_strict_bat_v2_offer_v2, select_strict_provider_offer_v1,
+    verify_strict_two_provider_bat_v2_offer_pair_v2, verify_strict_two_provider_offer_pair_v1,
+    StrictBatV2OfferSelectionV2, StrictProviderOfferSelectionV1, StrictProviderPairOptionsV1,
+    StrictProviderPaymentContextInputV1, VerifiedDistinctBatV2ProofPairV2,
+    VerifiedStrictTwoProviderBatV2OfferPairV2, VerifiedStrictTwoProviderOfferPairV1,
+    VerifiedStrictTwoProviderPaymentContextV1,
 };
 pub use transport::PirTransport;
 pub use verified_query::VerifiedQueryResult;

--- a/crates/sdk/client/src/service.rs
+++ b/crates/sdk/client/src/service.rs
@@ -12,14 +12,16 @@
 use ed25519_dalek::VerifyingKey;
 use pir_sdk::{PirError, PirResult};
 use pir_service_protocol::{
-    check_standard_cashu_spend_for_offer, ArcPresentationV1, AuthBeginV1, AuthRejectCode,
-    AuthResultV1, AuthScheme, AuthorizationProofV1, BitcoinPirCashuBatProofV1,
-    CashuManifestEpochFloorV1, CredentialKeysetEpochFloorV1, DeploymentStatus,
-    FreeAnonymousTicketV1, FreeAuthorizationProofV1, FreeModeV1, FreePowProofV1, OperationStartV1,
-    PaidReceiptV1, PolicyRollbackGuardV1, PowChallengeRequestV1, PowChallengeResponseV1,
-    ProviderId, ServicePolicyEpochFloorsV1, ServicePolicyRequestV1, ServicePolicyResponseV1,
-    ServicePolicyV1, StandardCashuSpendV1, REQ_AUTH_BEGIN_V1, REQ_POW_CHALLENGE_V1,
-    REQ_SERVICE_POLICY_V1, RESP_AUTH_RESULT_V1, RESP_POW_CHALLENGE_V1, RESP_SERVICE_POLICY_V1,
+    bat_acceptance_member_from_verified_policy_v2, check_standard_cashu_spend_for_offer,
+    verify_bat_acceptance_class_member_projection_v2, ArcPresentationV1, AuthBeginV1,
+    AuthRejectCode, AuthResultV1, AuthScheme, AuthorizationProofV1, BatAcceptanceClassV2,
+    BitcoinPirCashuBatProofV1, CashuManifestEpochFloorV1, CredentialKeysetEpochFloorV1,
+    DeploymentStatus, FreeAnonymousTicketV1, FreeAuthorizationProofV1, FreeModeV1, FreePowProofV1,
+    OperationStartV1, PaidReceiptV1, PolicyRollbackGuardV1, PowChallengeRequestV1,
+    PowChallengeResponseV1, ProviderId, ServicePolicyEpochFloorsV1, ServicePolicyRequestV1,
+    ServicePolicyResponseV1, ServicePolicyV1, StandardCashuSpendV1, REQ_AUTH_BEGIN_V1,
+    REQ_POW_CHALLENGE_V1, REQ_SERVICE_POLICY_V1, RESP_AUTH_RESULT_V1, RESP_POW_CHALLENGE_V1,
+    RESP_SERVICE_POLICY_V1,
 };
 
 use crate::protocol::encode_request;
@@ -199,6 +201,20 @@ pub struct AcceptedServicePolicyV1 {
     service_authorization_exporter: [u8; 32],
 }
 
+/// Client-side disposition for one BAT V2 admission attempt.
+///
+/// Only the two runtime responses that prove non-consumption are recoverable.
+/// Terminal and indeterminate outcomes require the selected vault record to be
+/// burned. This enum does not expose a retrying transport operation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BatV2AdmissionOutcomeV2 {
+    Granted(pir_service_protocol::AuthGrantedV1),
+    RecoverableDefinitelyNotSent { retry_after_ms: u32 },
+    RecoverableRetrySafe { retry_after_ms: u32 },
+    BurnTerminal,
+    BurnOutcomeUnknown,
+}
+
 impl core::fmt::Debug for AcceptedServicePolicyV1 {
     fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         formatter
@@ -280,6 +296,53 @@ impl AcceptedServicePolicyV1 {
         verified
             .offer(scope_id, offer_id)
             .map_err(protocol_verification_error)
+    }
+
+    /// Verify one exact current BAT V2 offer against caller-supplied canonical
+    /// issuer class bytes. The provider cannot substitute a copied class ID:
+    /// its signed policy projection must be an exact member of the signed
+    /// class before any class-only quote intent can be produced.
+    pub fn verify_current_bat_v2_offer_v2(
+        &self,
+        scope_id: &[u8; 32],
+        offer_id: u32,
+        class_bytes: &[u8],
+        now_unix: u64,
+    ) -> PirResult<crate::bat_v2::VerifiedCurrentBatV2OfferV2> {
+        if now_unix == 0 {
+            return Err(PirError::InvalidState(
+                "trusted wall clock is required for BAT V2 class verification".into(),
+            ));
+        }
+        let class = BatAcceptanceClassV2::decode(class_bytes).map_err(protocol_decode_error)?;
+        class.verify().map_err(protocol_verification_error)?;
+        if now_unix < class.key_not_before || now_unix > class.key_not_after {
+            return Err(PirError::VerificationFailed(
+                "BAT V2 class key is not currently active".into(),
+            ));
+        }
+        let verified = self
+            .policy
+            .verify_current_for_acquisition(
+                &self.policy.provider_id,
+                now_unix,
+                self.checkpoint.rollback_guard(),
+                self.checkpoint.epoch_floors(),
+                &self.policy_signing_key,
+            )
+            .map_err(protocol_verification_error)?;
+        if verified.policy_digest() != self.policy_digest {
+            return Err(PirError::VerificationFailed(
+                "accepted service-policy digest changed during BAT V2 class verification".into(),
+            ));
+        }
+        let member = bat_acceptance_member_from_verified_policy_v2(&verified, scope_id, offer_id)
+            .map_err(protocol_verification_error)?;
+        verify_bat_acceptance_class_member_projection_v2(&class, &member)
+            .map_err(protocol_verification_error)?;
+        Ok(crate::bat_v2::VerifiedCurrentBatV2OfferV2::new(
+            class, member,
+        ))
     }
 
     /// Dangerous unpaired primitive: build a BOLT11 quote intent from one
@@ -722,6 +785,9 @@ fn build_authorization_proof_for_offer_v1(
                 BitcoinPirCashuBatProofV1::decode(proof_bytes).map_err(protocol_decode_error)?,
             )
         }
+        // BAT V2 is deliberately absent: a provider policy and class ID are
+        // insufficient to release an issuer-wide bearer proof. The follow-up
+        // admission path must hold an exact verified class-member typestate.
         (AuthScheme::ArcV1Experimental, FreeModeV1::NotFree) => {
             if offer.deployment_status != DeploymentStatus::Experimental {
                 return Err(PirError::VerificationFailed(
@@ -980,6 +1046,76 @@ pub fn dangerous_unpaired_accept_service_authorization_response_v1(
     }
 }
 
+/// Classify exactly one already-received BAT V2 admission response. Malformed,
+/// mismatched, or otherwise unclassified post-send responses are deliberately
+/// `BurnOutcomeUnknown`; callers must not automatically replay the proof.
+pub fn accept_bat_v2_authorization_response_v2(
+    response: &[u8],
+    accepted: &AcceptedServicePolicyV1,
+    scope_id: [u8; 32],
+    offer_id: u32,
+) -> PirResult<BatV2AdmissionOutcomeV2> {
+    let scope_policy = accepted
+        .policy
+        .scopes
+        .iter()
+        .find(|entry| entry.scope.scope_id() == scope_id)
+        .ok_or_else(|| PirError::InvalidState("selected service scope is not in policy".into()))?;
+    let offer = scope_policy
+        .offers
+        .iter()
+        .find(|offer| offer.offer_id == offer_id)
+        .ok_or_else(|| PirError::InvalidState("selected service offer is not in policy".into()))?;
+    if offer.authorization != AuthScheme::BitcoinPirCashuBatV2
+        || offer.free_mode != FreeModeV1::NotFree
+    {
+        return Err(PirError::InvalidState(
+            "selected service offer is not BAT V2".into(),
+        ));
+    }
+    let Some((&opcode, body)) = response.split_first() else {
+        return Ok(BatV2AdmissionOutcomeV2::BurnOutcomeUnknown);
+    };
+    if opcode != RESP_AUTH_RESULT_V1 {
+        return Ok(BatV2AdmissionOutcomeV2::BurnOutcomeUnknown);
+    }
+    let result = match AuthResultV1::decode(body) {
+        Ok(result) => result,
+        Err(_) => return Ok(BatV2AdmissionOutcomeV2::BurnOutcomeUnknown),
+    };
+    Ok(classify_bat_v2_auth_result_v2(
+        result,
+        scope_id,
+        scope_policy.scope.entitlement_profile,
+    ))
+}
+
+fn classify_bat_v2_auth_result_v2(
+    result: AuthResultV1,
+    scope_id: [u8; 32],
+    entitlement_profile: u16,
+) -> BatV2AdmissionOutcomeV2 {
+    match result {
+        AuthResultV1::Granted(grant)
+            if grant.scope_id == scope_id && grant.enforced_profile == entitlement_profile =>
+        {
+            BatV2AdmissionOutcomeV2::Granted(grant)
+        }
+        AuthResultV1::Granted(_) => BatV2AdmissionOutcomeV2::BurnOutcomeUnknown,
+        AuthResultV1::Rejected(rejected) => match rejected.code {
+            AuthRejectCode::ServerBusy => BatV2AdmissionOutcomeV2::RecoverableDefinitelyNotSent {
+                retry_after_ms: rejected.retry_after_ms,
+            },
+            AuthRejectCode::ScopeUnavailable => BatV2AdmissionOutcomeV2::RecoverableRetrySafe {
+                retry_after_ms: rejected.retry_after_ms,
+            },
+            AuthRejectCode::InvalidOrSpent => BatV2AdmissionOutcomeV2::BurnTerminal,
+            AuthRejectCode::InternalAfterSpend => BatV2AdmissionOutcomeV2::BurnOutcomeUnknown,
+            _ => BatV2AdmissionOutcomeV2::BurnOutcomeUnknown,
+        },
+    }
+}
+
 /// Verify an authorization result against the exact scope/profile fixed by a
 /// retained redemption handle.
 pub fn dangerous_unpaired_accept_retained_service_authorization_response_v1(
@@ -1120,6 +1256,7 @@ fn decode_auth_scheme(value: u8) -> PirResult<AuthScheme> {
         3 => Ok(AuthScheme::CashuEcashV1),
         4 => Ok(AuthScheme::BitcoinPirCashuBatV1),
         5 => Ok(AuthScheme::ArcV1Experimental),
+        6 => Ok(AuthScheme::BitcoinPirCashuBatV2),
         _ => Err(PirError::Decode(
             "service policy checkpoint contains an unknown authorization scheme".into(),
         )),
@@ -1417,6 +1554,54 @@ mod tests {
         let mut trailing = encoded;
         trailing.push(0);
         assert!(ServicePolicyCheckpointV1::decode(&trailing).is_err());
+    }
+
+    #[test]
+    fn bat_v2_admission_outcomes_recover_only_proven_non_consumption() {
+        let scope_id = [0x44; 32];
+        let rejected = |code| {
+            AuthResultV1::Rejected(pir_service_protocol::AuthRejectedV1 {
+                code,
+                retry_after_ms: 250,
+            })
+        };
+        assert_eq!(
+            classify_bat_v2_auth_result_v2(rejected(AuthRejectCode::ServerBusy), scope_id, 2),
+            BatV2AdmissionOutcomeV2::RecoverableDefinitelyNotSent {
+                retry_after_ms: 250
+            }
+        );
+        assert_eq!(
+            classify_bat_v2_auth_result_v2(rejected(AuthRejectCode::ScopeUnavailable), scope_id, 2,),
+            BatV2AdmissionOutcomeV2::RecoverableRetrySafe {
+                retry_after_ms: 250
+            }
+        );
+        assert_eq!(
+            classify_bat_v2_auth_result_v2(rejected(AuthRejectCode::InvalidOrSpent), scope_id, 2,),
+            BatV2AdmissionOutcomeV2::BurnTerminal
+        );
+        assert_eq!(
+            classify_bat_v2_auth_result_v2(
+                rejected(AuthRejectCode::InternalAfterSpend),
+                scope_id,
+                2,
+            ),
+            BatV2AdmissionOutcomeV2::BurnOutcomeUnknown
+        );
+        assert_eq!(
+            classify_bat_v2_auth_result_v2(rejected(AuthRejectCode::WrongScope), scope_id, 2),
+            BatV2AdmissionOutcomeV2::BurnOutcomeUnknown
+        );
+    }
+
+    #[test]
+    fn generic_offer_builder_cannot_release_a_bat_v2_bearer() {
+        let (policy, _, _, _) = policy();
+        let mut offer = policy.scopes[0].offers[0].clone();
+        offer.authorization = AuthScheme::BitcoinPirCashuBatV2;
+        offer.free_mode = FreeModeV1::NotFree;
+        assert!(build_authorization_proof_for_offer_v1(&offer, &[]).is_err());
     }
 
     #[tokio::test]

--- a/crates/sdk/client/src/strict_pair.rs
+++ b/crates/sdk/client/src/strict_pair.rs
@@ -9,8 +9,8 @@ use pir_arc_adapter::{arc_public_key_fingerprint_v1, ARC_PUBLIC_KEY_LEN_V1};
 use pir_sdk::{PirError, PirResult};
 use pir_service_protocol::{
     bat_verification_key_fingerprint_v1, is_canonical_public_wss_endpoint_v1, AcquisitionMethod,
-    AuthScheme, AuthorizationProofV1, ProviderId, ServiceOfferV1, VerificationMode,
-    VerifiedDirectoryOperatorAssertionV1, VerifiedServiceOfferV1,
+    AuthScheme, AuthorizationProofV1, BitcoinPirCashuBatProofV2, ProviderId, ServiceOfferV1,
+    VerificationMode, VerifiedDirectoryOperatorAssertionV1, VerifiedServiceOfferV1,
 };
 
 use crate::service::AcceptedServicePolicyV1;
@@ -66,6 +66,25 @@ pub struct StrictProviderOfferSelectionV1<'policy> {
     directory_wss_endpoints: Option<Vec<String>>,
 }
 
+/// One current provider offer proven to be an exact member of an
+/// issuer-signed BAT V2 class, while retaining the ordinary strict-provider
+/// identity checks for pair construction.
+#[derive(Clone, Debug)]
+pub struct StrictBatV2OfferSelectionV2<'policy> {
+    base: StrictProviderOfferSelectionV1<'policy>,
+    class_offer: crate::bat_v2::VerifiedCurrentBatV2OfferV2,
+}
+
+impl<'policy> StrictBatV2OfferSelectionV2<'policy> {
+    pub const fn base(&self) -> &StrictProviderOfferSelectionV1<'policy> {
+        &self.base
+    }
+
+    pub const fn class_offer(&self) -> &crate::bat_v2::VerifiedCurrentBatV2OfferV2 {
+        &self.class_offer
+    }
+}
+
 impl<'policy> StrictProviderOfferSelectionV1<'policy> {
     pub const fn accepted_policy(&self) -> &'policy AcceptedServicePolicyV1 {
         self.accepted_policy
@@ -108,6 +127,98 @@ pub struct VerifiedStrictTwoProviderOfferPairV1<'first, 'second> {
     second: StrictProviderOfferSelectionV1<'second>,
     shared_issuer_correlation: bool,
     allow_shared_lightning_payee_correlation: bool,
+}
+
+/// A strict two-provider BAT V2 pair whose two independently signed provider
+/// policies are members of the same exact reviewed issuer class.
+///
+/// Sharing that issuer/class is the V2 design and is therefore not rejected
+/// as V1 raw-key reuse. Provider IDs, provider policy keys, directory operator
+/// keys, and later WebSocket origins remain independent.
+#[must_use]
+#[derive(Clone, Debug)]
+pub struct VerifiedStrictTwoProviderBatV2OfferPairV2<'first, 'second> {
+    pair: VerifiedStrictTwoProviderOfferPairV1<'first, 'second>,
+    class: pir_service_protocol::BatAcceptanceClassV2,
+}
+
+impl<'first, 'second> VerifiedStrictTwoProviderBatV2OfferPairV2<'first, 'second> {
+    pub const fn pair(&self) -> &VerifiedStrictTwoProviderOfferPairV1<'first, 'second> {
+        &self.pair
+    }
+
+    pub const fn class(&self) -> &pir_service_protocol::BatAcceptanceClassV2 {
+        &self.class
+    }
+
+    /// Decode and class-check both vault-selected proofs, then prove that the
+    /// issuer-global spend keys differ. The Web vault must additionally make
+    /// the two record IDs distinct before calling this method.
+    pub fn verify_distinct_proofs_v2(
+        &self,
+        first_proof_bytes: &[u8],
+        second_proof_bytes: &[u8],
+    ) -> PirResult<VerifiedDistinctBatV2ProofPairV2> {
+        let first = BitcoinPirCashuBatProofV2::decode(first_proof_bytes)
+            .map_err(|error| pair_error(format!("first BAT V2 proof is invalid: {error}")))?;
+        let second = BitcoinPirCashuBatProofV2::decode(second_proof_bytes)
+            .map_err(|error| pair_error(format!("second BAT V2 proof is invalid: {error}")))?;
+        first
+            .verify_class_binding(&self.class)
+            .map_err(|error| pair_error(format!("first BAT V2 proof has wrong class: {error}")))?;
+        second
+            .verify_class_binding(&self.class)
+            .map_err(|error| pair_error(format!("second BAT V2 proof has wrong class: {error}")))?;
+        let first_spend_key = first
+            .spend_key(&self.class.bat_verification_key)
+            .map_err(|error| pair_error(format!("first BAT V2 spend key is invalid: {error}")))?;
+        let second_spend_key = second
+            .spend_key(&self.class.bat_verification_key)
+            .map_err(|error| pair_error(format!("second BAT V2 spend key is invalid: {error}")))?;
+        if first_spend_key == second_spend_key {
+            return Err(pair_error(
+                "strict BAT V2 pair requires two different issuer-global spend keys",
+            ));
+        }
+        Ok(VerifiedDistinctBatV2ProofPairV2 {
+            first: AuthorizationProofV1::BitcoinPirCashuBatV2(first),
+            second: AuthorizationProofV1::BitcoinPirCashuBatV2(second),
+            first_spend_key,
+            second_spend_key,
+        })
+    }
+}
+
+/// Two exact class-bound BAT proofs proven distinct under the issuer-global
+/// spend-key derivation. This value is local-only and never serialized.
+#[derive(Clone, Debug)]
+pub struct VerifiedDistinctBatV2ProofPairV2 {
+    first: AuthorizationProofV1,
+    second: AuthorizationProofV1,
+    first_spend_key: [u8; 32],
+    second_spend_key: [u8; 32],
+}
+
+impl VerifiedDistinctBatV2ProofPairV2 {
+    pub const fn first_proof(&self) -> &AuthorizationProofV1 {
+        &self.first
+    }
+
+    pub const fn second_proof(&self) -> &AuthorizationProofV1 {
+        &self.second
+    }
+
+    pub const fn first_spend_key(&self) -> [u8; 32] {
+        self.first_spend_key
+    }
+
+    pub const fn second_spend_key(&self) -> [u8; 32] {
+        self.second_spend_key
+    }
+
+    pub fn into_proofs(self) -> (AuthorizationProofV1, AuthorizationProofV1) {
+        (self.first, self.second)
+    }
 }
 
 impl<'first, 'second> VerifiedStrictTwoProviderOfferPairV1<'first, 'second> {
@@ -478,6 +589,33 @@ pub fn select_strict_provider_offer_v1<'policy>(
     })
 }
 
+/// Select one exact current BAT V2 provider member. Canonical class bytes are
+/// supplied by the application trust path; this function performs no issuer
+/// fetch and does not accept an unsigned provider claim about membership.
+pub fn select_strict_bat_v2_offer_v2<'policy>(
+    accepted_policy: &'policy AcceptedServicePolicyV1,
+    scope_id: &[u8; 32],
+    offer_id: u32,
+    class_bytes: &[u8],
+    now_unix: u64,
+    directory_assertion: Option<VerifiedDirectoryOperatorAssertionV1<'_>>,
+) -> PirResult<StrictBatV2OfferSelectionV2<'policy>> {
+    let base = select_strict_provider_offer_v1(
+        accepted_policy,
+        scope_id,
+        offer_id,
+        now_unix,
+        directory_assertion,
+    )?;
+    let class_offer = accepted_policy.verify_current_bat_v2_offer_v2(
+        scope_id,
+        offer_id,
+        class_bytes,
+        now_unix,
+    )?;
+    Ok(StrictBatV2OfferSelectionV2 { base, class_offer })
+}
+
 /// Validate two independently selected provider offers and produce an
 /// unforgeable local typestate on success.
 pub fn verify_strict_two_provider_offer_pair_v1<'first, 'second>(
@@ -564,9 +702,30 @@ pub fn verify_strict_two_provider_offer_pair_v1<'first, 'second>(
         first,
         second,
         shared_issuer_correlation,
-        allow_shared_lightning_payee_correlation: options
-            .allow_shared_lightning_payee_correlation,
+        allow_shared_lightning_payee_correlation: options.allow_shared_lightning_payee_correlation,
     })
+}
+
+/// Validate two independently authenticated provider members of one exact BAT
+/// V2 class. A copied class ID without exact signed membership is rejected at
+/// selection; two different class artifacts are rejected here even if their
+/// commercial terms happen to match.
+pub fn verify_strict_two_provider_bat_v2_offer_pair_v2<'first, 'second>(
+    first: StrictBatV2OfferSelectionV2<'first>,
+    second: StrictBatV2OfferSelectionV2<'second>,
+    options: StrictProviderPairOptionsV1,
+) -> PirResult<VerifiedStrictTwoProviderBatV2OfferPairV2<'first, 'second>> {
+    if first.class_offer.class() != second.class_offer.class() {
+        return Err(pair_error(
+            "strict BAT V2 pair requires the same exact issuer-signed acceptance class",
+        ));
+    }
+    let class = first.class_offer.class().clone();
+    // Shared issuer correlation is inherent in BAT V2, but the ordinary
+    // strict-pair contract still requires the caller's one-shot explicit
+    // acknowledgement of that correlation (and of a shared payee, if any).
+    let pair = verify_strict_two_provider_offer_pair_v1(first.base, second.base, options)?;
+    Ok(VerifiedStrictTwoProviderBatV2OfferPairV2 { pair, class })
 }
 
 fn has_correlation_infrastructure(offer: &ServiceOfferV1) -> bool {
@@ -657,8 +816,9 @@ mod tests {
     use ed25519_dalek::SigningKey;
     use pir_arc_adapter::{ArcSecretKeyV1, ARC_SECRET_KEY_LEN_V1};
     use pir_service_protocol::{
-        derive_bat_key_id_v1, derive_provider_id, free_anonymous_ticket_key_id,
-        paid_receipt_key_id, AuthPaddingClassV1, BackendId, Bolt11QuoteKeyDelegationV1,
+        derive_bat_key_id_v1, derive_issuer_id, derive_provider_id, free_anonymous_ticket_key_id,
+        paid_receipt_key_id, AuthPaddingClassV1, BackendId, BatAcceptanceClassV2,
+        BatAcceptanceMemberV2, BatAcceptanceTermsV2, Bolt11QuoteKeyDelegationV1,
         CredentialKeyBindingClaimsV1, CredentialKeyBindingV1, CredentialUnitV1, DatasetBindingV1,
         DeploymentStatus, DirectoryAssertionRollbackGuardV1, DirectoryEndpointV1,
         DirectoryOperatorAssertionV1, DirectoryTransportV1, EntitlementLimitsV1,
@@ -720,6 +880,11 @@ mod tests {
             issuer_seed: u8,
             endpoint: &'a str,
             verification_key: [u8; 33],
+        },
+        BatV2 {
+            issuer_seed: u8,
+            endpoint: &'a str,
+            class_id: [u8; 32],
         },
         Arc {
             issuer_seed: u8,
@@ -808,6 +973,11 @@ mod tests {
                 endpoint,
                 verification_key,
             ),
+            OfferFixture::BatV2 {
+                issuer_seed,
+                endpoint,
+                class_id,
+            } => bat_v2_offer(issuer_seed, endpoint, class_id),
             OfferFixture::Arc {
                 issuer_seed,
                 endpoint,
@@ -1001,6 +1171,40 @@ mod tests {
         )
     }
 
+    fn bat_v2_offer(issuer_seed: u8, endpoint: &str, class_id: [u8; 32]) -> ServiceOfferV1 {
+        let issuer_key = SigningKey::from_bytes(&[issuer_seed; 32]);
+        ServiceOfferV1 {
+            offer_id: OFFER_ID,
+            acquisition: AcquisitionMethod::Bolt11V1,
+            free_mode: FreeModeV1::NotFree,
+            free_quota: 0,
+            free_window_seconds: 0,
+            free_pow_difficulty_bits: 0,
+            priority_class: 1,
+            authorization: AuthScheme::BitcoinPirCashuBatV2,
+            verification: VerificationMode::SharedIssuerOnline,
+            deployment_status: DeploymentStatus::Stable,
+            price: PriceV1::MilliSatoshi(1_000),
+            issuer_id: derive_issuer_id(&issuer_key.verifying_key().to_bytes()),
+            key_id: class_id.to_vec(),
+            credential_binding: None,
+            cashu_mint_manifest: None,
+            endpoint: endpoint.into(),
+            invoice_expiry_seconds: 10,
+            claim_window_seconds: 10,
+            minimum_credential_validity_seconds: 10,
+            retired_policy_grace_seconds: 30,
+            credential_count: 2,
+            credential_presentation_limit: 1,
+            privacy_leakage: PrivacyLeakageV1::from_bits(
+                PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                    | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                    | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+            )
+            .unwrap(),
+        }
+    }
+
     fn paid_offer(
         authorization: AuthScheme,
         binding: CredentialKeyBindingV1,
@@ -1148,6 +1352,103 @@ mod tests {
         hex::decode(hex_value).unwrap().try_into().unwrap()
     }
 
+    fn bat_v2_class(class_id: [u8; 32]) -> BatAcceptanceClassV2 {
+        BatAcceptanceClassV2::sign(
+            class_id,
+            1,
+            100,
+            1_500,
+            point("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"),
+            BatAcceptanceTermsV2 {
+                auth_padding_class: AuthPaddingClassV1::Class16KiB,
+                backend: BackendId::DpfPirV1,
+                workload: WorkloadId::DpfEvaluateJobV1,
+                protocol_version: 1,
+                dataset: DatasetBindingV1::Class { class_id: 1 },
+                operation_profile: 1,
+                entitlement_profile: 2,
+                limits: limits(),
+                priority_class: 1,
+                deployment_status: DeploymentStatus::Stable,
+                price_msat: 1_000,
+                issuer_endpoint: "https://issuer.invalid".into(),
+                invoice_expiry_seconds: 10,
+                claim_window_seconds: 10,
+                minimum_credential_validity_seconds: 10,
+                retired_policy_grace_seconds: 30,
+                credential_count: 2,
+                credential_presentation_limit: 1,
+                privacy_leakage: PrivacyLeakageV1::from_bits(
+                    PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                        | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                        | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+                )
+                .unwrap(),
+            },
+            vec![BatAcceptanceMemberV2 {
+                provider_id: [1; 32],
+                policy_digest: [2; 32],
+                scope_id: [3; 32],
+                offer_id: OFFER_ID,
+            }],
+            &SigningKey::from_bytes(&[90; 32]),
+        )
+        .unwrap()
+    }
+
+    fn reviewed_bat_v2_class(
+        class_id: [u8; 32],
+        issuer_seed: u8,
+        fixtures: &[&Fixture],
+    ) -> BatAcceptanceClassV2 {
+        let mut members = fixtures
+            .iter()
+            .map(|fixture| BatAcceptanceMemberV2 {
+                provider_id: fixture.accepted.policy().provider_id,
+                policy_digest: fixture.accepted.policy_digest(),
+                scope_id: fixture.scope_id,
+                offer_id: OFFER_ID,
+            })
+            .collect::<Vec<_>>();
+        members.sort();
+        BatAcceptanceClassV2::sign(
+            class_id,
+            1,
+            100,
+            230,
+            point("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"),
+            BatAcceptanceTermsV2 {
+                auth_padding_class: AuthPaddingClassV1::Class16KiB,
+                backend: BackendId::DpfPirV1,
+                workload: WorkloadId::DpfEvaluateJobV1,
+                protocol_version: 1,
+                dataset: DatasetBindingV1::Class { class_id: 1 },
+                operation_profile: 1,
+                entitlement_profile: 2,
+                limits: limits(),
+                priority_class: 1,
+                deployment_status: DeploymentStatus::Stable,
+                price_msat: 1_000,
+                issuer_endpoint: "https://issuer.example".into(),
+                invoice_expiry_seconds: 10,
+                claim_window_seconds: 10,
+                minimum_credential_validity_seconds: 10,
+                retired_policy_grace_seconds: 30,
+                credential_count: 2,
+                credential_presentation_limit: 1,
+                privacy_leakage: PrivacyLeakageV1::from_bits(
+                    PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                        | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                        | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+                )
+                .unwrap(),
+            },
+            members,
+            &SigningKey::from_bytes(&[issuer_seed; 32]),
+        )
+        .unwrap()
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn bolt_payment_context<'first, 'second>(
         pair: VerifiedStrictTwoProviderOfferPairV1<'first, 'second>,
@@ -1293,6 +1594,188 @@ mod tests {
             .unwrap(),
             AuthorizationProofV1::Free(FreeAuthorizationProofV1::OpenBestEffort)
         ));
+    }
+
+    #[test]
+    fn bat_v2_pair_requires_two_distinct_issuer_global_spend_keys() {
+        let first = fixture([1; 32], 11, OfferFixture::Free);
+        let second = fixture([2; 32], 12, OfferFixture::Free);
+        let generic = verify_strict_two_provider_offer_pair_v1(
+            select(&first),
+            select(&second),
+            StrictProviderPairOptionsV1::default(),
+        )
+        .unwrap();
+        let class = bat_v2_class([0xc1; 32]);
+        let pair = VerifiedStrictTwoProviderBatV2OfferPairV2 {
+            pair: generic,
+            class: class.clone(),
+        };
+        let first_proof = BitcoinPirCashuBatProofV2::from_class(
+            &class,
+            [0xd1; 32],
+            point("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"),
+        )
+        .unwrap();
+        let second_proof = BitcoinPirCashuBatProofV2::from_class(
+            &class,
+            [0xd2; 32],
+            point("02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5"),
+        )
+        .unwrap();
+        let distinct = pair
+            .verify_distinct_proofs_v2(
+                &first_proof.encode().unwrap(),
+                &second_proof.encode().unwrap(),
+            )
+            .unwrap();
+        assert_ne!(distinct.first_spend_key(), distinct.second_spend_key());
+        assert!(pair
+            .verify_distinct_proofs_v2(
+                &first_proof.encode().unwrap(),
+                &first_proof.encode().unwrap(),
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("different issuer-global spend keys"));
+
+        let other_class = bat_v2_class([0xc2; 32]);
+        let cross_class = BitcoinPirCashuBatProofV2::from_class(
+            &other_class,
+            [0xd3; 32],
+            point("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"),
+        )
+        .unwrap();
+        assert!(pair
+            .verify_distinct_proofs_v2(
+                &first_proof.encode().unwrap(),
+                &cross_class.encode().unwrap(),
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn bat_v2_pair_accepts_same_reviewed_class_and_rejects_copied_or_cross_class() {
+        let class_id = [0x42; 32];
+        let first = fixture(
+            [11; 32],
+            21,
+            OfferFixture::BatV2 {
+                issuer_seed: 90,
+                endpoint: "https://issuer.example",
+                class_id,
+            },
+        );
+        let second = fixture(
+            [12; 32],
+            22,
+            OfferFixture::BatV2 {
+                issuer_seed: 90,
+                endpoint: "https://issuer.example",
+                class_id,
+            },
+        );
+        let reviewed = reviewed_bat_v2_class(class_id, 90, &[&first, &second]);
+        let reviewed_bytes = reviewed.encode().unwrap();
+        assert!(verify_strict_two_provider_bat_v2_offer_pair_v2(
+            select_strict_bat_v2_offer_v2(
+                &first.accepted,
+                &first.scope_id,
+                OFFER_ID,
+                &reviewed_bytes,
+                NOW,
+                None,
+            )
+            .unwrap(),
+            select_strict_bat_v2_offer_v2(
+                &second.accepted,
+                &second.scope_id,
+                OFFER_ID,
+                &reviewed_bytes,
+                NOW,
+                None,
+            )
+            .unwrap(),
+            StrictProviderPairOptionsV1::default(),
+        )
+        .is_err());
+        let pair = verify_strict_two_provider_bat_v2_offer_pair_v2(
+            select_strict_bat_v2_offer_v2(
+                &first.accepted,
+                &first.scope_id,
+                OFFER_ID,
+                &reviewed_bytes,
+                NOW,
+                None,
+            )
+            .unwrap(),
+            select_strict_bat_v2_offer_v2(
+                &second.accepted,
+                &second.scope_id,
+                OFFER_ID,
+                &reviewed_bytes,
+                NOW,
+                None,
+            )
+            .unwrap(),
+            StrictProviderPairOptionsV1 {
+                allow_shared_issuer_correlation: true,
+                allow_shared_lightning_payee_correlation: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(pair.class(), &reviewed);
+        assert!(pair.pair().shared_issuer_correlation());
+
+        let copied_id_without_second_member = reviewed_bat_v2_class(class_id, 90, &[&first])
+            .encode()
+            .unwrap();
+        assert!(select_strict_bat_v2_offer_v2(
+            &second.accepted,
+            &second.scope_id,
+            OFFER_ID,
+            &copied_id_without_second_member,
+            NOW,
+            None,
+        )
+        .is_err());
+
+        let second_class_id = [0x43; 32];
+        let cross_second = fixture(
+            [13; 32],
+            23,
+            OfferFixture::BatV2 {
+                issuer_seed: 90,
+                endpoint: "https://issuer.example",
+                class_id: second_class_id,
+            },
+        );
+        let first_class = reviewed_bat_v2_class(class_id, 90, &[&first]);
+        let second_class = reviewed_bat_v2_class(second_class_id, 90, &[&cross_second]);
+        let error = verify_strict_two_provider_bat_v2_offer_pair_v2(
+            select_strict_bat_v2_offer_v2(
+                &first.accepted,
+                &first.scope_id,
+                OFFER_ID,
+                &first_class.encode().unwrap(),
+                NOW,
+                None,
+            )
+            .unwrap(),
+            select_strict_bat_v2_offer_v2(
+                &cross_second.accepted,
+                &cross_second.scope_id,
+                OFFER_ID,
+                &second_class.encode().unwrap(),
+                NOW,
+                None,
+            )
+            .unwrap(),
+            StrictProviderPairOptionsV1::default(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("same exact issuer-signed acceptance class"));
     }
 
     #[test]

--- a/crates/sdk/wasm/src/bat_v2.rs
+++ b/crates/sdk/wasm/src/bat_v2.rs
@@ -1,0 +1,722 @@
+//! Browser-facing, class-bound BAT V2 BOLT11 acquisition.
+//!
+//! JavaScript supplies canonical issuer class bytes and performs HTTPS. Rust
+//! verifies current provider membership once, then recovery contains only the
+//! signed class, quote-key stream, claim state, and wallet secrets.
+
+use pir_payment_crypto::{
+    blind_cashu_message_v1, sign_bip340_prehash_v1, verify_and_unblind_cashu_promise_v1,
+};
+use pir_sdk_client::{
+    AcceptedBolt11BatV2QuoteV2, AcceptedServicePolicyV1, Bolt11QuoteKeyCheckpointV1,
+    PreparedBolt11BatV2ClaimV2, PreparedBolt11BatV2QuoteV2,
+};
+use pir_service_protocol::{
+    BitcoinPirCashuBatIssuanceRequestItemV1, BitcoinPirCashuBatProofV2, Bolt11QuoteStatusV1,
+    UnverifiedCashuBatDleqTupleV1,
+};
+use wasm_bindgen::prelude::*;
+use zeroize::{Zeroize, Zeroizing};
+
+const RECOVERY_MAGIC_V2: &[u8; 8] = b"BPIRBAW2";
+const RECOVERY_VERSION_V2: u8 = 2;
+const MAX_RECOVERY_STATE_LEN_V2: usize = 4 * 1024 * 1024;
+
+struct BatWalletSecretV2 {
+    secret: Zeroizing<[u8; 32]>,
+    blinding_scalar: Zeroizing<[u8; 32]>,
+}
+
+/// Opaque class-bound acquisition handle. It emits issuer HTTP bodies only,
+/// never a provider admission frame.
+#[wasm_bindgen]
+pub struct WasmBolt11BatV2AcquisitionV2 {
+    prepared: PreparedBolt11BatV2QuoteV2,
+    claim_secret_key: Zeroizing<[u8; 32]>,
+    secrets: Vec<BatWalletSecretV2>,
+    quote: Option<AcceptedBolt11BatV2QuoteV2>,
+    claim: Option<PreparedBolt11BatV2ClaimV2>,
+}
+
+#[wasm_bindgen]
+impl WasmBolt11BatV2AcquisitionV2 {
+    /// Canonical body for `POST /v2/quotes/bolt11`.
+    #[wasm_bindgen(js_name = quoteIntentBytes)]
+    pub fn quote_intent_bytes(&self) -> Result<Vec<u8>, JsError> {
+        self.prepared.intent_bytes().map_err(js_error)
+    }
+
+    /// Persist this issuer/network/payee rollback checkpoint before POST.
+    #[wasm_bindgen(js_name = quoteKeyCheckpointBytes)]
+    pub fn quote_key_checkpoint_bytes(&self) -> Vec<u8> {
+        self.prepared.quote_key_checkpoint_bytes()
+    }
+
+    /// Opaque secret-bearing V2 recovery state. JavaScript must encrypt it.
+    #[wasm_bindgen(js_name = recoveryStateBytes)]
+    pub fn recovery_state_bytes(&self) -> Result<Vec<u8>, JsError> {
+        encode_recovery(self)
+    }
+
+    /// V1 acquisition recovery cannot pass this distinct magic/version gate.
+    pub fn restore(recovery_state: &[u8], now_unix: u64) -> Result<Self, JsError> {
+        decode_recovery(recovery_state, now_unix)
+    }
+
+    #[wasm_bindgen(js_name = acceptInitialQuote)]
+    pub fn accept_initial_quote(
+        &mut self,
+        quote_bytes: &[u8],
+        now_unix: u64,
+    ) -> Result<(), JsError> {
+        if self.quote.is_some() {
+            return Err(JsError::new("initial BAT V2 quote already accepted"));
+        }
+        self.quote = Some(
+            self.prepared
+                .accept_initial_quote_for_payment(quote_bytes, now_unix)
+                .map_err(js_error)?,
+        );
+        Ok(())
+    }
+
+    pub fn invoice(&self) -> Result<String, JsError> {
+        Ok(self.require_quote()?.invoice().to_owned())
+    }
+
+    #[wasm_bindgen(js_name = quoteIdHex)]
+    pub fn quote_id_hex(&self) -> Result<String, JsError> {
+        Ok(hex::encode(self.require_quote()?.quote_id()))
+    }
+
+    #[wasm_bindgen(js_name = quoteStatus)]
+    pub fn quote_status(&self) -> Result<String, JsError> {
+        Ok(status_name(self.require_quote()?.status()).to_owned())
+    }
+
+    #[wasm_bindgen(js_name = invoiceExpiresAtUnix)]
+    pub fn invoice_expires_at_unix(&self) -> Result<String, JsError> {
+        Ok(self.require_quote()?.invoice_expires_at().to_string())
+    }
+
+    #[wasm_bindgen(js_name = claimDeadlineUnix)]
+    pub fn claim_deadline_unix(&self) -> Result<String, JsError> {
+        Ok(self.require_quote()?.claim_deadline().to_string())
+    }
+
+    #[wasm_bindgen(js_name = buildStatusRequest)]
+    pub fn build_status_request(&self, requested_at: u64) -> Result<Vec<u8>, JsError> {
+        self.prepared
+            .build_status_request(
+                self.require_quote()?,
+                &self.claim_secret_key,
+                requested_at,
+                random_nonzero_32()?,
+                random_32()?,
+            )
+            .map_err(js_error)
+    }
+
+    #[wasm_bindgen(js_name = acceptStatus)]
+    pub fn accept_status(&mut self, quote_bytes: &[u8], now_unix: u64) -> Result<(), JsError> {
+        self.quote = Some(
+            self.require_quote()?
+                .accept_latest_after(&self.prepared, quote_bytes, now_unix)
+                .map_err(js_error)?,
+        );
+        Ok(())
+    }
+
+    /// Prepare or replay one byte-identical idempotent claim envelope.
+    #[wasm_bindgen(js_name = prepareClaim)]
+    pub fn prepare_claim(&mut self, now_unix: u64) -> Result<Vec<u8>, JsError> {
+        if self.claim.is_none() {
+            let items = issuance_items(&self.secrets)?;
+            self.claim = Some(
+                self.prepared
+                    .prepare_claim(
+                        self.require_quote()?,
+                        items,
+                        &self.claim_secret_key,
+                        random_32()?,
+                        now_unix,
+                    )
+                    .map_err(js_error)?,
+            );
+        }
+        Ok(self
+            .claim
+            .as_ref()
+            .expect("claim initialized")
+            .envelope_bytes()
+            .to_vec())
+    }
+
+    /// Verify exact response binding and every NUT-12 proof before releasing
+    /// a batch of class-bound vault records.
+    #[wasm_bindgen(js_name = finishClaim)]
+    pub fn finish_claim(
+        &self,
+        response_bytes: &[u8],
+        now_unix: u64,
+    ) -> Result<WasmIssuedBatV2ProofsV2, JsError> {
+        let claim = self
+            .claim
+            .as_ref()
+            .ok_or_else(|| JsError::new("prepare and persist the BAT V2 claim first"))?;
+        let checked = self
+            .prepared
+            .verify_issuance_response(self.require_quote()?, claim, response_bytes, now_unix)
+            .map_err(js_error)?;
+        let tuples = checked.into_unverified_dleq();
+        if tuples.len() != self.secrets.len() {
+            return Err(JsError::new(
+                "BAT V2 issuance response count differs from wallet state",
+            ));
+        }
+        let (proofs, global_spend_keys) =
+            finalize_issued_proofs(self.prepared.class(), &self.secrets, tuples)
+                .map_err(|error| JsError::new(&error))?;
+        Ok(WasmIssuedBatV2ProofsV2 {
+            proofs,
+            global_spend_keys,
+            issuer_id: self.prepared.class().issuer_id,
+            class_id: self.prepared.class().class_id,
+            class_digest: self.prepared.class().class_digest().map_err(js_error)?,
+            class_key_epoch: self.prepared.class().key_epoch,
+            bat_key_id: self.prepared.class().bat_key_id(),
+        })
+    }
+
+    fn require_quote(&self) -> Result<&AcceptedBolt11BatV2QuoteV2, JsError> {
+        self.quote
+            .as_ref()
+            .ok_or_else(|| JsError::new("no verified BAT V2 quote is available"))
+    }
+}
+
+fn finalize_issued_proofs(
+    class: &pir_service_protocol::BatAcceptanceClassV2,
+    secrets: &[BatWalletSecretV2],
+    tuples: Vec<UnverifiedCashuBatDleqTupleV1>,
+) -> Result<(Vec<Vec<u8>>, Vec<[u8; 32]>), String> {
+    if secrets.len() != tuples.len() {
+        return Err("BAT V2 issuance response count differs from wallet state".into());
+    }
+    let mut proofs = Vec::with_capacity(tuples.len());
+    let mut global_spend_keys = Vec::with_capacity(tuples.len());
+    for (secret, tuple) in secrets.iter().zip(tuples) {
+        let verified = verify_and_unblind_cashu_promise_v1(
+            &secret.secret[..],
+            &secret.blinding_scalar,
+            &tuple.issuer_public_key,
+            &tuple.blinded_message,
+            &tuple.blinded_signature,
+            &tuple.dleq_e,
+            &tuple.dleq_s,
+        )
+        .map_err(|error| error.to_string())?;
+        let proof = BitcoinPirCashuBatProofV2::from_class(
+            class,
+            *secret.secret,
+            *verified.unblinded_signature(),
+        )
+        .map_err(|error| error.to_string())?;
+        global_spend_keys.push(
+            proof
+                .spend_key(&class.bat_verification_key)
+                .map_err(|error| error.to_string())?,
+        );
+        proofs.push(proof.encode().map_err(|error| error.to_string())?.to_vec());
+    }
+    Ok((proofs, global_spend_keys))
+}
+
+/// Issued proofs are withheld as a batch until Web atomically stores all
+/// records and removes the acquisition recovery entry.
+#[wasm_bindgen]
+pub struct WasmIssuedBatV2ProofsV2 {
+    proofs: Vec<Vec<u8>>,
+    global_spend_keys: Vec<[u8; 32]>,
+    issuer_id: [u8; 32],
+    class_id: [u8; 32],
+    class_digest: [u8; 32],
+    class_key_epoch: u64,
+    bat_key_id: [u8; 32],
+}
+
+impl Drop for WasmIssuedBatV2ProofsV2 {
+    fn drop(&mut self) {
+        self.proofs.zeroize();
+        self.global_spend_keys.zeroize();
+    }
+}
+
+#[wasm_bindgen]
+impl WasmIssuedBatV2ProofsV2 {
+    pub fn count(&self) -> u32 {
+        self.proofs.len() as u32
+    }
+
+    pub fn proof(&self, index: u32) -> Result<Vec<u8>, JsError> {
+        self.proofs
+            .get(index as usize)
+            .cloned()
+            .ok_or_else(|| JsError::new("issued BAT V2 proof index is out of range"))
+    }
+
+    #[wasm_bindgen(js_name = globalSpendKeyHex)]
+    pub fn global_spend_key_hex(&self, index: u32) -> Result<String, JsError> {
+        self.global_spend_keys
+            .get(index as usize)
+            .map(hex::encode)
+            .ok_or_else(|| JsError::new("issued BAT V2 spend-key index is out of range"))
+    }
+
+    #[wasm_bindgen(js_name = classBindingJson)]
+    pub fn class_binding_json(&self) -> JsValue {
+        crate::to_js_object(&serde_json::json!({
+            "issuerIdHex": hex::encode(self.issuer_id),
+            "classIdHex": hex::encode(self.class_id),
+            "classDigestHex": hex::encode(self.class_digest),
+            "classKeyEpoch": self.class_key_epoch.to_string(),
+            "batKeyIdHex": hex::encode(self.bat_key_id),
+        }))
+    }
+}
+
+/// Called only by the verified policy handle in `service.rs`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn begin_bat_v2_acquisition_v2(
+    accepted: &AcceptedServicePolicyV1,
+    scope_id: &[u8],
+    offer_id: u32,
+    class_bytes: &[u8],
+    quote_delegation_bytes: &[u8],
+    quote_key_checkpoint_bytes: &[u8],
+    now_unix: u64,
+) -> Result<WasmBolt11BatV2AcquisitionV2, JsError> {
+    let scope_id: [u8; 32] = fixed(scope_id, "scope_id")?;
+    let checkpoint =
+        Bolt11QuoteKeyCheckpointV1::decode(quote_key_checkpoint_bytes).map_err(js_error)?;
+    let verified = accepted
+        .verify_current_bat_v2_offer_v2(&scope_id, offer_id, class_bytes, now_unix)
+        .map_err(js_error)?;
+    let (claim_secret_key, claim_pubkey_xonly) = fresh_claim_key()?;
+    let prepared = PreparedBolt11BatV2QuoteV2::from_verified_current_offer(
+        &verified,
+        quote_delegation_bytes,
+        &checkpoint,
+        now_unix,
+        claim_pubkey_xonly,
+        random_nonzero_32()?,
+    )
+    .map_err(js_error)?;
+    let count = usize::try_from(prepared.intent().credential_count)
+        .map_err(|_| JsError::new("BAT V2 credential count does not fit this browser"))?;
+    let mut secrets = Vec::with_capacity(count);
+    for _ in 0..count {
+        secrets.push(fresh_bat_secret()?);
+    }
+    Ok(WasmBolt11BatV2AcquisitionV2 {
+        prepared,
+        claim_secret_key: Zeroizing::new(claim_secret_key),
+        secrets,
+        quote: None,
+        claim: None,
+    })
+}
+
+fn issuance_items(
+    secrets: &[BatWalletSecretV2],
+) -> Result<Vec<BitcoinPirCashuBatIssuanceRequestItemV1>, JsError> {
+    secrets
+        .iter()
+        .map(|secret| {
+            Ok(BitcoinPirCashuBatIssuanceRequestItemV1 {
+                blinded_message: blind_cashu_message_v1(
+                    &secret.secret[..],
+                    &secret.blinding_scalar,
+                )
+                .map_err(js_error)?,
+            })
+        })
+        .collect()
+}
+
+fn encode_recovery(value: &WasmBolt11BatV2AcquisitionV2) -> Result<Vec<u8>, JsError> {
+    let mut out = Vec::new();
+    out.extend_from_slice(RECOVERY_MAGIC_V2);
+    out.push(RECOVERY_VERSION_V2);
+    put_bytes(&mut out, &value.prepared.intent_bytes().map_err(js_error)?)?;
+    put_bytes(&mut out, &value.prepared.class_bytes().map_err(js_error)?)?;
+    put_bytes(
+        &mut out,
+        &value.prepared.delegation_bytes().map_err(js_error)?,
+    )?;
+    put_bytes(&mut out, &value.prepared.quote_key_checkpoint_bytes())?;
+    out.extend_from_slice(&value.claim_secret_key[..]);
+    put_bytes(
+        &mut out,
+        &value
+            .quote
+            .as_ref()
+            .map(AcceptedBolt11BatV2QuoteV2::bytes)
+            .transpose()
+            .map_err(js_error)?
+            .unwrap_or_default(),
+    )?;
+    put_bytes(
+        &mut out,
+        value
+            .claim
+            .as_ref()
+            .map(PreparedBolt11BatV2ClaimV2::envelope_bytes)
+            .unwrap_or_default(),
+    )?;
+    put_count(&mut out, value.secrets.len())?;
+    for secret in &value.secrets {
+        out.extend_from_slice(&secret.secret[..]);
+        out.extend_from_slice(&secret.blinding_scalar[..]);
+    }
+    if out.len() > MAX_RECOVERY_STATE_LEN_V2 {
+        return Err(JsError::new("BAT V2 recovery state exceeds its bound"));
+    }
+    Ok(out)
+}
+
+fn decode_recovery(bytes: &[u8], now_unix: u64) -> Result<WasmBolt11BatV2AcquisitionV2, JsError> {
+    if bytes.len() < RECOVERY_MAGIC_V2.len() + 1 || bytes.len() > MAX_RECOVERY_STATE_LEN_V2 {
+        return Err(JsError::new("invalid BAT V2 recovery state length"));
+    }
+    let mut decoder = RecoveryDecoderV2::new(bytes);
+    if !has_recovery_domain_v2(bytes) {
+        return Err(JsError::new("unsupported BAT V2 recovery domain/version"));
+    }
+    decoder.take(RECOVERY_MAGIC_V2.len())?;
+    decoder.u8()?;
+    let intent = decoder.bytes()?;
+    let class = decoder.bytes()?;
+    let delegation = decoder.bytes()?;
+    let checkpoint = decoder.bytes()?;
+    let claim_secret_key = decoder.fixed::<32>()?;
+    let quote_bytes = decoder.bytes()?;
+    let claim_bytes = decoder.bytes()?;
+    let count = decoder.u32()? as usize;
+    let mut secrets = Vec::with_capacity(count);
+    for _ in 0..count {
+        secrets.push(BatWalletSecretV2 {
+            secret: Zeroizing::new(decoder.fixed::<32>()?),
+            blinding_scalar: Zeroizing::new(decoder.fixed::<32>()?),
+        });
+    }
+    decoder.finish()?;
+    let prepared =
+        PreparedBolt11BatV2QuoteV2::restore(&intent, &class, &delegation, &checkpoint, now_unix)
+            .map_err(js_error)?;
+    let (public, _) =
+        sign_bip340_prehash_v1(&claim_secret_key, &[7; 32], &[0; 32]).map_err(js_error)?;
+    if public != prepared.intent().claim_pubkey_xonly
+        || count
+            != usize::try_from(prepared.intent().credential_count)
+                .map_err(|_| JsError::new("BAT V2 credential count does not fit this browser"))?
+    {
+        return Err(JsError::new(
+            "BAT V2 recovery secrets do not match the class-only intent",
+        ));
+    }
+    let quote = if quote_bytes.is_empty() {
+        None
+    } else {
+        Some(
+            prepared
+                .restore_quote_snapshot(&quote_bytes, now_unix)
+                .map_err(js_error)?,
+        )
+    };
+    let claim = if claim_bytes.is_empty() {
+        None
+    } else {
+        Some(prepared.restore_claim(&claim_bytes).map_err(js_error)?)
+    };
+    if let Some(claim) = &claim {
+        if claim.credential_request().items != issuance_items(&secrets)? {
+            return Err(JsError::new(
+                "restored BAT V2 claim differs from wallet secrets",
+            ));
+        }
+    }
+    Ok(WasmBolt11BatV2AcquisitionV2 {
+        prepared,
+        claim_secret_key: Zeroizing::new(claim_secret_key),
+        secrets,
+        quote,
+        claim,
+    })
+}
+
+fn has_recovery_domain_v2(bytes: &[u8]) -> bool {
+    bytes.get(..RECOVERY_MAGIC_V2.len()) == Some(RECOVERY_MAGIC_V2.as_slice())
+        && bytes.get(RECOVERY_MAGIC_V2.len()) == Some(&RECOVERY_VERSION_V2)
+}
+
+fn fresh_claim_key() -> Result<([u8; 32], [u8; 32]), JsError> {
+    for _ in 0..32 {
+        let secret = random_nonzero_32()?;
+        if let Ok((public, _)) = sign_bip340_prehash_v1(&secret, &[7; 32], &[0; 32]) {
+            return Ok((secret, public));
+        }
+    }
+    Err(JsError::new(
+        "could not generate a canonical BIP340 claim key",
+    ))
+}
+
+fn fresh_bat_secret() -> Result<BatWalletSecretV2, JsError> {
+    for _ in 0..64 {
+        let secret = random_nonzero_32()?;
+        let blinding_scalar = random_nonzero_32()?;
+        if blind_cashu_message_v1(&secret, &blinding_scalar).is_ok() {
+            return Ok(BatWalletSecretV2 {
+                secret: Zeroizing::new(secret),
+                blinding_scalar: Zeroizing::new(blinding_scalar),
+            });
+        }
+    }
+    Err(JsError::new(
+        "could not generate a canonical BAT V2 blinding scalar",
+    ))
+}
+
+fn status_name(value: Bolt11QuoteStatusV1) -> &'static str {
+    match value {
+        Bolt11QuoteStatusV1::InvoiceOpen => "invoice-open",
+        Bolt11QuoteStatusV1::PaymentSettled => "payment-settled",
+        Bolt11QuoteStatusV1::CredentialClaimed => "credential-claimed",
+        Bolt11QuoteStatusV1::InvoiceExpiredPendingReconcile => "invoice-expired-pending-reconcile",
+        Bolt11QuoteStatusV1::LateSettledReconcile => "late-settled-reconcile",
+    }
+}
+
+fn random_32() -> Result<[u8; 32], JsError> {
+    let mut value = [0; 32];
+    getrandom::getrandom(&mut value).map_err(|_| JsError::new("Web Crypto RNG unavailable"))?;
+    Ok(value)
+}
+
+fn random_nonzero_32() -> Result<[u8; 32], JsError> {
+    for _ in 0..16 {
+        let value = random_32()?;
+        if value.iter().any(|byte| *byte != 0) {
+            return Ok(value);
+        }
+    }
+    Err(JsError::new("Web Crypto RNG repeatedly returned zero"))
+}
+
+fn fixed<const N: usize>(bytes: &[u8], field: &str) -> Result<[u8; N], JsError> {
+    bytes
+        .try_into()
+        .map_err(|_| JsError::new(&format!("{field} must be exactly {N} bytes")))
+}
+
+fn put_count(out: &mut Vec<u8>, count: usize) -> Result<(), JsError> {
+    let count = u32::try_from(count).map_err(|_| JsError::new("BAT V2 item count exceeds u32"))?;
+    out.extend_from_slice(&count.to_le_bytes());
+    Ok(())
+}
+
+fn put_bytes(out: &mut Vec<u8>, bytes: &[u8]) -> Result<(), JsError> {
+    let len = u32::try_from(bytes.len()).map_err(|_| JsError::new("BAT V2 field exceeds u32"))?;
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(bytes);
+    Ok(())
+}
+
+struct RecoveryDecoderV2<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> RecoveryDecoderV2<'a> {
+    const fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn take(&mut self, len: usize) -> Result<&'a [u8], JsError> {
+        let end = self
+            .offset
+            .checked_add(len)
+            .ok_or_else(|| JsError::new("BAT V2 recovery offset overflow"))?;
+        let value = self
+            .bytes
+            .get(self.offset..end)
+            .ok_or_else(|| JsError::new("truncated BAT V2 recovery state"))?;
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn u8(&mut self) -> Result<u8, JsError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u32(&mut self) -> Result<u32, JsError> {
+        Ok(u32::from_le_bytes(fixed(self.take(4)?, "u32")?))
+    }
+
+    fn fixed<const N: usize>(&mut self) -> Result<[u8; N], JsError> {
+        fixed(self.take(N)?, "fixed BAT V2 recovery field")
+    }
+
+    fn bytes(&mut self) -> Result<Vec<u8>, JsError> {
+        let len = self.u32()? as usize;
+        if len > MAX_RECOVERY_STATE_LEN_V2 {
+            return Err(JsError::new("BAT V2 recovery field exceeds its bound"));
+        }
+        Ok(self.take(len)?.to_vec())
+    }
+
+    fn finish(self) -> Result<(), JsError> {
+        if self.offset == self.bytes.len() {
+            Ok(())
+        } else {
+            Err(JsError::new("trailing BAT V2 recovery bytes"))
+        }
+    }
+}
+
+fn js_error(error: impl core::fmt::Display) -> JsError {
+    JsError::new(&error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use pir_payment_crypto::K256CashuMintKeyringV1;
+    use pir_service_protocol::{
+        AuthPaddingClassV1, BackendId, BatAcceptanceClassV2, BatAcceptanceMemberV2,
+        BatAcceptanceTermsV2, DatasetBindingV1, DeploymentStatus, EntitlementLimitsV1,
+        PrivacyLeakageV1, WorkloadId,
+    };
+
+    fn class(bat_verification_key: [u8; 33]) -> BatAcceptanceClassV2 {
+        BatAcceptanceClassV2::sign(
+            [0x41; 32],
+            1,
+            100,
+            1_000,
+            bat_verification_key,
+            BatAcceptanceTermsV2 {
+                auth_padding_class: AuthPaddingClassV1::Class16KiB,
+                backend: BackendId::DpfPirV1,
+                workload: WorkloadId::DpfEvaluateJobV1,
+                protocol_version: 1,
+                dataset: DatasetBindingV1::Class { class_id: 1 },
+                operation_profile: 1,
+                entitlement_profile: 2,
+                limits: EntitlementLimitsV1 {
+                    max_logical_inputs: 1,
+                    max_frames: 10,
+                    max_request_bytes: 10_000,
+                    max_response_bytes: 20_000,
+                    max_wall_time_ms: 1_000,
+                    max_concurrent_sockets: 1,
+                    max_hint_groups: 0,
+                    max_work_units: 100,
+                },
+                priority_class: 1,
+                deployment_status: DeploymentStatus::Stable,
+                price_msat: 1_000,
+                issuer_endpoint: "https://issuer.invalid".into(),
+                invoice_expiry_seconds: 10,
+                claim_window_seconds: 10,
+                minimum_credential_validity_seconds: 10,
+                retired_policy_grace_seconds: 30,
+                credential_count: 2,
+                credential_presentation_limit: 1,
+                privacy_leakage: PrivacyLeakageV1::from_bits(
+                    PrivacyLeakageV1::ISSUER_ISSUANCE_TIMING
+                        | PrivacyLeakageV1::ISSUER_REDEMPTION_TIMING
+                        | PrivacyLeakageV1::ISSUER_LEARNS_PROVIDER,
+                )
+                .unwrap(),
+            },
+            vec![BatAcceptanceMemberV2 {
+                provider_id: [1; 32],
+                policy_digest: [2; 32],
+                scope_id: [3; 32],
+                offer_id: 4,
+            }],
+            &SigningKey::from_bytes(&[5; 32]),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn v2_recovery_domain_rejects_v1_prefix() {
+        assert!(!has_recovery_domain_v2(&[1; 128]));
+        let mut v2 = RECOVERY_MAGIC_V2.to_vec();
+        v2.push(RECOVERY_VERSION_V2);
+        assert!(has_recovery_domain_v2(&v2));
+    }
+
+    #[test]
+    fn generated_wallet_secret_reconstructs_blinded_message() {
+        let secret = fresh_bat_secret().expect("secret");
+        let first =
+            blind_cashu_message_v1(&secret.secret[..], &secret.blinding_scalar).expect("blind");
+        let second =
+            blind_cashu_message_v1(&secret.secret[..], &secret.blinding_scalar).expect("blind");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn finish_proofs_verifies_dleq_and_derives_distinct_global_spend_keys() {
+        let keyring = K256CashuMintKeyringV1::from_secret_keys([[7; 32]]).unwrap();
+        let public_key = keyring.denomination_public_keys()[0];
+        let class = class(public_key);
+        let secrets = vec![
+            BatWalletSecretV2 {
+                secret: Zeroizing::new([11; 32]),
+                blinding_scalar: Zeroizing::new([12; 32]),
+            },
+            BatWalletSecretV2 {
+                secret: Zeroizing::new([13; 32]),
+                blinding_scalar: Zeroizing::new([14; 32]),
+            },
+        ];
+        let tuples = secrets
+            .iter()
+            .enumerate()
+            .map(|(index, secret)| {
+                let blinded_message =
+                    blind_cashu_message_v1(&secret.secret[..], &secret.blinding_scalar).unwrap();
+                let signed = keyring
+                    .blind_sign_with_dleq_v1(&public_key, &blinded_message, &[20 + index as u8; 32])
+                    .unwrap();
+                UnverifiedCashuBatDleqTupleV1 {
+                    issuer_public_key: public_key,
+                    blinded_message,
+                    blinded_signature: *signed.blinded_signature(),
+                    dleq_e: *signed.dleq_e(),
+                    dleq_s: *signed.dleq_s(),
+                }
+            })
+            .collect::<Vec<_>>();
+        let (proofs, spend_keys) =
+            finalize_issued_proofs(&class, &secrets, tuples.clone()).unwrap();
+        assert_eq!(proofs.len(), 2);
+        assert_ne!(spend_keys[0], spend_keys[1]);
+        for proof in proofs {
+            BitcoinPirCashuBatProofV2::decode(&proof)
+                .unwrap()
+                .verify_class_binding(&class)
+                .unwrap();
+        }
+
+        let mut tampered = tuples;
+        tampered[0].dleq_s[0] ^= 1;
+        assert!(finalize_issued_proofs(&class, &secrets, tampered).is_err());
+    }
+}

--- a/crates/sdk/wasm/src/lib.rs
+++ b/crates/sdk/wasm/src/lib.rs
@@ -68,6 +68,10 @@ mod standard_cashu;
 /// Browser-side BOLT11 quote acquisition and recovery state machine.
 pub mod bolt11;
 
+/// Class-bound BAT V2 acquisition and recovery bridge.
+pub mod bat_v2;
+pub use bat_v2::{WasmBolt11BatV2AcquisitionV2, WasmIssuedBatV2ProofsV2};
+
 /// Strict signed service-policy and provider-local admission bindings.
 pub mod service;
 pub use service::{

--- a/crates/sdk/wasm/src/service.rs
+++ b/crates/sdk/wasm/src/service.rs
@@ -510,6 +510,31 @@ impl WasmAcceptedServicePolicyV1 {
         )
     }
 
+    /// Begin class-bound BAT V2 acquisition only after the exact current
+    /// provider offer is proven a member of the caller-supplied signed class.
+    /// No provider coordinates enter the returned recovery state.
+    #[wasm_bindgen(js_name = beginBatV2Acquisition)]
+    pub fn begin_bat_v2_acquisition(
+        &self,
+        scope_id: &[u8],
+        offer_id: u32,
+        class_bytes: &[u8],
+        quote_delegation_bytes: &[u8],
+        quote_key_checkpoint_bytes: &[u8],
+        now_unix: u64,
+    ) -> Result<crate::bat_v2::WasmBolt11BatV2AcquisitionV2, JsError> {
+        self.require_checkpoint_persisted()?;
+        crate::bat_v2::begin_bat_v2_acquisition_v2(
+            &self.inner,
+            scope_id,
+            offer_id,
+            class_bytes,
+            quote_delegation_bytes,
+            quote_key_checkpoint_bytes,
+            now_unix,
+        )
+    }
+
     /// Decode and validate one canonical method proof against this exact
     /// signed scope/offer without sending or consuming it.
     #[wasm_bindgen(js_name = validateAuthorizationProof)]


### PR DESCRIPTION
## Summary
- add class-only BAT V2 quote, status, claim, NUT-12/DLEQ verification, unblinding, proof, and issuer-global spend-key handling
- verify provider offers against one exact issuer-signed class member before preparing an acquisition
- add V2 quote-status rollback/equivocation guards and a separately versioned secret recovery format
- expose a WASM acquisition handle and issued proof batch for an application-managed encrypted vault
- add strict two-provider BAT V2 class pairing with explicit shared-issuer acknowledgement and distinct spend-key checks
- keep generic V1/WASM proof builders fail-closed for scheme 6 so a copied class ID cannot bypass membership verification

## Validation
- three-package check: `pir-service-protocol`, `pir-sdk-client`, `pir-sdk-wasm`
- full library tests: protocol 155, client 346, WASM 101 passed
- BAT V2 focused review tests: client 8/8, WASM 3/3
- wasm32 check and `wasm-pack build --target web`
- scoped rustfmt, clippy with documented repository baseline allowances, and `git diff --check`

## Non-goals
- no Web vault/UI or class-distribution endpoint
- no generic BAT V2 authorization request path; scheme 6 remains fail-closed outside the verified class/member handle
- no deployment, browser, VPSBG, or funds operation