### PR TITLE
feat(web): add BAT V2 acquisition wallet

### DIFF
--- a/web/src/__tests__/bat-v2-vault.test.ts
+++ b/web/src/__tests__/bat-v2-vault.test.ts
@@ -32,18 +32,10 @@ beforeEach(async () => {
     configurable: true,
     value: webcrypto,
   });
-  const tails = new Map<string, Promise<unknown>>();
   Object.defineProperty(globalThis, 'navigator', {
     configurable: true,
     value: {
-      locks: {
-        request: <T>(name: string, _options: unknown, callback: () => Promise<T>) => {
-          const previous = tails.get(name) ?? Promise.resolve();
-          const result = previous.then(callback, callback);
-          tails.set(name, result.then(() => undefined, () => undefined));
-          return result;
-        },
-      },
+      locks: testLockManager(),
     },
   });
   await deleteDatabase(databaseName);
@@ -126,7 +118,33 @@ describe('BAT V2 class-only encrypted vault', () => {
     await expect(vault.listInventory()).resolves.toEqual([{ ...binding, count: 1 }]);
   });
 
-  it('conservatively burns every orphaned reservation when the vault reopens', async () => {
+  it('does not burn a reservation owned by another live vault handle', async () => {
+    const owner = await openVault();
+    await install(owner, [walletRecord(1, 2), walletRecord(3, 4)]);
+    const pair = await owner.reserveDistinctPair(binding, binding);
+    expect(pair).not.toBeNull();
+
+    const observer = await openVault();
+    await expect(observer.listInventory()).resolves.toEqual([]);
+    await owner.finishReservation(pair!.first, 'recover-safe');
+    await owner.finishReservation(pair!.second, 'recover-safe');
+    await expect(observer.listInventory()).resolves.toEqual([{ ...binding, count: 2 }]);
+  });
+
+  it('holds reservation ownership until both legs have completed', async () => {
+    const owner = await openVault();
+    await install(owner, [walletRecord(1, 2), walletRecord(3, 4)]);
+    const pair = await owner.reserveDistinctPair(binding, binding);
+    expect(pair).not.toBeNull();
+
+    await owner.finishReservation(pair!.first, 'recover-safe');
+    const observer = await openVault();
+    await expect(observer.listInventory()).resolves.toEqual([{ ...binding, count: 1 }]);
+    await owner.finishReservation(pair!.second, 'recover-safe');
+    await expect(observer.listInventory()).resolves.toEqual([{ ...binding, count: 2 }]);
+  });
+
+  it('releases reservation ownership on close so the next open burns the orphan', async () => {
     const vault = await openVault();
     await install(vault, [walletRecord(1, 2), walletRecord(3, 4)]);
     const pair = await vault.reserveDistinctPair(binding, binding);
@@ -206,4 +224,36 @@ function deleteDatabase(name: string): Promise<void> {
     request.onerror = () => reject(new Error(`failed to delete ${name}`));
     request.onblocked = () => reject(new Error(`delete ${name} was blocked`));
   });
+}
+
+function testLockManager(): LockManager {
+  const active = new Set<string>();
+  const waiters = new Map<string, Array<() => void>>();
+  const release = (name: string) => {
+    active.delete(name);
+    const queue = waiters.get(name);
+    const next = queue?.shift();
+    if (queue?.length === 0) waiters.delete(name);
+    next?.();
+  };
+  const wait = (name: string) => new Promise<void>((resolve) => {
+    const queue = waiters.get(name) ?? [];
+    queue.push(resolve);
+    waiters.set(name, queue);
+  });
+  const request = async <T>(
+    name: string,
+    options: LockOptions,
+    callback: (lock: Lock | null) => PromiseLike<T> | T,
+  ): Promise<T> => {
+    if (options.ifAvailable && active.has(name)) return callback(null);
+    while (active.has(name)) await wait(name);
+    active.add(name);
+    try {
+      return await callback({ name, mode: options.mode ?? 'exclusive' } as Lock);
+    } finally {
+      release(name);
+    }
+  };
+  return { request } as unknown as LockManager;
 }

--- a/web/src/__tests__/bat-v2-vault.test.ts
+++ b/web/src/__tests__/bat-v2-vault.test.ts
@@ -1,0 +1,209 @@
+import { webcrypto } from 'node:crypto';
+import { indexedDB as fakeIndexedDB } from 'fake-indexeddb';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  BatV2CredentialVaultV2,
+  type BatV2ClassBindingV2,
+  type BatV2WalletRecordV2,
+} from '../bat-v2-vault.js';
+
+const databaseName = 'bitcoinpir-bat-v2';
+const v1DatabaseName = 'bitcoinpir-admission-v1';
+const issuerIdHex = '11'.repeat(32);
+const classIdHex = '22'.repeat(32);
+const classDigestHex = '33'.repeat(32);
+const batKeyIdHex = '44'.repeat(32);
+const payeeHex = `02${'55'.repeat(32)}`;
+const binding: BatV2ClassBindingV2 = {
+  issuerIdHex,
+  classIdHex,
+  classDigestHex,
+  classKeyEpoch: '7',
+  batKeyIdHex,
+};
+let opened: BatV2CredentialVaultV2[] = [];
+
+beforeEach(async () => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    configurable: true,
+    value: fakeIndexedDB,
+  });
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    value: webcrypto,
+  });
+  const tails = new Map<string, Promise<unknown>>();
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {
+      locks: {
+        request: <T>(name: string, _options: unknown, callback: () => Promise<T>) => {
+          const previous = tails.get(name) ?? Promise.resolve();
+          const result = previous.then(callback, callback);
+          tails.set(name, result.then(() => undefined, () => undefined));
+          return result;
+        },
+      },
+    },
+  });
+  await deleteDatabase(databaseName);
+  await deleteDatabase(v1DatabaseName);
+  opened = [];
+});
+
+afterEach(async () => {
+  for (const vault of opened) vault.close();
+  opened = [];
+  await deleteDatabase(databaseName);
+  await deleteDatabase(v1DatabaseName);
+});
+
+describe('BAT V2 class-only encrypted vault', () => {
+  it('uses an independent database and never imports V1 records or coordinates', async () => {
+    await seedForeignV1Database();
+    const vault = await openVault();
+    await expect(vault.listInventory()).resolves.toEqual([]);
+
+    await install(vault, [walletRecord(1, 2)]);
+    const inventory = await vault.listInventory();
+    expect(inventory).toEqual([{ ...binding, count: 1 }]);
+    expect(inventory[0]).not.toHaveProperty('providerIdHex');
+    expect(inventory[0]).not.toHaveProperty('policyDigestHex');
+    expect(inventory[0]).not.toHaveProperty('scopeIdHex');
+    expect(inventory[0]).not.toHaveProperty('offerId');
+  });
+
+  it('atomically rejects issuer-global spend-key reuse and retains recovery', async () => {
+    const vault = await openVault();
+    await install(vault, [walletRecord(1, 9)]);
+    const recovery = await createRecovery(vault, 2);
+
+    await expect(vault.completeAcquisition(recovery.id, [
+      walletRecord(2, 10),
+      walletRecord(3, 10),
+    ])).rejects.toThrow(/duplicate global spend key/);
+    await expect(vault.getRecovery(recovery.id)).resolves.not.toBeNull();
+    await expect(vault.listInventory()).resolves.toEqual([{ ...binding, count: 1 }]);
+
+    await expect(vault.completeAcquisition(recovery.id, [walletRecord(2, 9)]))
+      .rejects.toThrow(/transaction|conflicted/);
+    await expect(vault.getRecovery(recovery.id)).resolves.not.toBeNull();
+    await expect(vault.listInventory()).resolves.toEqual([{ ...binding, count: 1 }]);
+  });
+
+  it('leaves a one-token wallet unchanged instead of leasing one proof twice', async () => {
+    const vault = await openVault();
+    await install(vault, [walletRecord(1, 2)]);
+
+    await expect(vault.reserveDistinctPair(binding, binding)).resolves.toBeNull();
+    await expect(vault.reserveDistinctPair(binding, {
+      ...binding,
+      classDigestHex: '99'.repeat(32),
+    })).rejects.toThrow(/one exact acceptance class/);
+    await expect(vault.listInventory()).resolves.toEqual([{ ...binding, count: 1 }]);
+  });
+
+  it('atomically leases two distinct proofs and supports recover-safe or burn completion', async () => {
+    const vault = await openVault();
+    await install(vault, [walletRecord(1, 2), walletRecord(3, 4)]);
+    const validationCopies: Uint8Array[] = [];
+
+    const pair = await vault.reserveDistinctPair(binding, binding, (record) => {
+      validationCopies.push(record.proof);
+    });
+    expect(pair).not.toBeNull();
+    expect(pair?.first.recordId).not.toBe(pair?.second.recordId);
+    expect(pair?.first.globalSpendKeyHex).not.toBe(pair?.second.globalSpendKeyHex);
+    expect(pair?.first.reservationId).toBe(pair?.second.reservationId);
+    expect(validationCopies).toHaveLength(2);
+    expect(validationCopies.every((proof) => proof.every((byte) => byte === 0))).toBe(true);
+    await expect(vault.listInventory()).resolves.toEqual([]);
+
+    await vault.finishReservation(pair!.first, 'recover-safe');
+    await vault.finishReservation(pair!.second, 'burn');
+    expect(pair!.first.proof.every((byte) => byte === 0)).toBe(true);
+    expect(pair!.second.proof.every((byte) => byte === 0)).toBe(true);
+    await expect(vault.listInventory()).resolves.toEqual([{ ...binding, count: 1 }]);
+  });
+
+  it('conservatively burns every orphaned reservation when the vault reopens', async () => {
+    const vault = await openVault();
+    await install(vault, [walletRecord(1, 2), walletRecord(3, 4)]);
+    const pair = await vault.reserveDistinctPair(binding, binding);
+    expect(pair).not.toBeNull();
+    pair!.first.proof.fill(0);
+    pair!.second.proof.fill(0);
+    vault.close();
+    opened = opened.filter((candidate) => candidate !== vault);
+
+    const reopened = await openVault();
+    await expect(reopened.listInventory()).resolves.toEqual([]);
+    await expect(reopened.finishReservation(pair!.first, 'recover-safe'))
+      .rejects.toThrow(/no longer available/);
+  });
+});
+
+async function openVault(): Promise<BatV2CredentialVaultV2> {
+  const vault = await BatV2CredentialVaultV2.open();
+  opened.push(vault);
+  return vault;
+}
+
+function walletRecord(proofByte: number, spendByte: number): BatV2WalletRecordV2 {
+  return {
+    ...binding,
+    proof: new Uint8Array(210).fill(proofByte),
+    globalSpendKeyHex: spendByte.toString(16).padStart(2, '0').repeat(32),
+  };
+}
+
+async function createRecovery(vault: BatV2CredentialVaultV2, marker: number) {
+  return vault.createRecovery({
+    issuerEndpoint: 'https://issuer.example',
+    issuerIdHex,
+    network: 'signet',
+    expectedPayeePubkeyHex: payeeHex,
+    state: new Uint8Array([marker]),
+  });
+}
+
+async function install(
+  vault: BatV2CredentialVaultV2,
+  records: BatV2WalletRecordV2[],
+): Promise<void> {
+  const recovery = await createRecovery(vault, records[0].proof[0]);
+  await vault.completeAcquisition(recovery.id, records);
+}
+
+function seedForeignV1Database(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(v1DatabaseName, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore('records', { keyPath: 'id' });
+    };
+    request.onsuccess = () => {
+      const db = request.result;
+      const tx = db.transaction('records', 'readwrite');
+      tx.objectStore('records').add({
+        id: 'aa'.repeat(32),
+        providerIdHex: 'bb'.repeat(32),
+        payload: new Uint8Array(210).fill(7),
+      });
+      tx.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      tx.onabort = () => reject(new Error('failed to seed foreign V1 database'));
+    };
+    request.onerror = () => reject(new Error('failed to open foreign V1 database'));
+  });
+}
+
+function deleteDatabase(name: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(new Error(`failed to delete ${name}`));
+    request.onblocked = () => reject(new Error(`delete ${name} was blocked`));
+  });
+}

