### PR TITLE
feat(web): add trusted BAT V2 class catalog resolution

### DIFF
--- a/crates/directory/nostr/src/entry.rs
+++ b/crates/directory/nostr/src/entry.rs
@@ -577,6 +577,10 @@ fn method_pair_match(acquisition: AcquisitionMethod, authorization: AuthScheme) 
                 AcquisitionMethod::Bolt11V1,
                 AuthScheme::BitcoinPirCashuBatV1
             )
+            | (
+                AcquisitionMethod::Bolt11V1,
+                AuthScheme::BitcoinPirCashuBatV2
+            )
             | (AcquisitionMethod::Bolt11V1, AuthScheme::ArcV1Experimental)
             | (AcquisitionMethod::CashuEcashV1, AuthScheme::CashuEcashV1)
     )
@@ -679,6 +683,7 @@ fn parse_authorization(value: &str) -> Result<AuthScheme, DirectoryErrorV1> {
         "bolt11-direct-receipt-v1" => Ok(AuthScheme::Bolt11DirectReceiptV1),
         "cashu-ecash-v1" => Ok(AuthScheme::CashuEcashV1),
         "bitcoinpir-cashu-bat-v1" => Ok(AuthScheme::BitcoinPirCashuBatV1),
+        "bitcoinpir-cashu-bat-v2" => Ok(AuthScheme::BitcoinPirCashuBatV2),
         "arc-v1-experimental" => Ok(AuthScheme::ArcV1Experimental),
         _ => Err(DirectoryErrorV1::InvalidCatalogHints),
     }

--- a/crates/directory/nostr/src/tests.rs
+++ b/crates/directory/nostr/src/tests.rs
@@ -61,6 +61,13 @@ fn hint(seed: u8) -> DirectoryCatalogHintV1 {
     }
 }
 
