### PR TITLE
feat(web): consume BAT V2 through typed admission

### DIFF
--- a/web/src/__tests__/adapter-lifecycle.test.ts
+++ b/web/src/__tests__/adapter-lifecycle.test.ts
@@ -1401,6 +1401,96 @@ describe('adapter WASM lifecycle', () => {
     );
   });
 
+  it('routes DPF BAT V2 only through the explicit one-sided typed primitive', async () => {
+    const dangerousUnpairedAuthorizeBatV2Service = vi.fn(async () => ({
+      kind: 'recoverable-definitely-not-sent',
+      retryAfterMs: 7,
+    }));
+    const authorizeService = vi.fn();
+    const adapter = strictDpfPair({
+      preflightDatabase: vi.fn(async () => {}),
+      isServerConnected: vi.fn(() => true),
+      dangerousUnpairedAuthorizeBatV2Service,
+      authorizeService,
+    });
+    const port = adapter.serviceAdmissionPort(0, 0);
+    await adapter.prepareStrictAdmission(0);
+    const verified = { marker: 'opaque-bat-v2' } as any;
+    const proof = new Uint8Array([1, 2, 3]);
+    await expect(port.authorizeBatV2!(verified, proof, 9n)).resolves.toEqual({
+      kind: 'recoverable-definitely-not-sent',
+      retryAfterMs: 7,
+    });
+    expect(dangerousUnpairedAuthorizeBatV2Service).toHaveBeenCalledOnce();
+    expect(dangerousUnpairedAuthorizeBatV2Service).toHaveBeenCalledWith(
+      0, 0, verified, proof, 9n,
+    );
+    expect(authorizeService).not.toHaveBeenCalled();
+  });
+
+  it('routes Harmony BAT V2 through role-explicit one-sided primitives without retry', async () => {
+    const hint = vi.fn(async () => ({ kind: 'burn-terminal' }));
+    const query = vi.fn(async () => ({ kind: 'burn-outcome-unknown' }));
+    const adapter = strictHarmonyPair({
+      preflightDatabase: vi.fn(async () => {}),
+      isProviderConnected: vi.fn(() => true),
+      dangerousUnpairedAuthorizeBatV2HintService: hint,
+      dangerousUnpairedAuthorizeBatV2QueryService: query,
+    });
+    await adapter.prepareStrictAdmission(0);
+    const verified = { marker: 'opaque-bat-v2' } as any;
+    const proof = new Uint8Array([4, 5]);
+    await expect(adapter.hintServiceAdmissionPort(0).authorizeBatV2!(
+      verified, proof, 10n,
+    )).resolves.toEqual({ kind: 'burn-terminal' });
+    await expect(adapter.queryServiceAdmissionPort(0).authorizeBatV2!(
+      verified, proof, 11n,
+    )).resolves.toEqual({ kind: 'burn-outcome-unknown' });
+    expect(hint).toHaveBeenCalledOnce();
+    expect(query).toHaveBeenCalledOnce();
+    expect(hint).toHaveBeenCalledWith(0, verified, proof, 10n);
+    expect(query).toHaveBeenCalledWith(0, verified, proof, 11n);
+  });
+
+  it('routes direct ORAM BAT V2 through its typed verified-handle primitive once', async () => {
+    const authorizeBatV2Service = vi.fn(async () => ({ kind: 'burn-terminal' }));
+    const adapter = new OramPirClientAdapter({
+      serverUrl: 'wss://oram.invalid',
+      strictVerification: true,
+      verifyOperatorIdentity: true,
+      expectedServerId: 'oram',
+      expectedServerPin: {
+        binarySha256Hex: BINARY_0,
+        measurementHex: '61'.repeat(48),
+      },
+    });
+    const state = adapter as any;
+    state.wasmClient = { authorizeBatV2Service };
+    state.connected = true;
+    state.strictReady = true;
+    state.secureChannelEstablished = true;
+    state.attestation = {
+      state: 'verified-vcek',
+      sevStatus: 'reportDataMatch',
+      vcekChain: 'pass',
+      pinStatus: 'match',
+    };
+    adapter.operatorIdentity = {
+      state: 'verified',
+      serverId: 'oram',
+      operatorPubkeyHex: '62'.repeat(32),
+    };
+    state.databaseProofs.set(3, { state: 'verified' });
+    const verified = { marker: 'opaque-bat-v2' } as any;
+    const proof = new Uint8Array([7, 8]);
+
+    await expect(adapter.serviceAdmissionPort(3).authorizeBatV2!(
+      verified, proof, 12n,
+    )).resolves.toEqual({ kind: 'burn-terminal' });
+    expect(authorizeBatV2Service).toHaveBeenCalledOnce();
+    expect(authorizeBatV2Service).toHaveBeenCalledWith(3, verified, proof, 12n);
+  });
+
   it('invalidates DPF acquisition binding when either prepared peer disconnects', async () => {
     const connected = [true, true];
     const verifyServicePolicySession = vi.fn();

--- a/web/src/__tests__/onion-service-admission.test.ts
+++ b/web/src/__tests__/onion-service-admission.test.ts
@@ -6,6 +6,8 @@ const mocked = vi.hoisted(() => ({
     exporter: Uint8Array;
     free: ReturnType<typeof vi.fn>;
     verifyPolicySession: ReturnType<typeof vi.fn>;
+    batV2AuthorizationRequest: ReturnType<typeof vi.fn>;
+    acceptBatV2AuthorizationResponse: ReturnType<typeof vi.fn>;
   }>,
 }));
 
@@ -16,6 +18,12 @@ vi.mock('../sdk-bridge.js', async (importOriginal) => {
     readonly exporter: Uint8Array;
     readonly free = vi.fn();
     readonly verifyPolicySession = vi.fn();
+    readonly batV2AuthorizationRequest = vi.fn(() =>
+      new Uint8Array([1, 0, 0, 0, 0x10]));
+    readonly acceptBatV2AuthorizationResponse = vi.fn(() => ({
+      kind: 'recoverable-retry-safe',
+      retryAfterMs: 5,
+    }));
 
     constructor(dbId: number, exporter: Uint8Array) {
       this.dbId = dbId;
@@ -118,6 +126,35 @@ describe('standalone OnionPIR service admission port', () => {
     )).rejects.toThrow('connection lost after send');
     expect(sendRaw).toHaveBeenCalledOnce();
     expect(mocked.instances).toHaveLength(1);
+    expect(mocked.instances[0].free).toHaveBeenCalledOnce();
+  });
+
+  it('sends one BAT V2 request made from the opaque verified handle and returns typed outcome', async () => {
+    mocked.instances.length = 0;
+    const sent: Uint8Array[] = [];
+    const sendRaw = vi.fn(async (request: Uint8Array) => {
+      sent.push(request.slice());
+      return new Uint8Array([1, 0, 0, 0, 0x90]);
+    });
+    const client = readyClient(sendRaw);
+    const verified = { marker: 'opaque-bat-v2' } as any;
+    const proof = new Uint8Array(210).fill(6);
+
+    await expect(client.serviceAdmissionPort(3).authorizeBatV2!(
+      verified, proof, 1_700_000_000n,
+    )).resolves.toEqual({
+      kind: 'recoverable-retry-safe',
+      retryAfterMs: 5,
+    });
+
+    expect(sendRaw).toHaveBeenCalledOnce();
+    expect(sent).toEqual([new Uint8Array([1, 0, 0, 0, 0x10])]);
+    expect(mocked.instances).toHaveLength(1);
+    expect(mocked.instances[0].batV2AuthorizationRequest).toHaveBeenCalledWith(
+      verified, proof, 1_700_000_000n,
+    );
+    expect(mocked.instances[0].acceptBatV2AuthorizationResponse)
+      .toHaveBeenCalledWith(expect.any(Uint8Array), verified);
     expect(mocked.instances[0].free).toHaveBeenCalledOnce();
   });
 });

--- a/web/src/__tests__/product-admission-controller.test.ts
+++ b/web/src/__tests__/product-admission-controller.test.ts
@@ -79,9 +79,14 @@ import {
   AdmissionCredentialVaultV1,
   type Bolt11CapabilityAcquisitionContextV1,
 } from '../admission-vault.js';
+import type {
+  BatV2ClassBindingV2,
+  BatV2CredentialVaultV2,
+} from '../bat-v2-vault.js';
 import {
   ProductAdmissionControllerV1,
   ProductAdmissionErrorV1,
+  type ProductBatV2ClassMemberSelectorV2,
 } from '../product-admission-controller.js';
 import {
   ProviderAdmissionSessionV1,
@@ -208,6 +213,27 @@ function paidOffer(
   };
 }
 
+function batV2Offer(offerId: number): ServiceOfferViewV1 {
+  return {
+    offerId,
+    acquisition: 'bolt11',
+    authorization: 'cashu-bat-v2',
+    freeMode: 'not-free',
+    verification: 'shared-issuer-online',
+    deploymentStatus: 'stable',
+    priorityClass: 1,
+    price: { kind: 'msat', amount: '1000' },
+    issuerIdHex: '91'.repeat(32),
+    keyIdHex: '92'.repeat(32),
+    batVerificationKeyFingerprintHex: '',
+    arcVerificationKeyFingerprintHex: '',
+    endpoint: 'https://bat-v2-issuer.example',
+    credentialCount: 2,
+    credentialPresentationLimit: 1,
+    privacyLeakageBits: 1,
+  };
+}
+
 function lightningTrust(
   offer: ServiceOfferViewV1,
   payee: Uint8Array,
@@ -315,6 +341,23 @@ function accepted(view: ServicePolicyViewV1): WasmAcceptedServicePolicyV1 {
     importStandardCashuToken: () => new Uint8Array([7, 7]),
     offersJson: () => structuredClone(view),
     beginBolt11Acquisition: () => { throw new Error('mocked at controller boundary'); },
+    verifyBatV2Redemption: (scopeId, offerId) => {
+      const offer = view.scopes[0].offers.find((candidate) => candidate.offerId === offerId);
+      const scopeIdHex = Buffer.from(scopeId).toString('hex');
+      if (!offer || offer.authorization !== 'cashu-bat-v2'
+          || scopeIdHex !== view.scopes[0].scopeIdHex) {
+        throw new Error('wrong BAT V2 class member');
+      }
+      return {
+        free: vi.fn(),
+        providerIdHex: view.providerIdHex,
+        policyDigestHex: view.policyDigestHex,
+        scopeIdHex,
+        offerId,
+        classIdHex: offer.keyIdHex,
+        assertRedemptionReady: vi.fn(),
+      };
+    },
   };
 }
 
@@ -414,14 +457,19 @@ function session(
     hasHarmonyAttach: target.workload === 'harmony-hint',
   }),
   retainedView?: RetainedServiceRedemptionViewV1,