--- a/web/src/__tests__/service-acquisition-v2.test.ts
+++ b/web/src/__tests__/service-acquisition-v2.test.ts
@@ -1,0 +1,383 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocked = vi.hoisted(() => ({ sdk: {} as Record<string, unknown> }));
+
+vi.mock('../sdk-bridge.js', () => ({
+  requireSdkWasm: () => mocked.sdk,
+}));
+
+import type {
+  BatV2RecoveryRecordV2,
+  BatV2WalletRecordV2,
+  LockedBatV2RecoveryV2,
+} from '../bat-v2-vault.js';
+import {
+  BatV2AcquisitionControllerV2,
+  BatV2RecoveryRequiredErrorV2,
+} from '../service-acquisition-v2.js';
+import type {
+  ServiceOfferViewV1,
+  ServiceScopeViewV1,
+  WasmAcceptedServicePolicyV1,
+  WasmBolt11BatV2AcquisitionV2,
+} from '../sdk-bridge.js';
+
+const issuerIdHex = '11'.repeat(32);
+const scopeIdHex = '22'.repeat(32);
+const classIdHex = '33'.repeat(32);
+const classDigestHex = '44'.repeat(32);
+const batKeyIdHex = '55'.repeat(32);
+const recoveryId = '66'.repeat(32);
+const payee = new Uint8Array([2, ...new Uint8Array(32).fill(7)]);
+const delegationType = 'application/vnd.bitcoinpir.bolt11-quote-key-delegation-v1';
+const quoteType = 'application/vnd.bitcoinpir.bolt11-quote-v1';
+const quoteIntentType = 'application/vnd.bitcoinpir.bat-v2-bolt11-quote-intent-v2';
+const statusType = 'application/vnd.bitcoinpir.bolt11-quote-status-request-v1';
+const claimType = 'application/vnd.bitcoinpir.bat-v2-bolt11-quote-claim-envelope-v2';
+const issuanceType = 'application/vnd.bitcoinpir.bat-v2-issuance-response-v2';
+
+class FakeBatV2Acquisition implements WasmBolt11BatV2AcquisitionV2 {
+  hasQuote: boolean;
+  settled: boolean;
+  claimPrepared: boolean;
+  free = vi.fn();
+
+  constructor(state: Uint8Array = new Uint8Array([0, 0, 0])) {
+    this.hasQuote = state[0] === 1;
+    this.settled = state[1] === 1;
+    this.claimPrepared = state[2] === 1;
+  }
+
+  quoteIntentBytes = () => new Uint8Array([1, 2, 3]);
+  quoteKeyCheckpointBytes = () => new Uint8Array([8, 8]);
+  recoveryStateBytes = () => new Uint8Array([
+    this.hasQuote ? 1 : 0,
+    this.settled ? 1 : 0,
+    this.claimPrepared ? 1 : 0,
+  ]);
+  acceptInitialQuote = () => { this.hasQuote = true; };
+  invoice = () => {
+    if (!this.hasQuote) throw new Error('no quote');
+    return 'lnbc1batv2';
+  };
+  quoteIdHex = () => '77'.repeat(32);
+  quoteStatus = () => this.settled ? 'payment-settled' as const : 'invoice-open' as const;
+  invoiceExpiresAtUnix = () => '9999999999';
+  claimDeadlineUnix = () => '9999999999';
+  buildStatusRequest = () => new Uint8Array([4, 5]);
+  acceptStatus = () => { this.settled = true; };
+  prepareClaim = () => {
+    this.claimPrepared = true;
+    return new Uint8Array([6, 7]);
+  };
+  finishClaim = () => ({
+    free: vi.fn(),
+    count: () => 1,
+    proof: () => new Uint8Array(210).fill(9),
+    globalSpendKeyHex: () => '88'.repeat(32),
+    classBindingJson: () => ({
+      issuerIdHex,
+      classIdHex,
+      classDigestHex,
+      classKeyEpoch: '4',
+      batKeyIdHex,
+    }),
+  });
+}
+
+class FakeVault {
+  recovery: BatV2RecoveryRecordV2 | null = null;
+  completed: BatV2WalletRecordV2[] | null = null;
+  createdWithoutProviderCoordinates = false;
+  advanceQuoteKeyCheckpoint = vi.fn(async (
+    _issuerIdHex: string,
+    _network: string,
+    _payeeHex: string,
+    initial: Uint8Array,
+    advance: (checkpoint: Uint8Array) => {
+      nextCheckpoint: Uint8Array;
+      value: WasmBolt11BatV2AcquisitionV2;
+    },
+  ) => advance(initial).value);
+
+  createRecovery = vi.fn(async (value: Omit<BatV2RecoveryRecordV2, 'id'>) => {
+    this.createdWithoutProviderCoordinates = !('providerIdHex' in value)
+      && !('policyDigestHex' in value)
+      && !('scopeIdHex' in value)
+      && !('offerId' in value);
+    this.recovery = { ...value, id: recoveryId, state: value.state.slice() };
+    return cloneRecovery(this.recovery);
+  });
+
+  getRecovery = vi.fn(async (id: string) =>
+    this.recovery?.id === id ? cloneRecovery(this.recovery) : null);
+
+  async withRecovery<T>(
+    id: string,
+    operation: (
+      recovery: BatV2RecoveryRecordV2,
+      locked: LockedBatV2RecoveryV2,
+    ) => Promise<T>,
+  ): Promise<T> {
+    if (!this.recovery || this.recovery.id !== id) throw new Error('recovery missing');
+    const exposed = cloneRecovery(this.recovery);
+    let terminal = false;
+    const locked: LockedBatV2RecoveryV2 = {
+      persistState: async (state) => {
+        if (terminal || !this.recovery) throw new Error('terminal');
+        this.recovery.state.fill(0);
+        this.recovery.state = state.slice();
+        exposed.state.fill(0);
+        exposed.state = state.slice();
+      },
+      complete: async (records) => {
+        if (terminal) throw new Error('terminal');
+        terminal = true;
+        this.completed = records.map((record) => ({ ...record, proof: record.proof.slice() }));
+        this.recovery = null;
+        return records.map((_record, index) => (index + 1).toString(16).padStart(64, '0'));
+      },
+    };
+    return operation(exposed, locked);
+  }
+}
+
+beforeEach(() => {
+  mocked.sdk = {
+    initial_bolt11_quote_key_checkpoint_v1: () => new Uint8Array([1]),
+    WasmBolt11BatV2AcquisitionV2: {
+      restore: (state: Uint8Array) => new FakeBatV2Acquisition(state),
+    },
+  };
+});
+
+describe('BAT V2 class-bound acquisition and recovery', () => {
+  it('uses the verified member entry and exactly one request per quote/status/claim method', async () => {
+    const vault = new FakeVault();
+    const offer = signedOffer();
+    const scope = signedScope(offer);
+    const classBytes = new Uint8Array([10, 11, 12]);
+    const begin = vi.fn((
+      scopeBytes: Uint8Array,
+      offerId: number,
+      receivedClass: Uint8Array,
+    ) => {
+      expect(bytesToHex(scopeBytes)).toBe(scopeIdHex);
+      expect(offerId).toBe(7);
+      expect(receivedClass).toEqual(classBytes);
+      return new FakeBatV2Acquisition();
+    });
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string, init: RequestInit = {}) => {
+      requests.push({ url, init });
+      if (url.endsWith('/v1/quote-keys/current')) {
+        return binaryResponse(delegationType, [1]);
+      }
+      if (url.endsWith('/v2/quotes/bolt11')) return binaryResponse(quoteType, [2]);
+      if (url.endsWith('/status')) return binaryResponse(quoteType, [3]);
+      if (url.endsWith('/claim')) return binaryResponse(issuanceType, [4]);
+      throw new Error(`unexpected URL ${url}`);
+    }) as unknown as typeof fetch;
+
+    const controller = await BatV2AcquisitionControllerV2.start({
+      vault: vault as never,
+      policy: signedPolicy(begin),
+      scope,
+      offer,
+      classBytes,
+      network: 'signet',
+      expectedPayeePubkey: payee,
+      fetchImpl,
+      assertReady: () => undefined,
+    });
+
+    expect(begin).toHaveBeenCalledOnce();
+    expect(vault.createdWithoutProviderCoordinates).toBe(true);
+    expect(requests).toHaveLength(2);
+    expect(requests[1].url).toBe('https://issuer.example/v2/quotes/bolt11');
+    expect(contentType(requests[1].init)).toBe(quoteIntentType);
+    expect(acceptType(requests[1].init)).toBe(quoteType);
+    await expect(controller.ensureQuote()).resolves.toBe('lnbc1batv2');
+    expect(requests).toHaveLength(2);
+
+    await expect(controller.pollStatus()).resolves.toBe('payment-settled');
+    expect(requests).toHaveLength(3);
+    expect(requests[2].url).toBe(`https://issuer.example/v2/quotes/${'77'.repeat(32)}/status`);
+    expect(contentType(requests[2].init)).toBe(statusType);
+    expect(acceptType(requests[2].init)).toBe(quoteType);
+
+    await expect(controller.claim()).resolves.toBe(1);
+    expect(requests).toHaveLength(4);
+    expect(requests[3].url).toBe(`https://issuer.example/v2/quotes/${'77'.repeat(32)}/claim`);
+    expect(contentType(requests[3].init)).toBe(claimType);
+    expect(acceptType(requests[3].init)).toBe(issuanceType);
+    expect(vault.recovery).toBeNull();
+    expect(vault.completed).toEqual([{
+      issuerIdHex,
+      classIdHex,
+      classDigestHex,
+      classKeyEpoch: '4',
+      batKeyIdHex,
+      proof: new Uint8Array(210).fill(9),
+      globalSpendKeyHex: '88'.repeat(32),
+    }]);
+    controller.close();
+  });
+
+  it('returns the exact durable recovery after a lost quote response and resumes without I/O', async () => {
+    const vault = new FakeVault();
+    const firstFetch = vi.fn(async (url: string, init: RequestInit = {}) => {
+      if (url.endsWith('/v1/quote-keys/current')) return binaryResponse(delegationType, [1]);
+      expect(contentType(init)).toBe(quoteIntentType);
+      throw new Error('response lost');
+    }) as unknown as typeof fetch;
+    const offer = signedOffer();
+
+    const failure = await BatV2AcquisitionControllerV2.start({
+      vault: vault as never,
+      policy: signedPolicy(() => new FakeBatV2Acquisition()),
+      scope: signedScope(offer),
+      offer,
+      classBytes: new Uint8Array([1]),
+      network: 'signet',
+      expectedPayeePubkey: payee,
+      fetchImpl: firstFetch,
+      assertReady: () => undefined,
+    }).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(BatV2RecoveryRequiredErrorV2);
+    expect((failure as BatV2RecoveryRequiredErrorV2).recoveryId).toBe(recoveryId);
+    expect(firstFetch).toHaveBeenCalledTimes(2);
+    expect(vault.recovery?.id).toBe(recoveryId);
+
+    const resumeFetch = vi.fn(async (url: string) => {
+      expect(url).toBe('https://issuer.example/v2/quotes/bolt11');
+      return binaryResponse(quoteType, [2]);
+    }) as unknown as typeof fetch;
+    const resumed = await BatV2AcquisitionControllerV2.resume({
+      vault: vault as never,
+      recoveryId,
+      issuerEndpoint: 'https://issuer.example',
+      issuerIdHex,
+      network: 'signet',
+      expectedPayeePubkey: payee,
+      fetchImpl: resumeFetch,
+      assertReady: () => undefined,
+    });
+    expect(resumeFetch).not.toHaveBeenCalled();
+    await expect(resumed.ensureQuote()).resolves.toBe('lnbc1batv2');
+    expect(resumeFetch).toHaveBeenCalledOnce();
+    resumed.close();
+  });
+
+  it('rechecks strict-session readiness after delegation and sends no quote POST', async () => {
+    const vault = new FakeVault();
+    let ready = true;
+    const fetchImpl = vi.fn(async (url: string) => {
+      expect(url).toBe('https://issuer.example/v1/quote-keys/current');
+      ready = false;
+      return binaryResponse(delegationType, [1]);
+    }) as unknown as typeof fetch;
+    const offer = signedOffer();
+
+    await expect(BatV2AcquisitionControllerV2.start({
+      vault: vault as never,
+      policy: signedPolicy(() => new FakeBatV2Acquisition()),
+      scope: signedScope(offer),
+      offer,
+      classBytes: new Uint8Array([1]),
+      network: 'signet',
+      expectedPayeePubkey: payee,
+      fetchImpl,
+      assertReady: () => {
+        if (!ready) throw new Error('strict pair rotated');
+      },
+    })).rejects.toThrow(/strict pair rotated/);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(vault.createRecovery).not.toHaveBeenCalled();
+  });
+});
+
+function signedOffer(): ServiceOfferViewV1 {
+  return {
+    offerId: 7,
+    acquisition: 'bolt11',
+    authorization: 'cashu-bat-v2',
+    freeMode: 'not-free',
+    verification: 'shared-issuer-online',
+    deploymentStatus: 'stable',
+    priorityClass: 1,
+    price: { kind: 'msat', amount: '1000' },
+    issuerIdHex,
+    keyIdHex: '99'.repeat(16),
+    batVerificationKeyFingerprintHex: 'aa'.repeat(32),
+    arcVerificationKeyFingerprintHex: '',
+    endpoint: 'https://issuer.example',
+    credentialCount: 2,
+    credentialPresentationLimit: 1,
+    privacyLeakageBits: 1,
+  };
+}
+
+function signedScope(offer: ServiceOfferViewV1): ServiceScopeViewV1 {
+  return {
+    scopeIdHex,
+    backend: 'dpf-pir',
+    workload: 'dpf-query',
+    protocolVersion: 1,
+    operationProfile: 1,
+    entitlementProfile: 1,
+    dataset: { kind: 'manifest-root', rootHex: 'ab'.repeat(32) },
+    limits: {
+      maxLogicalInputs: 1,
+      maxFrames: 64,
+      maxRequestBytes: '1048576',
+      maxResponseBytes: '2097152',
+      maxWallTimeMs: 30_000,
+      maxConcurrentSockets: 1,
+      maxHintGroups: 0,
+      maxWorkUnits: '10000',
+    },
+    offers: [offer],
+  };
+}
+
+function signedPolicy(
+  begin: NonNullable<WasmAcceptedServicePolicyV1['beginBatV2Acquisition']>,
+): WasmAcceptedServicePolicyV1 {
+  return {
+    free: vi.fn(),
+    providerIdHex: 'bc'.repeat(32),
+    policyDigestHex: 'cd'.repeat(32),
+    policyEpoch: '1',
+    expiresAtUnix: '9999999999',
+    checkpointBytes: () => new Uint8Array([1]),
+    acknowledgeCheckpointPersisted: vi.fn(),
+    validateAuthorizationProof: vi.fn(),
+    importStandardCashuToken: vi.fn(),
+    offersJson: vi.fn(),
+    beginBolt11Acquisition: () => { throw new Error('wrong acquisition path'); },
+    beginBatV2Acquisition: begin,
+  };
+}
+
+function binaryResponse(contentTypeValue: string, bytes: number[]): Response {
+  return new Response(new Uint8Array(bytes), {
+    headers: { 'Content-Type': contentTypeValue },
+  });
+}
+
+function contentType(init: RequestInit): string | null {
+  return new Headers(init.headers).get('Content-Type');
+}
+
+function acceptType(init: RequestInit): string | null {
+  return new Headers(init.headers).get('Accept');
+}
+
+function cloneRecovery(value: BatV2RecoveryRecordV2): BatV2RecoveryRecordV2 {
+  return { ...value, state: value.state.slice() };
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}