+fn hint_v2(seed: u8) -> DirectoryCatalogHintV1 {
+    DirectoryCatalogHintV1 {
+        authorization: AuthScheme::BitcoinPirCashuBatV2,
+        ..hint(seed)
+    }
+}
+
 fn active_entry(sequence: u64, assertion_epoch: u64) -> DirectoryEntryV1 {
     DirectoryEntryV1::new_active(
         sequence,
@@ -237,6 +244,32 @@ fn publisher_entry_roundtrip_is_pinned_and_nip01_signed() {
         secp.verify_schnorr(&signature, &message, &public_key)
             .unwrap();
     }
+}
+
+#[test]
+fn bat_v2_capability_hint_roundtrips_without_class_trust_fields() {
+    let publisher = DirectoryPublisherKeyV1::from_secret_bytes([21; 32]).unwrap();
+    let entry = DirectoryEntryV1::new_active(
+        1,
+        2_500,
+        operator_assertion(1, 22),
+        vec![hint_v2(9)],
+        health(DirectoryHealthClassV1::Available),
+        NOW,
+    )
+    .unwrap();
+    let json = signed_entry(&publisher, &entry, NOW, 23)
+        .to_json_bytes()
+        .unwrap();
+    let verified = verify_directory_entry_event_v1(&json, publisher.public_key(), NOW).unwrap();
+    assert_eq!(
+        verified.discovery_entry().catalog_hints()[0].authorization,
+        AuthScheme::BitcoinPirCashuBatV2
+    );
+    let text = std::str::from_utf8(&json).unwrap();
+    assert!(text.contains("bitcoinpir-cashu-bat-v2"));
+    assert!(!text.contains("class_digest"));
+    assert!(!text.contains("class_path"));
 }
 
 #[test]

--- a/crates/sdk/wasm/src/service.rs
+++ b/crates/sdk/wasm/src/service.rs
@@ -545,6 +545,24 @@ impl WasmVerifiedBatV2RedemptionV2 {
         hex::encode(self.inner.class().class_id)
     }
 
+    /// Full class coordinates derived from the canonical signed class bytes.
+    /// Web compares this projection with its trusted catalog binding before a
+    /// proof can leave durable storage; a class ID alone is not epoch-unique.
+    #[wasm_bindgen(js_name = classBindingJson)]
+    pub fn class_binding_json(&self) -> Result<JsValue, JsError> {
+        let class = self.inner.class();
+        let class_digest = class
+            .class_digest()
+            .map_err(|error| JsError::new(&error.to_string()))?;
+        Ok(crate::to_js_object(&serde_json::json!({
+            "issuerIdHex": hex::encode(class.issuer_id),
+            "classIdHex": hex::encode(class.class_id),
+            "classDigestHex": hex::encode(class_digest),
+            "classKeyEpoch": class.key_epoch.to_string(),
+            "batKeyIdHex": hex::encode(class.bat_key_id()),
+        })))
+    }
+
     #[wasm_bindgen(js_name = assertRedemptionReady)]
     pub fn assert_redemption_ready(&self, now_unix: u64) -> Result<(), JsError> {
         self.inner

--- a/web/src/__tests__/bat-v2-class-catalog.test.ts
+++ b/web/src/__tests__/bat-v2-class-catalog.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  BatV2PublicClassCatalogResolverV2,
+  MAX_BAT_V2_PUBLIC_CLASS_BYTES_V2,
+  parseBatV2PublicClassCatalogV2,
+  parseTrustedBatV2PublicClassCatalogRefV2,
+  type BatV2PublicClassEntryV2,
+} from '../bat-v2-class-catalog.js';
+import { bytesToHex, hexToBytes, sha256 } from '../hash.js';
+import { ProviderAdmissionSessionV1 } from '../service-admission.js';
+import type { ServiceOfferViewV1, WasmVerifiedBatV2RedemptionV2 } from '../sdk-bridge.js';
+
+const ISSUER = '11'.repeat(32);
+const CLASS_ID = '22'.repeat(32);
+const PROVIDER = '33'.repeat(32);
+const POLICY = '44'.repeat(32);
+const SCOPE = '55'.repeat(32);
+const POLICY_KEY = '66'.repeat(32);
+const BASE = 'https://web.example/app';
+
+function digest(bytes: Uint8Array): string {
+  return bytesToHex(sha256(bytes));
+}
+
+function member(overrides: Record<string, unknown> = {}) {
+  return {
+    providerIdHex: PROVIDER,
+    policyDigestHex: POLICY,
+    scopeIdHex: SCOPE,
+    offerId: 7,
+    ...overrides,
+  };
+}
+
+function entry(
+  epoch: number,
+  status: 'current' | 'retained',
+  classBytes: Uint8Array,
+  overrides: Record<string, unknown> = {},
+) {
+  const artifactSha256Hex = digest(classBytes);
+  return {
+    issuerIdHex: ISSUER,
+    classIdHex: CLASS_ID,
+    classKeyEpoch: String(epoch),
+    classDigestHex: `${epoch.toString(16).padStart(2, '0')}`.repeat(32),
+    batKeyIdHex: `${(epoch + 16).toString(16).padStart(2, '0')}`.repeat(32),
+    keyNotBeforeUnix: '1000',
+    keyNotAfterUnix: '18446744073709551615',
+    status,
+    artifact: {
+      path: `/proofs/bat-v2/classes/${artifactSha256Hex}.bin`,
+      sha256Hex: artifactSha256Hex,
+    },
+    members: [member()],
+    ...overrides,
+  };
+}
+
+function catalog(entries: unknown[]) {
+  return { version: 2, entries };
+}
+
+function offer(overrides: Partial<ServiceOfferViewV1> = {}): ServiceOfferViewV1 {
+  return {
+    offerId: 7,
+    acquisition: 'bolt11',
+    authorization: 'cashu-bat-v2',
+    freeMode: 'not-free',
+    verification: 'shared-issuer-online',
+    deploymentStatus: 'stable',
+    priorityClass: 1,
+    price: { kind: 'msat', amount: '1000' },
+    issuerIdHex: ISSUER,
+    keyIdHex: CLASS_ID,
+    batVerificationKeyFingerprintHex: '77'.repeat(32),
+    arcVerificationKeyFingerprintHex: '',
+    endpoint: 'https://issuer.example',
+    credentialCount: 2,
+    credentialPresentationLimit: 1,
+    privacyLeakageBits: 0,
+    ...overrides,
+  };
+}
+
+function setup(entries: ReturnType<typeof entry>[], artifacts: Uint8Array[]) {
+  const serialized = JSON.stringify(catalog(entries));
+  const catalogBytes = new TextEncoder().encode(serialized);
+  const catalogSha = digest(catalogBytes);
+  const catalogPath = `/proofs/bat-v2/catalogs/${catalogSha}.json`;
+  const bodies = new Map<string, Uint8Array>([[catalogPath, catalogBytes]]);
+  entries.forEach((value, index) => bodies.set(value.artifact.path, artifacts[index]));
+  const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    expect(init).toMatchObject({ credentials: 'omit', redirect: 'error', cache: 'no-store' });
+    const path = new URL(String(url)).pathname;
+    const body = bodies.get(path);
+    return body ? new Response(body.slice(), { status: 200 }) : new Response(null, { status: 404 });
+  }) as unknown as typeof fetch;
+  const resolver = new BatV2PublicClassCatalogResolverV2({
+    version: 2,
+    path: catalogPath,
+    sha256Hex: catalogSha,
+  }, { baseHref: BASE, fetchImpl, nowUnix: () => 1_500n });
+  return { resolver, fetchImpl, bodies, serialized };
+}
+
+const selector = {
+  role: 'first',
+  providerIdHex: PROVIDER,
+  policyDigestHex: POLICY,
+  scopeIdHex: SCOPE,
+  offerId: 7,
+  offer: offer(),
+};
+
+describe('canonical BAT V2 public class catalog', () => {
+  it('accepts one explicit current head and freezes exact canonical members', () => {
+    const parsed = parseBatV2PublicClassCatalogV2(JSON.stringify(catalog([
+      entry(1, 'current', new Uint8Array([1, 2, 3])),
+    ])));
+    expect(parsed.entries[0].status).toBe('current');
+    expect(Object.isFrozen(parsed.entries[0].members)).toBe(true);
+  });
+
+  it('rejects V1, unknown fields, unsorted members, and partial refs', () => {
+    const good = entry(1, 'current', new Uint8Array([1]));
+    expect(() => parseBatV2PublicClassCatalogV2(JSON.stringify({ version: 1, entries: [good] })))
+      .toThrow(/unknown version/);
+    expect(() => parseBatV2PublicClassCatalogV2(JSON.stringify(catalog([
+      { ...good, dynamicIssuerUrl: 'https://issuer.example/class' },
+    ])))).toThrow(/unknown, missing, or non-canonical/);
+    expect(() => parseBatV2PublicClassCatalogV2(JSON.stringify(catalog([{
+      ...good,
+      members: [member({ providerIdHex: '99'.repeat(32) }), member()],
+    }])))).toThrow(/strictly canonical-sorted/);
+    expect(() => parseTrustedBatV2PublicClassCatalogRefV2({
+      version: 2,
+      path: `/proofs/bat-v2/catalogs/${'aa'.repeat(32)}.json`,
+    })).toThrow(/unknown, missing/);
+  });
+
+  it('requires exactly one explicit current head per issuer/class', () => {
+    const first = entry(1, 'current', new Uint8Array([1]));
+    const second = entry(2, 'current', new Uint8Array([2]));
+    expect(() => parseBatV2PublicClassCatalogV2(JSON.stringify(catalog([first, second]))))
+      .toThrow(/exactly one explicit current/);
+    expect(() => parseBatV2PublicClassCatalogV2(JSON.stringify(catalog([
+      { ...first, status: 'retained' },
+      { ...second, status: 'retained' },
+    ])))).toThrow(/exactly one explicit current/);
+  });
+});
+
+describe('current exact class resolution', () => {
+  it('selects the explicit current head during an overlapping retained rotation', async () => {
+    const oldBytes = new Uint8Array([1, 1, 1]);
+    const currentBytes = new Uint8Array([2, 2, 2]);
+    const old = entry(1, 'retained', oldBytes);
+    const current = entry(2, 'current', currentBytes);
+    const { resolver, fetchImpl } = setup([old, current], [oldBytes, currentBytes]);
+    const resolved = await resolver.resolveCurrent(selector);
+    expect(Array.from(resolved.classBytes)).toEqual(Array.from(currentBytes));
+    expect(resolved.binding.classKeyEpoch).toBe('2');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ['V1 authorization', { offer: offer({ authorization: 'cashu-bat' }) }],
+    ['cross class', { offer: offer({ keyIdHex: '88'.repeat(32) }) }],
+    ['unknown member', { policyDigestHex: '99'.repeat(32) }],
+  ])('fails closed for %s', async (_label, override) => {
+    const bytes = new Uint8Array([3]);
+    const { resolver } = setup([entry(1, 'current', bytes)], [bytes]);
+    await expect(resolver.resolveCurrent({ ...selector, ...override })).rejects.toThrow();
+  });
+
+  it('rejects inactive heads, hash mismatches, and over-limit streams', async () => {
+    const bytes = new Uint8Array([4]);
+    const inactive = entry(1, 'current', bytes, { keyNotAfterUnix: '1499' });
+    await expect(setup([inactive], [bytes]).resolver.resolveCurrent(selector))
+      .rejects.toThrow(/inactive/);
+
+    const mismatch = setup([entry(1, 'current', bytes)], [bytes]);
+    mismatch.bodies.set((JSON.parse(mismatch.serialized).entries[0] as BatV2PublicClassEntryV2)
+      .artifact.path, new Uint8Array([5]));
+    await expect(mismatch.resolver.resolveCurrent(selector)).rejects.toThrow(/SHA-256 mismatch/);
+
+    const oversized = new Uint8Array(MAX_BAT_V2_PUBLIC_CLASS_BYTES_V2 + 1);
+    const limited = setup([entry(1, 'current', bytes)], [oversized]);
+    await expect(limited.resolver.resolveCurrent(selector)).rejects.toThrow(/byte fetch limit/);
+  });
+});
+
+describe('retained exact class resolution', () => {
+  it('maps wallet binding plus provider to one member, retained policy, and opaque handle', async () => {
+    const classBytes = new Uint8Array([9, 8, 7]);
+    const retainedEntry = entry(1, 'retained', classBytes);
+    const currentBytes = new Uint8Array([6, 5, 4]);
+    const currentEntry = entry(2, 'current', currentBytes);
+    const { resolver } = setup(
+      [retainedEntry, currentEntry],
+      [classBytes, currentBytes],
+    );
+    const verified: WasmVerifiedBatV2RedemptionV2 = {
+      free: vi.fn(),
+      providerIdHex: PROVIDER,
+      policyDigestHex: POLICY,
+      scopeIdHex: SCOPE,
+      offerId: 7,
+      classIdHex: CLASS_ID,
+      classBindingJson: () => ({
+        issuerIdHex: retainedEntry.issuerIdHex,
+        classIdHex: retainedEntry.classIdHex,
+        classDigestHex: retainedEntry.classDigestHex,
+        classKeyEpoch: retainedEntry.classKeyEpoch,
+        batKeyIdHex: retainedEntry.batKeyIdHex,
+      }),
+      assertRedemptionReady: vi.fn(),
+    };
+    const accepted = {
+      free: vi.fn(),
+      providerIdHex: PROVIDER,
+      policyDigestHex: POLICY,
+      scopeIdHex: SCOPE,
+      offerId: 7,
+      verifyBatV2Redemption: vi.fn(() => verified),
+    };
+    const ready = vi.fn();
+    const port = {
+      assertTrustAnchor: vi.fn(),
+      captureReadinessGuard: vi.fn(() => ready),
+      fetchRetainedBatV2Policy: vi.fn(async (..._args: unknown[]) => accepted),
+    };
+    const session = new ProviderAdmissionSessionV1(
+      {} as never,
+      port as never,
+      { providerId: hexToBytes(PROVIDER), policySigningKey: hexToBytes(POLICY_KEY) },
+      {
+        backend: 'dpf-pir',
+        workload: 'dpf-query',
+        protocolVersion: 1,
+        expectedDatasetManifestRootHex: '77'.repeat(32),
+      },
+    );
+    const resolved = await resolver.resolveRetained({
+      binding: {
+        issuerIdHex: retainedEntry.issuerIdHex,
+        classIdHex: retainedEntry.classIdHex,
+        classDigestHex: retainedEntry.classDigestHex,
+        classKeyEpoch: retainedEntry.classKeyEpoch,
+        batKeyIdHex: retainedEntry.batKeyIdHex,
+      },
+      providerIdHex: PROVIDER,
+      session,
+    });
+    expect(resolved.verifiedRedemption).toBe(verified);
+    expect(port.fetchRetainedBatV2Policy).toHaveBeenCalledOnce();
+    const args = port.fetchRetainedBatV2Policy.mock.calls[0];
+    expect(bytesToHex(args[2] as Uint8Array)).toBe(POLICY);
+    expect(bytesToHex(args[3] as Uint8Array)).toBe(SCOPE);
+    expect(args[4]).toBe(7);
+    expect(accepted.verifyBatV2Redemption).toHaveBeenCalledOnce();
+    expect(ready).toHaveBeenCalledTimes(3);
+    resolved.classArtifact.classBytes.fill(0);
+    resolved.verifiedRedemption.free();
+    session.close();
+  });
+
+  it.each([
+    ['digest', { classDigestHex: 'ab'.repeat(32) }],
+    ['epoch', { classKeyEpoch: '9' }],
+    ['BAT key', { batKeyIdHex: 'ac'.repeat(32) }],
+  ])('rejects a retained handle with a mismatched verified %s before AUTH', async (
+    _label,
+    mismatch,
+  ) => {
+    const classBytes = new Uint8Array([9, 8, 7]);
+    const retainedEntry = entry(1, 'retained', classBytes);
+    const binding = {
+      issuerIdHex: retainedEntry.issuerIdHex,
+      classIdHex: retainedEntry.classIdHex,
+      classDigestHex: retainedEntry.classDigestHex,
+      classKeyEpoch: retainedEntry.classKeyEpoch,
+      batKeyIdHex: retainedEntry.batKeyIdHex,
+    };
+    const verified: WasmVerifiedBatV2RedemptionV2 = {
+      free: vi.fn(),
+      providerIdHex: PROVIDER,
+      policyDigestHex: POLICY,
+      scopeIdHex: SCOPE,
+      offerId: 7,
+      classIdHex: CLASS_ID,
+      classBindingJson: () => ({ ...binding, ...mismatch }),
+      assertRedemptionReady: vi.fn(),
+    };
+    const accepted = {
+      free: vi.fn(),
+      providerIdHex: PROVIDER,
+      policyDigestHex: POLICY,
+      scopeIdHex: SCOPE,
+      offerId: 7,
+      verifyBatV2Redemption: vi.fn(() => verified),
+    };
+    const authorizeBatV2 = vi.fn();
+    const port = {
+      assertTrustAnchor: vi.fn(),
+      captureReadinessGuard: vi.fn(() => vi.fn()),
+      fetchRetainedBatV2Policy: vi.fn(async (..._args: unknown[]) => accepted),
+      authorizeBatV2,
+    };
+    const session = new ProviderAdmissionSessionV1(
+      {} as never,
+      port as never,
+      { providerId: hexToBytes(PROVIDER), policySigningKey: hexToBytes(POLICY_KEY) },
+      {
+        backend: 'dpf-pir',
+        workload: 'dpf-query',
+        protocolVersion: 1,
+        expectedDatasetManifestRootHex: '77'.repeat(32),
+      },
+    );
+    await expect(session.verifyRetainedBatV2ClassMember(
+      member(),
+      { classBytes, binding },
+    )).rejects.toThrow(/exact signed class binding/);
+    expect(authorizeBatV2).not.toHaveBeenCalled();
+    expect(verified.free).toHaveBeenCalledOnce();
+    expect(accepted.free).toHaveBeenCalledOnce();
+    session.close();
+  });
+
+  it('rejects a provider with multiple members before retained policy fetch', async () => {
+    const bytes = new Uint8Array([1, 9]);
+    const duplicatedProvider = entry(1, 'current', bytes, {
+      members: [member(), member({ offerId: 8 })],
+    });
+    const { resolver } = setup([duplicatedProvider], [bytes]);
+    const session = { verifyRetainedBatV2ClassMember: vi.fn() } as unknown as ProviderAdmissionSessionV1;
+    await expect(resolver.resolveRetained({
+      binding: {
+        issuerIdHex: duplicatedProvider.issuerIdHex,
+        classIdHex: duplicatedProvider.classIdHex,
+        classDigestHex: duplicatedProvider.classDigestHex,
+        classKeyEpoch: duplicatedProvider.classKeyEpoch,
+        batKeyIdHex: duplicatedProvider.batKeyIdHex,
+      },
+      providerIdHex: PROVIDER,
+      session,
+    })).rejects.toThrow(/no unique exact class member/);
+    expect(session.verifyRetainedBatV2ClassMember).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/directory-vault.test.ts
+++ b/web/src/__tests__/directory-vault.test.ts
@@ -160,6 +160,29 @@ describe('encrypted directory rollback vault', () => {
     expect(Object.isFrozen(entry.entry.operator_assertion.endpoints)).toBe(true);
   });
 
+  it('accepts a scheme-6 capability hint without importing any class trust', async () => {
+    const vault = await DirectoryRollbackVaultV1.open();
+    opened.push(vault);
+    const candidate = new Candidate(0, false, [activeProvider]) as any;
+    const original = candidate.selectableCatalogJson.bind(candidate);
+    candidate.selectableCatalogJson = () => {
+      const catalog = withActiveEntry(JSON.parse(original()), activeProvider);
+      catalog.shards[3].entries[0].entry.catalog_hints = [{
+        scope_id: '99'.repeat(32),
+        backend: 'dpf-pir-v1',
+        workload: 'dpf-evaluate-job-v1',
+        acquisition: 'bolt11-v1',
+        authorization: 'bitcoinpir-cashu-bat-v2',
+        deployment: 'stable',
+      }];
+      return JSON.stringify(catalog);
+    };
+    const selected = await vault.acceptCatalog(candidate, 1_500n);
+    expect(selected.shards[3].entries[0].entry.catalog_hints[0].authorization)
+      .toBe('bitcoinpir-cashu-bat-v2');
+    expect(JSON.stringify(selected)).not.toMatch(/classDigest|classPath|issuerUrl/);
+  });
+
   it('rejects unknown selectable fields, non-conservative expiry, and expired output', async () => {
     const vault = await DirectoryRollbackVaultV1.open();
     opened.push(vault);

--- a/web/src/__tests__/product-admission-controller.test.ts
+++ b/web/src/__tests__/product-admission-controller.test.ts
@@ -355,6 +355,13 @@ function accepted(view: ServicePolicyViewV1): WasmAcceptedServicePolicyV1 {
         scopeIdHex,
         offerId,
         classIdHex: offer.keyIdHex,
+        classBindingJson: () => ({
+          issuerIdHex: offer.issuerIdHex,
+          classIdHex: offer.keyIdHex,
+          classDigestHex: '93'.repeat(32),
+          classKeyEpoch: '4',
+          batKeyIdHex: '94'.repeat(32),
+        }),
         assertRedemptionReady: vi.fn(),
       };
     },

--- a/web/src/__tests__/product-provider-bootstrap.test.ts
+++ b/web/src/__tests__/product-provider-bootstrap.test.ts
@@ -5,6 +5,7 @@ import {
   defaultProviderIdsForAdmissionRoutesV1,
   expectedLightningPayeeForOfferV1,
   parseProductTrustedBootstrapV1,
+  productBatV2ClassCatalogRefV2,
   providerLightningPayeeTrustV1,
 } from '../product-provider-bootstrap.js';
 import type { ServiceOfferViewV1 } from '../sdk-bridge.js';
@@ -66,6 +67,15 @@ function parseProvider(overrides: Record<string, unknown> = {}) {
     network: 'signet',
     providers: [{ ...bootstrapProvider(), ...overrides }],
   })).providers[0];
+}
+
+function bootstrapWithCatalog(catalogRef: unknown) {
+  return parseProductTrustedBootstrapV1(JSON.stringify({
+    version: 1,
+    network: 'signet',
+    providers: [bootstrapProvider()],
+    batV2ClassCatalog: catalogRef,
+  }));
 }
 
 function offer(overrides: Partial<ServiceOfferViewV1> = {}): ServiceOfferViewV1 {
@@ -153,6 +163,32 @@ describe('explicit product role routing', () => {
     expect(defaultProviderIdsForAdmissionRoutesV1([
       { providerIdHex: '01', supportedWorkloads: ['dpf-query'] },
     ], [['query', 'harmony-query']])).toEqual({});
+  });
+});
+
+describe('trusted BAT V2 class catalog render seam', () => {
+  it('pins one immutable same-origin path independently of directory hints', () => {
+    const sha256Hex = 'aa'.repeat(32);
+    const parsed = bootstrapWithCatalog({
+      version: 2,
+      path: `/proofs/bat-v2/catalogs/${sha256Hex}.json`,
+      sha256Hex,
+    });
+    const owned = productBatV2ClassCatalogRefV2(parsed)!;
+    expect(owned.sha256Hex).toBe(sha256Hex);
+    owned.sha256Hex = 'bb'.repeat(32);
+    expect(parsed.batV2ClassCatalog?.sha256Hex).toBe(sha256Hex);
+  });
+
+  it('rejects partial, mutable, and cross-origin catalog refs', () => {
+    const sha256Hex = 'aa'.repeat(32);
+    for (const ref of [
+      { version: 2, path: `/proofs/bat-v2/catalogs/${sha256Hex}.json` },
+      { version: 2, path: `/proofs/bat-v2/catalogs/latest.json`, sha256Hex },
+      { version: 2, path: 'https://issuer.example/catalog.json', sha256Hex },
+    ]) {
+      expect(() => bootstrapWithCatalog(ref)).toThrow();
+    }
   });
 });
 

--- a/web/src/__tests__/proof-artifact-fetch.test.ts
+++ b/web/src/__tests__/proof-artifact-fetch.test.ts
@@ -84,4 +84,37 @@ describe('same-origin proof artifact fetch', () => {
       fetchImpl: redirectedFetch,
     })).rejects.toThrow(/redirect rejected/);
   });