+  authorizeBatV2Impl: NonNullable<ServiceAdmissionPortV1['authorizeBatV2']> = async (
+    _verified, _proof, _now,
+  ) => ({ kind: 'burn-terminal' }),
 ): {
   session: ProviderAdmissionSessionV1;
   authorize: ReturnType<typeof vi.fn>;
   assertReady: ReturnType<typeof vi.fn>;
+  authorizeBatV2: ReturnType<typeof vi.fn>;
 } {
   let refresh = 0;
   const authorize = vi.fn(authorizeImpl);
   const assertReady = vi.fn();
+  const authorizeBatV2 = vi.fn(authorizeBatV2Impl);
   const retainedHandle = (): WasmAcceptedRetainedServiceRedemptionV1 => {
     if (!retainedView) throw new Error('unused');
     return {
@@ -446,6 +494,7 @@ function session(
     captureReadinessGuard: () => assertReady,
     assertRetainedSessionBinding: vi.fn(),
     authorize,
+    authorizeBatV2,
     authorizeRetained: async () => {
       if (!retainedView) throw new Error('unused');
       return {
@@ -470,6 +519,7 @@ function session(
     ),
     authorize,
     assertReady,
+    authorizeBatV2,
   };
 }
 
@@ -573,6 +623,178 @@ describe('product admission lifecycle', () => {
     await expect(controller.executeQuery(currentShapes(controller), query)).rejects.toThrow(/must be authorized/);
     expect(query).toHaveBeenCalledOnce();
     expect(state.takes).toBe(1);
+  });
+
+  it('resets a retry-safe BAT V2 pair, then consumes two provider-independent proofs', async () => {
+    const { vault } = fakeVault();
+    const target = testTarget('dpf-pir', 'dpf-query');
+    const firstOffer = batV2Offer(81);
+    const secondOffer = batV2Offer(82);
+    const classBinding: BatV2ClassBindingV2 = {
+      issuerIdHex: firstOffer.issuerIdHex,
+      classIdHex: firstOffer.keyIdHex,
+      classDigestHex: '93'.repeat(32),
+      classKeyEpoch: '4',
+      batKeyIdHex: '94'.repeat(32),
+    };
+    const events: string[] = [];
+    const reservationId = 'product-bat-v2-reservation';
+    let available = 2;
+    const lease = (recordId: string, marker: number) => ({
+      ...classBinding,
+      proof: new Uint8Array(210).fill(marker),
+      globalSpendKeyHex: marker.toString(16).padStart(2, '0').repeat(32),
+      recordId,
+      reservationId,
+    });
+    const reserveDistinctPair = vi.fn(async (
+      firstBinding: BatV2ClassBindingV2,
+      secondBinding: BatV2ClassBindingV2,
+      validate?: (record: ReturnType<typeof lease>) => void,
+    ) => {
+      events.push('reserve');
+      if (available < 2) return null;
+      expect(firstBinding).toEqual(classBinding);
+      expect(secondBinding).toEqual(classBinding);
+      expect(firstBinding).not.toHaveProperty('providerIdHex');
+      const firstLease = lease('proof-a', 0x31);
+      const secondLease = lease('proof-b', 0x32);
+      validate?.(firstLease);
+      validate?.(secondLease);
+      available = 0;
+      return { reservationId, first: firstLease, second: secondLease };
+    });
+    const finishReservation = vi.fn(async (
+      reserved: ReturnType<typeof lease>,
+      disposition: 'recover-safe' | 'burn',
+    ) => {
+      reserved.proof.fill(0);
+      if (disposition === 'recover-safe') available += 1;
+    });
+    const batV2Vault = {
+      reserveDistinctPair,
+      finishReservation,
+      listInventory: vi.fn(async () => available > 0
+        ? [{ ...classBinding, count: available }]
+        : []),
+    } as unknown as BatV2CredentialVaultV2;
+    const granted = (scopeIdHex: string, label: string) => async (
+      _verified: unknown,
+      proof: Uint8Array,
+    ) => {
+      events.push(label);
+      expect(proof).toHaveLength(210);
+      return {
+        kind: 'granted' as const,
+        grant: {
+          scopeIdHex,
+          enforcedProfile: 2,
+          expiresInMs: 1000,
+          hasHarmonyAttach: false,
+        },
+      };
+    };
+    let firstAttempt = 0;
+    const firstAuthorize = async (_verified: unknown, proof: Uint8Array) => {
+      expect(proof).toHaveLength(210);
+      firstAttempt += 1;
+      if (firstAttempt === 1) {
+        events.push('send-a-retry-safe');
+        return { kind: 'recoverable-retry-safe' as const, retryAfterMs: 5 };
+      }
+      events.push('send-a');
+      return {
+        kind: 'granted' as const,
+        grant: {
+          scopeIdHex: HEX.scope0,
+          enforcedProfile: 2,
+          expiresInMs: 1000,
+          hasHarmonyAttach: false,
+        },
+      };
+    };
+    const first = session(
+      vault,
+      [policy(HEX.provider0, HEX.policy0, HEX.scope0, target, [firstOffer])],
+      HEX.provider0,
+      HEX.key0,
+      target,
+      undefined,
+      undefined,
+      firstAuthorize,
+    );
+    const second = session(
+      vault,
+      [policy(HEX.provider1, HEX.policy1, HEX.scope1, target, [secondOffer])],
+      HEX.provider1,
+      HEX.key1,
+      target,
+      undefined,
+      undefined,
+      granted(HEX.scope1, 'send-b'),
+    );
+    const resolveBatV2Class = vi.fn(async (_selector: ProductBatV2ClassMemberSelectorV2) => ({
+      classBytes: new Uint8Array([1, 2, 3, 4]),
+      binding: classBinding,
+    }));
+    const sharedPayee = new Uint8Array([2, ...new Uint8Array(32).fill(8)]);
+    const controller = new ProductAdmissionControllerV1({
+      topology: 'independent-pair',
+      vault,
+      batV2Vault,
+      resolveBatV2Class,
+    });
+    await controller.prepare(async () => ({
+      legs: [
+        {
+          role: 'server0', label: 'Server 0', session: first.session, ...target,
+          providerEndpoint: PROVIDER_ENDPOINT.first,
+          lightningPayeeTrust: lightningTrust(firstOffer, sharedPayee),
+        },
+        {
+          role: 'server1', label: 'Server 1', session: second.session, ...target,
+          providerEndpoint: PROVIDER_ENDPOINT.second,
+          lightningPayeeTrust: lightningTrust(secondOffer, sharedPayee),
+        },
+      ],
+      close: vi.fn(),
+    }));
+    controller.setAllowSharedInfrastructureCorrelationOnce(true);
+    await controller.selectOffer('server0', {
+      scopeIdHex: HEX.scope0,
+      offerId: firstOffer.offerId,
+    });
+    await controller.selectOffer('server1', {
+      scopeIdHex: HEX.scope1,
+      offerId: secondOffer.offerId,
+    });
+
+    await expect(controller.authorize('server0')).rejects.toMatchObject({
+      code: 'bat-v2-retry-safe',
+    });
+    expect(controller.snapshot().legs[0]).toMatchObject({ status: 'ready' });
+    await controller.authorize('server0');
+    await controller.authorize('server1');
+
+    expect(events).toEqual([
+      'reserve', 'send-a-retry-safe',
+      'reserve', 'send-a', 'send-b',
+    ]);
+    expect(resolveBatV2Class).toHaveBeenCalledTimes(4);
+    for (const [selector] of resolveBatV2Class.mock.calls) {
+      expect(selector).not.toHaveProperty('proof');
+      expect(selector.offer.authorization).toBe('cashu-bat-v2');
+      expect(selector.offer.keyIdHex).toBe(classBinding.classIdHex);
+    }
+    expect(reserveDistinctPair).toHaveBeenCalledTimes(2);
+    expect(finishReservation.mock.calls.map(([, disposition]) => disposition))
+      .toEqual(['recover-safe', 'recover-safe', 'burn', 'burn']);
+    expect(first.authorize).not.toHaveBeenCalled();
+    expect(second.authorize).not.toHaveBeenCalled();
+    expect(first.authorizeBatV2).toHaveBeenCalledTimes(2);
+    expect(second.authorizeBatV2).toHaveBeenCalledOnce();
+    expect(controller.canQuery()).toBe(true);
+    await controller.close();
   });
 
   it('automates independent signed Free selections without touching paid offers', async () => {

--- a/web/src/__tests__/provider-payment-selection.test.ts
+++ b/web/src/__tests__/provider-payment-selection.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { assertIndependentProviderOfferPairV1 } from '../provider-payment-selection.js';
+import {
+  assertIndependentProviderBatV2ProjectionPairV2,
+  assertIndependentProviderOfferPairV1,
+  VerifiedProviderBatV2ProjectionV2,
+  type BatV2ClassArtifactV2,
+} from '../provider-payment-selection.js';
 import type { ProviderTrustAnchorV1 } from '../service-admission.js';
 import type { ServiceOfferViewV1 } from '../sdk-bridge.js';
 
@@ -39,7 +44,110 @@ function offer(overrides: Partial<ServiceOfferViewV1> = {}): ServiceOfferViewV1 
   };
 }
 
+const batV2Class: BatV2ClassArtifactV2 = {
+  classBytes: new Uint8Array([7, 8, 9]),
+  binding: {
+    issuerIdHex: '31'.repeat(32),
+    classIdHex: '41'.repeat(32),
+    classDigestHex: '51'.repeat(32),
+    classKeyEpoch: '3',
+    batKeyIdHex: '61'.repeat(32),
+  },
+};
+
+function batV2Projection(providerByte: number, classArtifact = batV2Class) {
+  const policyDigestHex = `${providerByte + 70}`.repeat(32);
+  const scopeIdHex = `${providerByte + 80}`.repeat(32);
+  const selectedTrust = trust(providerByte, providerByte + 10, providerByte + 20);
+  return VerifiedProviderBatV2ProjectionV2.create({
+    trust: selectedTrust,
+    offer: offer({
+      authorization: 'cashu-bat-v2',
+      verification: 'shared-issuer-online',
+      keyIdHex: classArtifact.binding.classIdHex,
+      batVerificationKeyFingerprintHex: '',
+    }),
+    providerEndpoint: `wss://pir-${providerByte}.example`,
+    expectedLightningPayeePubkey: new Uint8Array([2, ...new Uint8Array(32).fill(9)]),
+    trustedOperatorSigningKey:
+      selectedTrust.directoryAssertion!.operatorSigningKeyEd25519.slice(),
+    policyDigestHex,
+    scopeIdHex,
+    offerId: 1,
+    classArtifact,
+    verifiedRedemption: {
+      free: vi.fn(),
+      providerIdHex: Array.from(selectedTrust.providerId, (byte) =>
+        byte.toString(16).padStart(2, '0')).join(''),
+      policyDigestHex,
+      scopeIdHex,
+      offerId: 1,
+      classIdHex: classArtifact.binding.classIdHex,
+      assertRedemptionReady: vi.fn(),
+    },
+  });
+}
+
 describe('local independent-provider payment selection', () => {
+  it('retains two exact verified BAT V2 members of one byte-identical class', () => {
+    const first = batV2Projection(1);
+    const second = batV2Projection(2);
+    try {
+      expect(() => assertIndependentProviderBatV2ProjectionPairV2(
+        first,
+        second,
+        {
+          allowSharedIssuerCorrelation: true,
+          allowSharedLightningPayeeCorrelation: true,
+        },
+      )).not.toThrow();
+    } finally {
+      first.close();
+      second.close();
+    }
+  });
+
+  it('rejects a copied class ID backed by different signed class bytes', () => {
+    const first = batV2Projection(1);
+    const second = batV2Projection(2, {
+      classBytes: new Uint8Array([7, 8, 10]),
+      binding: { ...batV2Class.binding },
+    });
+    try {
+      expect(() => assertIndependentProviderBatV2ProjectionPairV2(
+        first,
+        second,
+        {
+          allowSharedIssuerCorrelation: true,
+          allowSharedLightningPayeeCorrelation: true,
+        },
+      )).toThrow(/same exact issuer-signed acceptance class/);
+    } finally {
+      first.close();
+      second.close();
+    }
+  });
+
+  it('rejects byte-copied artifacts carrying a different class projection', () => {
+    const first = batV2Projection(1);
+    const second = batV2Projection(2, {
+      classBytes: batV2Class.classBytes.slice(),
+      binding: { ...batV2Class.binding, classDigestHex: '52'.repeat(32) },
+    });
+    try {
+      expect(() => assertIndependentProviderBatV2ProjectionPairV2(
+        first,
+        second,
+        {
+          allowSharedIssuerCorrelation: true,
+          allowSharedLightningPayeeCorrelation: true,
+        },
+      )).toThrow(/same exact issuer-signed acceptance class/);
+    } finally {
+      first.close();
+      second.close();
+    }
+  });
   it('accepts independent providers, issuers, origins, and BAT raw keys', () => {
     expect(() => assertIndependentProviderOfferPairV1(
       { trust: trust(1, 11, 21), offer: offer() },

--- a/web/src/__tests__/service-admission.test.ts
+++ b/web/src/__tests__/service-admission.test.ts
@@ -12,12 +12,14 @@ vi.mock('../sdk-bridge.js', async () => {
 import {
   AmbiguousCapabilitySpendErrorV1,
   ProviderAdmissionSessionV1,
+  VerifiedIndependentProviderBatV2PairV2,
   VerifiedIndependentProviderPairV1,
   VerifiedSingleProviderOfferV1,
   VerifiedSingleProviderRetainedOfferV1,
   type ServiceAdmissionPortV1,
   type ServiceAdmissionTargetV1,
   type ServiceAdmissionVaultV1,
+  type BatV2AdmissionVaultV2,
 } from '../service-admission.js';
 import type { AdmissionCapabilityV1 } from '../admission-vault.js';
 import type {
@@ -97,6 +99,23 @@ function accepted(view: ServicePolicyViewV1) {
     importStandardCashuToken: () => new Uint8Array([7, 7]),
     offersJson: () => view,
     beginBolt11Acquisition: () => { throw new Error('unused'); },
+    verifyBatV2Redemption: (scopeId: Uint8Array, offerId: number) => {
+      const selected = view.scopes[0].offers[0];
+      if (selected.authorization !== 'cashu-bat-v2'
+          || offerId !== selected.offerId
+          || Buffer.from(scopeId).toString('hex') !== view.scopes[0].scopeIdHex) {
+        throw new Error('wrong BAT V2 member');
+      }
+      return {
+        free: vi.fn(),
+        providerIdHex: view.providerIdHex,
+        policyDigestHex: view.policyDigestHex,
+        scopeIdHex: view.scopes[0].scopeIdHex,
+        offerId,
+        classIdHex: selected.keyIdHex,
+        assertRedemptionReady: vi.fn(),
+      };
+    },
   } satisfies WasmAcceptedServicePolicyV1;
 }
 
@@ -137,6 +156,27 @@ function retainedAccepted(
     assertRedemptionReady: vi.fn(),
     validateAuthorizationProof: vi.fn(),
     redemptionJson: () => structuredClone(view),
+  };
+}
+
+function batV2Offer(): ServiceOfferViewV1 {
+  return {
+    offerId: 101,
+    acquisition: 'bolt11',
+    authorization: 'cashu-bat-v2',
+    freeMode: 'not-free',
+    verification: 'shared-issuer-online',
+    deploymentStatus: 'stable',
+    priorityClass: 1,
+    price: { kind: 'msat', amount: '1000' },
+    issuerIdHex: '71'.repeat(32),
+    keyIdHex: '72'.repeat(32),
+    batVerificationKeyFingerprintHex: '',
+    arcVerificationKeyFingerprintHex: '',
+    endpoint: 'https://shared-issuer.example',
+    credentialCount: 2,
+    credentialPresentationLimit: 1,
+    privacyLeakageBits: 0,
   };
 }
 
@@ -1210,6 +1250,7 @@ describe('provider admission orchestration', () => {
         scopeIdHex: scopeHex,
         offerId: 90,
         providerEndpoint: 'wss://provider-a.example',
+        lightningNetwork: 'bitcoin',
       } },
       { kind: 'retained', value: second },
     )).not.toThrow();
@@ -1286,5 +1327,280 @@ describe('provider admission orchestration', () => {
       scheme: 'cashu-bat',
     })).rejects.toThrow(/does not match capability scheme/);
     expect(retiredBinding).toBeNull();
+  });
+
+  it('reserves two class-only BAT V2 proofs before either typed adapter call', async () => {
+    const events: string[] = [];
+    const dispositions: string[] = [];
+    let firstSendGate: Promise<void> | null = null;
+    const classBinding = {
+      issuerIdHex: '71'.repeat(32),
+      classIdHex: '72'.repeat(32),
+      classDigestHex: '73'.repeat(32),
+      classKeyEpoch: '4',
+      batKeyIdHex: '74'.repeat(32),
+    };
+    const artifact = { classBytes: new Uint8Array([1, 2, 3]), binding: classBinding };
+    const reservationId = 'reservation-v2';
+    const lease = (recordId: string, spendByte: number) => ({
+      ...classBinding,
+      proof: new Uint8Array(210).fill(spendByte),
+      globalSpendKeyHex: spendByte.toString(16).padStart(2, '0').repeat(32),
+      recordId,
+      reservationId,
+    });
+    const batVault: BatV2AdmissionVaultV2 = {
+      reserveDistinctPair: vi.fn(async (_first, _second, validate) => {
+        events.push('reserve');
+        const first = lease('record-a', 0x31);
+        const second = lease('record-b', 0x32);
+        validate?.(first);
+        validate?.(second);
+        return { reservationId, first, second };
+      }),
+      finishReservation: vi.fn(async (_lease, disposition) => {
+        dispositions.push(disposition);
+      }),
+    };
+    const firstView = policy(batV2Offer(), providerHex, scopeHex);
+    const secondView = policy(batV2Offer(), secondProviderHex, secondScopeHex);
+    const makePort = (
+      label: string,
+      view: ServicePolicyViewV1,
+      endpoint: string,
+      operator: Uint8Array,
+    ): ServiceAdmissionPortV1 => ({
+      assertTrustAnchor: vi.fn(),
+      providerEndpoint: () => endpoint,
+      operatorSigningKey: () => operator.slice(),
+      fetchPolicy: async () => accepted(view),
+      assertSessionBinding: vi.fn(),
+      captureReadinessGuard: () => vi.fn(),
+      authorize: async () => { throw new Error('V1 must not send'); },
+      authorizeBatV2: async () => {
+        events.push(label);
+        if (label === 'send-a') await firstSendGate;
+        return {
+          kind: 'granted',
+          grant: {
+            scopeIdHex: view.scopes[0].scopeIdHex,
+            enforcedProfile: 3,
+            expiresInMs: 1000,
+            hasHarmonyAttach: false,
+          },
+        };
+      },
+      requestPowChallenge: async () => { throw new Error('unused'); },
+    });
+    const firstSession = new ProviderAdmissionSessionV1(
+      vault,
+      makePort('send-a', firstView, 'wss://provider-a.example', providerId),
+      { providerId, policySigningKey: policyKey },
+      DPF_TARGET,
+    );
+    const secondSession = new ProviderAdmissionSessionV1(
+      vault,
+      makePort('send-b', secondView, 'wss://provider-b.example', secondProviderId),
+      { providerId: secondProviderId, policySigningKey: secondPolicyKey },
+      DPF_TARGET,
+    );
+    await firstSession.refreshPolicy();
+    await secondSession.refreshPolicy();
+    const payee = new Uint8Array([2, ...new Uint8Array(32).fill(8)]);
+    const createPair = () => VerifiedIndependentProviderBatV2PairV2.create(
+      {
+        session: firstSession,
+        scopeIdHex: scopeHex,
+        offerId: 101,
+        providerEndpoint: 'wss://provider-a.example',
+        lightningNetwork: 'bitcoin',
+        expectedLightningPayeePubkey: payee,
+        classArtifact: artifact,
+      },
+      {
+        session: secondSession,
+        scopeIdHex: secondScopeHex,
+        offerId: 101,
+        providerEndpoint: 'wss://provider-b.example',
+        lightningNetwork: 'bitcoin',
+        expectedLightningPayeePubkey: payee,
+        classArtifact: artifact,
+      },
+      batVault,
+      {
+        allowSharedIssuerCorrelation: true,
+        allowSharedLightningPayeeCorrelation: true,
+      },
+    );
+    const pair = createPair();
+    await expect(pair.authorize('first')).resolves.toMatchObject({ kind: 'granted' });
+    await expect(pair.authorize('second')).resolves.toMatchObject({ kind: 'granted' });
+    expect(events).toEqual(['reserve', 'send-a', 'send-b']);
+    expect(dispositions).toEqual(['burn', 'burn']);
+    await pair.close();
+
+    events.length = 0;
+    dispositions.length = 0;
+    let releaseFirstSend!: () => void;
+    firstSendGate = new Promise<void>((resolve) => { releaseFirstSend = resolve; });
+    const closingPair = createPair();
+    const authorization = closingPair.authorize('first');
+    await vi.waitFor(() => expect(events).toEqual(['reserve', 'send-a']));
+    const closing = closingPair.close();
+    await Promise.resolve();
+    expect(dispositions).toEqual([]);
+
+    releaseFirstSend();
+    await expect(authorization).resolves.toMatchObject({ kind: 'granted' });
+    await closing;
+    expect(dispositions).toEqual(['burn', 'recover-safe']);
+    firstSession.close();
+    secondSession.close();
+  });
+
+  it('performs zero sends for missing or duplicate BAT V2 pair inventory', async () => {
+    const send = vi.fn();
+    const classBinding = {
+      issuerIdHex: '71'.repeat(32),
+      classIdHex: '72'.repeat(32),
+      classDigestHex: '73'.repeat(32),
+      classKeyEpoch: '4',
+      batKeyIdHex: '74'.repeat(32),
+    };
+    const viewA = policy(batV2Offer(), providerHex, scopeHex);
+    const viewB = policy(batV2Offer(), secondProviderHex, secondScopeHex);
+    const port = (
+      view: ServicePolicyViewV1,
+      endpoint: string,
+      operator: Uint8Array,
+      withBatV2 = true,
+    ): ServiceAdmissionPortV1 => {
+      const value: ServiceAdmissionPortV1 = {
+        assertTrustAnchor: vi.fn(),
+        providerEndpoint: () => endpoint,
+        operatorSigningKey: () => operator.slice(),
+        fetchPolicy: async () => accepted(view),
+        assertSessionBinding: vi.fn(),
+        captureReadinessGuard: () => vi.fn(),
+        authorize: async () => { throw new Error('unused'); },
+        requestPowChallenge: async () => { throw new Error('unused'); },
+      };
+      if (withBatV2) {
+        value.authorizeBatV2 = async () => {
+          send();
+          return { kind: 'burn-terminal' };
+        };
+      }
+      return value;
+    };
+    const first = new ProviderAdmissionSessionV1(
+      vault, port(viewA, 'wss://a.example', providerId),
+      { providerId, policySigningKey: policyKey }, DPF_TARGET,
+    );
+    const second = new ProviderAdmissionSessionV1(
+      vault, port(viewB, 'wss://b.example', secondProviderId),
+      { providerId: secondProviderId, policySigningKey: secondPolicyKey }, DPF_TARGET,
+    );
+    await first.refreshPolicy();
+    await second.refreshPolicy();
+    const artifact = { classBytes: new Uint8Array([1]), binding: classBinding };
+    const payee = new Uint8Array([2, ...new Uint8Array(32).fill(8)]);
+    const create = (
+      batVault: BatV2AdmissionVaultV2,
+      firstSession = first,
+    ) =>
+      VerifiedIndependentProviderBatV2PairV2.create(
+        { session: firstSession, scopeIdHex: scopeHex, offerId: 101,
+          providerEndpoint: 'wss://a.example', lightningNetwork: 'bitcoin',
+          expectedLightningPayeePubkey: payee,
+          classArtifact: artifact },
+        { session: second, scopeIdHex: secondScopeHex, offerId: 101,
+          providerEndpoint: 'wss://b.example', lightningNetwork: 'bitcoin',
+          expectedLightningPayeePubkey: payee,
+          classArtifact: artifact },
+        batVault,
+        { allowSharedIssuerCorrelation: true, allowSharedLightningPayeeCorrelation: true },
+      );
+    const missing = create({
+      reserveDistinctPair: async () => null,
+      finishReservation: vi.fn(),
+    });
+    await expect(missing.authorize('first')).rejects.toThrow(/two distinct BAT V2 proofs/);
+    expect(send).not.toHaveBeenCalled();
+    await missing.close();
+
+    const duplicateLease = {
+      ...classBinding,
+      proof: new Uint8Array(210).fill(5),
+      globalSpendKeyHex: '75'.repeat(32),
+      recordId: 'record-a',
+      reservationId: 'reservation-duplicate',
+    };
+    const duplicate = create({
+      reserveDistinctPair: async () => ({
+        reservationId: 'reservation-duplicate',
+        first: duplicateLease,
+        second: { ...duplicateLease, proof: duplicateLease.proof.slice(), recordId: 'record-b' },
+      }),
+      finishReservation: vi.fn(async () => {}),
+    });
+    await expect(duplicate.authorize('first')).rejects.toThrow(/non-distinct/);
+    expect(send).not.toHaveBeenCalled();
+    await duplicate.close();
+
+    const mismatchedFirst = {
+      ...duplicateLease,
+      recordId: 'record-c',
+      reservationId: 'reservation-mismatch',
+      classDigestHex: '76'.repeat(32),
+      proof: new Uint8Array(210).fill(6),
+    };
+    const mismatchedSecond = {
+      ...duplicateLease,
+      recordId: 'record-d',
+      reservationId: 'reservation-mismatch',
+      globalSpendKeyHex: '77'.repeat(32),
+      proof: new Uint8Array(210).fill(7),
+    };
+    const finishMismatch = vi.fn(async (
+      reserved: typeof mismatchedFirst,
+      _disposition: 'recover-safe' | 'burn',
+    ) => {
+      reserved.proof.fill(0);
+    });
+    const mismatched = create({
+      reserveDistinctPair: async () => ({
+        reservationId: 'reservation-mismatch',
+        first: mismatchedFirst,
+        second: mismatchedSecond,
+      }),
+      finishReservation: finishMismatch,
+    });
+    await expect(mismatched.authorize('first')).rejects.toThrow(/exact verified class/);
+    expect(finishMismatch).toHaveBeenCalledTimes(2);
+    expect(finishMismatch.mock.calls.every(([, disposition]) =>
+      disposition === 'recover-safe')).toBe(true);
+    expect(mismatchedFirst.proof.every((byte) => byte === 0)).toBe(true);
+    expect(mismatchedSecond.proof.every((byte) => byte === 0)).toBe(true);
+    expect(send).not.toHaveBeenCalled();
+    await mismatched.close();
+
+    const unsupportedFirst = new ProviderAdmissionSessionV1(
+      vault, port(viewA, 'wss://a.example', providerId, false),
+      { providerId, policySigningKey: policyKey }, DPF_TARGET,
+    );
+    await unsupportedFirst.refreshPolicy();
+    const reserveDistinctPair = vi.fn(async () => null);
+    const unsupported = create({
+      reserveDistinctPair,
+      finishReservation: vi.fn(),
+    }, unsupportedFirst);
+    await expect(unsupported.authorize('first')).rejects.toThrow(/does not expose typed BAT V2/);
+    expect(reserveDistinctPair).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+    await unsupported.close();
+    unsupportedFirst.close();
+    first.close();
+    second.close();
   });
 });

--- a/web/src/dpf-adapter.ts
+++ b/web/src/dpf-adapter.ts
@@ -1144,6 +1144,18 @@ export class BatchPirClientAdapter {
         offerId,
         nowUnix,
       ),
+      fetchRetainedBatV2Policy: (
+        providerId, policyKey, policyDigest, scopeId, offerId, nowUnix,
+      ) => client().fetchRetainedBatV2Policy(
+        serverIndex,
+        dbId,
+        providerId,
+        policyKey,
+        policyDigest,
+        scopeId,
+        offerId,
+        nowUnix,
+      ),
       assertSessionBinding: (policy) =>
         authorizedClient().verifyServicePolicySession(serverIndex, policy),
       captureReadinessGuard: () => {
@@ -1163,6 +1175,14 @@ export class BatchPirClientAdapter {
         authorizedClient().verifyRetainedServiceSession(serverIndex, policy, nowUnix),
       authorize: (policy, scopeId, offerId, proof) =>
         authorizedClient().authorizeService(serverIndex, dbId, policy, scopeId, offerId, proof),
+      authorizeBatV2: (verified, proof, nowUnix) =>
+        authorizedClient().dangerousUnpairedAuthorizeBatV2Service(
+          serverIndex,
+          dbId,
+          verified,
+          proof,
+          nowUnix,
+        ),
       authorizeRetained: (policy, proof, nowUnix) =>
         authorizedClient().dangerousUnpairedAuthorizeRetainedService(
           serverIndex, dbId, policy, proof, nowUnix,

--- a/web/src/harmonypir-adapter.ts
+++ b/web/src/harmonypir-adapter.ts
@@ -1357,12 +1357,21 @@ export class HarmonyPirClientAdapter {
       ) => client().fetchRetainedServiceRedemption(
         0, dbId, providerId, policyKey, policyDigest, scopeId, offerId, nowUnix,
       ),
+      fetchRetainedBatV2Policy: (
+        providerId, policyKey, policyDigest, scopeId, offerId, nowUnix,
+      ) => client().fetchRetainedBatV2Policy(
+        0, dbId, providerId, policyKey, policyDigest, scopeId, offerId, nowUnix,
+      ),
       assertSessionBinding: (policy) => authorizedClient().verifyServicePolicySession(0, policy),
       captureReadinessGuard: () => this.captureServiceReadinessGuard(0, dbId),
       assertRetainedSessionBinding: (policy, nowUnix) =>
         authorizedClient().verifyRetainedServiceSession(0, policy, nowUnix),
       authorize: (policy, scopeId, offerId, proof) =>
         authorizedClient().authorizeHintService(dbId, policy, scopeId, offerId, proof),
+      authorizeBatV2: (verified, proof, nowUnix) =>
+        authorizedClient().dangerousUnpairedAuthorizeBatV2HintService(
+          dbId, verified, proof, nowUnix,
+        ),
       authorizeRetained: (policy, proof, nowUnix) =>
         authorizedClient().dangerousUnpairedAuthorizeRetainedHintService(
           dbId,
@@ -1394,12 +1403,21 @@ export class HarmonyPirClientAdapter {
       ) => client().fetchRetainedServiceRedemption(
         1, dbId, providerId, policyKey, policyDigest, scopeId, offerId, nowUnix,
       ),
+      fetchRetainedBatV2Policy: (
+        providerId, policyKey, policyDigest, scopeId, offerId, nowUnix,
+      ) => client().fetchRetainedBatV2Policy(
+        1, dbId, providerId, policyKey, policyDigest, scopeId, offerId, nowUnix,
+      ),
       assertSessionBinding: (policy) => authorizedClient().verifyServicePolicySession(1, policy),
       captureReadinessGuard: () => this.captureServiceReadinessGuard(1, dbId),
       assertRetainedSessionBinding: (policy, nowUnix) =>
         authorizedClient().verifyRetainedServiceSession(1, policy, nowUnix),
       authorize: (policy, scopeId, offerId, proof) =>
         authorizedClient().authorizeQueryService(dbId, policy, scopeId, offerId, proof),
+      authorizeBatV2: (verified, proof, nowUnix) =>
+        authorizedClient().dangerousUnpairedAuthorizeBatV2QueryService(
+          dbId, verified, proof, nowUnix,
+        ),
       authorizeRetained: (policy, proof, nowUnix) =>
         authorizedClient().dangerousUnpairedAuthorizeRetainedQueryService(
           dbId,

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -268,6 +268,7 @@ export type { Bat } from './cashu-bat.js';
 export {
   AmbiguousCapabilitySpendErrorV1,
   ProviderAdmissionSessionV1,
+  VerifiedIndependentProviderBatV2PairV2,
   VerifiedIndependentProviderPairV1,
   VerifiedSingleProviderOfferV1,
   VerifiedSingleProviderRetainedOfferV1,
@@ -282,12 +283,20 @@ export type {
   ProductQueryShapeV1,
   ProductQueryShapesByRoleV1,
 } from './service-entitlement.js';
-export { assertIndependentProviderOfferPairV1 } from './provider-payment-selection.js';
-export type {
-  IndependentProviderSelectionOptionsV1,
-  SelectedProviderOfferV1,
+export {
+  assertIndependentProviderBatV2ProjectionPairV2,
+  assertIndependentProviderOfferPairV1,
+  VerifiedProviderBatV2ProjectionV2,
 } from './provider-payment-selection.js';
 export type {
+  BatV2ClassArtifactV2,
+  IndependentProviderSelectionOptionsV1,
+  SelectedProviderOfferV1,
+  VerifiedProviderBatV2ProjectionInputV2,
+} from './provider-payment-selection.js';
+export type {
+  BatV2AdmissionVaultV2,
+  IndependentProviderBatV2AdmissionSelectionV2,
   ProviderTrustAnchorV1,
   ProviderAdmissionSelectionV1,
   IndependentProviderAdmissionSelectionV1,
@@ -302,6 +311,11 @@ export type {
   ServiceAdmissionVaultV1,
   ServiceAuthorizationOptionsV1,
 } from './service-admission.js';
+export type {
+  BatV2AdmissionOutcomeV2,
+  WasmAcceptedRetainedBatV2PolicyV2,
+  WasmVerifiedBatV2RedemptionV2,
+} from './sdk-bridge.js';
 export {
   AdmissionCredentialVaultV1,
   validateBindingV1,
@@ -406,6 +420,8 @@ export type {
   ProductAdmissionResourceV1,
   ProductAdmissionSnapshotV1,
   ProductAdmissionTopologyV1,
+  ProductBatV2ClassMemberSelectorV2,
+  ProductBatV2ClassResolverV2,
   ProductOfferChoiceV1,
   ProductOfferOptionV1,
   ProductStrictBootstrapV1,

--- a/web/src/onionpir_client.ts
+++ b/web/src/onionpir_client.ts
@@ -1128,6 +1128,20 @@ export class OnionPirWebClient {
           nowUnix,
         );
       }),
+      fetchRetainedBatV2Policy: (
+        providerId, policyKey, policyDigest, scopeId, offerId, nowUnix,
+      ) => roundtrip(async (state) => {
+        const response = await this.sendRaw(state.retainedPolicyRequest(policyDigest));
+        return state.acceptRetainedBatV2PolicyResponse(
+          response,
+          providerId,
+          policyKey,
+          policyDigest,
+          scopeId,
+          offerId,
+          nowUnix,
+        );
+      }),
       assertSessionBinding: (policy) => {
         const state = admission();
         try {
@@ -1168,6 +1182,18 @@ export class OnionPirWebClient {
           try {
             const response = await this.sendRaw(request);
             return state.acceptAuthorizationResponse(response, policy, scopeId);
+          } finally {
+            request.fill(0);
+          }
+        }),
+      authorizeBatV2: (verified, proof, nowUnix) =>
+        roundtrip(async (state) => {
+          // Rust rechecks current/retained membership and proof/class binding
+          // before returning request bytes. Exactly one socket send follows.
+          const request = state.batV2AuthorizationRequest(verified, proof, nowUnix);
+          try {
+            const response = await this.sendRaw(request);
+            return state.acceptBatV2AuthorizationResponse(response, verified);
           } finally {
             request.fill(0);
           }

--- a/web/src/oram-adapter.ts
+++ b/web/src/oram-adapter.ts
@@ -325,6 +325,11 @@ export class OramPirClientAdapter {
       ) => client().fetchRetainedServiceRedemption(
         dbId, providerId, policyKey, policyDigest, scopeId, offerId, nowUnix,
       ),
+      fetchRetainedBatV2Policy: (
+        providerId, policyKey, policyDigest, scopeId, offerId, nowUnix,
+      ) => client().fetchRetainedBatV2Policy(
+        dbId, providerId, policyKey, policyDigest, scopeId, offerId, nowUnix,
+      ),
       assertSessionBinding: (policy) => client().verifyServicePolicySession(policy),
       captureReadinessGuard: () => {
         const expectedClient = client();
@@ -344,6 +349,8 @@ export class OramPirClientAdapter {
         client().verifyRetainedServiceSession(policy, nowUnix),
       authorize: (policy, scopeId, offerId, proof) =>
         client().authorizeService(dbId, policy, scopeId, offerId, proof),
+      authorizeBatV2: (verified, proof, nowUnix) =>
+        client().authorizeBatV2Service(dbId, verified, proof, nowUnix),
       authorizeRetained: (policy, proof, nowUnix) =>
         client().authorizeRetainedService(dbId, policy, proof, nowUnix),
       requestPowChallenge: (policy, scopeId, offerId, nowUnix) =>

--- a/web/src/product-admission-controller.ts
+++ b/web/src/product-admission-controller.ts
@@ -18,16 +18,24 @@ import {
   type LightningNetworkNameV1,
 } from './admission-vault.js';
 import {
+  BatV2CredentialVaultV2,
+  validateBatV2ClassBindingV2,
+  type BatV2ClassBindingV2,
+} from './bat-v2-vault.js';
+import {
   AmbiguousCapabilitySpendErrorV1,
   ProviderAdmissionSessionV1,
   VerifiedIndependentProviderPairV1,
+  VerifiedIndependentProviderBatV2PairV2,
   VerifiedSingleProviderOfferV1,
   VerifiedSingleProviderRetainedOfferV1,
   type IndependentProviderPairAdmissionSelectionV1,
+  type IndependentProviderBatV2AdmissionSelectionV2,
   type ProviderPairBolt11AcquisitionOptionsV1,
   type ProviderPairSideV1,
   type ServiceAuthorizationOptionsV1,
 } from './service-admission.js';
+import type { BatV2ClassArtifactV2 } from './provider-payment-selection.js';
 import {
   Bolt11RecoveryRequiredErrorV1,
   resumeBolt11AcquisitionV1,
@@ -41,6 +49,7 @@ import type {
   ServicePolicyViewV1,
   RetainedServiceRedemptionViewV1,
   ServiceScopeViewV1,
+  BatV2AdmissionOutcomeV2,
 } from './sdk-bridge.js';
 import {
   assertProductQueryShapeFitsScopeV1,
@@ -72,8 +81,12 @@ export type ProductAdmissionLegStatusV1 =
   | 'ambiguous-spend'
   | 'failed';
 
-export interface ProductAdmissionResourceBindingV1
-  extends AdmissionCapabilityBindingV1 {
+export interface ProductAdmissionResourceBindingV1 {
+  providerIdHex: string;
+  policyDigestHex: string;
+  scopeIdHex: string;
+  offerId: number;
+  scheme: AdmissionSchemeV1 | 'cashu-bat-v2';
   /** Trusted dataset identifier, normally the verified bucket super-root. */
   datasetIdHex: string;
   /** Exact Harmony PRP backend, or another resource-specific variant. */
@@ -129,7 +142,25 @@ export interface ProductAdmissionControllerOptionsV1 {
   vault: AdmissionCredentialVaultV1;
   /** Test seam; production uses the restart-safe encrypted recovery adapter. */
   resumeBolt11?: typeof resumeBolt11AcquisitionV1;
+  /** Required only when both independent paid legs select BAT V2. */
+  batV2Vault?: BatV2CredentialVaultV2;
+  /** Trusted release/class-registry resolver. It receives one exact signed
+   * provider member and must return the canonical issuer-signed artifact. */
+  resolveBatV2Class?: ProductBatV2ClassResolverV2;
 }
+
+export interface ProductBatV2ClassMemberSelectorV2 {
+  role: string;
+  providerIdHex: string;
+  policyDigestHex: string;
+  scopeIdHex: string;
+  offerId: number;
+  offer: ServiceOfferViewV1;
+}
+
+export type ProductBatV2ClassResolverV2 = (
+  selector: ProductBatV2ClassMemberSelectorV2,
+) => BatV2ClassArtifactV2 | Promise<BatV2ClassArtifactV2>;
 
 export interface ProductOfferChoiceV1 {
   scopeIdHex: string;
@@ -206,6 +237,7 @@ export type ProductAdmissionErrorCodeV1 =
   | 'lightning-payee-untrusted'
   | 'bolt11-recovery-required'
   | 'capability-inventory-empty'
+  | 'bat-v2-retry-safe'
   | 'ambiguous-capability-spend'
   | 'resource-failed-after-authorization'
   | 'operation-failed';
@@ -270,6 +302,7 @@ export class ProductAdmissionControllerV1 {
   private errorCode: ProductAdmissionErrorCodeV1 | null = null;
   private queryAttempted = false;
   private queryShapesFrozen = false;
+  private batV2Pair: VerifiedIndependentProviderBatV2PairV2 | null = null;
   /** Invalidated synchronously when a strict admission attempt starts closing. */
   private lifecycleGeneration = 0;
   private readonly resumeBolt11Impl: typeof resumeBolt11AcquisitionV1;
@@ -395,6 +428,7 @@ export class ProductAdmissionControllerV1 {
     if (this.legs.some((leg) => leg.transitionInFlight)) {
       throw new ProductAdmissionErrorV1('operation-failed', 'an admission transition is in flight');
     }
+    await this.closeBatV2Pair();
     this.closeAcquisitions();
     for (const leg of this.legs) resetLegForPolicy(leg);
     try {
@@ -693,6 +727,10 @@ export class ProductAdmissionControllerV1 {
         );
       }
       this.assertSelectionPrivacyIfComplete();
+      const chosenOffer = selectedOffer(leg);
+      if (chosenOffer.authorization === 'cashu-bat-v2') {
+        return this.authorizeBatV2Leg(role, leg);
+      }
       const frozen = this.freezeSelection();
       const binding = selectedCapabilityBinding(leg);
 
@@ -708,7 +746,6 @@ export class ProductAdmissionControllerV1 {
         leg.status = 'ready';
       }
 
-      const chosenOffer = selectedOffer(leg);
       await this.assertPairAcquisitionBarrier();
       if (leg.retainedSelected || requiresVaultCapability(chosenOffer)) {
         await this.refreshLegInventory(leg);
@@ -758,6 +795,179 @@ export class ProductAdmissionControllerV1 {
     });
   }
 
+  private async authorizeBatV2Leg(
+    role: string,
+    leg: LegStateV1,
+  ): Promise<ProductAdmissionSnapshotV1> {
+    if (this.options.topology !== 'independent-pair'
+        || this.legs.length !== 2
+        || this.legs.some((candidate) => candidate.retainedSelected !== null
+          || candidate.selected?.offer.authorization !== 'cashu-bat-v2')) {
+      throw new ProductAdmissionErrorV1(
+        'offer-selection-invalidated',
+        'BAT V2 consumption requires two current exact class-member offers',
+      );
+    }
+    if (!this.options.batV2Vault || !this.options.resolveBatV2Class) {
+      throw new ProductAdmissionErrorV1(
+        'commercial-admission-unconfigured',
+        'BAT V2 requires the independent class wallet and trusted class resolver',
+      );
+    }
+
+    const resourceBinding = productBatV2ResourceBinding(leg);
+    if (leg.resource) {
+      leg.status = 'checking-cache';
+      if (await leg.resource.restore(selectedResourceBinding(leg, resourceBinding))) {
+        leg.status = 'cached-resource-ready';
+        leg.errorCode = null;
+        this.updateReadyPhase();
+        if (this.phase === 'ready-to-query') await this.closeBatV2Pair();
+        return this.snapshot();
+      }
+      leg.status = 'ready';
+    }
+
+    // Rebuild the ordinary strict-pair guard before resolving public class
+    // artifacts. Neither resolver input nor the vault contains proof bytes.
+    this.freezeSelection();
+    let pair: VerifiedIndependentProviderBatV2PairV2;
+    try {
+      pair = await this.requireBatV2Pair();
+    } catch (cause) {
+      if (/two distinct BAT V2 proofs/i.test(errorMessage(cause))) {
+        leg.errorCode = 'capability-inventory-empty';
+        throw new ProductAdmissionErrorV1(
+          'capability-inventory-empty',
+          'two distinct issuer-wide BAT V2 proofs are required before either provider send',
+          { cause },
+        );
+      }
+      throw cause;
+    }
+
+    leg.status = 'authorizing';
+    leg.credentialFlowStarted = true;
+    let outcome: BatV2AdmissionOutcomeV2;
+    try {
+      outcome = await pair.authorize(this.sideFor(role));
+    } catch (cause) {
+      if (/two distinct BAT V2 proofs/i.test(errorMessage(cause))) {
+        leg.status = 'ready';
+        leg.errorCode = 'capability-inventory-empty';
+        throw new ProductAdmissionErrorV1(
+          'capability-inventory-empty',
+          'two distinct issuer-wide BAT V2 proofs are required before either provider send',
+          { cause },
+        );
+      }
+      if (cause instanceof AmbiguousCapabilitySpendErrorV1) {
+        await this.closeBatV2PairAndRefresh(pair).catch(() => {
+          // The proof remains reserved/burn-intended; preserve the more useful
+          // may-have-been-sent error for the caller.
+        });
+        leg.status = 'ambiguous-spend';
+        leg.errorCode = 'ambiguous-capability-spend';
+        throw new ProductAdmissionErrorV1(
+          'ambiguous-capability-spend',
+          'BAT V2 may be spent after the one-shot admission call; do not retry it',
+          { cause },
+        );
+      }
+      await this.closeBatV2PairAndRefresh(pair).catch(() => {
+        // Preserve the local exact-gate failure. Unfinished reservations stay
+        // fail-closed in the V2 vault if release itself fails.
+      });
+      throw cause;
+    }
+
+    if (outcome.kind === 'recoverable-definitely-not-sent'
+        || outcome.kind === 'recoverable-retry-safe') {
+      leg.status = 'ready';
+      leg.errorCode = null;
+      await this.closeBatV2PairAndRefresh(pair);
+      throw new ProductAdmissionErrorV1(
+        'bat-v2-retry-safe',
+        'BAT V2 proof was recovered safely; retry only by explicit user action',
+      );
+    }
+    if (outcome.kind === 'burn-terminal') {
+      leg.status = 'failed';
+      leg.errorCode = 'operation-failed';
+      await this.closeBatV2PairAndRefresh(pair);
+      throw new ProductAdmissionErrorV1(
+        'operation-failed',
+        'BAT V2 authorization was terminal and the proof was burned',
+      );
+    }
+    if (outcome.kind === 'burn-outcome-unknown') {
+      leg.status = 'ambiguous-spend';
+      leg.errorCode = 'ambiguous-capability-spend';
+      await this.closeBatV2PairAndRefresh(pair);
+      throw new ProductAdmissionErrorV1(
+        'ambiguous-capability-spend',
+        'BAT V2 authorization outcome is unknown and the proof was burned',
+      );
+    }
+
+    leg.grant = { ...outcome.grant };
+    if (leg.resource) {
+      try {
+        await leg.resource.acquireAfterAuthorization(
+          selectedResourceBinding(leg, resourceBinding),
+        );
+      } catch (cause) {
+        await this.closeBatV2PairAndRefresh(pair).catch(() => {
+          // The provider grant is authoritative; keep its resource failure as
+          // the surfaced recovery instruction.
+        });
+        leg.status = 'failed';
+        leg.errorCode = 'resource-failed-after-authorization';
+        throw new ProductResourceFailedAfterAuthorizationErrorV1({ cause });
+      }
+    }
+    leg.status = 'authorized';
+    leg.errorCode = null;
+    await this.refreshBatV2Inventory(pair.classBinding());
+    this.updateReadyPhase();
+    if (this.phase === 'ready-to-query') await this.closeBatV2Pair();
+    return this.snapshot();
+  }
+
+  private async requireBatV2Pair(): Promise<VerifiedIndependentProviderBatV2PairV2> {
+    if (this.batV2Pair) return this.batV2Pair;
+    const vault = this.options.batV2Vault!;
+    const resolver = this.options.resolveBatV2Class!;
+    const artifacts = await Promise.all(this.legs.map(async (leg) =>
+      normalizeProductBatV2ClassArtifactV2(await resolver(batV2ResolverSelector(leg)))));
+    try {
+      const pair = VerifiedIndependentProviderBatV2PairV2.create(
+        productBatV2Selection(this.legs[0], artifacts[0]),
+        productBatV2Selection(this.legs[1], artifacts[1]),
+        vault,
+        {
+          allowSharedIssuerCorrelation: this.allowSharedInfrastructureCorrelationOnce,
+          allowSharedLightningPayeeCorrelation: this.allowSharedInfrastructureCorrelationOnce,
+        },
+      );
+      this.batV2Pair = pair;
+      await this.refreshBatV2Inventory(pair.classBinding());
+      return pair;
+    } finally {
+      for (const artifact of artifacts) artifact.classBytes.fill(0);
+    }
+  }
+
+  private async refreshBatV2Inventory(binding: BatV2ClassBindingV2): Promise<void> {
+    const vault = this.options.batV2Vault;
+    if (!vault) return;
+    const inventory = await vault.listInventory();
+    const count = inventory.find((entry) => sameBatV2ClassBindingV2(entry, binding))?.count ?? 0;
+    for (const leg of this.legs) {
+      if (selectedOffer(leg).authorization === 'cashu-bat-v2') leg.inventory = count;
+    }
+  }
+
   async startBolt11(role: string): Promise<ProductAdmissionSnapshotV1> {
     const leg = this.requireSelectedLeg(role);
     this.assertCredentialFlowTopologyReady();
@@ -766,6 +976,12 @@ export class ProductAdmissionControllerV1 {
       this.freezeQueryShapesForCredentialFlow();
       if (leg.selected!.offer.acquisition !== 'bolt11') {
         throw new ProductAdmissionErrorV1('operation-failed', 'selected offer is not BOLT11');
+      }
+      if (leg.selected!.offer.authorization === 'cashu-bat-v2') {
+        throw new ProductAdmissionErrorV1(
+          'operation-failed',
+          'BAT V2 acquisition uses the independent class-wallet controller',
+        );
       }
       const payee = selectedExpectedLightningPayee(leg);
       const frozen = this.freezeSelection();
@@ -979,8 +1195,11 @@ export class ProductAdmissionControllerV1 {
     for (const leg of this.legs) {
       if (leg.resource?.persistAfterQuery && hasAdmissionSelection(leg)) {
         try {
+          const binding = selectedOffer(leg).authorization === 'cashu-bat-v2'
+            ? productBatV2ResourceBinding(leg)
+            : selectedCapabilityBinding(leg);
           await leg.resource.persistAfterQuery(
-            selectedResourceBinding(leg, selectedCapabilityBinding(leg)),
+            selectedResourceBinding(leg, binding),
           );
         } catch {
           // Query/results remain valid. A missing cache write only forces the
@@ -1034,16 +1253,23 @@ export class ProductAdmissionControllerV1 {
   async close(): Promise<void> {
     this.lifecycleGeneration += 1;
     this.closeAcquisitions();
+    let closeFailure: unknown = null;
+    try {
+      await this.closeBatV2Pair();
+    } catch (error) {
+      closeFailure = error;
+    }
     for (const leg of this.legs) {
       if (!leg.transitionInFlight) {
         try { leg.session.close(); } catch { /* closing transport below is authoritative */ }
       }
     }
-    let closeFailure: unknown = null;
     try {
       await this.closeBootstrapOnly();
     } catch (error) {
-      closeFailure = error;
+      closeFailure = closeFailure
+        ? new AggregateError([closeFailure, error], 'product admission close failed')
+        : error;
     } finally {
       this.legs = [];
       this.phase = 'idle';
@@ -1248,6 +1474,7 @@ export class ProductAdmissionControllerV1 {
         continue;
       }
       const offer = selectedOffer(candidate);
+      if (offer.authorization === 'cashu-bat-v2') continue;
       if (!candidate.retainedSelected && !requiresVaultCapability(offer)) continue;
       await this.refreshLegInventory(candidate);
       if ((candidate.inventory ?? 0) <= 0) {
@@ -1402,6 +1629,8 @@ export class ProductAdmissionControllerV1 {
           && leg.errorCode !== 'capability-inventory-empty'
           && leg.errorCode !== 'lightning-payee-untrusted'
           && !(cause instanceof ProductAdmissionErrorV1
+            && cause.code === 'bat-v2-retry-safe')
+          && !(cause instanceof ProductAdmissionErrorV1
             && cause.code === 'pair-correlation-rejected')) {
         leg.status = 'failed';
         leg.errorCode = cause instanceof ProductAdmissionErrorV1
@@ -1469,6 +1698,14 @@ export class ProductAdmissionControllerV1 {
       leg.inventory = null;
       return;
     }
+    if (leg.selected.offer.authorization === 'cashu-bat-v2') {
+      if (this.batV2Pair) {
+        await this.refreshBatV2Inventory(this.batV2Pair.classBinding());
+      } else {
+        leg.inventory = null;
+      }
+      return;
+    }
     leg.inventory = await this.options.vault.countCapabilities(
       selectedCapabilityBinding(leg),
       currentCapabilityAcquisitionContext(leg),
@@ -1531,6 +1768,20 @@ export class ProductAdmissionControllerV1 {
       leg.acquisition?.close();
       leg.acquisition = null;
     }
+  }
+
+  private async closeBatV2Pair(): Promise<void> {
+    const pair = this.batV2Pair;
+    this.batV2Pair = null;
+    await pair?.close();
+  }
+
+  private async closeBatV2PairAndRefresh(
+    pair: VerifiedIndependentProviderBatV2PairV2,
+  ): Promise<void> {
+    const binding = pair.classBinding();
+    await this.closeBatV2Pair();
+    await this.refreshBatV2Inventory(binding);
   }
 
   private async closeBootstrapOnly(): Promise<void> {
@@ -1795,7 +2046,10 @@ function sameCapabilityBinding(
 
 function selectedResourceBinding(
   leg: LegStateV1,
-  binding: AdmissionCapabilityBindingV1,
+  binding: Pick<
+    ProductAdmissionResourceBindingV1,
+    'providerIdHex' | 'policyDigestHex' | 'scopeIdHex' | 'offerId' | 'scheme'
+  >,
 ): ProductAdmissionResourceBindingV1 {
   if (!leg.resource) throw new Error('provider leg has no bound resource');
   return {
@@ -1803,6 +2057,101 @@ function selectedResourceBinding(
     datasetIdHex: canonicalHex32(leg.resource.datasetIdHex),
     variant: requireVariant(leg.resource.variant),
   };
+}
+
+function productBatV2ResourceBinding(
+  leg: LegStateV1,
+): Omit<ProductAdmissionResourceBindingV1, 'datasetIdHex' | 'variant'> {
+  if (!leg.selected || leg.selected.offer.authorization !== 'cashu-bat-v2') {
+    throw new ProductAdmissionErrorV1(
+      'offer-selection-invalidated',
+      'the selected provider offer is not BAT V2',
+    );
+  }
+  return {
+    providerIdHex: canonicalHex32(leg.policy.providerIdHex),
+    policyDigestHex: canonicalHex32(leg.policy.policyDigestHex),
+    scopeIdHex: canonicalHex32(leg.selected.scopeIdHex),
+    offerId: leg.selected.offerId,
+    scheme: 'cashu-bat-v2',
+  };
+}
+
+function batV2ResolverSelector(leg: LegStateV1): ProductBatV2ClassMemberSelectorV2 {
+  if (!leg.selected || leg.selected.offer.authorization !== 'cashu-bat-v2') {
+    throw new ProductAdmissionErrorV1(
+      'offer-selection-invalidated',
+      'BAT V2 resolver requires one current exact signed offer',
+    );
+  }
+  return {
+    role: leg.role,
+    providerIdHex: canonicalHex32(leg.policy.providerIdHex),
+    policyDigestHex: canonicalHex32(leg.policy.policyDigestHex),
+    scopeIdHex: canonicalHex32(leg.selected.scopeIdHex),
+    offerId: leg.selected.offerId,
+    offer: cloneOffer(leg.selected.offer),
+  };
+}
+
+function productBatV2Selection(
+  leg: LegStateV1,
+  classArtifact: BatV2ClassArtifactV2,
+): IndependentProviderBatV2AdmissionSelectionV2 {
+  if (!leg.selected || leg.selected.offer.authorization !== 'cashu-bat-v2'
+      || !leg.providerEndpoint) {
+    throw new ProductAdmissionErrorV1(
+      'offer-selection-invalidated',
+      'BAT V2 requires a current exact offer on an adapter-bound provider endpoint',
+    );
+  }
+  return {
+    session: leg.session,
+    scopeIdHex: leg.selected.scopeIdHex,
+    offerId: leg.selected.offerId,
+    providerEndpoint: leg.providerEndpoint,
+    lightningNetwork: leg.network ?? 'bitcoin',
+    expectedLightningPayeePubkey: selectedExpectedLightningPayee(leg),
+    classArtifact,
+  };
+}
+
+function normalizeProductBatV2ClassArtifactV2(value: BatV2ClassArtifactV2): BatV2ClassArtifactV2 {
+  if (!value || !(value.classBytes instanceof Uint8Array) || value.classBytes.length === 0
+      || !value.binding || typeof value.binding !== 'object') {
+    throw new ProductAdmissionErrorV1(
+      'operation-failed',
+      'trusted BAT V2 resolver returned a malformed class artifact',
+    );
+  }
+  try {
+    validateBatV2ClassBindingV2(value.binding);
+  } catch (cause) {
+    throw new ProductAdmissionErrorV1(
+      'operation-failed',
+      'trusted BAT V2 resolver returned an invalid class binding',
+      { cause },
+    );
+  }
+  return {
+    classBytes: value.classBytes.slice(),
+    binding: { ...value.binding },
+  };
+}
+
+function sameBatV2ClassBindingV2(
+  left: BatV2ClassBindingV2,
+  right: BatV2ClassBindingV2,
+): boolean {
+  return left.issuerIdHex === right.issuerIdHex
+    && left.classIdHex === right.classIdHex
+    && left.classDigestHex === right.classDigestHex
+    && left.classKeyEpoch === right.classKeyEpoch
+    && left.batKeyIdHex === right.batKeyIdHex;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function schemeForOffer(offer: ServiceOfferViewV1): AdmissionSchemeV1 {

--- a/web/src/provider-payment-selection.ts
+++ b/web/src/provider-payment-selection.ts
@@ -7,7 +7,14 @@
  */
 
 import type { ProviderTrustAnchorV1 } from './service-admission.js';
-import type { ServiceOfferViewV1 } from './sdk-bridge.js';
+import {
+  validateBatV2ClassBindingV2,
+  type BatV2ClassBindingV2,
+} from './bat-v2-vault.js';
+import type {
+  ServiceOfferViewV1,
+  WasmVerifiedBatV2RedemptionV2,
+} from './sdk-bridge.js';
 
 export interface SelectedProviderOfferV1 {
   trust: ProviderTrustAnchorV1;
@@ -25,6 +32,168 @@ export interface IndependentProviderSelectionOptionsV1 {
   allowSharedIssuerCorrelation?: boolean;
   /** Explicitly allow one Lightning payee to observe both purchases. */
   allowSharedLightningPayeeCorrelation?: boolean;
+}
+
+/** Canonical, issuer-signed class bytes plus the independently verified
+ * wallet projection derived from those exact bytes. */
+export interface BatV2ClassArtifactV2 {
+  classBytes: Uint8Array;
+  binding: BatV2ClassBindingV2;
+}
+
+export interface VerifiedProviderBatV2ProjectionInputV2
+  extends SelectedProviderOfferV1 {
+  policyDigestHex: string;
+  scopeIdHex: string;
+  offerId: number;
+  classArtifact: BatV2ClassArtifactV2;
+  verifiedRedemption: WasmVerifiedBatV2RedemptionV2;
+}
+
+/**
+ * Runtime typestate retaining the exact verified class/member handle. A plain
+ * copied provider selection cannot stand in for this object, and all mutable
+ * byte inputs are copied before they are retained.
+ */
+export class VerifiedProviderBatV2ProjectionV2 {
+  private closed = false;
+  private readonly selectedValue: SelectedProviderOfferV1;
+  private readonly classBytesValue: Uint8Array;
+  private readonly bindingValue: BatV2ClassBindingV2;
+
+  private constructor(
+    private readonly policyDigestValue: string,
+    private readonly scopeIdValue: string,
+    private readonly offerIdValue: number,
+    private readonly redemptionValue: WasmVerifiedBatV2RedemptionV2,
+    input: VerifiedProviderBatV2ProjectionInputV2,
+  ) {
+    this.selectedValue = cloneSelectedProviderOfferV1(input);
+    this.classBytesValue = input.classArtifact.classBytes.slice();
+    this.bindingValue = { ...input.classArtifact.binding };
+  }
+
+  static create(
+    input: VerifiedProviderBatV2ProjectionInputV2,
+  ): VerifiedProviderBatV2ProjectionV2 {
+    const providerIdHex = fixedHex('BAT V2 provider ID', input.trust.providerId);
+    const policyDigestHex = canonicalNonzeroHex32(
+      'BAT V2 policy digest', input.policyDigestHex,
+    );
+    const scopeIdHex = canonicalNonzeroHex32('BAT V2 scope ID', input.scopeIdHex);
+    if (!Number.isSafeInteger(input.offerId)
+        || input.offerId <= 0 || input.offerId > 0xffff_ffff) {
+      throw new Error('BAT V2 offer ID must be a positive u32');
+    }
+    if (!(input.classArtifact.classBytes instanceof Uint8Array)
+        || input.classArtifact.classBytes.length === 0) {
+      throw new Error('BAT V2 selection requires canonical signed class bytes');
+    }
+    validateBatV2ClassBindingV2(input.classArtifact.binding);
+    assertBatV2OfferShape(input.offer, input.classArtifact.binding, input.offerId);
+    const verified = input.verifiedRedemption;
+    if (!verified || typeof verified.assertRedemptionReady !== 'function'
+        || typeof verified.free !== 'function') {
+      throw new Error('BAT V2 selection requires an opaque verified redemption handle');
+    }
+    if (verified.providerIdHex !== providerIdHex
+        || verified.policyDigestHex !== policyDigestHex
+        || verified.scopeIdHex !== scopeIdHex
+        || verified.offerId !== input.offerId
+        || verified.classIdHex !== input.classArtifact.binding.classIdHex) {
+      throw new Error('BAT V2 verified class/member projection changed coordinates');
+    }
+    return new VerifiedProviderBatV2ProjectionV2(
+      policyDigestHex,
+      scopeIdHex,
+      input.offerId,
+      verified,
+      input,
+    );
+  }
+
+  selected(): SelectedProviderOfferV1 {
+    this.assertOpen();
+    return cloneSelectedProviderOfferV1(this.selectedValue);
+  }
+
+  coordinates(): {
+    policyDigestHex: string;
+    scopeIdHex: string;
+    offerId: number;
+  } {
+    this.assertOpen();
+    return {
+      policyDigestHex: this.policyDigestValue,
+      scopeIdHex: this.scopeIdValue,
+      offerId: this.offerIdValue,
+    };
+  }
+
+  classArtifact(): BatV2ClassArtifactV2 {
+    this.assertOpen();
+    return {
+      classBytes: this.classBytesValue.slice(),
+      binding: { ...this.bindingValue },
+    };
+  }
+
+  verifiedRedemption(): WasmVerifiedBatV2RedemptionV2 {
+    this.assertOpen();
+    return this.redemptionValue;
+  }
+
+  assertRedemptionReady(nowUnix: bigint): void {
+    this.assertOpen();
+    this.redemptionValue.assertRedemptionReady(nowUnix);
+    const selected = this.selectedValue;
+    if (this.redemptionValue.providerIdHex !== fixedHex(
+      'BAT V2 provider ID', selected.trust.providerId,
+    )
+        || this.redemptionValue.policyDigestHex !== this.policyDigestValue
+        || this.redemptionValue.scopeIdHex !== this.scopeIdValue
+        || this.redemptionValue.offerId !== this.offerIdValue
+        || this.redemptionValue.classIdHex !== this.bindingValue.classIdHex) {
+      throw new Error('BAT V2 verified redemption handle changed after selection');
+    }
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.classBytesValue.fill(0);
+    this.redemptionValue.free();
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new Error('BAT V2 provider projection is closed');
+  }
+}
+
+/** Validate provider independence plus byte-exact common class identity. */
+export function assertIndependentProviderBatV2ProjectionPairV2(
+  first: VerifiedProviderBatV2ProjectionV2,
+  second: VerifiedProviderBatV2ProjectionV2,
+  options: IndependentProviderSelectionOptionsV1 = {},
+): void {
+  if (!(first instanceof VerifiedProviderBatV2ProjectionV2)
+      || !(second instanceof VerifiedProviderBatV2ProjectionV2)) {
+    throw new Error('BAT V2 pair requires exact verified provider projections');
+  }
+  const firstClass = first.classArtifact();
+  const secondClass = second.classArtifact();
+  try {
+    if (!equalBytes(firstClass.classBytes, secondClass.classBytes)
+        || classBindingKeyV2(firstClass.binding) !== classBindingKeyV2(secondClass.binding)) {
+      throw new Error(
+        'strict BAT V2 pair requires the same exact issuer-signed acceptance class',
+      );
+    }
+    assertIndependentProviderOfferPairV1(first.selected(), second.selected(), options);
+  } finally {
+    firstClass.classBytes.fill(0);
+    secondClass.classBytes.fill(0);
+  }
 }
 
 export function assertIndependentProviderOfferPairV1(
@@ -200,4 +369,62 @@ function canonicalNonzeroHex32(field: string, value: string): string {
     throw new Error(`${field} must be non-zero lowercase 32-byte hex`);
   }
   return value;
+}
+
+function assertBatV2OfferShape(
+  offer: ServiceOfferViewV1,
+  binding: BatV2ClassBindingV2,
+  offerId: number,
+): void {
+  if (offer.offerId !== offerId
+      || offer.acquisition !== 'bolt11'
+      || offer.authorization !== 'cashu-bat-v2'
+      || offer.verification !== 'shared-issuer-online'
+      || offer.issuerIdHex !== binding.issuerIdHex
+      || offer.keyIdHex !== binding.classIdHex) {
+    throw new Error('selected offer is not this exact BAT V2 class member');
+  }
+}
+
+function cloneSelectedProviderOfferV1(
+  value: SelectedProviderOfferV1,
+): SelectedProviderOfferV1 {
+  return {
+    trust: {
+      providerId: value.trust.providerId.slice(),
+      policySigningKey: value.trust.policySigningKey.slice(),
+      directoryAssertion: value.trust.directoryAssertion
+        ? {
+          ...value.trust.directoryAssertion,
+          operatorSigningKeyEd25519:
+            value.trust.directoryAssertion.operatorSigningKeyEd25519.slice(),
+          policyDigest: value.trust.directoryAssertion.policyDigest.slice(),
+        }
+        : undefined,
+    },
+    offer: { ...value.offer, price: { ...value.offer.price } },
+    providerEndpoint: value.providerEndpoint,
+    expectedLightningPayeePubkey: value.expectedLightningPayeePubkey?.slice(),
+    trustedOperatorSigningKey: value.trustedOperatorSigningKey?.slice(),
+  };
+}
+
+function classBindingKeyV2(value: BatV2ClassBindingV2): string {
+  validateBatV2ClassBindingV2(value);
+  return [
+    value.issuerIdHex,
+    value.classIdHex,
+    value.classDigestHex,
+    value.classKeyEpoch,
+    value.batKeyIdHex,
+  ].join(':');
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+  let mismatch = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    mismatch |= left[index] ^ right[index];
+  }
+  return mismatch === 0;
 }

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -427,6 +427,15 @@ export interface WasmStandaloneOnionServiceAdmissionV1 {
     offerId: number,
     nowUnix: bigint,
   ): WasmAcceptedRetainedServiceRedemptionV1;
+  acceptRetainedBatV2PolicyResponse(
+    responseFrame: Uint8Array,
+    expectedProviderId: Uint8Array,
+    policySigningKey: Uint8Array,
+    expectedPolicyDigest: Uint8Array,
+    scopeId: Uint8Array,
+    offerId: number,
+    nowUnix: bigint,
+  ): WasmAcceptedRetainedBatV2PolicyV2;
   powChallengeRequest(
     policy: WasmAcceptedServicePolicyV1,
     scopeId: Uint8Array,
@@ -450,6 +459,11 @@ export interface WasmStandaloneOnionServiceAdmissionV1 {
     proofBytes: Uint8Array,
     nowUnix: bigint,
   ): Uint8Array;
+  batV2AuthorizationRequest(
+    verified: WasmVerifiedBatV2RedemptionV2,
+    proofBytes: Uint8Array,
+    nowUnix: bigint,
+  ): Uint8Array;
   acceptAuthorizationResponse(
     responseFrame: Uint8Array,
     policy: WasmAcceptedServicePolicyV1,
@@ -460,6 +474,10 @@ export interface WasmStandaloneOnionServiceAdmissionV1 {
     policy: WasmAcceptedRetainedServiceRedemptionV1,
     nowUnix: bigint,
   ): ServiceGrantViewV1;
+  acceptBatV2AuthorizationResponse(
+    responseFrame: Uint8Array,
+    verified: WasmVerifiedBatV2RedemptionV2,
+  ): BatV2AdmissionOutcomeV2;
 }
 
 /**
@@ -675,6 +693,13 @@ export interface WasmAcceptedServicePolicyV1 {
     quoteKeyCheckpointBytes: Uint8Array,
     nowUnix: bigint,
   ): WasmBolt11BatV2AcquisitionV2;
+  /** Sole current-policy route to an opaque exact BAT V2 redemption member. */
+  verifyBatV2Redemption?(
+    scopeId: Uint8Array,
+    offerId: number,
+    classBytes: Uint8Array,
+    nowUnix: bigint,
+  ): WasmVerifiedBatV2RedemptionV2;
 }
 
 /** Exact historical signed policy typestate, usable only for one retained
@@ -689,6 +714,39 @@ export interface WasmAcceptedRetainedServiceRedemptionV1 {
   validateAuthorizationProof(proofBytes: Uint8Array): void;
   redemptionJson(nowUnix: bigint): RetainedServiceRedemptionViewV1;
 }
+
+/** Exact historical BAT V2 selector. It cannot construct AUTH until the
+ * issuer-signed class is rechecked and an opaque verified handle is returned. */
+export interface WasmAcceptedRetainedBatV2PolicyV2 {
+  free(): void;
+  readonly providerIdHex: string;
+  readonly policyDigestHex: string;
+  readonly scopeIdHex: string;
+  readonly offerId: number;
+  verifyBatV2Redemption(
+    classBytes: Uint8Array,
+    nowUnix: bigint,
+  ): WasmVerifiedBatV2RedemptionV2;
+}
+
+/** Current-or-retained exact scheme-6 authority. JavaScript cannot construct
+ * or retarget it; the backend consumes it directly without string parsing. */
+export interface WasmVerifiedBatV2RedemptionV2 {
+  free(): void;
+  readonly providerIdHex: string;
+  readonly policyDigestHex: string;
+  readonly scopeIdHex: string;
+  readonly offerId: number;
+  readonly classIdHex: string;
+  assertRedemptionReady(nowUnix: bigint): void;
+}
+
+export type BatV2AdmissionOutcomeV2 =
+  | { kind: 'granted'; grant: ServiceGrantViewV1 }
+  | { kind: 'recoverable-definitely-not-sent'; retryAfterMs: number | null }
+  | { kind: 'recoverable-retry-safe'; retryAfterMs: number | null }
+  | { kind: 'burn-terminal' }
+  | { kind: 'burn-outcome-unknown' };
 
 export type WasmLightningNetworkV1 = 'bitcoin' | 'testnet' | 'signet' | 'regtest';
 
@@ -897,6 +955,16 @@ export interface WasmDpfClient {
     offerId: number,
     nowUnix: bigint,
   ): Promise<WasmAcceptedRetainedServiceRedemptionV1>;
+  fetchRetainedBatV2Policy(
+    serverIndex: number,
+    dbId: number,
+    expectedProviderId: Uint8Array,
+    policySigningKey: Uint8Array,
+    expectedPolicyDigest: Uint8Array,
+    scopeId: Uint8Array,
+    offerId: number,
+    nowUnix: bigint,
+  ): Promise<WasmAcceptedRetainedBatV2PolicyV2>;
   verifyServicePolicySession(
     serverIndex: number,
     policy: WasmAcceptedServicePolicyV1,
@@ -914,6 +982,14 @@ export interface WasmDpfClient {
     offerId: number,
     proofBytes: Uint8Array,
   ): Promise<ServiceGrantViewV1>;
+  /** One-sided primitive; the Web strict-pair typestate is the caller. */
+  dangerousUnpairedAuthorizeBatV2Service(
+    serverIndex: number,
+    dbId: number,
+    verified: WasmVerifiedBatV2RedemptionV2,
+    proofBytes: Uint8Array,
+    nowUnix: bigint,
+  ): Promise<BatV2AdmissionOutcomeV2>;
   /** Low-level one-sided retained redemption. The strict DPF adapter calls
    * this only after its two-provider readiness and product-pair checks. */
   dangerousUnpairedAuthorizeRetainedService(
@@ -1040,6 +1116,16 @@ export interface WasmHarmonyClient {
     offerId: number,
     nowUnix: bigint,
   ): Promise<WasmAcceptedRetainedServiceRedemptionV1>;
+  fetchRetainedBatV2Policy(
+    providerIndex: number,
+    dbId: number,
+    expectedProviderId: Uint8Array,
+    policySigningKey: Uint8Array,
+    expectedPolicyDigest: Uint8Array,
+    scopeId: Uint8Array,
+    offerId: number,
+    nowUnix: bigint,
+  ): Promise<WasmAcceptedRetainedBatV2PolicyV2>;
   verifyServicePolicySession(
     providerIndex: number,
     policy: WasmAcceptedServicePolicyV1,
@@ -1056,6 +1142,13 @@ export interface WasmHarmonyClient {
     offerId: number,
     proofBytes: Uint8Array,
   ): Promise<ServiceGrantViewV1>;
+  /** One-sided primitive; the Web strict hint/query pair is the caller. */
+  dangerousUnpairedAuthorizeBatV2HintService(
+    dbId: number,
+    verified: WasmVerifiedBatV2RedemptionV2,
+    proofBytes: Uint8Array,
+    nowUnix: bigint,
+  ): Promise<BatV2AdmissionOutcomeV2>;
   /** Low-level retained hint redemption without a native hint/query pair. */
   dangerousUnpairedAuthorizeRetainedHintService(
     dbId: number,
@@ -1070,6 +1163,13 @@ export interface WasmHarmonyClient {
     offerId: number,
     proofBytes: Uint8Array,
   ): Promise<ServiceGrantViewV1>;
+  /** One-sided primitive; the Web strict hint/query pair is the caller. */
+  dangerousUnpairedAuthorizeBatV2QueryService(
+    dbId: number,
+    verified: WasmVerifiedBatV2RedemptionV2,
+    proofBytes: Uint8Array,
+    nowUnix: bigint,
+  ): Promise<BatV2AdmissionOutcomeV2>;
   /** Low-level retained query redemption without a native hint/query pair. */
   dangerousUnpairedAuthorizeRetainedQueryService(
     dbId: number,
@@ -1211,6 +1311,15 @@ export interface WasmOramClient {
     offerId: number,
     nowUnix: bigint,
   ): Promise<WasmAcceptedRetainedServiceRedemptionV1>;
+  fetchRetainedBatV2Policy(
+    dbId: number,
+    expectedProviderId: Uint8Array,
+    policySigningKey: Uint8Array,
+    expectedPolicyDigest: Uint8Array,
+    scopeId: Uint8Array,
+    offerId: number,
+    nowUnix: bigint,
+  ): Promise<WasmAcceptedRetainedBatV2PolicyV2>;
   verifyServicePolicySession(policy: WasmAcceptedServicePolicyV1): void;
   verifyRetainedServiceSession(
     policy: WasmAcceptedRetainedServiceRedemptionV1,
@@ -1223,6 +1332,12 @@ export interface WasmOramClient {
     offerId: number,
     proofBytes: Uint8Array,
   ): Promise<ServiceGrantViewV1>;
+  authorizeBatV2Service(
+    dbId: number,
+    verified: WasmVerifiedBatV2RedemptionV2,
+    proofBytes: Uint8Array,
+    nowUnix: bigint,
+  ): Promise<BatV2AdmissionOutcomeV2>;
   authorizeRetainedService(
     dbId: number,
     policy: WasmAcceptedRetainedServiceRedemptionV1,

--- a/web/src/service-admission.ts
+++ b/web/src/service-admission.ts
@@ -15,6 +15,11 @@ import {
   type Bolt11CapabilityAcquisitionContextV1,
   type LightningNetworkNameV1,
 } from './admission-vault.js';
+import {
+  type BatV2ClassBindingV2,
+  type BatV2DistinctPairReservationV2,
+  type BatV2ReservedProofV2,
+} from './bat-v2-vault.js';
 import { hexToBytes } from './hash.js';
 import {
   requireSdkWasm,
@@ -23,14 +28,20 @@ import {
   type ServicePolicyViewV1,
   type ServiceScopeViewV1,
   type RetainedServiceRedemptionViewV1,
+  type BatV2AdmissionOutcomeV2,
+  type WasmAcceptedRetainedBatV2PolicyV2,
   type WasmAcceptedServicePolicyV1,
   type WasmAcceptedRetainedServiceRedemptionV1,
+  type WasmVerifiedBatV2RedemptionV2,
   type WasmServicePowChallengeV1,
 } from './sdk-bridge.js';
 import {
+  assertIndependentProviderBatV2ProjectionPairV2,
   assertIndependentProviderOfferPairV1,
+  type BatV2ClassArtifactV2,
   type IndependentProviderSelectionOptionsV1,
   type SelectedProviderOfferV1,
+  VerifiedProviderBatV2ProjectionV2,
 } from './provider-payment-selection.js';
 import {
   Bolt11AcquisitionControllerV1,
@@ -49,6 +60,9 @@ const PAIR_AUTHORIZATION_V1 = Symbol('BitcoinPIR/verified-pair-authorization/v1'
 const PAIR_RETAINED_AUTHORIZATION_V1 = Symbol('BitcoinPIR/verified-pair-retained-authorization/v1');
 const PAIR_ACQUISITION_V1 = Symbol('BitcoinPIR/verified-pair-acquisition/v1');
 const PAIR_CASHU_IMPORT_V1 = Symbol('BitcoinPIR/verified-pair-cashu-import/v1');
+const PAIR_BAT_V2_PROJECTION_V2 = Symbol('BitcoinPIR/verified-bat-v2-projection/v2');
+const PAIR_BAT_V2_PREFLIGHT_V2 = Symbol('BitcoinPIR/verified-bat-v2-preflight/v2');
+const PAIR_BAT_V2_AUTHORIZATION_V2 = Symbol('BitcoinPIR/verified-bat-v2-authorization/v2');
 
 export interface ProviderTrustAnchorV1 {
   /** Pinned 32-byte provider identity, independent of the peer PIR server. */
@@ -90,6 +104,16 @@ export interface ServiceAdmissionPortV1 {
     offerId: number,
     nowUnix: bigint,
   ): Promise<WasmAcceptedRetainedServiceRedemptionV1>;
+  /** Historical scheme-6 selector; it remains unusable until exact class
+   * membership produces a `WasmVerifiedBatV2RedemptionV2`. */
+  fetchRetainedBatV2Policy?(
+    expectedProviderId: Uint8Array,
+    policySigningKey: Uint8Array,
+    expectedPolicyDigest: Uint8Array,
+    scopeId: Uint8Array,
+    offerId: number,
+    nowUnix: bigint,
+  ): Promise<WasmAcceptedRetainedBatV2PolicyV2>;
   /** Fail synchronously unless the policy came from this live channel session. */
   assertSessionBinding(policy: WasmAcceptedServicePolicyV1): void;
   /**
@@ -113,6 +137,13 @@ export interface ServiceAdmissionPortV1 {
     proofBytes: Uint8Array,
     nowUnix: bigint,
   ): Promise<ServiceGrantViewV1>;
+  /** Sole typed scheme-6 call. The adapter performs exactly one native/WASM
+   * call, never parses an exception string, and never retries. */
+  authorizeBatV2?(
+    verified: WasmVerifiedBatV2RedemptionV2,
+    proofBytes: Uint8Array,
+    nowUnix: bigint,
+  ): Promise<BatV2AdmissionOutcomeV2>;
   requestPowChallenge(
     policy: WasmAcceptedServicePolicyV1,
     scopeId: Uint8Array,
@@ -208,6 +239,13 @@ export interface IndependentProviderAdmissionSelectionV1
   expectedLightningPayeePubkey?: Uint8Array;
 }
 
+/** One current, independently selected provider offer plus the exact trusted
+ * class artifact against which Rust must re-prove signed membership. */
+export interface IndependentProviderBatV2AdmissionSelectionV2
+  extends IndependentProviderAdmissionSelectionV1 {
+  classArtifact: BatV2ClassArtifactV2;
+}
+
 /** One already-inspected historical signed offer, frozen before pair use. */
 export interface IndependentRetainedProviderAdmissionSelectionV1 {
   session: ProviderAdmissionSessionV1;
@@ -280,6 +318,7 @@ export class ProviderAdmissionSessionV1 {
     | 'acquire'
     | 'import-cashu'
     | 'authorize'
+    | 'authorize-bat-v2'
     | 'inspect-retained'
     | 'authorize-retained'
     | null = null;
@@ -777,6 +816,116 @@ export class ProviderAdmissionSessionV1 {
     }
   }
 
+  [PAIR_BAT_V2_PROJECTION_V2](
+    selection: SessionPairSelectionV1,
+    scopeIdHex: string,
+    offerId: number,
+    classArtifact: BatV2ClassArtifactV2,
+    expectedLightningPayeePubkey: Uint8Array | undefined,
+  ): SessionBatV2LegV2 {
+    if (this.transitionInFlight !== null) {
+      throw new Error(`service admission ${this.transitionInFlight} transition is already in flight`);
+    }
+    const canonicalScopeIdHex = canonicalHex32('BAT V2 scope ID', scopeIdHex);
+    this.assertCurrentPairSelection(selection, canonicalScopeIdHex, offerId);
+    const scope = this.requireScope(canonicalScopeIdHex);
+    const accepted = this.accepted;
+    if (!accepted || !this.view) throw new Error('fetch and persist service policy first');
+    if (selection.offer.authorization !== 'cashu-bat-v2') {
+      throw new Error('selected signed offer is not BAT V2');
+    }
+    this.port.assertSessionBinding(accepted);
+    const assertReady = this.port.captureReadinessGuard();
+    const nowUnix = trustedNowUnixV1();
+    assertReady();
+    let verified: WasmVerifiedBatV2RedemptionV2 | null = null;
+    try {
+      const verifyBatV2Redemption = accepted.verifyBatV2Redemption;
+      if (typeof verifyBatV2Redemption !== 'function') {
+        throw new Error('loaded SDK does not support verified BAT V2 redemption');
+      }
+      verified = verifyBatV2Redemption.call(
+        accepted,
+        hexToBytes32('scopeIdHex', canonicalScopeIdHex),
+        offerId,
+        classArtifact.classBytes,
+        nowUnix,
+      );
+      const connection = this[PAIR_CONNECTION_CONTEXT_V1]();
+      const projection = VerifiedProviderBatV2ProjectionV2.create({
+        ...selection,
+        providerEndpoint: connection.providerEndpoint,
+        trustedOperatorSigningKey: connection.trustedOperatorSigningKey,
+        expectedLightningPayeePubkey: expectedLightningPayeePubkey?.slice(),
+        policyDigestHex: selection.policyDigestHex,
+        scopeIdHex: canonicalScopeIdHex,
+        offerId,
+        classArtifact,
+        verifiedRedemption: verified,
+      });
+      verified = null;
+      return {
+        session: this,
+        selection,
+        scopeIdHex: canonicalScopeIdHex,
+        offerId,
+        entitlementProfile: scope.entitlementProfile,
+        projection,
+        assertReady,
+      };
+    } finally {
+      verified?.free();
+    }
+  }
+
+  [PAIR_BAT_V2_PREFLIGHT_V2](leg: SessionBatV2LegV2, nowUnix: bigint): void {
+    this.assertBatV2Preflight(leg, nowUnix);
+  }
+
+  async [PAIR_BAT_V2_AUTHORIZATION_V2](
+    leg: SessionBatV2LegV2,
+    proofBytes: Uint8Array,
+    nowUnix: bigint,
+    onAdapterCallStart: () => void,
+  ): Promise<BatV2AdmissionOutcomeV2> {
+    this.beginTransition('authorize-bat-v2');
+    try {
+      // This exact-member/session check runs immediately before the adapter
+      // receives proof bytes. Opaque current and retained handles share the
+      // same `assertRedemptionReady` contract.
+      this.assertBatV2Preflight(leg, nowUnix, true);
+      const authorize = this.port.authorizeBatV2;
+      if (typeof authorize !== 'function') {
+        throw new Error('this verified adapter does not expose typed BAT V2 admission');
+      }
+      onAdapterCallStart();
+      return await authorize.call(this.port, leg.projection.verifiedRedemption(), proofBytes, nowUnix);
+    } finally {
+      this.transitionInFlight = null;
+    }
+  }
+
+  private assertBatV2Preflight(
+    leg: SessionBatV2LegV2,
+    nowUnix: bigint,
+    duringAuthorization = false,
+  ): void {
+    if (leg.session !== this) throw new Error('BAT V2 projection belongs to another session');
+    if (this.transitionInFlight !== null
+        && !(duringAuthorization && this.transitionInFlight === 'authorize-bat-v2')) {
+      throw new Error(`service admission ${this.transitionInFlight} transition is already in flight`);
+    }
+    this.assertCurrentPairSelection(leg.selection, leg.scopeIdHex, leg.offerId);
+    const accepted = this.accepted;
+    if (!accepted) throw new Error('fetch and persist service policy first');
+    if (typeof this.port.authorizeBatV2 !== 'function') {
+      throw new Error('this verified adapter does not expose typed BAT V2 admission');
+    }
+    this.port.assertSessionBinding(accepted);
+    leg.assertReady();
+    leg.projection.assertRedemptionReady(nowUnix);
+  }
+
   close(): void {
     if (this.transitionInFlight !== null) {
       throw new Error(`cannot close service admission during ${this.transitionInFlight}`);
@@ -793,6 +942,7 @@ export class ProviderAdmissionSessionV1 {
       | 'acquire'
       | 'import-cashu'
       | 'authorize'
+      | 'authorize-bat-v2'
       | 'inspect-retained'
       | 'authorize-retained',
   ): void {
@@ -960,6 +1110,16 @@ interface SessionPairSelectionV1 extends SelectedProviderOfferV1 {
   policyDigestHex: string;
   policyRevision: number;
   offerFingerprint: string;
+}
+
+interface SessionBatV2LegV2 {
+  session: ProviderAdmissionSessionV1;
+  selection: SessionPairSelectionV1;
+  scopeIdHex: string;
+  offerId: number;
+  entitlementProfile: number;
+  projection: VerifiedProviderBatV2ProjectionV2;
+  assertReady: () => void;
 }
 
 interface SessionRetainedPairSelectionV1 extends SelectedProviderOfferV1 {
@@ -1254,6 +1414,260 @@ export class VerifiedIndependentProviderPairV1 {
   }
 }
 
+/** Narrow structural surface used by the scheme-6 pair orchestrator. */
+export interface BatV2AdmissionVaultV2 {
+  reserveDistinctPair(
+    firstBinding: BatV2ClassBindingV2,
+    secondBinding: BatV2ClassBindingV2,
+    validateBeforeReserve?: (record: {
+      proof: Uint8Array;
+      globalSpendKeyHex: string;
+    } & BatV2ClassBindingV2) => void,
+  ): Promise<BatV2DistinctPairReservationV2 | null>;
+  finishReservation(
+    lease: BatV2ReservedProofV2,
+    disposition: 'recover-safe' | 'burn',
+  ): Promise<void>;
+}
+
+/**
+ * Browser-local BAT V2 pair. Both exact provider members are verified before
+ * the vault atomically reserves two issuer-wide proofs, so zero/one proof (or
+ * a duplicate global spend key) causes zero provider sends.
+ */
+export class VerifiedIndependentProviderBatV2PairV2 {
+  private reservation: BatV2DistinctPairReservationV2 | null = null;
+  private readonly finished = new Set<ProviderPairSideV1>();
+  /** Persist the intended terminal disposition before awaiting IndexedDB so
+   * close can never recover a proof whose adapter call may have started. */
+  private readonly dispositions = new Map<
+    ProviderPairSideV1,
+    'recover-safe' | 'burn'
+  >();
+  private inFlight = false;
+  private activeAuthorization: Promise<void> | null = null;
+  private closePromise: Promise<void> | null = null;
+  private closed = false;
+
+  private constructor(
+    private readonly first: SessionBatV2LegV2,
+    private readonly second: SessionBatV2LegV2,
+    private readonly vault: BatV2AdmissionVaultV2,
+  ) {}
+
+  static create(
+    firstSelection: IndependentProviderBatV2AdmissionSelectionV2,
+    secondSelection: IndependentProviderBatV2AdmissionSelectionV2,
+    vault: BatV2AdmissionVaultV2,
+    options: IndependentProviderSelectionOptionsV1 = {},
+  ): VerifiedIndependentProviderBatV2PairV2 {
+    // Preserve every ordinary provider/operator/origin/payee independence
+    // check. BAT V2's shared issuer remains an explicit one-shot choice.
+    VerifiedIndependentProviderPairV1.create(firstSelection, secondSelection, options);
+    if (!vault || typeof vault.reserveDistinctPair !== 'function'
+        || typeof vault.finishReservation !== 'function') {
+      throw new Error('BAT V2 pair requires the encrypted pair-reservation vault');
+    }
+    const firstVerified = firstSelection.session[PAIR_SELECTION_V1](
+      firstSelection.scopeIdHex,
+      firstSelection.offerId,
+    );
+    const secondVerified = secondSelection.session[PAIR_SELECTION_V1](
+      secondSelection.scopeIdHex,
+      secondSelection.offerId,
+    );
+    let first: SessionBatV2LegV2 | null = null;
+    let second: SessionBatV2LegV2 | null = null;
+    try {
+      first = firstSelection.session[PAIR_BAT_V2_PROJECTION_V2](
+        firstVerified,
+        firstSelection.scopeIdHex,
+        firstSelection.offerId,
+        firstSelection.classArtifact,
+        firstSelection.expectedLightningPayeePubkey,
+      );
+      second = secondSelection.session[PAIR_BAT_V2_PROJECTION_V2](
+        secondVerified,
+        secondSelection.scopeIdHex,
+        secondSelection.offerId,
+        secondSelection.classArtifact,
+        secondSelection.expectedLightningPayeePubkey,
+      );
+      assertIndependentProviderBatV2ProjectionPairV2(
+        first.projection,
+        second.projection,
+        options,
+      );
+      return new VerifiedIndependentProviderBatV2PairV2(first, second, vault);
+    } catch (error) {
+      first?.projection.close();
+      second?.projection.close();
+      throw error;
+    }
+  }
+
+  classBinding(): BatV2ClassBindingV2 {
+    this.assertOpen();
+    const artifact = this.first.projection.classArtifact();
+    try {
+      return { ...artifact.binding };
+    } finally {
+      artifact.classBytes.fill(0);
+    }
+  }
+
+  async authorize(side: ProviderPairSideV1): Promise<BatV2AdmissionOutcomeV2> {
+    this.assertOpen();
+    if (this.inFlight) throw new Error('a BAT V2 pair authorization is already in flight');
+    if (this.dispositions.has(side)) throw new Error('this BAT V2 provider leg already finished');
+    this.inFlight = true;
+    let releaseActive!: () => void;
+    const active = new Promise<void>((resolve) => { releaseActive = resolve; });
+    this.activeAuthorization = active;
+    let lease: BatV2ReservedProofV2 | null = null;
+    let adapterCalled = false;
+    try {
+      const reservation = await this.ensureReservation();
+      lease = side === 'first' ? reservation.first : reservation.second;
+      const leg = this.leg(side);
+      const nowUnix = trustedNowUnixV1();
+      leg.session[PAIR_BAT_V2_PREFLIGHT_V2](leg, nowUnix);
+      const raw = await leg.session[PAIR_BAT_V2_AUTHORIZATION_V2](
+        leg,
+        lease.proof,
+        nowUnix,
+        () => { adapterCalled = true; },
+      );
+      const outcome = normalizeBatV2AdmissionOutcomeV2(raw, leg);
+      await this.finish(side, lease, batV2DispositionV2(outcome));
+      return cloneBatV2AdmissionOutcomeV2(outcome);
+    } catch (cause) {
+      if (lease && !this.finished.has(side)) {
+        // Once the adapter call begins, even a synchronous native error is
+        // conservatively a burn. All earlier local/preflight failures recover.
+        const disposition = this.dispositions.get(side)
+          ?? (adapterCalled ? 'burn' : 'recover-safe');
+        await this.finish(side, lease, disposition)
+          .catch(() => { /* preserve the authoritative admission failure */ });
+      }
+      if (adapterCalled) {
+        throw new AmbiguousCapabilitySpendErrorV1(
+          'BAT V2 admission failed after the one-shot adapter call began',
+          { cause },
+        );
+      }
+      throw cause;
+    } finally {
+      lease?.proof.fill(0);
+      this.inFlight = false;
+      releaseActive();
+      if (this.activeAuthorization === active) this.activeAuthorization = null;
+    }
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closed = true;
+    const operation = this.finishClose(this.activeAuthorization);
+    this.closePromise = operation;
+    return operation;
+  }
+
+  private async finishClose(active: Promise<void> | null): Promise<void> {
+    await active;
+    const reservation = this.reservation;
+    const releases: Promise<void>[] = [];
+    if (reservation) {
+      if (!this.finished.has('first')) {
+        releases.push(this.finish(
+          'first',
+          reservation.first,
+          this.dispositions.get('first') ?? 'recover-safe',
+        ));
+      }
+      if (!this.finished.has('second')) {
+        releases.push(this.finish(
+          'second',
+          reservation.second,
+          this.dispositions.get('second') ?? 'recover-safe',
+        ));
+      }
+    }
+    const outcomes = await Promise.allSettled(releases);
+    this.first.projection.close();
+    this.second.projection.close();
+    const failures = outcomes.filter(
+      (outcome): outcome is PromiseRejectedResult => outcome.status === 'rejected',
+    );
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures.map((failure) => failure.reason),
+        'failed to release one or more unused BAT V2 reservations',
+      );
+    }
+  }
+
+  private async ensureReservation(): Promise<BatV2DistinctPairReservationV2> {
+    if (this.reservation) return this.reservation;
+    const nowUnix = trustedNowUnixV1();
+    this.first.session[PAIR_BAT_V2_PREFLIGHT_V2](this.first, nowUnix);
+    this.second.session[PAIR_BAT_V2_PREFLIGHT_V2](this.second, nowUnix);
+    const binding = this.classBinding();
+    const reservation = await this.vault.reserveDistinctPair(
+      binding,
+      binding,
+      (record) => assertBatV2ReservedRecordBindingV2(record, binding),
+    );
+    if (!reservation) {
+      throw new Error('two distinct BAT V2 proofs are not available for this exact class');
+    }
+    try {
+      if (reservation.first.recordId === reservation.second.recordId
+          || reservation.first.globalSpendKeyHex === reservation.second.globalSpendKeyHex
+          || reservation.first.reservationId !== reservation.reservationId
+          || reservation.second.reservationId !== reservation.reservationId) {
+        throw new Error('BAT V2 vault returned a non-distinct pair reservation');
+      }
+      assertBatV2ReservedRecordBindingV2(reservation.first, binding);
+      assertBatV2ReservedRecordBindingV2(reservation.second, binding);
+    } catch (error) {
+      await Promise.allSettled([
+        this.vault.finishReservation(reservation.first, 'recover-safe'),
+        this.vault.finishReservation(reservation.second, 'recover-safe'),
+      ]);
+      reservation.first.proof.fill(0);
+      reservation.second.proof.fill(0);
+      throw error;
+    }
+    this.reservation = reservation;
+    return reservation;
+  }
+
+  private async finish(
+    side: ProviderPairSideV1,
+    lease: BatV2ReservedProofV2,
+    disposition: 'recover-safe' | 'burn',
+  ): Promise<void> {
+    const existing = this.dispositions.get(side);
+    if (existing !== undefined && existing !== disposition) {
+      throw new Error('BAT V2 reservation disposition cannot be weakened after a send boundary');
+    }
+    this.dispositions.set(side, disposition);
+    await this.vault.finishReservation(lease, disposition);
+    this.finished.add(side);
+  }
+
+  private leg(side: ProviderPairSideV1): SessionBatV2LegV2 {
+    if (side === 'first') return this.first;
+    if (side === 'second') return this.second;
+    throw new Error('provider pair side must be first or second');
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw new Error('BAT V2 provider pair is closed');
+  }
+}
+
 export interface LiveOperatorIdentityV1 {
   state: string;
   serverId?: string;
@@ -1292,6 +1706,95 @@ export function verifiedLiveOperatorSigningKeyV1(
     throw new Error('strict pair admission requires a verified live operator signing key');
   }
   return hexToBytes(identity.operatorPubkeyHex);
+}
+
+function normalizeBatV2AdmissionOutcomeV2(
+  value: BatV2AdmissionOutcomeV2,
+  leg: SessionBatV2LegV2,
+): BatV2AdmissionOutcomeV2 {
+  if (!value || typeof value !== 'object' || typeof value.kind !== 'string') {
+    return { kind: 'burn-outcome-unknown' };
+  }
+  if (value.kind === 'granted') {
+    const grant = value.grant;
+    if (!grant || typeof grant !== 'object'
+        || canonicalHex32OrNull(grant.scopeIdHex) !== leg.scopeIdHex
+        || grant.enforcedProfile !== leg.entitlementProfile
+        || !Number.isSafeInteger(grant.expiresInMs)
+        || grant.expiresInMs < 0
+        || typeof grant.hasHarmonyAttach !== 'boolean') {
+      return { kind: 'burn-outcome-unknown' };
+    }
+    return { kind: 'granted', grant: { ...grant } };
+  }
+  if (value.kind === 'recoverable-definitely-not-sent'
+      || value.kind === 'recoverable-retry-safe') {
+    const retryAfterMs = value.retryAfterMs;
+    if (retryAfterMs !== null
+        && (!Number.isSafeInteger(retryAfterMs) || retryAfterMs < 0)) {
+      return { kind: 'burn-outcome-unknown' };
+    }
+    return { kind: value.kind, retryAfterMs };
+  }
+  if (value.kind === 'burn-terminal' || value.kind === 'burn-outcome-unknown') {
+    return { kind: value.kind };
+  }
+  return { kind: 'burn-outcome-unknown' };
+}
+
+function batV2DispositionV2(
+  outcome: BatV2AdmissionOutcomeV2,
+): 'recover-safe' | 'burn' {
+  return outcome.kind === 'recoverable-definitely-not-sent'
+    || outcome.kind === 'recoverable-retry-safe'
+    ? 'recover-safe'
+    : 'burn';
+}
+
+function cloneBatV2AdmissionOutcomeV2(
+  outcome: BatV2AdmissionOutcomeV2,
+): BatV2AdmissionOutcomeV2 {
+  return outcome.kind === 'granted'
+    ? { kind: 'granted', grant: { ...outcome.grant } }
+    : { ...outcome };
+}
+
+function assertBatV2ReservedRecordBindingV2(
+  record: BatV2ClassBindingV2 & {
+    proof: Uint8Array;
+    globalSpendKeyHex: string;
+  },
+  expected: BatV2ClassBindingV2,
+): void {
+  if (!(record.proof instanceof Uint8Array) || record.proof.length !== 210
+      || canonicalHex32('BAT V2 global spend key', record.globalSpendKeyHex)
+        !== record.globalSpendKeyHex
+      || batV2ClassBindingKeyV2(record) !== batV2ClassBindingKeyV2(expected)) {
+    throw new Error('reserved BAT V2 proof does not match the exact verified class');
+  }
+}
+
+function batV2ClassBindingKeyV2(value: BatV2ClassBindingV2): string {
+  const epoch = canonicalPositiveDecimalV2('BAT V2 class key epoch', value.classKeyEpoch);
+  return [
+    canonicalHex32('BAT V2 issuer ID', value.issuerIdHex),
+    canonicalHex32('BAT V2 class ID', value.classIdHex),
+    canonicalHex32('BAT V2 class digest', value.classDigestHex),
+    epoch,
+    canonicalHex32('BAT V2 BAT key ID', value.batKeyIdHex),
+  ].join(':');
+}
+
+function canonicalPositiveDecimalV2(field: string, value: string): string {
+  if (!/^[1-9][0-9]*$/.test(value)) throw new Error(`${field} must be a positive decimal`);
+  return value;
+}
+
+function canonicalHex32OrNull(value: unknown): string | null {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value)
+    && !/^0{64}$/.test(value)
+    ? value
+    : null;
 }
 
 function validatePolicyView(


### PR DESCRIPTION
## Summary
- add exact current/retained BAT V2 member selection and typed WASM admission outcomes
- wire DPF, Harmony, OnionPIR, and ORAM adapters without string-parsing or automatic retries
- reserve two provider-independent BAT records atomically before any paid two-leg query and apply recover-safe vs burn dispositions correctly

## Safety boundary
- generic V1 paths remain fail-closed for scheme 6
- DPF/Harmony low-level single-leg entrypoints remain explicitly dangerous/unpaired
- missing ports, insufficient/duplicate inventory, or binding mismatch fail before network I/O
- concurrent close waits for in-flight authorization; retry-safe outcomes rebuild a fresh pair on explicit retry
- no class distribution/catalog, render profile, UI activation, browser run, deployment, or funds in this slice

## Verification
- `npm run build`
- six focused Vitest files: 136/136 passed
- `git diff --check origin/main...HEAD`
- independent P0/P1 review: PASS after closing three lifecycle findings