--- a/web/src/bat-v2-vault.ts
+++ b/web/src/bat-v2-vault.ts
@@ -18,6 +18,7 @@ const RECOVERY_STORE = 'recoveries';
 const QUOTE_KEY_STORE = 'quote-key-checkpoints';
 const KEY_ID = 'non-extractable-aes-gcm-v1';
 const GLOBAL_LOCK = 'bitcoinpir:bat-v2-vault:v1';
+const RESERVATION_OWNER_LOCK_PREFIX = 'bitcoinpir:bat-v2-reservation-owner:v1';
 const RECORD_AAD_DOMAIN = 'BitcoinPIR/bat-v2-vault/record/v1';
 const RECOVERY_AAD_DOMAIN = 'BitcoinPIR/bat-v2-vault/recovery/v1';
 const QUOTE_KEY_AAD_DOMAIN = 'BitcoinPIR/bat-v2-vault/quote-key-checkpoint/v1';
@@ -115,7 +116,14 @@ interface DecryptedRecordV1 {
   plain: PlainRecordV1;
 }
 
+interface ReservationOwnerV1 {
+  readonly remainingRecordIds: Set<string>;
+  release(): void;
+}
+
 export class BatV2CredentialVaultV2 {
+  private readonly reservationOwners = new Map<string, ReservationOwnerV1>();
+
   private constructor(
     private readonly db: IDBDatabase,
     private readonly key: CryptoKey,
@@ -149,6 +157,9 @@ export class BatV2CredentialVaultV2 {
   }
 
   close(): void {
+    for (const reservationId of [...this.reservationOwners.keys()]) {
+      this.releaseReservationOwner(reservationId);
+    }
     this.db.close();
   }
 
@@ -359,18 +370,32 @@ export class BatV2CredentialVaultV2 {
         }
 
         const reservationId = randomId();
-        const firstLease = reservedProof(firstMatch, reservationId);
-        const secondLease = reservedProof(secondMatch, reservationId);
-        const replacements = await Promise.all([firstMatch, secondMatch].map(({ row, plain }) =>
-          this.encryptRecord(
-            row.id,
-            walletRecord(plain),
-            'reserved',
-            reservationId,
-            row.spendKeyDigestHex,
-          )));
-        await putRecordsTransaction(this.db, replacements);
-        return { reservationId, first: firstLease, second: secondLease };
+        const owner = await acquireReservationOwnerLock(reservationId);
+        this.reservationOwners.set(reservationId, {
+          remainingRecordIds: new Set([firstMatch.row.id, secondMatch.row.id]),
+          release: owner.release,
+        });
+        let firstLease: BatV2ReservedProofV2 | undefined;
+        let secondLease: BatV2ReservedProofV2 | undefined;
+        try {
+          firstLease = reservedProof(firstMatch, reservationId);
+          secondLease = reservedProof(secondMatch, reservationId);
+          const replacements = await Promise.all([firstMatch, secondMatch].map(({ row, plain }) =>
+            this.encryptRecord(
+              row.id,
+              walletRecord(plain),
+              'reserved',
+              reservationId,
+              row.spendKeyDigestHex,
+            )));
+          await putRecordsTransaction(this.db, replacements);
+          return { reservationId, first: firstLease, second: secondLease };
+        } catch (error) {
+          firstLease?.proof.fill(0);
+          secondLease?.proof.fill(0);
+          this.releaseReservationOwner(reservationId);
+          throw error;
+        }
       } finally {
         zeroPlainRecords(records);
       }
@@ -413,6 +438,7 @@ export class BatV2CredentialVaultV2 {
             ),
           );
         }