+
+  it('cancels a streaming body at the byte limit and can require streaming', async () => {
+    const cancel = vi.fn();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) { controller.enqueue(new Uint8Array([1, 2])); },
+      cancel,
+    });
+    const streamingFetch = vi.fn(async () => new Response(stream)) as unknown as typeof fetch;
+    await expect(fetchProofArtifactBytesV1('/proofs/a.bin', {
+      baseHref: BASE_HREF,
+      fetchImpl: streamingFetch,
+      maxBytes: 1,
+      requireStreaming: true,
+    })).rejects.toThrow(/fetch limit/);
+    expect(cancel).toHaveBeenCalledOnce();
+
+    const arrayBuffer = vi.fn(async () => new Uint8Array([1]).buffer);
+    const nonStreamingFetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      redirected: false,
+      url: '',
+      headers: new Headers(),
+      body: null,
+      arrayBuffer,
+    } as unknown as Response)) as unknown as typeof fetch;
+    await expect(fetchProofArtifactBytesV1('/proofs/a.bin', {
+      baseHref: BASE_HREF,
+      fetchImpl: nonStreamingFetch,
+      requireStreaming: true,
+    })).rejects.toThrow(/bounded byte stream/);
+    expect(arrayBuffer).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/__tests__/provider-payment-selection.test.ts
+++ b/web/src/__tests__/provider-payment-selection.test.ts
@@ -55,7 +55,11 @@ const batV2Class: BatV2ClassArtifactV2 = {
   },
 };
 