+        this.finishReservationOwnerLeg(lease.reservationId, lease.recordId);
       } finally {
         zeroPlainRecord(decrypted.plain);
         lease.proof.fill(0);
@@ -423,13 +449,36 @@ export class BatV2CredentialVaultV2 {
   private async burnOrphanedReservationsUnlocked(): Promise<void> {
     const records = await this.decryptAllRecordsUnlocked();
     try {
-      const orphaned = records
-        .filter(({ plain }) => plain.state === 'reserved')
-        .map(({ row }) => row.id);
-      if (orphaned.length > 0) await deleteRecordsTransaction(this.db, orphaned);
+      const reservations = new Map<string, string[]>();
+      for (const { row, plain } of records) {
+        if (plain.state !== 'reserved') continue;
+        const reservationId = plain.reservationId!;
+        const ids = reservations.get(reservationId) ?? [];
+        ids.push(row.id);
+        reservations.set(reservationId, ids);
+      }
+      for (const [reservationId, ids] of reservations) {
+        await withAvailableReservationOwnerLock(reservationId, async () => {
+          await deleteRecordsTransaction(this.db, ids);
+        });
+      }
     } finally {
       zeroPlainRecords(records);
     }
+  }
+
+  private finishReservationOwnerLeg(reservationId: string, recordId: string): void {
+    const owner = this.reservationOwners.get(reservationId);
+    if (!owner) return;
+    owner.remainingRecordIds.delete(recordId);
+    if (owner.remainingRecordIds.size === 0) this.releaseReservationOwner(reservationId);
+  }
+
+  private releaseReservationOwner(reservationId: string): void {
+    const owner = this.reservationOwners.get(reservationId);
+    if (!owner) return;
+    this.reservationOwners.delete(reservationId);
+    owner.release();
   }
 
   private async completeAcquisitionUnlocked(
@@ -822,6 +871,68 @@ function requireBrowserPrimitives(): void {
 
 async function withExclusiveLock<T>(body: () => Promise<T>): Promise<T> {
   return navigator.locks.request(GLOBAL_LOCK, { mode: 'exclusive' }, body);
+}
+
+async function acquireReservationOwnerLock(
+  reservationId: string,
+): Promise<Pick<ReservationOwnerV1, 'release'>> {
+  const name = reservationOwnerLockName(reservationId);
+  let releaseHeldLock!: () => void;
+  const held = new Promise<void>((resolve) => {
+    releaseHeldLock = resolve;
+  });
+  let resolveAcquired!: () => void;
+  let rejectAcquired!: (error: unknown) => void;
+  const acquired = new Promise<void>((resolve, reject) => {
+    resolveAcquired = resolve;
+    rejectAcquired = reject;
+  });
+  let request: Promise<void>;
+  try {
+    request = Promise.resolve(
+      navigator.locks.request(name, { mode: 'exclusive' }, async (lock) => {
+        if (!lock) throw new Error('BAT V2 reservation owner lock was not acquired');
+        resolveAcquired();
+        await held;
+      }),
+    );
+  } catch (error) {
+    rejectAcquired(error);
+    throw error;
+  }
+  void request.then(
+    () => rejectAcquired(new Error('BAT V2 reservation owner lock ended before acquisition')),
+    rejectAcquired,
+  );
+  await acquired;
+  let released = false;
+  return {
+    release: () => {
+      if (released) return;
+      released = true;
+      releaseHeldLock();
+    },
+  };
+}
+
+async function withAvailableReservationOwnerLock(
+  reservationId: string,
+  body: () => Promise<void>,
+): Promise<void> {
+  await navigator.locks.request(
+    reservationOwnerLockName(reservationId),
+    { mode: 'exclusive', ifAvailable: true },
+    async (lock) => {
+      if (!lock) return;
+      await body();
+    },
+  );
+}
+
+function reservationOwnerLockName(reservationId: string): string {
+  return `${RESERVATION_OWNER_LOCK_PREFIX}:${canonicalOpaqueId(
+    'BAT V2 reservation ID', reservationId,
+  )}`;
 }
 
 function openDb(): Promise<IDBDatabase> {

--- a/web/src/bat-v2-vault.ts
+++ b/web/src/bat-v2-vault.ts
@@ -1,0 +1,1024 @@
+import { Buffer } from 'buffer';
+
+/**
+ * Encrypted, issuer/class-scoped browser wallet for issuer-wide BAT V2.
+ *
+ * This database is intentionally disjoint from `bitcoinpir-admission-v1`.
+ * BAT V2 records never acquire provider/policy/scope/offer coordinates and
+ * V1 records are neither read nor migrated.  Web Locks serialize all wallet
+ * mutations across tabs; IndexedDB transactions make pair reservation and
+ * acquisition completion atomic.
+ */
+
+const DB_NAME = 'bitcoinpir-bat-v2';
+const DB_VERSION = 1;
+const META_STORE = 'meta';
+const RECORD_STORE = 'records';
+const RECOVERY_STORE = 'recoveries';
+const QUOTE_KEY_STORE = 'quote-key-checkpoints';
+const KEY_ID = 'non-extractable-aes-gcm-v1';
+const GLOBAL_LOCK = 'bitcoinpir:bat-v2-vault:v1';
+const RECORD_AAD_DOMAIN = 'BitcoinPIR/bat-v2-vault/record/v1';
+const RECOVERY_AAD_DOMAIN = 'BitcoinPIR/bat-v2-vault/recovery/v1';
+const QUOTE_KEY_AAD_DOMAIN = 'BitcoinPIR/bat-v2-vault/quote-key-checkpoint/v1';
+const QUOTE_KEY_ID_DOMAIN = 'BitcoinPIR/bat-v2-vault/quote-key-id/v1';
+const SPEND_KEY_DIGEST_DOMAIN = 'BitcoinPIR/bat-v2-vault/spend-key/v1';
+const SPEND_KEY_INDEX = 'by-spend-key-digest';
+const BAT_V2_PROOF_LEN = 210;
+const MAX_RECOVERY_STATE_LEN = 4 * 1024 * 1024;
+const MAX_QUOTE_KEY_CHECKPOINT_LEN = 64 * 1024;
+
+export type LightningNetworkNameV2 = 'bitcoin' | 'testnet' | 'signet' | 'regtest';
+
+export interface BatV2ClassBindingV2 {
+  issuerIdHex: string;
+  classIdHex: string;
+  classDigestHex: string;
+  classKeyEpoch: string;
+  batKeyIdHex: string;
+}
+
+export interface BatV2WalletRecordV2 extends BatV2ClassBindingV2 {
+  proof: Uint8Array;
+  globalSpendKeyHex: string;
+}
+
+export interface BatV2WalletInventoryV2 extends BatV2ClassBindingV2 {
+  count: number;
+}
+
+export interface BatV2RecoveryRecordV2 {
+  id: string;
+  issuerEndpoint: string;
+  issuerIdHex: string;
+  network: LightningNetworkNameV2;
+  expectedPayeePubkeyHex: string;
+  /** Opaque secret-bearing `WasmBolt11BatV2AcquisitionV2` recovery bytes. */
+  state: Uint8Array;
+}
+
+export interface BatV2ReservedProofV2 extends BatV2WalletRecordV2 {
+  readonly recordId: string;
+  readonly reservationId: string;
+}
+
+export interface BatV2DistinctPairReservationV2 {
+  readonly reservationId: string;
+  readonly first: BatV2ReservedProofV2;
+  readonly second: BatV2ReservedProofV2;
+}
+
+export type BatV2ReservationDispositionV2 = 'recover-safe' | 'burn';
+
+export interface LockedBatV2RecoveryV2 {
+  persistState(state: Uint8Array): Promise<void>;
+  complete(records: BatV2WalletRecordV2[]): Promise<string[]>;
+}
+
+interface KeyRecordV1 {
+  id: string;
+  key: CryptoKey;
+}
+
+interface CipherRecordV1 {
+  id: string;
+  spendKeyDigestHex: string;
+  iv: ArrayBuffer;
+  ciphertext: ArrayBuffer;
+}
+
+interface CipherRecoveryV1 {
+  id: string;
+  iv: ArrayBuffer;
+  ciphertext: ArrayBuffer;
+}
+
+interface PlainRecordV1 extends BatV2ClassBindingV2 {
+  version: 1;
+  proofBase64: string;
+  globalSpendKeyHex: string;
+  state: 'available' | 'reserved';
+  reservationId?: string;
+}
+
+interface PlainRecoveryV1 {
+  version: 1;
+  issuerEndpoint: string;
+  issuerIdHex: string;
+  network: LightningNetworkNameV2;
+  expectedPayeePubkeyHex: string;
+  stateBase64: string;
+}
+
+interface DecryptedRecordV1 {
+  row: CipherRecordV1;
+  plain: PlainRecordV1;
+}
+
+export class BatV2CredentialVaultV2 {
+  private constructor(
+    private readonly db: IDBDatabase,
+    private readonly key: CryptoKey,
+  ) {}
+
+  static async open(): Promise<BatV2CredentialVaultV2> {
+    requireBrowserPrimitives();
+    return withExclusiveLock(async () => {
+      const db = await openDb();
+      try {
+        let key = await getValue<KeyRecordV1>(db, META_STORE, KEY_ID).then((row) => row?.key);
+        if (!key) {
+          key = await crypto.subtle.generateKey(
+            { name: 'AES-GCM', length: 256 },
+            false,
+            ['encrypt', 'decrypt'],
+          );
+          await putValue(db, META_STORE, { id: KEY_ID, key } satisfies KeyRecordV1);
+        }
+        if (key.extractable || key.algorithm.name !== 'AES-GCM') {
+          throw new Error('BAT V2 vault key is not a non-extractable AES-GCM key');
+        }
+        const vault = new BatV2CredentialVaultV2(db, key);
+        await vault.burnOrphanedReservationsUnlocked();
+        return vault;
+      } catch (error) {
+        db.close();
+        throw error;
+      }
+    });
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  /** Create encrypted class-only recovery before the first issuer POST. */
+  async createRecovery(
+    recovery: Omit<BatV2RecoveryRecordV2, 'id'>,
+  ): Promise<BatV2RecoveryRecordV2> {
+    const id = randomId();
+    const value = { ...recovery, id, state: recovery.state.slice() };
+    validateRecovery(value);
+    const row = await this.encryptRecovery(value);
+    await withExclusiveLock(async () => addValue(this.db, RECOVERY_STORE, row));
+    return cloneRecovery(value);
+  }
+
+  async getRecovery(id: string): Promise<BatV2RecoveryRecordV2 | null> {
+    canonicalOpaqueId('BAT V2 recovery ID', id);
+    return withExclusiveLock(async () => {
+      const row = await getValue<CipherRecoveryV1>(this.db, RECOVERY_STORE, id);
+      return row ? this.decryptRecovery(row) : null;
+    });
+  }
+
+  async listRecoveries(): Promise<BatV2RecoveryRecordV2[]> {
+    return withExclusiveLock(async () => {
+      const rows = await getAllValues<CipherRecoveryV1>(this.db, RECOVERY_STORE);
+      return Promise.all(rows.map((row) => this.decryptRecovery(row)));
+    });
+  }
+
+  /** Durably advance the issuer/network/payee quote-key rollback checkpoint. */
+  async advanceQuoteKeyCheckpoint<T>(
+    issuerIdHex: string,
+    network: LightningNetworkNameV2,
+    expectedPayeePubkeyHex: string,
+    initialCheckpoint: Uint8Array,
+    advance: (current: Uint8Array) => {
+      nextCheckpoint: Uint8Array;
+      value: T;
+      discard?: () => void;
+    },
+  ): Promise<T> {
+    const issuerId = canonicalHex32('issuerIdHex', issuerIdHex);
+    if (!['bitcoin', 'testnet', 'signet', 'regtest'].includes(network)) {
+      throw new Error('unsupported BAT V2 Lightning network');
+    }
+    const payee = canonicalCompressedPointHex('expectedPayeePubkeyHex', expectedPayeePubkeyHex);
+    validateQuoteKeyCheckpoint(initialCheckpoint);
+    const id = await quoteKeyCheckpointId(issuerId, network, payee);
+    return withExclusiveLock(async () => {
+      const row = await getValue<CipherRecoveryV1>(this.db, QUOTE_KEY_STORE, id);
+      const current = row
+        ? await this.decryptOpaqueBytes(row, QUOTE_KEY_AAD_DOMAIN)
+        : initialCheckpoint.slice();
+      const input = current.slice();
+      let result: ReturnType<typeof advance>;
+      try {
+        result = advance(input);
+      } finally {
+        input.fill(0);
+        current.fill(0);
+      }
+      try {
+        validateQuoteKeyCheckpoint(result.nextCheckpoint);
+        await putValue(
+          this.db,
+          QUOTE_KEY_STORE,
+          await this.encryptOpaqueBytes(id, result.nextCheckpoint, QUOTE_KEY_AAD_DOMAIN),
+        );
+        return result.value;
+      } catch (error) {
+        result.discard?.();
+        throw error;
+      } finally {
+        result.nextCheckpoint.fill(0);
+      }
+    });
+  }
+
+  /**
+   * Serialize one restore/issuer-I/O/persist transition. The lock spans the
+   * callback so a stale status response cannot overwrite a persisted claim.
+   */
+  async withRecovery<T>(
+    recoveryId: string,
+    operation: (
+      recovery: BatV2RecoveryRecordV2,
+      locked: LockedBatV2RecoveryV2,
+    ) => Promise<T>,
+  ): Promise<T> {
+    canonicalOpaqueId('BAT V2 recovery ID', recoveryId);
+    return withExclusiveLock(async () => {
+      const row = await getValue<CipherRecoveryV1>(this.db, RECOVERY_STORE, recoveryId);
+      if (!row) throw new Error('BAT V2 recovery was not found (it may be complete)');
+      const current = await this.decryptRecovery(row);
+      const exposed = cloneRecovery(current);
+      let terminal = false;
+      const locked: LockedBatV2RecoveryV2 = {
+        persistState: async (state) => {
+          if (terminal) throw new Error('BAT V2 recovery transition is already terminal');
+          validateRecoveryState(state);
+          const successor = { ...current, state: state.slice() };
+          await putValue(this.db, RECOVERY_STORE, await this.encryptRecovery(successor));
+          current.state.fill(0);
+          current.state = successor.state;
+          exposed.state.fill(0);
+          exposed.state = successor.state.slice();
+        },
+        complete: async (records) => {
+          if (terminal) throw new Error('BAT V2 recovery transition is already terminal');
+          const ids = await this.completeAcquisitionUnlocked(recoveryId, current, records);
+          terminal = true;
+          return ids;
+        },
+      };
+      try {
+        return await operation(exposed, locked);
+      } finally {
+        current.state.fill(0);
+        exposed.state.fill(0);
+      }
+    });
+  }
+
+  /**
+   * Install a verified issuance batch and delete its recovery in one IDB
+   * transaction. The issuer/class tuple is provider-independent.
+   */
+  async completeAcquisition(
+    recoveryId: string,
+    records: BatV2WalletRecordV2[],
+  ): Promise<string[]> {
+    canonicalOpaqueId('BAT V2 recovery ID', recoveryId);
+    if (records.length === 0 || records.length > 65_535) {
+      throw new Error('BAT V2 acquisition returned an invalid proof count');
+    }
+    return withExclusiveLock(async () => {
+      const recoveryRow = await getValue<CipherRecoveryV1>(this.db, RECOVERY_STORE, recoveryId);
+      if (!recoveryRow) throw new Error('BAT V2 recovery was not found (it may be complete)');
+      const recovery = await this.decryptRecovery(recoveryRow);
+      try {
+        return await this.completeAcquisitionUnlocked(recoveryId, recovery, records);
+      } finally {
+        recovery.state.fill(0);
+      }
+    });
+  }
+
+  /** Aggregate non-secret class inventory; proofs and spend keys never escape. */
+  async listInventory(): Promise<BatV2WalletInventoryV2[]> {
+    return withExclusiveLock(async () => {
+      const records = await this.decryptAllRecordsUnlocked();
+      const aggregate = new Map<string, BatV2WalletInventoryV2>();
+      try {
+        for (const { plain } of records) {
+          if (plain.state !== 'available') continue;
+          const key = classBindingKey(plain);
+          const existing = aggregate.get(key);
+          if (existing) existing.count += 1;
+          else aggregate.set(key, { ...classBinding(plain), count: 1 });
+        }
+        return [...aggregate.values()].sort((left, right) =>
+          classBindingKey(left).localeCompare(classBindingKey(right)));
+      } finally {
+        zeroPlainRecords(records);
+      }
+    });
+  }
+
+  /**
+   * Atomically reserve two distinct proofs before either provider sees one.
+   * A single proof, or two rows with the same issuer-global spend key, yields
+   * no lease and leaves the wallet unchanged.
+   */
+  async reserveDistinctPair(
+    firstBinding: BatV2ClassBindingV2,
+    secondBinding: BatV2ClassBindingV2,
+    validateBeforeReserve?: (record: BatV2WalletRecordV2) => void,
+  ): Promise<BatV2DistinctPairReservationV2 | null> {
+    const first = normalizeClassBinding(firstBinding);
+    const second = normalizeClassBinding(secondBinding);
+    if (!sameClassBinding(first, second)) {
+      throw new Error('a BAT V2 pair must use one exact acceptance class');
+    }
+    return withExclusiveLock(async () => {
+      const records = await this.decryptAllRecordsUnlocked();
+      let firstMatch: DecryptedRecordV1 | undefined;
+      let secondMatch: DecryptedRecordV1 | undefined;
+      try {
+        firstMatch = records.find(({ plain }) =>
+          plain.state === 'available' && sameClassBinding(plain, first));
+        secondMatch = records.find(({ row, plain }) =>
+          row.id !== firstMatch?.row.id
+            && row.spendKeyDigestHex !== firstMatch?.row.spendKeyDigestHex
+            && plain.state === 'available'
+            && sameClassBinding(plain, second));
+        if (!firstMatch || !secondMatch) return null;
+
+        if (validateBeforeReserve) {
+          for (const selected of [firstMatch, secondMatch]) {
+            const candidate = walletRecord(selected.plain);
+            try {
+              validateBeforeReserve(candidate);
+            } finally {
+              candidate.proof.fill(0);
+            }
+          }
+        }
+
+        const reservationId = randomId();
+        const firstLease = reservedProof(firstMatch, reservationId);
+        const secondLease = reservedProof(secondMatch, reservationId);
+        const replacements = await Promise.all([firstMatch, secondMatch].map(({ row, plain }) =>
+          this.encryptRecord(
+            row.id,
+            walletRecord(plain),
+            'reserved',
+            reservationId,
+            row.spendKeyDigestHex,
+          )));
+        await putRecordsTransaction(this.db, replacements);
+        return { reservationId, first: firstLease, second: secondLease };
+      } finally {
+        zeroPlainRecords(records);
+      }
+    });
+  }
+
+  /** Complete one reserved leg. Recover-safe makes it available; burn deletes it. */
+  async finishReservation(
+    lease: BatV2ReservedProofV2,
+    disposition: BatV2ReservationDispositionV2,
+  ): Promise<void> {
+    if (disposition !== 'recover-safe' && disposition !== 'burn') {
+      throw new Error('unknown BAT V2 reservation disposition');
+    }
+    canonicalOpaqueId('BAT V2 record ID', lease.recordId);
+    canonicalOpaqueId('BAT V2 reservation ID', lease.reservationId);
+    await withExclusiveLock(async () => {
+      const row = await getValue<CipherRecordV1>(this.db, RECORD_STORE, lease.recordId);
+      if (!row) throw new Error('BAT V2 reserved proof is no longer available');
+      const decrypted = await this.decryptRecord(row);
+      try {
+        if (decrypted.plain.state !== 'reserved'
+            || decrypted.plain.reservationId !== lease.reservationId
+            || !sameClassBinding(decrypted.plain, lease)
+            || decrypted.plain.globalSpendKeyHex !== lease.globalSpendKeyHex) {
+          throw new Error('BAT V2 reservation lease does not match durable state');
+        }
+        if (disposition === 'burn') {
+          await deleteValue(this.db, RECORD_STORE, row.id);
+        } else {
+          await putValue(
+            this.db,
+            RECORD_STORE,
+            await this.encryptRecord(
+              row.id,
+              walletRecord(decrypted.plain),
+              'available',
+              undefined,
+              row.spendKeyDigestHex,
+            ),
+          );
+        }
+      } finally {
+        zeroPlainRecord(decrypted.plain);
+        lease.proof.fill(0);
+      }
+    });
+  }
+
+  private async burnOrphanedReservationsUnlocked(): Promise<void> {
+    const records = await this.decryptAllRecordsUnlocked();
+    try {
+      const orphaned = records
+        .filter(({ plain }) => plain.state === 'reserved')
+        .map(({ row }) => row.id);
+      if (orphaned.length > 0) await deleteRecordsTransaction(this.db, orphaned);
+    } finally {
+      zeroPlainRecords(records);
+    }
+  }
+
+  private async completeAcquisitionUnlocked(
+    recoveryId: string,
+    recovery: BatV2RecoveryRecordV2,
+    records: BatV2WalletRecordV2[],
+  ): Promise<string[]> {
+    if (records.length === 0 || records.length > 65_535) {
+      throw new Error('BAT V2 acquisition returned an invalid proof count');
+    }
+    const normalized = records.map(normalizeWalletRecord);
+    try {
+      for (const record of normalized) {
+        if (record.issuerIdHex !== recovery.issuerIdHex) {
+          throw new Error('issued BAT V2 proof does not match the recovery issuer');
+        }
+      }
+      requireSingleClassBatch(normalized);
+      const spendDigests = await Promise.all(normalized.map((record) =>
+        spendKeyDigestHex(record.globalSpendKeyHex)));
+      if (new Set(spendDigests).size !== spendDigests.length) {
+        throw new Error('BAT V2 issuance returned a duplicate global spend key');
+      }
+      const ids = normalized.map(() => randomId());
+      const encrypted = await Promise.all(normalized.map((record, index) =>
+        this.encryptRecord(ids[index], record, 'available', undefined, spendDigests[index])));
+      await completeAcquisitionTransaction(this.db, recoveryId, encrypted);
+      recovery.state.fill(0);
+      return ids;
+    } finally {
+      for (const record of normalized) record.proof.fill(0);
+    }
+  }
+
+  private async decryptAllRecordsUnlocked(): Promise<DecryptedRecordV1[]> {
+    const rows = await getAllValues<CipherRecordV1>(this.db, RECORD_STORE);
+    const result: DecryptedRecordV1[] = [];
+    try {
+      for (const row of rows) result.push(await this.decryptRecord(row));
+      return result;
+    } catch (error) {
+      zeroPlainRecords(result);
+      throw error;
+    }
+  }
+
+  private async encryptRecord(
+    id: string,
+    record: BatV2WalletRecordV2,
+    state: PlainRecordV1['state'],
+    reservationId: string | undefined,
+    spendDigest?: string,
+  ): Promise<CipherRecordV1> {
+    canonicalOpaqueId('BAT V2 record ID', id);
+    const normalized = normalizeWalletRecord(record);
+    const spendKeyDigest = spendDigest ?? await spendKeyDigestHex(normalized.globalSpendKeyHex);
+    canonicalHex32('spendKeyDigestHex', spendKeyDigest);
+    if ((state === 'reserved') !== (reservationId !== undefined)) {
+      throw new Error('BAT V2 reserved state must carry exactly one reservation ID');
+    }
+    if (reservationId !== undefined) canonicalOpaqueId('BAT V2 reservation ID', reservationId);
+    const plain: PlainRecordV1 = {
+      version: 1,
+      ...classBinding(normalized),
+      proofBase64: bytesToBase64(normalized.proof),
+      globalSpendKeyHex: normalized.globalSpendKeyHex,
+      state,
+      ...(reservationId === undefined ? {} : { reservationId }),
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(plain));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    try {
+      const ciphertext = await crypto.subtle.encrypt(
+        {
+          name: 'AES-GCM',
+          iv: ownedArrayBuffer(iv),
+          additionalData: aad(RECORD_AAD_DOMAIN, id, spendKeyDigest),
+        },
+        this.key,
+        ownedArrayBuffer(bytes),
+      );
+      return { id, spendKeyDigestHex: spendKeyDigest, iv: ownedArrayBuffer(iv), ciphertext };
+    } finally {
+      bytes.fill(0);
+      normalized.proof.fill(0);
+    }
+  }
+
+  private async decryptRecord(row: CipherRecordV1): Promise<DecryptedRecordV1> {
+    try {
+      canonicalOpaqueId('BAT V2 record ID', row.id);
+      canonicalHex32('spendKeyDigestHex', row.spendKeyDigestHex);
+      const bytes = new Uint8Array(await crypto.subtle.decrypt(
+        {
+          name: 'AES-GCM',
+          iv: row.iv,
+          additionalData: aad(RECORD_AAD_DOMAIN, row.id, row.spendKeyDigestHex),
+        },
+        this.key,
+        row.ciphertext,
+      ));
+      try {
+        const plain = JSON.parse(new TextDecoder().decode(bytes)) as PlainRecordV1;
+        validatePlainRecord(plain);
+        const actualDigest = await spendKeyDigestHex(plain.globalSpendKeyHex);
+        if (actualDigest !== row.spendKeyDigestHex) throw new Error('spend key digest');
+        return { row, plain };
+      } finally {
+        bytes.fill(0);
+      }
+    } catch {
+      throw new Error('BAT V2 wallet record authentication or decoding failed');
+    }
+  }
+
+  private async encryptRecovery(value: BatV2RecoveryRecordV2): Promise<CipherRecoveryV1> {
+    validateRecovery(value);
+    const plain: PlainRecoveryV1 = {
+      version: 1,
+      issuerEndpoint: canonicalIssuerEndpoint(value.issuerEndpoint),
+      issuerIdHex: canonicalHex32('issuerIdHex', value.issuerIdHex),
+      network: value.network,
+      expectedPayeePubkeyHex: canonicalCompressedPointHex(
+        'expectedPayeePubkeyHex', value.expectedPayeePubkeyHex,
+      ),
+      stateBase64: bytesToBase64(value.state),
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(plain));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    try {
+      const ciphertext = await crypto.subtle.encrypt(
+        {
+          name: 'AES-GCM',
+          iv: ownedArrayBuffer(iv),
+          additionalData: aad(RECOVERY_AAD_DOMAIN, value.id),
+        },
+        this.key,
+        ownedArrayBuffer(bytes),
+      );
+      return { id: value.id, iv: ownedArrayBuffer(iv), ciphertext };
+    } finally {
+      bytes.fill(0);
+    }
+  }
+
+  private async encryptOpaqueBytes(
+    id: string,
+    value: Uint8Array,
+    domain: string,
+  ): Promise<CipherRecoveryV1> {
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await crypto.subtle.encrypt(
+      {
+        name: 'AES-GCM',
+        iv: ownedArrayBuffer(iv),
+        additionalData: aad(domain, id),
+      },
+      this.key,
+      ownedArrayBuffer(value),
+    );
+    return { id, iv: ownedArrayBuffer(iv), ciphertext };
+  }
+
+  private async decryptOpaqueBytes(row: CipherRecoveryV1, domain: string): Promise<Uint8Array> {
+    try {
+      return new Uint8Array(await crypto.subtle.decrypt(
+        {
+          name: 'AES-GCM',
+          iv: row.iv,
+          additionalData: aad(domain, row.id),
+        },
+        this.key,
+        row.ciphertext,
+      ));
+    } catch {
+      throw new Error('BAT V2 quote-key checkpoint authentication failed');
+    }
+  }
+
+  private async decryptRecovery(row: CipherRecoveryV1): Promise<BatV2RecoveryRecordV2> {
+    try {
+      canonicalOpaqueId('BAT V2 recovery ID', row.id);
+      const bytes = new Uint8Array(await crypto.subtle.decrypt(
+        {
+          name: 'AES-GCM',
+          iv: row.iv,
+          additionalData: aad(RECOVERY_AAD_DOMAIN, row.id),
+        },
+        this.key,
+        row.ciphertext,
+      ));
+      try {
+        const plain = JSON.parse(new TextDecoder().decode(bytes)) as PlainRecoveryV1;
+        if (plain.version !== 1) throw new Error('version');
+        const value: BatV2RecoveryRecordV2 = {
+          id: row.id,
+          issuerEndpoint: plain.issuerEndpoint,
+          issuerIdHex: plain.issuerIdHex,
+          network: plain.network,
+          expectedPayeePubkeyHex: plain.expectedPayeePubkeyHex,
+          state: base64ToBytes(plain.stateBase64),
+        };
+        validateRecovery(value);
+        return value;
+      } finally {
+        bytes.fill(0);
+      }
+    } catch {
+      throw new Error('BAT V2 recovery authentication or decoding failed');
+    }
+  }
+}
+
+export function validateBatV2ClassBindingV2(binding: BatV2ClassBindingV2): void {
+  normalizeClassBinding(binding);
+}
+
+export function validateBatV2WalletRecordV2(record: BatV2WalletRecordV2): void {
+  const normalized = normalizeWalletRecord(record);
+  normalized.proof.fill(0);
+}
+
+function normalizeWalletRecord(record: BatV2WalletRecordV2): BatV2WalletRecordV2 {
+  const binding = normalizeClassBinding(record);
+  if (!(record.proof instanceof Uint8Array) || record.proof.length !== BAT_V2_PROOF_LEN) {
+    throw new Error(`BAT V2 proof must be exactly ${BAT_V2_PROOF_LEN} bytes`);
+  }
+  return {
+    ...binding,
+    proof: record.proof.slice(),
+    globalSpendKeyHex: canonicalHex32('globalSpendKeyHex', record.globalSpendKeyHex),
+  };
+}
+
+function normalizeClassBinding(binding: BatV2ClassBindingV2): BatV2ClassBindingV2 {
+  return {
+    issuerIdHex: canonicalHex32('issuerIdHex', binding.issuerIdHex),
+    classIdHex: canonicalHex32('classIdHex', binding.classIdHex),
+    classDigestHex: canonicalHex32('classDigestHex', binding.classDigestHex),
+    classKeyEpoch: canonicalPositiveDecimal('classKeyEpoch', binding.classKeyEpoch),
+    batKeyIdHex: canonicalHex32('batKeyIdHex', binding.batKeyIdHex),
+  };
+}
+
+function validatePlainRecord(plain: PlainRecordV1): void {
+  if (plain.version !== 1) throw new Error('version');
+  normalizeClassBinding(plain);
+  canonicalHex32('globalSpendKeyHex', plain.globalSpendKeyHex);
+  const proof = base64ToBytes(plain.proofBase64);
+  try {
+    if (proof.length !== BAT_V2_PROOF_LEN) throw new Error('proof length');
+  } finally {
+    proof.fill(0);
+  }
+  if (plain.state === 'available') {
+    if (plain.reservationId !== undefined) throw new Error('available reservation');
+  } else if (plain.state === 'reserved') {
+    if (plain.reservationId === undefined) throw new Error('missing reservation');
+    canonicalOpaqueId('BAT V2 reservation ID', plain.reservationId);
+  } else {
+    throw new Error('state');
+  }
+}
+
+function walletRecord(plain: PlainRecordV1): BatV2WalletRecordV2 {
+  return {
+    ...classBinding(plain),
+    proof: base64ToBytes(plain.proofBase64),
+    globalSpendKeyHex: plain.globalSpendKeyHex,
+  };
+}
+
+function reservedProof(record: DecryptedRecordV1, reservationId: string): BatV2ReservedProofV2 {
+  return {
+    ...walletRecord(record.plain),
+    recordId: record.row.id,
+    reservationId,
+  };
+}
+
+function classBinding(value: BatV2ClassBindingV2): BatV2ClassBindingV2 {
+  return {
+    issuerIdHex: value.issuerIdHex,
+    classIdHex: value.classIdHex,
+    classDigestHex: value.classDigestHex,
+    classKeyEpoch: value.classKeyEpoch,
+    batKeyIdHex: value.batKeyIdHex,
+  };
+}
+
+function classBindingKey(value: BatV2ClassBindingV2): string {
+  return [
+    value.issuerIdHex,
+    value.classIdHex,
+    value.classDigestHex,
+    value.classKeyEpoch,
+    value.batKeyIdHex,
+  ].join(':');
+}
+
+function sameClassBinding(left: BatV2ClassBindingV2, right: BatV2ClassBindingV2): boolean {
+  return classBindingKey(left) === classBindingKey(right);
+}
+
+function requireSingleClassBatch(records: BatV2WalletRecordV2[]): void {
+  const first = classBindingKey(records[0]);
+  if (records.some((record) => classBindingKey(record) !== first)) {
+    throw new Error('one BAT V2 issuance batch must belong to one exact class');
+  }
+}
+
+function validateRecovery(value: BatV2RecoveryRecordV2): void {
+  canonicalOpaqueId('BAT V2 recovery ID', value.id);
+  canonicalIssuerEndpoint(value.issuerEndpoint);
+  canonicalHex32('issuerIdHex', value.issuerIdHex);
+  if (!['bitcoin', 'testnet', 'signet', 'regtest'].includes(value.network)) {
+    throw new Error('unsupported BAT V2 Lightning network');
+  }
+  canonicalCompressedPointHex('expectedPayeePubkeyHex', value.expectedPayeePubkeyHex);
+  validateRecoveryState(value.state);
+}
+
+function validateRecoveryState(state: Uint8Array): void {
+  if (!(state instanceof Uint8Array) || state.length === 0 || state.length > MAX_RECOVERY_STATE_LEN) {
+    throw new Error('BAT V2 recovery state exceeds its bound');
+  }
+}
+
+function validateQuoteKeyCheckpoint(value: Uint8Array): void {
+  if (!(value instanceof Uint8Array)
+      || value.length === 0
+      || value.length > MAX_QUOTE_KEY_CHECKPOINT_LEN) {
+    throw new Error('BAT V2 quote-key checkpoint exceeds its bound');
+  }
+}
+
+async function quoteKeyCheckpointId(
+  issuerIdHex: string,
+  network: LightningNetworkNameV2,
+  payeeHex: string,
+): Promise<string> {
+  const bytes = new TextEncoder().encode(
+    `${QUOTE_KEY_ID_DOMAIN}\0${issuerIdHex}\0${network}\0${payeeHex}`,
+  );
+  try {
+    return bytesToHex(new Uint8Array(await crypto.subtle.digest('SHA-256', bytes)));
+  } finally {
+    bytes.fill(0);
+  }
+}
+
+function cloneRecovery(value: BatV2RecoveryRecordV2): BatV2RecoveryRecordV2 {
+  return { ...value, state: value.state.slice() };
+}
+
+function zeroPlainRecord(plain: PlainRecordV1): void {
+  const proof = base64ToBytes(plain.proofBase64);
+  proof.fill(0);
+  plain.proofBase64 = '';
+  plain.globalSpendKeyHex = '';
+}
+
+function zeroPlainRecords(records: DecryptedRecordV1[]): void {
+  for (const { plain } of records) zeroPlainRecord(plain);
+}
+
+async function spendKeyDigestHex(globalSpendKeyHex: string): Promise<string> {
+  const key = hexToBytes(canonicalHex32('globalSpendKeyHex', globalSpendKeyHex));
+  const domain = new TextEncoder().encode(SPEND_KEY_DIGEST_DOMAIN);
+  const bytes = new Uint8Array(domain.length + key.length);
+  bytes.set(domain);
+  bytes.set(key, domain.length);
+  try {
+    return bytesToHex(new Uint8Array(await crypto.subtle.digest('SHA-256', bytes)));
+  } finally {
+    key.fill(0);
+    bytes.fill(0);
+  }
+}
+
+function requireBrowserPrimitives(): void {
+  if (typeof indexedDB === 'undefined') throw new Error('IndexedDB is required for BAT V2 storage');
+  if (typeof crypto === 'undefined' || !crypto.subtle) {
+    throw new Error('WebCrypto is required for BAT V2 storage');
+  }
+  if (typeof navigator === 'undefined' || !navigator.locks) {
+    throw new Error('Web Locks are required for BAT V2 at-most-once storage');
+  }
+}
+
+async function withExclusiveLock<T>(body: () => Promise<T>): Promise<T> {
+  return navigator.locks.request(GLOBAL_LOCK, { mode: 'exclusive' }, body);
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(META_STORE)) {
+        db.createObjectStore(META_STORE, { keyPath: 'id' });
+      }
+      if (!db.objectStoreNames.contains(RECORD_STORE)) {
+        const records = db.createObjectStore(RECORD_STORE, { keyPath: 'id' });
+        records.createIndex(SPEND_KEY_INDEX, 'spendKeyDigestHex', { unique: true });
+      }
+      if (!db.objectStoreNames.contains(RECOVERY_STORE)) {
+        db.createObjectStore(RECOVERY_STORE, { keyPath: 'id' });
+      }
+      if (!db.objectStoreNames.contains(QUOTE_KEY_STORE)) {
+        db.createObjectStore(QUOTE_KEY_STORE, { keyPath: 'id' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(new Error('failed to open BAT V2 IndexedDB'));
+    request.onblocked = () => reject(new Error('BAT V2 IndexedDB upgrade is blocked'));
+  });
+}
+
+function getValue<T>(db: IDBDatabase, storeName: string, key: IDBValidKey): Promise<T | undefined> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readonly');
+    const request = tx.objectStore(storeName).get(key);
+    request.onsuccess = () => resolve(request.result as T | undefined);
+    request.onerror = () => reject(new Error(`BAT V2 IndexedDB ${storeName} read failed`));
+    tx.onabort = () => reject(new Error(`BAT V2 IndexedDB ${storeName} read aborted`));
+  });
+}
+
+function getAllValues<T>(db: IDBDatabase, storeName: string): Promise<T[]> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readonly');
+    const request = tx.objectStore(storeName).getAll();
+    request.onsuccess = () => resolve(request.result as T[]);
+    request.onerror = () => reject(new Error(`BAT V2 IndexedDB ${storeName} scan failed`));
+    tx.onabort = () => reject(new Error(`BAT V2 IndexedDB ${storeName} scan aborted`));
+  });
+}
+
+function putValue(db: IDBDatabase, storeName: string, value: unknown): Promise<void> {
+  return writeOne(db, storeName, 'put', value);
+}
+
+function addValue(db: IDBDatabase, storeName: string, value: unknown): Promise<void> {
+  return writeOne(db, storeName, 'add', value);
+}
+
+function deleteValue(db: IDBDatabase, storeName: string, key: IDBValidKey): Promise<void> {
+  return writeOne(db, storeName, 'delete', key);
+}
+
+function writeOne(
+  db: IDBDatabase,
+  storeName: string,
+  operation: 'put' | 'add' | 'delete',
+  value: unknown,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(storeName, 'readwrite');
+    const store = tx.objectStore(storeName);
+    if (operation === 'delete') store.delete(value as IDBValidKey);
+    else if (operation === 'put') store.put(value);
+    else store.add(value);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(new Error(`BAT V2 IndexedDB ${storeName} write failed`));
+    tx.onabort = () => reject(new Error(`BAT V2 IndexedDB ${storeName} write aborted`));
+  });
+}
+
+function completeAcquisitionTransaction(
+  db: IDBDatabase,
+  recoveryId: string,
+  records: CipherRecordV1[],
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction([RECOVERY_STORE, RECORD_STORE], 'readwrite');
+    const recoveries = tx.objectStore(RECOVERY_STORE);
+    const wallet = tx.objectStore(RECORD_STORE);
+    const get = recoveries.get(recoveryId);
+    get.onsuccess = () => {
+      if (!get.result) {
+        tx.abort();
+        return;
+      }
+      for (const record of records) wallet.add(record);
+      recoveries.delete(recoveryId);
+    };
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(new Error('BAT V2 acquisition transaction failed'));
+    tx.onabort = () => reject(new Error('BAT V2 acquisition was already complete or conflicted'));
+  });
+}
+
+function putRecordsTransaction(db: IDBDatabase, records: CipherRecordV1[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(RECORD_STORE, 'readwrite');
+    const store = tx.objectStore(RECORD_STORE);
+    for (const record of records) store.put(record);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(new Error('BAT V2 pair reservation failed'));
+    tx.onabort = () => reject(new Error('BAT V2 pair reservation aborted'));
+  });
+}
+
+function deleteRecordsTransaction(db: IDBDatabase, ids: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(RECORD_STORE, 'readwrite');
+    const store = tx.objectStore(RECORD_STORE);
+    for (const id of ids) store.delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(new Error('BAT V2 orphan burn failed'));
+    tx.onabort = () => reject(new Error('BAT V2 orphan burn aborted'));
+  });
+}
+
+function aad(domain: string, id: string, binding = ''): ArrayBuffer {
+  return ownedArrayBuffer(new TextEncoder().encode(`${domain}\0${id}\0${binding}`));
+}
+
+function randomId(): string {
+  return bytesToHex(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+function canonicalOpaqueId(field: string, value: string): string {
+  return canonicalHex32(field, value);
+}
+
+function canonicalHex32(field: string, value: string): string {
+  if (!/^[0-9a-fA-F]{64}$/.test(value) || /^0{64}$/i.test(value)) {
+    throw new Error(`${field} must be non-zero 32-byte hex`);
+  }
+  return value.toLowerCase();
+}
+
+function canonicalPositiveDecimal(field: string, value: string): string {
+  if (!/^[1-9][0-9]*$/.test(value)) throw new Error(`${field} must be a positive decimal`);
+  const parsed = BigInt(value);
+  if (parsed > 0xffff_ffff_ffff_ffffn) throw new Error(`${field} exceeds u64`);
+  return parsed.toString();
+}
+
+function canonicalCompressedPointHex(field: string, value: string): string {
+  if (!/^(02|03)[0-9a-fA-F]{64}$/.test(value)) {
+    throw new Error(`${field} must be a compressed 33-byte point`);
+  }
+  return value.toLowerCase();
+}
+
+function canonicalIssuerEndpoint(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('BAT V2 issuer endpoint must be an absolute URL');
+  }
+  const loopback = url.hostname === '127.0.0.1'
+    || url.hostname === 'localhost'
+    || url.hostname === '[::1]';
+  if (url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) {
+    throw new Error('BAT V2 issuer endpoint must use HTTPS');
+  }
+  if (url.username || url.password || url.search || url.hash
+      || (url.pathname !== '' && url.pathname !== '/')) {
+    throw new Error('BAT V2 issuer endpoint must be a credential-free origin');
+  }
+  return url.origin;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value)) throw new Error('invalid base64');
+  const bytes = new Uint8Array(Buffer.from(value, 'base64'));
+  if (bytesToBase64(bytes) !== value) throw new Error('non-canonical base64');
+  return bytes;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function hexToBytes(value: string): Uint8Array {
+  return new Uint8Array(value.match(/.{2}/g)?.map((byte) => Number.parseInt(byte, 16)) ?? []);
+}
+
+function ownedArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.length);
+  copy.set(bytes);
+  return copy.buffer;
+}

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -328,6 +328,36 @@ export type {
   ResumeBolt11AcquisitionV1,
 } from './service-acquisition.js';
 