-function batV2Projection(providerByte: number, classArtifact = batV2Class) {
+function batV2Projection(
+  providerByte: number,
+  classArtifact = batV2Class,
+  verifiedBinding = classArtifact.binding,
+) {
   const policyDigestHex = `${providerByte + 70}`.repeat(32);
   const scopeIdHex = `${providerByte + 80}`.repeat(32);
   const selectedTrust = trust(providerByte, providerByte + 10, providerByte + 20);
@@ -83,12 +87,20 @@ function batV2Projection(providerByte: number, classArtifact = batV2Class) {
       scopeIdHex,
       offerId: 1,
       classIdHex: classArtifact.binding.classIdHex,
+      classBindingJson: () => ({ ...verifiedBinding }),
       assertRedemptionReady: vi.fn(),
     },
   });
 }
 
 describe('local independent-provider payment selection', () => {
+  it('rejects a current redemption handle from another class digest before pairing', () => {
+    expect(() => batV2Projection(1, batV2Class, {
+      ...batV2Class.binding,
+      classDigestHex: '52'.repeat(32),
+    })).toThrow(/exact signed class binding/);
+  });
+
   it('retains two exact verified BAT V2 members of one byte-identical class', () => {
     const first = batV2Projection(1);
     const second = batV2Projection(2);

--- a/web/src/__tests__/service-admission.test.ts
+++ b/web/src/__tests__/service-admission.test.ts
@@ -113,6 +113,13 @@ function accepted(view: ServicePolicyViewV1) {
         scopeIdHex: view.scopes[0].scopeIdHex,
         offerId,
         classIdHex: selected.keyIdHex,
+        classBindingJson: () => ({
+          issuerIdHex: selected.issuerIdHex,
+          classIdHex: selected.keyIdHex,
+          classDigestHex: '73'.repeat(32),
+          classKeyEpoch: '4',
+          batKeyIdHex: '74'.repeat(32),
+        }),
         assertRedemptionReady: vi.fn(),
       };
     },

--- a/web/src/bat-v2-class-catalog.ts
+++ b/web/src/bat-v2-class-catalog.ts
@@ -1,0 +1,523 @@
+/**
+ * Trusted, public BAT V2 class discovery.
+ *
+ * The Nostr directory may advertise scheme 6, but it never supplies any value
+ * consumed here.  A trusted Web bootstrap pins one canonical catalog, and the
+ * catalog in turn pins immutable class bytes.  Rust/WASM remains the final
+ * authority for the class codec, issuer signature, validity, and exact member.
+ */
+
+import {
+  validateBatV2ClassBindingV2,
+  type BatV2ClassBindingV2,
+} from './bat-v2-vault.js';
+import { bytesToHex, sha256 } from './hash.js';
+import { fetchProofArtifactBytesV1 } from './proof-artifact-fetch.js';
+import type {
+  ProductBatV2ClassMemberSelectorV2,
+  ProductBatV2ClassResolverV2,
+} from './product-admission-controller.js';
+import type { BatV2ClassArtifactV2 } from './provider-payment-selection.js';
+import {
+  type ProviderAdmissionSessionV1,
+  type RetainedBatV2ExactMemberV2,
+} from './service-admission.js';
+import type { WasmVerifiedBatV2RedemptionV2 } from './sdk-bridge.js';
+import { trustedNowUnixV1 } from './trusted-time.js';
+
+export const MAX_BAT_V2_PUBLIC_CLASS_CATALOG_BYTES_V2 = 2 * 1024 * 1024;
+export const MAX_BAT_V2_PUBLIC_CLASS_BYTES_V2 = 512 * 1024;
+export const MAX_BAT_V2_PUBLIC_CLASS_ENTRIES_V2 = 1_024;
+export const MAX_BAT_V2_PUBLIC_CLASS_MEMBERS_V2 = 4_096;
+export const MAX_BAT_V2_PUBLIC_CLASS_TOTAL_MEMBERS_V2 = 16_384;
+
+const U64_MAX = 0xffff_ffff_ffff_ffffn;
+const CATALOG_PATH = /^\/proofs\/bat-v2\/catalogs\/([0-9a-f]{64})\.json$/;
+const CLASS_PATH = /^\/proofs\/bat-v2\/classes\/([0-9a-f]{64})\.bin$/;
+
+export interface TrustedBatV2PublicClassCatalogRefV2 {
+  version: 2;
+  path: string;
+  sha256Hex: string;
+}
+
+export interface BatV2PublicClassArtifactRefV2 {
+  path: string;
+  sha256Hex: string;
+}
+
+export interface BatV2PublicClassMemberV2 extends RetainedBatV2ExactMemberV2 {}
+
+export interface BatV2PublicClassEntryV2 extends BatV2ClassBindingV2 {
+  keyNotBeforeUnix: string;
+  keyNotAfterUnix: string;
+  /** Explicit acquisition head. Epoch/time are never used to infer it. */
+  status: 'current' | 'retained';
+  artifact: BatV2PublicClassArtifactRefV2;
+  members: readonly BatV2PublicClassMemberV2[];
+}
+
+export interface BatV2PublicClassCatalogV2 {
+  version: 2;
+  entries: readonly BatV2PublicClassEntryV2[];
+}
+
+export interface BatV2PublicClassCatalogResolverOptionsV2 {
+  baseHref?: string;
+  fetchImpl?: typeof fetch;
+  /** Test seam only. Production defaults to the browser's trusted wall clock. */
+  nowUnix?: () => bigint;
+}
+
+export interface RetainedBatV2ClassResolutionInputV2 {
+  binding: BatV2ClassBindingV2;
+  providerIdHex: string;
+  session: ProviderAdmissionSessionV1;
+}
+
+export interface RetainedBatV2ClassResolutionV2 {
+  member: BatV2PublicClassMemberV2;
+  classArtifact: BatV2ClassArtifactV2;
+  /** Caller owns this opaque handle and must call `free()`. */
+  verifiedRedemption: WasmVerifiedBatV2RedemptionV2;
+}
+
+/** Parse the only trusted-render input. Partial or mutable-looking refs fail closed. */
+export function parseTrustedBatV2PublicClassCatalogRefV2(
+  value: unknown,
+): TrustedBatV2PublicClassCatalogRefV2 {
+  const record = exactRecord(value, ['version', 'path', 'sha256Hex'], 'BAT V2 catalog ref');
+  if (record.version !== 2) throw new Error('BAT V2 catalog ref has an unknown version');
+  const sha256Hex = nonzeroHex32('BAT V2 catalog SHA-256', record.sha256Hex);
+  const path = immutablePath('BAT V2 catalog', record.path, CATALOG_PATH, sha256Hex);
+  return Object.freeze({ version: 2, path, sha256Hex });
+}
+
+/**
+ * Parse the canonical source-gate format. The byte-for-byte JSON check rejects
+ * whitespace, reordered/unknown keys, duplicate JSON keys, and alternate
+ * numeric/string spellings before a catalog can be published and pinned.
+ */
+export function parseBatV2PublicClassCatalogV2(
+  serialized: string,
+): BatV2PublicClassCatalogV2 {
+  if (typeof serialized !== 'string'
+      || serialized.length > MAX_BAT_V2_PUBLIC_CLASS_CATALOG_BYTES_V2
+      || new TextEncoder().encode(serialized).length > MAX_BAT_V2_PUBLIC_CLASS_CATALOG_BYTES_V2) {
+    throw new Error('BAT V2 public class catalog exceeds its byte limit');
+  }
+  let parsed: unknown;
+  try { parsed = JSON.parse(serialized); } catch {
+    throw new Error('BAT V2 public class catalog must be valid JSON');
+  }
+  const envelope = exactRecord(parsed, ['version', 'entries'], 'BAT V2 public class catalog');
+  if (envelope.version !== 2) throw new Error('BAT V2 public class catalog has an unknown version');
+  if (!Array.isArray(envelope.entries) || envelope.entries.length === 0
+      || envelope.entries.length > MAX_BAT_V2_PUBLIC_CLASS_ENTRIES_V2) {
+    throw new Error('BAT V2 public class catalog has an invalid entry count');
+  }
+
+  let totalMembers = 0;
+  const entries = envelope.entries.map((entry, index) => {
+    const value = parseEntry(entry, index);
+    totalMembers += value.members.length;
+    if (totalMembers > MAX_BAT_V2_PUBLIC_CLASS_TOTAL_MEMBERS_V2) {
+      throw new Error('BAT V2 public class catalog exceeds its total member limit');
+    }
+    return value;
+  });
+  requireStrictOrder(entries, compareEntries, 'BAT V2 class entries');
+  requireUnique(entries.map((entry) => entry.artifact.path), 'BAT V2 class artifact path');
+  requireExactlyOneCurrentHead(entries);
+
+  const canonical = freezeCatalog({ version: 2, entries });
+  if (JSON.stringify(canonical) !== serialized) {
+    throw new Error('BAT V2 public class catalog is not canonical JSON');
+  }
+  return canonical;
+}
+
+export class BatV2PublicClassCatalogResolverV2 {
+  private readonly trusted: TrustedBatV2PublicClassCatalogRefV2;
+  private readonly options: BatV2PublicClassCatalogResolverOptionsV2;
+  private catalogPromise: Promise<BatV2PublicClassCatalogV2> | null = null;
+  private readonly artifactPromises = new Map<string, Promise<Uint8Array>>();
+
+  constructor(
+    trusted: TrustedBatV2PublicClassCatalogRefV2,
+    options: BatV2PublicClassCatalogResolverOptionsV2 = {},
+  ) {
+    this.trusted = parseTrustedBatV2PublicClassCatalogRefV2(trusted);
+    if (options.nowUnix !== undefined && typeof options.nowUnix !== 'function') {
+      throw new Error('BAT V2 catalog nowUnix must be a function');
+    }
+    this.options = { ...options };
+  }
+
+  /** Drop-in resolver for the existing product current-policy controller. */
+  readonly resolveCurrent: ProductBatV2ClassResolverV2 = async (selector) => {
+    const exact = exactCurrentSelector(selector);
+    const catalog = await this.catalog();
+    const memberMatches = catalog.entries.filter((entry) =>
+      entry.status === 'current'
+      &&
+      entry.issuerIdHex === exact.offer.issuerIdHex
+      && entry.classIdHex === exact.offer.keyIdHex
+      && entry.members.some((member) => sameMember(member, exact)));
+    const entry = uniqueCurrentEntry(memberMatches, this.nowUnix());
+    return this.artifact(entry);
+  };
+
+  /**
+   * Resolve a historical wallet binding without trusting a caller-supplied
+   * policy selector. The exact member is learned from the pinned catalog, then
+   * the session fetches that one retained signed policy and Rust re-verifies
+   * the canonical issuer-signed class/member.
+   */
+  readonly resolveRetained = async (
+    input: RetainedBatV2ClassResolutionInputV2,
+  ): Promise<RetainedBatV2ClassResolutionV2> => {
+    validateBatV2ClassBindingV2(input.binding);
+    const providerIdHex = nonzeroHex32('retained BAT V2 provider ID', input.providerIdHex);
+    if (!input.session || typeof input.session.verifyRetainedBatV2ClassMember !== 'function') {
+      throw new Error('retained BAT V2 resolution requires a provider admission session');
+    }
+    const catalog = await this.catalog();
+    const bindingMatches = catalog.entries.filter((entry) => sameBinding(entry, input.binding));
+    if (bindingMatches.length !== 1) {
+      throw new Error('retained BAT V2 wallet binding has no unique trusted class');
+    }
+    const entry = bindingMatches[0];
+    assertActive(entry, this.nowUnix(), 'retained BAT V2 class');
+    const members = entry.members.filter((member) => member.providerIdHex === providerIdHex);
+    if (members.length !== 1) {
+      throw new Error('retained BAT V2 provider has no unique exact class member');
+    }
+    const member = { ...members[0] };
+    const classArtifact = await this.artifact(entry);
+    let verifiedRedemption: WasmVerifiedBatV2RedemptionV2 | null = null;
+    try {
+      verifiedRedemption = await input.session.verifyRetainedBatV2ClassMember(
+        member,
+        classArtifact,
+      );
+      return { member, classArtifact, verifiedRedemption };
+    } catch (error) {
+      verifiedRedemption?.free();
+      classArtifact.classBytes.fill(0);
+      throw error;
+    }
+  };
+
+  private nowUnix(): bigint {
+    const value = this.options.nowUnix?.() ?? trustedNowUnixV1();
+    if (typeof value !== 'bigint' || value < 0n || value > U64_MAX) {
+      throw new Error('BAT V2 catalog time must be a canonical u64');
+    }
+    return value;
+  }
+
+  private catalog(): Promise<BatV2PublicClassCatalogV2> {
+    this.catalogPromise ??= this.fetchCatalog();
+    return this.catalogPromise;
+  }
+
+  private async fetchCatalog(): Promise<BatV2PublicClassCatalogV2> {
+    const bytes = await fetchProofArtifactBytesV1(this.trusted.path, {
+      baseHref: this.options.baseHref,
+      fetchImpl: this.options.fetchImpl,
+      maxBytes: MAX_BAT_V2_PUBLIC_CLASS_CATALOG_BYTES_V2,
+      requireStreaming: true,
+    });
+    requireSha256('BAT V2 public class catalog', bytes, this.trusted.sha256Hex);
+    let serialized: string;
+    try { serialized = new TextDecoder('utf-8', { fatal: true }).decode(bytes); } catch {
+      throw new Error('BAT V2 public class catalog is not canonical UTF-8');
+    }
+    return parseBatV2PublicClassCatalogV2(serialized);
+  }
+
+  private async artifact(entry: BatV2PublicClassEntryV2): Promise<BatV2ClassArtifactV2> {
+    const cacheKey = `${entry.artifact.path}:${entry.artifact.sha256Hex}`;
+    let pending = this.artifactPromises.get(cacheKey);
+    if (!pending) {
+      pending = this.fetchArtifact(entry);
+      this.artifactPromises.set(cacheKey, pending);
+    }
+    const classBytes = await pending;
+    return { classBytes: classBytes.slice(), binding: bindingFromEntry(entry) };
+  }
+
+  private async fetchArtifact(entry: BatV2PublicClassEntryV2): Promise<Uint8Array> {
+    const bytes = await fetchProofArtifactBytesV1(entry.artifact.path, {
+      baseHref: this.options.baseHref,
+      fetchImpl: this.options.fetchImpl,
+      maxBytes: MAX_BAT_V2_PUBLIC_CLASS_BYTES_V2,
+      requireStreaming: true,
+    });
+    if (bytes.length === 0) throw new Error('BAT V2 class artifact is empty');
+    requireSha256('BAT V2 class artifact', bytes, entry.artifact.sha256Hex);
+    return bytes;
+  }
+}
+
+function parseEntry(value: unknown, index: number): BatV2PublicClassEntryV2 {
+  const entry = exactRecord(value, [
+    'issuerIdHex', 'classIdHex', 'classKeyEpoch', 'classDigestHex', 'batKeyIdHex',
+    'keyNotBeforeUnix', 'keyNotAfterUnix', 'status', 'artifact', 'members',
+  ], `BAT V2 class entry ${index}`);
+  const binding: BatV2ClassBindingV2 = {
+    issuerIdHex: nonzeroHex32(`BAT V2 class entry ${index} issuer ID`, entry.issuerIdHex),
+    classIdHex: nonzeroHex32(`BAT V2 class entry ${index} class ID`, entry.classIdHex),
+    classKeyEpoch: positiveU64(`BAT V2 class entry ${index} key epoch`, entry.classKeyEpoch),
+    classDigestHex: nonzeroHex32(`BAT V2 class entry ${index} class digest`, entry.classDigestHex),
+    batKeyIdHex: nonzeroHex32(`BAT V2 class entry ${index} BAT key ID`, entry.batKeyIdHex),
+  };
+  validateBatV2ClassBindingV2(binding);
+  const keyNotBeforeUnix = u64Decimal(
+    `BAT V2 class entry ${index} key not-before`, entry.keyNotBeforeUnix,
+  );
+  const keyNotAfterUnix = u64Decimal(
+    `BAT V2 class entry ${index} key not-after`, entry.keyNotAfterUnix,
+  );
+  if (BigInt(keyNotBeforeUnix) > BigInt(keyNotAfterUnix)) {
+    throw new Error(`BAT V2 class entry ${index} has an invalid key window`);
+  }
+  if (entry.status !== 'current' && entry.status !== 'retained') {
+    throw new Error(`BAT V2 class entry ${index} status is invalid`);
+  }
+  const artifactRecord = exactRecord(
+    entry.artifact, ['path', 'sha256Hex'], `BAT V2 class entry ${index} artifact`,
+  );
+  const artifactSha256Hex = nonzeroHex32(
+    `BAT V2 class entry ${index} artifact SHA-256`, artifactRecord.sha256Hex,
+  );
+  const artifact = Object.freeze({
+    path: immutablePath(
+      `BAT V2 class entry ${index} artifact`,
+      artifactRecord.path,
+      CLASS_PATH,
+      artifactSha256Hex,
+    ),
+    sha256Hex: artifactSha256Hex,
+  });
+  if (!Array.isArray(entry.members) || entry.members.length === 0
+      || entry.members.length > MAX_BAT_V2_PUBLIC_CLASS_MEMBERS_V2) {
+    throw new Error(`BAT V2 class entry ${index} has an invalid member count`);
+  }
+  const members = entry.members.map((member, memberIndex) => Object.freeze(parseMember(
+    member, index, memberIndex,
+  )));
+  requireStrictOrder(members, compareMembers, `BAT V2 class entry ${index} members`);
+  return Object.freeze({
+    ...binding,
+    keyNotBeforeUnix,
+    keyNotAfterUnix,
+    status: entry.status,
+    artifact,
+    members: Object.freeze(members),
+  });
+}
+
+function parseMember(value: unknown, entryIndex: number, memberIndex: number): BatV2PublicClassMemberV2 {
+  const member = exactRecord(value, [
+    'providerIdHex', 'policyDigestHex', 'scopeIdHex', 'offerId',
+  ], `BAT V2 class entry ${entryIndex} member ${memberIndex}`);
+  if (!Number.isSafeInteger(member.offerId) || (member.offerId as number) <= 0
+      || (member.offerId as number) > 0xffff_ffff) {
+    throw new Error(`BAT V2 class entry ${entryIndex} member ${memberIndex} offer ID is invalid`);
+  }
+  return {
+    providerIdHex: nonzeroHex32('BAT V2 member provider ID', member.providerIdHex),
+    policyDigestHex: nonzeroHex32('BAT V2 member policy digest', member.policyDigestHex),
+    scopeIdHex: nonzeroHex32('BAT V2 member scope ID', member.scopeIdHex),
+    offerId: member.offerId as number,
+  };
+}
+
+function exactCurrentSelector(
+  selector: ProductBatV2ClassMemberSelectorV2,
+): ProductBatV2ClassMemberSelectorV2 {
+  if (!selector || typeof selector !== 'object' || !selector.offer) {
+    throw new Error('BAT V2 current selector is malformed');
+  }
+  const member = parseMember({
+    providerIdHex: selector.providerIdHex,
+    policyDigestHex: selector.policyDigestHex,
+    scopeIdHex: selector.scopeIdHex,
+    offerId: selector.offerId,
+  }, 0, 0);
+  const offer = selector.offer;
+  if (offer.offerId !== member.offerId
+      || offer.acquisition !== 'bolt11'
+      || offer.authorization !== 'cashu-bat-v2'
+      || offer.verification !== 'shared-issuer-online') {
+    throw new Error('selected signed offer is not a current BAT V2 class offer');
+  }
+  nonzeroHex32('BAT V2 offer issuer ID', offer.issuerIdHex);
+  nonzeroHex32('BAT V2 offer class ID', offer.keyIdHex);
+  return { ...selector, ...member, offer: { ...offer, price: { ...offer.price } } };
+}
+
+function uniqueCurrentEntry(
+  matches: readonly BatV2PublicClassEntryV2[],
+  nowUnix: bigint,
+): BatV2PublicClassEntryV2 {
+  const active = matches.filter((entry) => isActive(entry, nowUnix));
+  if (active.length !== 1) {
+    if (active.length > 1) throw new Error('current BAT V2 member matches multiple active classes');
+    if (matches.length > 0) throw new Error('current BAT V2 class key window is inactive');
+    throw new Error('current BAT V2 member is absent from the trusted class catalog');
+  }
+  return active[0];
+}
+
+function assertActive(entry: BatV2PublicClassEntryV2, nowUnix: bigint, label: string): void {
+  if (!isActive(entry, nowUnix)) throw new Error(`${label} key window is inactive`);
+}
+
+function isActive(entry: BatV2PublicClassEntryV2, nowUnix: bigint): boolean {
+  return BigInt(entry.keyNotBeforeUnix) <= nowUnix && nowUnix <= BigInt(entry.keyNotAfterUnix);
+}
+
+function sameMember(
+  member: BatV2PublicClassMemberV2,
+  selector: Pick<ProductBatV2ClassMemberSelectorV2,
+    'providerIdHex' | 'policyDigestHex' | 'scopeIdHex' | 'offerId'>,
+): boolean {
+  return member.providerIdHex === selector.providerIdHex
+    && member.policyDigestHex === selector.policyDigestHex
+    && member.scopeIdHex === selector.scopeIdHex
+    && member.offerId === selector.offerId;
+}
+
+function sameBinding(
+  entry: BatV2PublicClassEntryV2,
+  binding: BatV2ClassBindingV2,
+): boolean {
+  return entry.issuerIdHex === binding.issuerIdHex
+    && entry.classIdHex === binding.classIdHex
+    && entry.classDigestHex === binding.classDigestHex
+    && entry.classKeyEpoch === binding.classKeyEpoch
+    && entry.batKeyIdHex === binding.batKeyIdHex;
+}
+
+function bindingFromEntry(entry: BatV2PublicClassEntryV2): BatV2ClassBindingV2 {
+  return {
+    issuerIdHex: entry.issuerIdHex,
+    classIdHex: entry.classIdHex,
+    classDigestHex: entry.classDigestHex,
+    classKeyEpoch: entry.classKeyEpoch,
+    batKeyIdHex: entry.batKeyIdHex,
+  };
+}
+
+function compareMembers(left: BatV2PublicClassMemberV2, right: BatV2PublicClassMemberV2): number {
+  return compareAscii(left.providerIdHex, right.providerIdHex)
+    || compareAscii(left.policyDigestHex, right.policyDigestHex)
+    || compareAscii(left.scopeIdHex, right.scopeIdHex)
+    || left.offerId - right.offerId;
+}
+
+function compareEntries(left: BatV2PublicClassEntryV2, right: BatV2PublicClassEntryV2): number {
+  return compareAscii(left.issuerIdHex, right.issuerIdHex)
+    || compareAscii(left.classIdHex, right.classIdHex)
+    || compareBigInt(BigInt(left.classKeyEpoch), BigInt(right.classKeyEpoch));
+}
+
+function compareAscii(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareBigInt(left: bigint, right: bigint): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function requireStrictOrder<T>(
+  values: readonly T[],
+  compare: (left: T, right: T) => number,
+  label: string,
+): void {
+  for (let index = 1; index < values.length; index += 1) {
+    if (compare(values[index - 1], values[index]) >= 0) {
+      throw new Error(`${label} must be strictly canonical-sorted without duplicates`);
+    }
+  }
+}
+
+function requireUnique(values: readonly string[], label: string): void {
+  if (new Set(values).size !== values.length) throw new Error(`duplicate ${label}`);
+}
+
+function requireExactlyOneCurrentHead(entries: readonly BatV2PublicClassEntryV2[]): void {
+  const groups = new Map<string, number>();
+  for (const entry of entries) {
+    const key = `${entry.issuerIdHex}:${entry.classIdHex}`;
+    const count = groups.get(key) ?? 0;
+    groups.set(key, count + (entry.status === 'current' ? 1 : 0));
+  }
+  for (const count of groups.values()) {
+    if (count !== 1) {
+      throw new Error('each BAT V2 issuer/class must have exactly one explicit current head');
+    }
+  }
+}
+
+function immutablePath(
+  label: string,
+  value: unknown,
+  pattern: RegExp,
+  expectedDigest: string,
+): string {
+  if (typeof value !== 'string') throw new Error(`${label} path is invalid`);
+  const match = pattern.exec(value);
+  if (!match || match[1] !== expectedDigest) {
+    throw new Error(`${label} path must be immutable and named by its SHA-256`);
+  }
+  return value;
+}
+
+function positiveU64(field: string, value: unknown): string {
+  const canonical = u64Decimal(field, value);
+  if (canonical === '0') throw new Error(`${field} must be non-zero`);
+  return canonical;
+}
+
+function u64Decimal(field: string, value: unknown): string {
+  if (typeof value !== 'string' || !/^(0|[1-9][0-9]*)$/.test(value)) {
+    throw new Error(`${field} must be a canonical u64 decimal`);
+  }
+  const parsed = BigInt(value);
+  if (parsed > U64_MAX) throw new Error(`${field} exceeds u64`);
+  return value;
+}
+
+function nonzeroHex32(field: string, value: unknown): string {
+  if (typeof value !== 'string' || !/^[0-9a-f]{64}$/.test(value) || /^0{64}$/.test(value)) {
+    throw new Error(`${field} must be non-zero lowercase 32-byte hex`);
+  }
+  return value;
+}
+
+function exactRecord(
+  value: unknown,
+  keys: readonly string[],
+  label: string,
+): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const actual = Object.keys(value);
+  if (actual.length !== keys.length || actual.some((key, index) => key !== keys[index])) {
+    throw new Error(`${label} has unknown, missing, or non-canonical fields`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireSha256(label: string, bytes: Uint8Array, expectedHex: string): void {
+  if (bytesToHex(sha256(bytes)) !== expectedHex) throw new Error(`${label} SHA-256 mismatch`);
+}
+
+function freezeCatalog(catalog: BatV2PublicClassCatalogV2): BatV2PublicClassCatalogV2 {
+  return Object.freeze({ version: 2, entries: Object.freeze([...catalog.entries]) });
+}

--- a/web/src/directory-vault.ts
+++ b/web/src/directory-vault.ts
@@ -93,7 +93,8 @@ export interface DirectoryDiscoveryEntryJsonV1 {
       | 'harmony-query-job-v1' | 'onion-evaluate-job-v1' | 'tee-oram-query-v1';
     acquisition: 'free-v1' | 'bolt11-v1' | 'cashu-ecash-v1';
     authorization: 'free-v1' | 'bolt11-direct-receipt-v1' | 'cashu-ecash-v1'
-      | 'bitcoinpir-cashu-bat-v1' | 'arc-v1-experimental';
+      | 'bitcoinpir-cashu-bat-v1' | 'bitcoinpir-cashu-bat-v2'
+      | 'arc-v1-experimental';
     deployment: 'stable' | 'experimental';
   }>;
   health: { class: 'unknown' | 'available' | 'degraded' | 'unavailable'; observed_bucket: number };
@@ -568,7 +569,9 @@ function parseDiscoveryEntry(
       ] as const),
       authorization: exactStringMember('catalog hint authorization', hint.authorization, [
         'free-v1', 'bolt11-direct-receipt-v1', 'cashu-ecash-v1',
-        'bitcoinpir-cashu-bat-v1', 'arc-v1-experimental',
+        // This advertises transport capability only. No class path, digest, or
+        // issuer trust is ever accepted from the directory.
+        'bitcoinpir-cashu-bat-v1', 'bitcoinpir-cashu-bat-v2', 'arc-v1-experimental',
       ] as const),
       deployment: exactStringMember('catalog hint deployment', hint.deployment, [
         'stable', 'experimental',

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -299,6 +299,7 @@ export type {
   IndependentProviderBatV2AdmissionSelectionV2,
   ProviderTrustAnchorV1,
   ProviderAdmissionSelectionV1,
+  RetainedBatV2ExactMemberV2,
   IndependentProviderAdmissionSelectionV1,
   IndependentRetainedProviderAdmissionSelectionV1,
   IndependentProviderPairAdmissionSelectionV1,
@@ -349,6 +350,26 @@ export {
   validateBatV2ClassBindingV2,
   validateBatV2WalletRecordV2,
 } from './bat-v2-vault.js';
+export {
+  BatV2PublicClassCatalogResolverV2,
+  MAX_BAT_V2_PUBLIC_CLASS_BYTES_V2,
+  MAX_BAT_V2_PUBLIC_CLASS_CATALOG_BYTES_V2,
+  MAX_BAT_V2_PUBLIC_CLASS_ENTRIES_V2,
+  MAX_BAT_V2_PUBLIC_CLASS_MEMBERS_V2,
+  MAX_BAT_V2_PUBLIC_CLASS_TOTAL_MEMBERS_V2,
+  parseBatV2PublicClassCatalogV2,
+  parseTrustedBatV2PublicClassCatalogRefV2,
+} from './bat-v2-class-catalog.js';
+export type {
+  BatV2PublicClassArtifactRefV2,
+  BatV2PublicClassCatalogResolverOptionsV2,
+  BatV2PublicClassCatalogV2,
+  BatV2PublicClassEntryV2,
+  BatV2PublicClassMemberV2,
+  RetainedBatV2ClassResolutionInputV2,
+  RetainedBatV2ClassResolutionV2,
+  TrustedBatV2PublicClassCatalogRefV2,
+} from './bat-v2-class-catalog.js';
 export type {
   BatV2ClassBindingV2,
   BatV2DistinctPairReservationV2,
@@ -448,6 +469,7 @@ export {
   directoryBoundProviderTrustAnchorV1,
   manualProviderAdmissionTrustAnchorV1,
   parseProductTrustedBootstrapV1,
+  productBatV2ClassCatalogRefV2,
   expectedLightningPayeeForOfferV1,
   providerArkFingerprintV1,
   providerLightningPayeeTrustV1,

--- a/web/src/product-provider-bootstrap.ts
+++ b/web/src/product-provider-bootstrap.ts
@@ -8,6 +8,10 @@ import { directoryProviderTrustAnchorV1 } from './nostr-directory.js';
 import type { ProviderTrustAnchorV1 } from './service-admission.js';
 import type { LightningNetworkNameV1 } from './admission-vault.js';
 import type { ServiceOfferViewV1 } from './sdk-bridge.js';
+import {
+  parseTrustedBatV2PublicClassCatalogRefV2,
+  type TrustedBatV2PublicClassCatalogRefV2,
+} from './bat-v2-class-catalog.js';
 
 const MAX_LIGHTNING_PAYEE_TRUST_ENTRIES_V1 = 64;
 
@@ -58,6 +62,8 @@ export interface ProductTrustedBootstrapV1 {
   version: 1;
   network: LightningNetworkNameV1;
   providers: ProductTrustedProviderV1[];
+  /** Independent trusted-render root. Directory catalog hints never fill it. */
+  batV2ClassCatalog?: TrustedBatV2PublicClassCatalogRefV2;
 }
 
 /**
@@ -102,7 +108,19 @@ export function parseProductTrustedBootstrapV1(serialized: string): ProductTrust
   }
   const providers = parsed.providers.map((value, index) => parseProvider(value, index));
   requireUnique(providers.map((value) => value.providerIdHex), 'provider ID');
-  return { version: 1, network: parsed.network, providers };
+  const batV2ClassCatalog = parsed.batV2ClassCatalog === undefined
+    ? undefined
+    : parseTrustedBatV2PublicClassCatalogRefV2(parsed.batV2ClassCatalog);
+  return { version: 1, network: parsed.network, providers, batV2ClassCatalog };
+}
+
+/** Return an owned trusted catalog ref; callers cannot mutate bootstrap state. */
+export function productBatV2ClassCatalogRefV2(
+  bootstrap: ProductTrustedBootstrapV1,
+): TrustedBatV2PublicClassCatalogRefV2 | undefined {
+  return bootstrap.batV2ClassCatalog
+    ? { ...bootstrap.batV2ClassCatalog }
+    : undefined;
 }
 
 /** Manual anchors cannot pre-commit an unknown live policy epoch/digest. */

--- a/web/src/proof-artifact-fetch.ts
+++ b/web/src/proof-artifact-fetch.ts
@@ -5,6 +5,8 @@ export interface ProofArtifactFetchOptionsV1 {
   baseHref?: string;
   fetchImpl?: typeof fetch;
   maxBytes?: number;
+  /** Reject non-streaming responses instead of allocating an unbounded body. */
+  requireStreaming?: boolean;
 }
 
 /** Resolve a manifest-controlled artifact path without permitting an SSRF-like request. */
@@ -67,8 +69,57 @@ export async function fetchProofArtifactBytesV1(
   if (contentLength !== null) {
     const declaredLength = Number(contentLength);
     if (!Number.isSafeInteger(declaredLength) || declaredLength < 0 || declaredLength > maxBytes) {
+      await response.body?.cancel('proof artifact declared byte limit exceeded').catch(() => {});
       throw new Error(`proof artifact ${path} exceeds the ${maxBytes}-byte fetch limit`);
     }
+  }
+  const stream = response.body;
+  if (stream && typeof stream.getReader === 'function') {
+    const reader = stream.getReader();
+    let bytes = new Uint8Array(Math.min(maxBytes, 64 * 1024));
+    let total = 0;
+    let cancelled = false;
+    const cancel = async (reason: string): Promise<void> => {
+      cancelled = true;
+      await reader.cancel(reason).catch(() => {});
+    };
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!(value instanceof Uint8Array)) {
+          await cancel('non-byte proof artifact stream');
+          throw new Error(`proof artifact ${path} returned a non-byte stream`);
+        }
+        if (value.byteLength === 0) continue;
+        if (value.byteLength > maxBytes - total) {
+          await cancel('proof artifact byte limit exceeded');
+          throw new Error(`proof artifact ${path} exceeds the ${maxBytes}-byte fetch limit`);
+        }
+        const nextTotal = total + value.byteLength;
+        if (nextTotal > bytes.length) {
+          const capacity = Math.min(
+            maxBytes,
+            Math.max(nextTotal, Math.max(1, bytes.length) * 2),
+          );
+          const grown = new Uint8Array(capacity);
+          grown.set(bytes.subarray(0, total));
+          bytes = grown;
+        }
+        bytes.set(value, total);
+        total = nextTotal;
+      }
+    } catch (error) {
+      if (!cancelled) await cancel('proof artifact stream rejected');
+      throw error;
+    } finally {
+      reader.releaseLock();
+    }
+    return bytes.slice(0, total);
+  }
+  if (options.requireStreaming) {
+    await response.body?.cancel('bounded proof artifact stream required').catch(() => {});
+    throw new Error(`proof artifact ${path} does not expose a bounded byte stream`);
   }
   const bytes = new Uint8Array(await response.arrayBuffer());
   if (bytes.length > maxBytes) {

--- a/web/src/provider-payment-selection.ts
+++ b/web/src/provider-payment-selection.ts
@@ -93,16 +93,17 @@ export class VerifiedProviderBatV2ProjectionV2 {
     assertBatV2OfferShape(input.offer, input.classArtifact.binding, input.offerId);
     const verified = input.verifiedRedemption;
     if (!verified || typeof verified.assertRedemptionReady !== 'function'
+        || typeof verified.classBindingJson !== 'function'
         || typeof verified.free !== 'function') {
       throw new Error('BAT V2 selection requires an opaque verified redemption handle');
     }
     if (verified.providerIdHex !== providerIdHex
         || verified.policyDigestHex !== policyDigestHex
         || verified.scopeIdHex !== scopeIdHex
-        || verified.offerId !== input.offerId
-        || verified.classIdHex !== input.classArtifact.binding.classIdHex) {
+        || verified.offerId !== input.offerId) {
       throw new Error('BAT V2 verified class/member projection changed coordinates');
     }
+    assertVerifiedBatV2ClassBindingV2(verified, input.classArtifact.binding);
     return new VerifiedProviderBatV2ProjectionV2(
       policyDigestHex,
       scopeIdHex,
@@ -152,10 +153,10 @@ export class VerifiedProviderBatV2ProjectionV2 {
     )
         || this.redemptionValue.policyDigestHex !== this.policyDigestValue
         || this.redemptionValue.scopeIdHex !== this.scopeIdValue
-        || this.redemptionValue.offerId !== this.offerIdValue
-        || this.redemptionValue.classIdHex !== this.bindingValue.classIdHex) {
+        || this.redemptionValue.offerId !== this.offerIdValue) {
       throw new Error('BAT V2 verified redemption handle changed after selection');
     }
+    assertVerifiedBatV2ClassBindingV2(this.redemptionValue, this.bindingValue);
   }
 
   close(): void {
@@ -418,6 +419,41 @@ function classBindingKeyV2(value: BatV2ClassBindingV2): string {
     value.classKeyEpoch,
     value.batKeyIdHex,
   ].join(':');
+}
+
+/**
+ * Compare a trusted TypeScript binding with the full binding independently
+ * derived by Rust from the canonical signed class. This is intentionally
+ * shared by current and retained paths so neither can weaken to classId-only.
+ */
+export function assertVerifiedBatV2ClassBindingV2(
+  verified: WasmVerifiedBatV2RedemptionV2,
+  expected: BatV2ClassBindingV2,
+): void {
+  validateBatV2ClassBindingV2(expected);
+  if (!verified || typeof verified.classBindingJson !== 'function') {
+    throw new Error('BAT V2 verified redemption lacks a full class binding');
+  }
+  const projected = verified.classBindingJson() as unknown;
+  if (projected === null || typeof projected !== 'object' || Array.isArray(projected)) {
+    throw new Error('BAT V2 verified redemption returned an invalid class binding');
+  }
+  const value = projected as Partial<BatV2ClassBindingV2>;
+  const actual: BatV2ClassBindingV2 = {
+    issuerIdHex: value.issuerIdHex as string,
+    classIdHex: value.classIdHex as string,
+    classDigestHex: value.classDigestHex as string,
+    classKeyEpoch: value.classKeyEpoch as string,
+    batKeyIdHex: value.batKeyIdHex as string,
+  };
+  try {
+    validateBatV2ClassBindingV2(actual);
+  } catch {
+    throw new Error('BAT V2 verified redemption returned an invalid class binding');
+  }
+  if (classBindingKeyV2(actual) !== classBindingKeyV2(expected)) {
+    throw new Error('BAT V2 verified redemption does not match the exact signed class binding');
+  }
 }
 
 function equalBytes(left: Uint8Array, right: Uint8Array): boolean {

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -738,6 +738,8 @@ export interface WasmVerifiedBatV2RedemptionV2 {
   readonly scopeIdHex: string;
   readonly offerId: number;
   readonly classIdHex: string;
+  /** Full binding derived from the canonical class bytes verified by Rust. */
+  classBindingJson(): BatV2ClassBindingViewV2;
   assertRedemptionReady(nowUnix: bigint): void;
 }
 

--- a/web/src/service-admission.ts
+++ b/web/src/service-admission.ts
@@ -16,6 +16,7 @@ import {
   type LightningNetworkNameV1,
 } from './admission-vault.js';
 import {
+  validateBatV2ClassBindingV2,
   type BatV2ClassBindingV2,
   type BatV2DistinctPairReservationV2,
   type BatV2ReservedProofV2,
@@ -36,6 +37,7 @@ import {
   type WasmServicePowChallengeV1,
 } from './sdk-bridge.js';
 import {
+  assertVerifiedBatV2ClassBindingV2,
   assertIndependentProviderBatV2ProjectionPairV2,
   assertIndependentProviderOfferPairV1,
   type BatV2ClassArtifactV2,
@@ -226,6 +228,14 @@ export interface ProviderAdmissionSelectionV1 {
   offerId: number;
 }
 
+/** Exact historical scheme-6 selector learned from a trusted class catalog. */
+export interface RetainedBatV2ExactMemberV2 {
+  providerIdHex: string;
+  policyDigestHex: string;
+  scopeIdHex: string;
+  offerId: number;
+}
+
 /**
  * One provider leg plus the independently trusted network context that must be
  * frozen before a two-provider capability can be acquired or retired.
@@ -320,6 +330,7 @@ export class ProviderAdmissionSessionV1 {
     | 'authorize'
     | 'authorize-bat-v2'
     | 'inspect-retained'
+    | 'inspect-retained-bat-v2'
     | 'authorize-retained'
     | null = null;
 
@@ -715,6 +726,70 @@ export class ProviderAdmissionSessionV1 {
     }
   }
 
+  /**
+   * Close a trusted-catalog member against one exact historical signed policy.
+   * This is metadata verification only: no proof is read, reserved, or sent.
+   * The returned opaque handle is the sole authority accepted by typed scheme-6
+   * adapter authorization and must be freed by its caller.
+   */
+  async verifyRetainedBatV2ClassMember(
+    member: RetainedBatV2ExactMemberV2,
+    classArtifact: BatV2ClassArtifactV2,
+  ): Promise<WasmVerifiedBatV2RedemptionV2> {
+    this.beginTransition('inspect-retained-bat-v2');
+    let retained: WasmAcceptedRetainedBatV2PolicyV2 | null = null;
+    let verified: WasmVerifiedBatV2RedemptionV2 | null = null;
+    try {
+      const canonical = exactRetainedBatV2Member(member, this.trust);
+      const binding = { ...classArtifact.binding };
+      validateBatV2ClassBindingV2(binding);
+      if (!(classArtifact.classBytes instanceof Uint8Array)
+          || classArtifact.classBytes.length === 0
+          || classArtifact.classBytes.length > 512 * 1024) {
+        throw new Error('retained BAT V2 class bytes are empty or exceed the codec limit');
+      }
+      const classBytes = classArtifact.classBytes.slice();
+      const fetchRetained = this.port.fetchRetainedBatV2Policy;
+      if (typeof fetchRetained !== 'function') {
+        throw new Error('this strict adapter does not support retained BAT V2 policy fetch');
+      }
+      const nowUnix = trustedNowUnixV1();
+      this.port.assertTrustAnchor(this.trust);
+      const assertReady = this.port.captureReadinessGuard();
+      assertReady();
+      try {
+        retained = await fetchRetained.call(
+          this.port,
+          this.trust.providerId.slice(),
+          this.trust.policySigningKey.slice(),
+          hexToBytes32('retained BAT V2 policy digest', canonical.policyDigestHex),
+          hexToBytes32('retained BAT V2 scope ID', canonical.scopeIdHex),
+          canonical.offerId,
+          nowUnix,
+        );
+        assertReady();
+        assertRetainedBatV2HandleMatchesMember(retained, canonical);
+        verified = retained.verifyBatV2Redemption(classBytes, nowUnix);
+        assertVerifiedBatV2HandleMatchesMember(
+          verified,
+          canonical,
+          binding,
+        );
+        verified.assertRedemptionReady(nowUnix);
+        assertReady();
+        const result = verified;
+        verified = null;
+        return result;
+      } finally {
+        classBytes.fill(0);
+      }
+    } finally {
+      verified?.free();
+      retained?.free();
+      this.transitionInFlight = null;
+    }
+  }
+
   async [PAIR_ACQUISITION_V1](
     selection: SessionPairSelectionV1,
     scopeIdHex: string,
@@ -944,6 +1019,7 @@ export class ProviderAdmissionSessionV1 {
       | 'authorize'
       | 'authorize-bat-v2'
       | 'inspect-retained'
+      | 'inspect-retained-bat-v2'
       | 'authorize-retained',
   ): void {
     if (this.transitionInFlight !== null) {
@@ -2015,6 +2091,66 @@ function exactRetainedBinding(
     throw new Error('retained capability provider does not match this trusted provider');
   }
   return canonical;
+}
+
+function exactRetainedBatV2Member(
+  member: RetainedBatV2ExactMemberV2,
+  trust: ProviderTrustAnchorV1,
+): RetainedBatV2ExactMemberV2 {
+  if (!member || typeof member !== 'object') {
+    throw new Error('retained BAT V2 member is malformed');
+  }
+  const canonical: RetainedBatV2ExactMemberV2 = {
+    providerIdHex: canonicalHex32('retained BAT V2 provider ID', member.providerIdHex),
+    policyDigestHex: canonicalHex32('retained BAT V2 policy digest', member.policyDigestHex),
+    scopeIdHex: canonicalHex32('retained BAT V2 scope ID', member.scopeIdHex),
+    offerId: member.offerId,
+  };
+  if (!Number.isSafeInteger(canonical.offerId)
+      || canonical.offerId <= 0
+      || canonical.offerId > 0xffff_ffff) {
+    throw new Error('retained BAT V2 offer ID must be a non-zero u32');
+  }
+  if (canonical.providerIdHex !== bytesToLowerHex(trust.providerId)) {
+    throw new Error('retained BAT V2 member does not match this trusted provider');
+  }
+  return canonical;
+}
+
+function assertRetainedBatV2HandleMatchesMember(
+  accepted: WasmAcceptedRetainedBatV2PolicyV2,
+  member: RetainedBatV2ExactMemberV2,
+): void {
+  if (!accepted
+      || typeof accepted.verifyBatV2Redemption !== 'function'
+      || canonicalHex32('retained BAT V2 handle provider ID', accepted.providerIdHex)
+        !== member.providerIdHex
+      || canonicalHex32('retained BAT V2 handle policy digest', accepted.policyDigestHex)
+        !== member.policyDigestHex
+      || canonicalHex32('retained BAT V2 handle scope ID', accepted.scopeIdHex)
+        !== member.scopeIdHex
+      || accepted.offerId !== member.offerId) {
+    throw new Error('retained BAT V2 policy response does not match the exact catalog member');
+  }
+}
+
+function assertVerifiedBatV2HandleMatchesMember(
+  verified: WasmVerifiedBatV2RedemptionV2,
+  member: RetainedBatV2ExactMemberV2,
+  expectedBinding: BatV2ClassBindingV2,
+): void {
+  if (!verified
+      || typeof verified.assertRedemptionReady !== 'function'
+      || canonicalHex32('verified BAT V2 provider ID', verified.providerIdHex)
+        !== member.providerIdHex
+      || canonicalHex32('verified BAT V2 policy digest', verified.policyDigestHex)
+        !== member.policyDigestHex
+      || canonicalHex32('verified BAT V2 scope ID', verified.scopeIdHex)
+        !== member.scopeIdHex
+      || verified.offerId !== member.offerId) {
+    throw new Error('verified BAT V2 redemption does not match the exact class member');
+  }
+  assertVerifiedBatV2ClassBindingV2(verified, expectedBinding);
 }
 
 function requireRetainedServicePort(


### PR DESCRIPTION
## What changed

- add a canonical, bounded BAT V2 public class catalog with explicit current and retained epochs
- resolve immutable same-origin class artifacts by pinned SHA-256, using streaming byte limits and no ambient credentials or redirects
- close current and retained provider members through exact signed policy and full five-field Rust/WASM class binding
- advertise scheme 6 in directory hints without treating directory data as class trust
- expose the trusted catalog ref through the static product bootstrap

## Why

BAT V2 wallet records are provider-independent. Rotation therefore needs an exact trusted catalog that can map a current offer or a retained wallet binding to the correct issuer-signed class and member without trusting provider or directory-supplied class metadata.

## Safety boundaries

The directory remains discovery-only. Catalog and class paths are content-addressed and same-origin; Rust/WASM remains authoritative for canonical class bytes, issuer signature, member projection and class binding. No dynamic issuer GET, deployment, private material or production activation is added.

## Validation

- `npm run build`
- seven focused Vitest files: 108 passed
- `cargo test --locked --offline -p pir-directory-nostr`: 11 passed
- `cargo test --locked --offline -p pir-sdk-wasm --lib`: 102 passed, 1 existing ignored
- `cargo check --locked --offline -p pir-sdk-wasm --target wasm32-unknown-unknown`
- `git diff --check`

Independent P0/P1 review: PASS.