+// Issuer-wide BAT V2 acquisition and its independent encrypted wallet. These
+// exports deliberately do not adapt BAT V2 into the provider-scoped V1 vault.
+export {
+  BatV2CredentialVaultV2,
+  validateBatV2ClassBindingV2,
+  validateBatV2WalletRecordV2,
+} from './bat-v2-vault.js';
+export type {
+  BatV2ClassBindingV2,
+  BatV2DistinctPairReservationV2,
+  BatV2RecoveryRecordV2,
+  BatV2ReservedProofV2,
+  BatV2ReservationDispositionV2,
+  BatV2WalletInventoryV2,
+  BatV2WalletRecordV2,
+  LightningNetworkNameV2,
+  LockedBatV2RecoveryV2,
+} from './bat-v2-vault.js';
+export {
+  BatV2AcquisitionControllerV2,
+  BatV2RecoveryRequiredErrorV2,
+  resumeBatV2AcquisitionV2,
+} from './service-acquisition-v2.js';
+export type {
+  BatV2AcquisitionHandleV2,
+  BatV2QuoteStatusNameV2,
+  ResumeBatV2AcquisitionV2,
+  StartBatV2AcquisitionV2,
+} from './service-acquisition-v2.js';
+
 // Explicit strict-multi or centralized/degraded Nostr directory refresh and
 // durable rollback storage. Centralized mode never activates implicitly.
 export {

--- a/web/src/product-admission-controller.ts
+++ b/web/src/product-admission-controller.ts
@@ -1813,6 +1813,9 @@ function schemeForOffer(offer: ServiceOfferViewV1): AdmissionSchemeV1 {
     }
     return 'free-anonymous-ticket';
   }
+  if (offer.authorization === 'cashu-bat-v2') {
+    throw new Error('BAT V2 requires the class-bound admission path');
+  }
   return offer.authorization;
 }
 

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -169,6 +169,10 @@ interface PirSdkWasm {
   WasmBolt11AcquisitionV1: {
     restore(state: Uint8Array, nowUnix: bigint): WasmBolt11AcquisitionV1;
   };
+  /** Restore an opaque class-bound BAT V2 acquisition. */
+  WasmBolt11BatV2AcquisitionV2: {
+    restore(state: Uint8Array, nowUnix: bigint): WasmBolt11BatV2AcquisitionV2;
+  };
   /** Strict transport-neutral verifier for complete multi-relay catalogs. */
   WasmDirectoryCatalogCandidateV1: {
     /**
@@ -559,6 +563,7 @@ export interface ServiceOfferViewV1 {
     | 'bolt11-direct-receipt'
     | 'cashu-ecash'
     | 'cashu-bat'
+    | 'cashu-bat-v2'
     | 'arc-experimental';
   freeMode:
     | 'not-free'
@@ -661,6 +666,15 @@ export interface WasmAcceptedServicePolicyV1 {
     quoteKeyCheckpointBytes: Uint8Array,
     nowUnix: bigint,
   ): WasmBolt11AcquisitionV1;
+  /** Begin acquisition only after Rust verifies the exact signed class member. */
+  beginBatV2Acquisition?(
+    scopeId: Uint8Array,
+    offerId: number,
+    classBytes: Uint8Array,
+    quoteDelegationBytes: Uint8Array,
+    quoteKeyCheckpointBytes: Uint8Array,
+    nowUnix: bigint,
+  ): WasmBolt11BatV2AcquisitionV2;
 }
 
 /** Exact historical signed policy typestate, usable only for one retained
@@ -704,6 +718,41 @@ export interface WasmBolt11AcquisitionV1 {
   accept_status(quoteBytes: Uint8Array, nowUnix: bigint): void;
   prepare_claim(nowUnix: bigint): Uint8Array;
   finish_claim(responseBytes: Uint8Array, nowUnix: bigint): WasmIssuedCapabilitiesV1;
+}
+
+/** Secret-bearing, provider-independent BAT V2 acquisition state. */
+export interface WasmBolt11BatV2AcquisitionV2 {
+  free(): void;
+  quoteIntentBytes(): Uint8Array;
+  quoteKeyCheckpointBytes(): Uint8Array;
+  recoveryStateBytes(): Uint8Array;
+  acceptInitialQuote(quoteBytes: Uint8Array, nowUnix: bigint): void;
+  invoice(): string;
+  quoteIdHex(): string;
+  quoteStatus(): WasmBolt11QuoteStatusV1;
+  invoiceExpiresAtUnix(): string;
+  claimDeadlineUnix(): string;
+  buildStatusRequest(requestedAt: bigint): Uint8Array;
+  acceptStatus(quoteBytes: Uint8Array, nowUnix: bigint): void;
+  prepareClaim(nowUnix: bigint): Uint8Array;
+  finishClaim(responseBytes: Uint8Array, nowUnix: bigint): WasmIssuedBatV2ProofsV2;
+}
+
+/** Verified issuer-wide proofs withheld until the Web vault commits a batch. */
+export interface WasmIssuedBatV2ProofsV2 {
+  free(): void;
+  count(): number;
+  proof(index: number): Uint8Array;
+  globalSpendKeyHex(index: number): string;
+  classBindingJson(): BatV2ClassBindingViewV2;
+}
+
+export interface BatV2ClassBindingViewV2 {
+  issuerIdHex: string;
+  classIdHex: string;
+  classDigestHex: string;
+  classKeyEpoch: string;
+  batKeyIdHex: string;
 }
 
 /** Verified, provider-local capability batch returned by one paid claim. */

--- a/web/src/service-acquisition-v2.ts
+++ b/web/src/service-acquisition-v2.ts
@@ -1,0 +1,612 @@
+/**
+ * Restart-safe, class-bound BOLT11 acquisition for issuer-wide BAT V2.
+ *
+ * Every method performs at most one issuer request. Recovery is encrypted in
+ * the independent BAT V2 vault and contains no provider/policy/scope/offer
+ * coordinates. Lost responses are resumed only by an explicit caller action.
+ */
+
+import {
+  BatV2CredentialVaultV2,
+  type BatV2ClassBindingV2,
+  type BatV2RecoveryRecordV2,
+  type BatV2WalletRecordV2,
+  type LightningNetworkNameV2,
+  type LockedBatV2RecoveryV2,
+} from './bat-v2-vault.js';
+import { hexToBytes } from './hash.js';
+import {
+  requireSdkWasm,
+  type ServiceOfferViewV1,
+  type ServiceScopeViewV1,
+  type WasmAcceptedServicePolicyV1,
+  type WasmBolt11BatV2AcquisitionV2,
+  type WasmBolt11QuoteStatusV1,
+  type WasmIssuedBatV2ProofsV2,
+} from './sdk-bridge.js';
+import { fetchQuoteKeyDelegationV1 } from './service-acquisition.js';
+import { trustedNowUnixV1 } from './trusted-time.js';
+
+const CT_BAT_V2_QUOTE_INTENT =
+  'application/vnd.bitcoinpir.bat-v2-bolt11-quote-intent-v2';
+const CT_QUOTE = 'application/vnd.bitcoinpir.bolt11-quote-v1';
+const CT_STATUS_REQUEST = 'application/vnd.bitcoinpir.bolt11-quote-status-request-v1';
+const CT_BAT_V2_CLAIM_ENVELOPE =
+  'application/vnd.bitcoinpir.bat-v2-bolt11-quote-claim-envelope-v2';
+const CT_BAT_V2_ISSUANCE_RESPONSE =
+  'application/vnd.bitcoinpir.bat-v2-issuance-response-v2';
+const MAX_QUOTE_BYTES = 12 * 1024;
+const MAX_ISSUANCE_RESPONSE_BYTES = 128 * 1024;
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+
+export type BatV2QuoteStatusNameV2 = WasmBolt11QuoteStatusV1;
+
+export interface BatV2AcquisitionHandleV2 {
+  readonly recoveryId: string;
+  ensureQuote(): Promise<string>;
+  invoice(): string;
+  status(): BatV2QuoteStatusNameV2;
+  invoiceExpiresAtUnix(): bigint;
+  claimDeadlineUnix(): bigint;
+  pollStatus(): Promise<BatV2QuoteStatusNameV2>;
+  claim(): Promise<number>;
+  close(): void;
+}
+
+export interface StartBatV2AcquisitionV2 {
+  vault: BatV2CredentialVaultV2;
+  policy: WasmAcceptedServicePolicyV1;
+  scope: ServiceScopeViewV1;
+  offer: ServiceOfferViewV1;
+  /** Canonical issuer-signed class artifact injected by the trusted release. */
+  classBytes: Uint8Array;
+  network: LightningNetworkNameV2;
+  expectedPayeePubkey: Uint8Array;
+  fetchImpl?: typeof fetch;
+  requestTimeoutMs?: number;
+  allowInsecureLoopback?: boolean;
+  /** Revalidates the selected current strict pair before any invoice escape. */
+  assertReady: () => void;
+}
+
+export interface ResumeBatV2AcquisitionV2 {
+  vault: BatV2CredentialVaultV2;
+  recoveryId: string;
+  issuerEndpoint: string;
+  issuerIdHex: string;
+  network: LightningNetworkNameV2;
+  expectedPayeePubkey: Uint8Array;
+  fetchImpl?: typeof fetch;
+  requestTimeoutMs?: number;
+  allowInsecureLoopback?: boolean;
+  assertReady: () => void;
+}
+
+export class BatV2RecoveryRequiredErrorV2 extends Error {
+  constructor(
+    readonly recoveryId: string,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'BatV2RecoveryRequiredErrorV2';
+  }
+}
+
+export class BatV2AcquisitionControllerV2 implements BatV2AcquisitionHandleV2 {
+  private completed = false;
+  private closed = false;
+
+  private constructor(
+    private readonly vault: BatV2CredentialVaultV2,
+    private readonly recovery: BatV2RecoveryRecordV2,
+    private wasm: WasmBolt11BatV2AcquisitionV2 | null,
+    private readonly fetchImpl: typeof fetch,
+    private readonly allowInsecureLoopback: boolean,
+    private readonly requestTimeoutMs: number,
+    private readonly assertReadyForInvoice: () => void,
+  ) {}
+
+  static async start(options: StartBatV2AcquisitionV2): Promise<BatV2AcquisitionControllerV2> {
+    validateStart(options);
+    options.assertReady();
+    const allowInsecure = options.allowInsecureLoopback ?? false;
+    const endpoint = canonicalIssuerEndpoint(options.offer.endpoint, allowInsecure);
+    const issuerIdHex = canonicalHex32('offer.issuerIdHex', options.offer.issuerIdHex);
+    const payee = fixedBytes('expectedPayeePubkey', options.expectedPayeePubkey, 33);
+    const payeeHex = bytesToHex(payee);
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const timeout = requestTimeout(options.requestTimeoutMs);
+    const delegation = await fetchQuoteKeyDelegationV1(
+      endpoint,
+      undefined,
+      fetchImpl,
+      allowInsecure,
+      timeout,
+    );
+    options.assertReady();
+    const sdk = requireSdkWasm();
+    const initial = sdk.initial_bolt11_quote_key_checkpoint_v1(
+      hexToBytes32('offer.issuerIdHex', issuerIdHex),
+      options.network,
+      payee,
+    );
+    const acquisition = await options.vault.advanceQuoteKeyCheckpoint(
+      issuerIdHex,
+      options.network,
+      payeeHex,
+      initial,
+      (checkpoint) => {
+        options.assertReady();
+        const begin = options.policy.beginBatV2Acquisition;
+        if (typeof begin !== 'function') {
+          throw new Error('loaded SDK does not support verified BAT V2 acquisition');
+        }
+        const handle = begin.call(
+          options.policy,
+          hexToBytes32('scope.scopeIdHex', options.scope.scopeIdHex),
+          options.offer.offerId,
+          options.classBytes,
+          delegation,
+          checkpoint,
+          trustedNowUnixV1(),
+        );
+        return {
+          nextCheckpoint: handle.quoteKeyCheckpointBytes(),
+          value: handle,
+          discard: () => handle.free(),
+        };
+      },
+    );
+    let recovery: BatV2RecoveryRecordV2;
+    try {
+      options.assertReady();
+      recovery = await options.vault.createRecovery({
+        issuerEndpoint: endpoint,
+        issuerIdHex,
+        network: options.network,
+        expectedPayeePubkeyHex: payeeHex,
+        state: acquisition.recoveryStateBytes(),
+      });
+    } catch (error) {
+      acquisition.free();
+      throw error;
+    }
+    const controller = new BatV2AcquisitionControllerV2(
+      options.vault,
+      recovery,
+      acquisition,
+      fetchImpl,
+      allowInsecure,
+      timeout,
+      options.assertReady,
+    );
+    try {
+      await controller.ensureQuote();
+      options.assertReady();
+      return controller;
+    } catch (cause) {
+      controller.close();
+      throw new BatV2RecoveryRequiredErrorV2(
+        recovery.id,
+        'BAT V2 quote response may be lost; resume this exact encrypted recovery',
+        { cause },
+      );
+    }
+  }
+
+  static async resume(options: ResumeBatV2AcquisitionV2): Promise<BatV2AcquisitionControllerV2> {
+    options.assertReady();
+    const recovery = await options.vault.getRecovery(options.recoveryId);
+    options.assertReady();
+    if (!recovery) throw new Error('BAT V2 recovery was not found (it may be complete)');
+    const allowInsecure = options.allowInsecureLoopback ?? false;
+    const endpoint = canonicalIssuerEndpoint(options.issuerEndpoint, allowInsecure);
+    const issuerIdHex = canonicalHex32('issuerIdHex', options.issuerIdHex);
+    const payee = fixedBytes('expectedPayeePubkey', options.expectedPayeePubkey, 33);
+    if (recovery.issuerEndpoint !== endpoint
+        || recovery.issuerIdHex !== issuerIdHex
+        || recovery.network !== options.network
+        || recovery.expectedPayeePubkeyHex !== bytesToHex(payee)) {
+      throw new Error('BAT V2 recovery does not match issuer/network/payee context');
+    }
+    let wasm: WasmBolt11BatV2AcquisitionV2 | null = requireSdkWasm()
+      .WasmBolt11BatV2AcquisitionV2.restore(recovery.state, trustedNowUnixV1());
+    try {
+      options.assertReady();
+      const controller = new BatV2AcquisitionControllerV2(
+        options.vault,
+        recovery,
+        wasm,
+        options.fetchImpl ?? fetch,
+        allowInsecure,
+        requestTimeout(options.requestTimeoutMs),
+        options.assertReady,
+      );
+      wasm = null;
+      return controller;
+    } finally {
+      wasm?.free();
+    }
+  }
+
+  get recoveryId(): string {
+    return this.recovery.id;
+  }
+
+  async ensureQuote(): Promise<string> {
+    this.assertReadyForInvoice();
+    return this.withLockedRecovery(async (wasm, recovery, locked) => {
+      this.assertReadyForInvoice();
+      try {
+        const invoice = wasm.invoice();
+        this.assertReadyForInvoice();
+        return invoice;
+      } catch {
+        // A pre-quote recovery intentionally has no invoice yet.
+      }
+      const body = wasm.quoteIntentBytes();
+      this.assertReadyForInvoice();
+      const response = await requestBinary(
+        this.fetchImpl,
+        issuerUrl(recovery.issuerEndpoint, 'v2/quotes/bolt11', this.allowInsecureLoopback),
+        CT_BAT_V2_QUOTE_INTENT,
+        CT_QUOTE,
+        body,
+        MAX_QUOTE_BYTES,
+        this.requestTimeoutMs,
+      );
+      let staleAfterPost: unknown = null;
+      try {
+        this.assertReadyForInvoice();
+      } catch (error) {
+        staleAfterPost = error;
+      }
+      wasm.acceptInitialQuote(response, trustedNowUnixV1());
+      await locked.persistState(wasm.recoveryStateBytes());
+      if (staleAfterPost) throw staleAfterPost;
+      this.assertReadyForInvoice();
+      return wasm.invoice();
+    });
+  }
+
+  invoice(): string {
+    this.assertReadyForInvoice();
+    return this.requireHandle().invoice();
+  }
+
+  status(): BatV2QuoteStatusNameV2 {
+    return this.requireHandle().quoteStatus();
+  }
+
+  invoiceExpiresAtUnix(): bigint {
+    return BigInt(this.requireHandle().invoiceExpiresAtUnix());
+  }
+
+  claimDeadlineUnix(): bigint {
+    return BigInt(this.requireHandle().claimDeadlineUnix());
+  }
+
+  async pollStatus(): Promise<BatV2QuoteStatusNameV2> {
+    return this.withLockedRecovery(async (wasm, recovery, locked) => {
+      const quoteId = canonicalHex32('quoteId', wasm.quoteIdHex());
+      const response = await requestBinary(
+        this.fetchImpl,
+        issuerUrl(
+          recovery.issuerEndpoint,
+          `v2/quotes/${quoteId}/status`,
+          this.allowInsecureLoopback,
+        ),
+        CT_STATUS_REQUEST,
+        CT_QUOTE,
+        wasm.buildStatusRequest(trustedNowUnixV1()),
+        MAX_QUOTE_BYTES,
+        this.requestTimeoutMs,
+      );
+      wasm.acceptStatus(response, trustedNowUnixV1());
+      await locked.persistState(wasm.recoveryStateBytes());
+      return wasm.quoteStatus();
+    });
+  }
+
+  async claim(): Promise<number> {
+    return this.withLockedRecovery(async (wasm, recovery, locked) => {
+      const quoteId = canonicalHex32('quoteId', wasm.quoteIdHex());
+      const body = wasm.prepareClaim(trustedNowUnixV1());
+      await locked.persistState(wasm.recoveryStateBytes());
+      const response = await requestBinary(
+        this.fetchImpl,
+        issuerUrl(
+          recovery.issuerEndpoint,
+          `v2/quotes/${quoteId}/claim`,
+          this.allowInsecureLoopback,
+        ),
+        CT_BAT_V2_CLAIM_ENVELOPE,
+        CT_BAT_V2_ISSUANCE_RESPONSE,
+        body,
+        MAX_ISSUANCE_RESPONSE_BYTES,
+        this.requestTimeoutMs,
+      );
+      const issued = wasm.finishClaim(response, trustedNowUnixV1());
+      const records: BatV2WalletRecordV2[] = [];
+      try {
+        const binding = validateClassBinding(issued.classBindingJson());
+        if (binding.issuerIdHex !== recovery.issuerIdHex) {
+          throw new Error('issued BAT V2 class does not match the recovery issuer');
+        }
+        const count = issued.count();
+        if (!Number.isSafeInteger(count) || count <= 0 || count > 65_535) {
+          throw new Error('issuer returned an invalid BAT V2 proof count');
+        }
+        for (let index = 0; index < count; index += 1) {
+          records.push({
+            ...binding,
+            proof: issued.proof(index),
+            globalSpendKeyHex: issued.globalSpendKeyHex(index),
+          });
+        }
+        await locked.complete(records);
+        this.completed = true;
+        return count;
+      } finally {
+        for (const record of records) record.proof.fill(0);
+        issued.free();
+      }
+    });
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.wasm?.free();
+    this.wasm = null;
+    this.recovery.state.fill(0);
+  }
+
+  private async withLockedRecovery<T>(
+    operation: (
+      wasm: WasmBolt11BatV2AcquisitionV2,
+      recovery: BatV2RecoveryRecordV2,
+      locked: LockedBatV2RecoveryV2,
+    ) => Promise<T>,
+  ): Promise<T> {
+    this.requireActive();
+    return this.vault.withRecovery(this.recovery.id, async (recovery, locked) => {
+      this.requireActive();
+      const working = requireSdkWasm().WasmBolt11BatV2AcquisitionV2.restore(
+        recovery.state,
+        trustedNowUnixV1(),
+      );
+      try {
+        return await operation(working, recovery, locked);
+      } finally {
+        working.free();
+        if (!this.closed) {
+          this.wasm?.free();
+          this.wasm = null;
+          this.recovery.state.fill(0);
+          if (!this.completed) {
+            this.wasm = requireSdkWasm().WasmBolt11BatV2AcquisitionV2.restore(
+              recovery.state,
+              trustedNowUnixV1(),
+            );
+          }
+        }
+        recovery.state.fill(0);
+      }
+    });
+  }
+
+  private requireActive(): void {
+    if (this.closed) throw new Error('BAT V2 acquisition controller is closed');
+    if (this.completed) throw new Error('BAT V2 acquisition is already complete');
+  }
+
+  private requireHandle(): WasmBolt11BatV2AcquisitionV2 {
+    this.requireActive();
+    if (!this.wasm) throw new Error('BAT V2 acquisition state is unavailable');
+    return this.wasm;
+  }
+}
+
+export function resumeBatV2AcquisitionV2(
+  options: ResumeBatV2AcquisitionV2,
+): Promise<BatV2AcquisitionHandleV2> {
+  return BatV2AcquisitionControllerV2.resume(options);
+}
+
+function validateStart(options: StartBatV2AcquisitionV2): void {
+  requestTimeout(options.requestTimeoutMs);
+  if (typeof options.assertReady !== 'function') {
+    throw new Error('BAT V2 acquisition requires a strict-session readiness guard');
+  }
+  if (!(options.classBytes instanceof Uint8Array) || options.classBytes.length === 0) {
+    throw new Error('BAT V2 acquisition requires canonical signed class bytes');
+  }
+  if (options.offer.acquisition !== 'bolt11'
+      || options.offer.authorization !== 'cashu-bat-v2'
+      || options.offer.verification !== 'shared-issuer-online') {
+    throw new Error('selected signed offer is not storeless BAT V2');
+  }
+  if (!options.scope.offers.some((offer) =>
+    offer === options.offer
+      || (offer.offerId === options.offer.offerId
+        && offer.authorization === 'cashu-bat-v2'
+        && offer.issuerIdHex === options.offer.issuerIdHex
+        && offer.endpoint === options.offer.endpoint))) {
+    throw new Error('selected BAT V2 offer is not from this verified scope');
+  }
+  canonicalHex32('offer.issuerIdHex', options.offer.issuerIdHex);
+  fixedBytes('expectedPayeePubkey', options.expectedPayeePubkey, 33);
+}
+
+function validateClassBinding(value: unknown): BatV2ClassBindingV2 {
+  if (value === null || typeof value !== 'object') {
+    throw new Error('WASM returned an invalid BAT V2 class binding');
+  }
+  const record = value as Record<string, unknown>;
+  return {
+    issuerIdHex: canonicalHex32('class.issuerIdHex', record.issuerIdHex),
+    classIdHex: canonicalHex32('class.classIdHex', record.classIdHex),
+    classDigestHex: canonicalHex32('class.classDigestHex', record.classDigestHex),
+    classKeyEpoch: canonicalPositiveDecimal('class.classKeyEpoch', record.classKeyEpoch),
+    batKeyIdHex: canonicalHex32('class.batKeyIdHex', record.batKeyIdHex),
+  };
+}
+
+async function requestBinary(
+  fetchImpl: typeof fetch,
+  url: string,
+  requestContentType: string,
+  expectedContentType: string,
+  body: Uint8Array,
+  maxResponseBytes: number,
+  timeoutMs: number,
+): Promise<Uint8Array> {
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort('BAT V2 issuer request timed out'), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        Accept: expectedContentType,
+        'Content-Type': requestContentType,
+      },
+      body: ownedArrayBuffer(body),
+      credentials: 'omit',
+      cache: 'no-store',
+      redirect: 'error',
+      referrerPolicy: 'no-referrer',
+      signal: abort.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`BAT V2 issuer rejected POST with HTTP ${response.status}`);
+    }
+    const contentType = response.headers.get('Content-Type')?.split(';', 1)[0]?.trim().toLowerCase();
+    if (contentType !== expectedContentType) {
+      throw new Error('BAT V2 issuer returned an unexpected content type');
+    }
+    const encoding = response.headers.get('Content-Encoding');
+    if (encoding !== null && encoding.trim().toLowerCase() !== 'identity') {
+      throw new Error('BAT V2 issuer returned an unsupported content encoding');
+    }
+    const declared = response.headers.get('Content-Length');
+    if (declared !== null) {
+      const length = Number(declared);
+      if (!Number.isSafeInteger(length) || length <= 0 || length > maxResponseBytes) {
+        throw new Error('BAT V2 issuer response exceeds its bound');
+      }
+    }
+    const bytes = await readBodyBounded(response, maxResponseBytes);
+    if (bytes.length === 0 || bytes.length > maxResponseBytes) {
+      throw new Error('BAT V2 issuer returned an empty or oversized response');
+    }
+    if (declared !== null && bytes.length !== Number(declared)) {
+      throw new Error('BAT V2 issuer response length differs from Content-Length');
+    }
+    return bytes;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function readBodyBounded(response: Response, max: number): Promise<Uint8Array> {
+  if (!response.body) throw new Error('BAT V2 issuer returned no response body');
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!(value instanceof Uint8Array)) throw new Error('invalid BAT V2 response stream');
+      total += value.length;
+      if (!Number.isSafeInteger(total) || total > max) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error('BAT V2 issuer response exceeds its bound');
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+function requestTimeout(value: number | undefined): number {
+  const timeout = value ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeout) || timeout < 1_000 || timeout > 60_000) {
+    throw new Error('BAT V2 issuer timeout must be in 1000..=60000 ms');
+  }
+  return timeout;
+}
+
+function issuerUrl(endpoint: string, relative: string, allowInsecure: boolean): string {
+  return new URL(relative, `${canonicalIssuerEndpoint(endpoint, allowInsecure)}/`).toString();
+}
+
+function canonicalIssuerEndpoint(value: string, allowInsecure: boolean): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('BAT V2 issuer endpoint must be an absolute URL');
+  }
+  const loopback = url.hostname === '127.0.0.1'
+    || url.hostname === 'localhost'
+    || url.hostname === '[::1]';
+  if (url.protocol !== 'https:' && !(allowInsecure && loopback && url.protocol === 'http:')) {
+    throw new Error('BAT V2 issuer endpoint must use HTTPS');
+  }
+  if (url.username || url.password || url.search || url.hash
+      || (url.pathname !== '' && url.pathname !== '/')) {
+    throw new Error('BAT V2 issuer endpoint must be a credential-free origin');
+  }
+  return url.origin;
+}
+
+function canonicalHex32(field: string, value: unknown): string {
+  if (typeof value !== 'string'
+      || !/^[0-9a-fA-F]{64}$/.test(value)
+      || /^0{64}$/i.test(value)) {
+    throw new Error(`${field} must be non-zero 32-byte hex`);
+  }
+  return value.toLowerCase();
+}
+
+function canonicalPositiveDecimal(field: string, value: unknown): string {
+  if (typeof value !== 'string' || !/^[1-9][0-9]*$/.test(value)) {
+    throw new Error(`${field} must be a positive decimal`);
+  }
+  const parsed = BigInt(value);
+  if (parsed > 0xffff_ffff_ffff_ffffn) throw new Error(`${field} exceeds u64`);
+  return parsed.toString();
+}
+
+function fixedBytes(field: string, value: Uint8Array, length: number): Uint8Array {
+  if (!(value instanceof Uint8Array) || value.length !== length) {
+    throw new Error(`${field} must be exactly ${length} bytes`);
+  }
+  if (value.every((byte) => byte === 0)) throw new Error(`${field} must be non-zero`);
+  return value.slice();
+}
+
+function hexToBytes32(field: string, value: string): Uint8Array {
+  return fixedBytes(field, hexToBytes(canonicalHex32(field, value)), 32);
+}
+
+function bytesToHex(value: Uint8Array): string {
+  return Array.from(value, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function ownedArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.length);
+  copy.set(bytes);
+  return copy.buffer;
+}


### PR DESCRIPTION
## Summary
- add an independent class-bound BAT V2 acquisition and recovery flow
- store provider-agnostic proofs in a separate encrypted IndexedDB vault with issuer-global spend-key uniqueness
- atomically reserve distinct two-leg credentials and preserve live reservations with owner Web Locks
- keep generic V1 admission paths fail-closed for scheme 6

## Verification
- `npm run build`
- `npx vitest run src/__tests__/bat-v2-vault.test.ts src/__tests__/service-acquisition-v2.test.ts` (10 passed)
- two independent P0/P1 reviews, including the multi-tab owner-lock fix
- `git diff --check origin/main...HEAD`

## Non-goals
- no production browser check
- no V2 AUTH/product adapter wiring in this slice
- no deployment, VPSBG, routing, or funds