### PR TITLE
feat(deploy): add BAT V2 source-ready profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,16 @@ deploy/payment-v1/db1-free-pow-bat/*
 !deploy/payment-v1/db1-free-pow-bat/README.md
 !deploy/payment-v1/db1-free-pow-bat/pir1-service-policy.toml.in
 !deploy/payment-v1/db1-free-pow-bat/pir2-service-policy.toml.in
+!deploy/payment-v1/bat-v2-source-ready/
+deploy/payment-v1/bat-v2-source-ready/*
+!deploy/payment-v1/bat-v2-source-ready/README.md
+!deploy/payment-v1/bat-v2-source-ready/bat-v2-class.toml.in
+!deploy/payment-v1/bat-v2-source-ready/provider-accounting-authorization.toml.in
+!deploy/payment-v1/bat-v2-source-ready/source-profile.json.in
+!deploy/payment-v1/bat-v2-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in
+!deploy/payment-v1/bat-v2-source-ready/pir1-storeless-bat-v2-provider.service.in
+!deploy/payment-v1/bat-v2-source-ready/pir2-public-artifact-set.env.in
+!deploy/payment-v1/bat-v2-source-ready/pir2-sealed-startup.env.in
 !deploy/payment-v1/systemd/
 deploy/payment-v1/systemd/*
 !deploy/payment-v1/systemd/bhtm-caddy.directory-public-edge.conf.in

--- a/deploy/payment-v1/bat-v2-source-ready/README.md
+++ b/deploy/payment-v1/bat-v2-source-ready/README.md
@@ -29,3 +29,38 @@ The old `db1-free-pow-bat` templates still contain provider-bound V1 bindings.
 They are not BAT V2 render inputs and must not be completed or deployed as the
 issuer-wide product. Versioned issuer/pir1/pir2 render profiles and the public
 class catalog are separate source slices.
+
+## Versioned source profile
+
+`source-profile.json.in` is the closed public render contract for the issuer,
+pir1, and pir2. It deliberately requires one current and at least one retained
+signed policy/class epoch for each provider. This is a source-ready rotation
+continuity contract, not permission to fabricate history: retained entries
+must be real, previously issued canonical artifacts. A deployment with no real
+retained epoch stays blocked until a new profile version explicitly permits it.
+
+The schema accepts at most eight retained policies per provider and eight
+retained classes. Every pir2 retained artifact has its own digest-derived
+immutable runtime path and file SHA-256; the canonical artifact-set file is
+itself SHA-256-bound into the current-boot Ready-preflight attempt token. Both
+Ready invocations repeat the exact retained-policy and class arguments. The
+existing Rust loaders remain authoritative for canonical decoding, signatures,
+member coverage, class forks, unused classes, and role-key separation.
+
+`pir1-storeless-bat-v2-provider.service.in` is the only profile that names a
+plaintext clearing seed. The measured pir2 run path accepts only the sealed
+Ready key injection and rejects plaintext/V1 clearing fallbacks. The issuer
+unit registers current/retained public policy and class sets plus exactly one
+current accounting triple per provider; it creates no retained-accounting
+runtime.
+
+Run the browserless source gate with:
+
+```sh
+node scripts/payment-bat-v2-source-profile-gate.mjs
+node --test scripts/payment-bat-v2-source-profile-gate.test.mjs
+```
+
+These templates remain inert: rendering, private materialization, UKI builds,
+VPSBG operations, installation, activation, Lightning use, and funds need
+their own approval.

--- a/deploy/payment-v1/bat-v2-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in
+++ b/deploy/payment-v1/bat-v2-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in
@@ -1,0 +1,76 @@
+# Inert BAT V2 source-profile template. Rendering and activation are separate approvals.
+[Unit]
+Description=BitcoinPIR Mainnet Lightning BAT V2 issuer (source template only)
+After=network-online.target bitcoinpir-mainnet-lightning-v1-core.service bitcoinpir-mainnet-lightning-v1-preflight.service bitcoinpir-mainnet-lightning-v1-cln-rpc-guard.service
+Wants=network-online.target
+Requisite=bitcoinpir-mainnet-lightning-v1-core.service
+Requires=bitcoinpir-mainnet-lightning-v1-preflight.service bitcoinpir-mainnet-lightning-v1-cln-rpc-guard.service
+BindsTo=bitcoinpir-mainnet-lightning-v1-preflight.service bitcoinpir-mainnet-lightning-v1-cln-rpc-guard.service
+ConditionPathExists=/etc/bitcoinpir/payment-v1/BAT-V2-SOURCE-PROFILE-RENDERED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/MAINNET-BAT-V2-ACTIVATION-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/LIGHTNING-CUSTODY-APPROVED
+
+[Service]
+Type=simple
+User=bitcoinpir-mainnet-issuer
+Group=bitcoinpir-mainnet-issuer
+UMask=0077
+StateDirectory=bitcoinpir-mainnet-bat-v2-issuer
+StateDirectoryMode=0700
+WorkingDirectory=/var/lib/bitcoinpir-mainnet-bat-v2-issuer
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@/payment-issuer
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/bat-v2/issuer/payment-issuer.sha256
+ExecStart=/opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@/payment-issuer serve-cln \
+    --bind 127.0.0.1:5610 \
+    --max-connections 128 \
+    --allow-origin @BITCOINPIR_WEB_ORIGIN@ \
+    --store /var/lib/bitcoinpir-mainnet-bat-v2-issuer/issuer.sqlite3 \
+    --remote-rollback-authority-config /etc/bitcoinpir/payment-v1/bat-v2/issuer/remote-rollback-authority.toml \
+    --quote-delegation /etc/bitcoinpir/payment-v1/mainnet-lightning-v1/quote-delegation.bin \
+    --quote-signing-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/quote-signing.key \
+    --credential-derivation-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/credential-derivation.key \
+    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-current.bin=@PIR1_POLICY_VERIFYING_KEY_HEX@ \
+    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-current.bin=@PIR2_POLICY_VERIFYING_KEY_HEX@ \
+    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-retained.bin=@PIR1_POLICY_VERIFYING_KEY_HEX@ \
+    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-retained.bin=@PIR2_POLICY_VERIFYING_KEY_HEX@ \
+    --bat-v2-class /etc/bitcoinpir/payment-v1/bat-v2/public/classes/current.bin \
+    --bat-v2-class /etc/bitcoinpir/payment-v1/bat-v2/public/classes/retained.bin \
+    --bat-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/bat-current.key \
+    --bat-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/bat-retained.key \
+    --bat-v2-accounting-authorization /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-authorization.bin \
+    --bat-v2-accounting-approval /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-approval.bin \
+    --bat-v2-accounting-operator-verifying-key /etc/bitcoinpir/payment-v1/bat-v2/public/keys/pir1-operator-verifying.key \
+    --bat-v2-accounting-authorization /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir2-authorization.bin \
+    --bat-v2-accounting-approval /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir2-approval.bin \
+    --bat-v2-accounting-operator-verifying-key /etc/bitcoinpir/payment-v1/bat-v2/public/keys/pir2-operator-verifying.key \
+    --issuer-settlement-signing-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/issuer-settlement-signing.key \
+    --cln-rpc-socket /run/bitcoinpir-mainnet-cln-rpc-guard/issuer/issuer-rpc \
+    --cln-rpc-expected-uid @CLN_GUARD_UID@ \
+    --cln-rpc-expected-gid @ISSUER_GID@ \
+    --cln-rpc-timeout-seconds 10
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/bat-v2 /etc/bitcoinpir/payment-v1/mainnet-lightning-v1 /run/bitcoinpir-mainnet-cln-rpc-guard/issuer /opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@
+ReadWritePaths=/var/lib/bitcoinpir-mainnet-bat-v2-issuer
+InaccessiblePaths=-/srv/lightning -/srv/bitcoin -/run/bitcoinpir-source-fair-edge
+
+# No [Install] section: this checked-in file is not an activation artifact.

--- a/deploy/payment-v1/bat-v2-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in
+++ b/deploy/payment-v1/bat-v2-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in
@@ -30,9 +30,9 @@ ExecStart=/opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@/payment-issuer 
     --quote-signing-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/quote-signing.key \
     --credential-derivation-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/credential-derivation.key \
     --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-current.bin=@PIR1_POLICY_VERIFYING_KEY_HEX@ \
-    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-current.bin=@PIR2_POLICY_VERIFYING_KEY_HEX@ \
+    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-current.bin=73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5 \
     --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-retained.bin=@PIR1_POLICY_VERIFYING_KEY_HEX@ \
-    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-retained.bin=@PIR2_POLICY_VERIFYING_KEY_HEX@ \
+    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-retained.bin=73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5 \
     --bat-v2-class /etc/bitcoinpir/payment-v1/bat-v2/public/classes/current.bin \
     --bat-v2-class /etc/bitcoinpir/payment-v1/bat-v2/public/classes/retained.bin \
     --bat-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/bat-current.key \

--- a/deploy/payment-v1/bat-v2-source-ready/pir1-storeless-bat-v2-provider.service.in
+++ b/deploy/payment-v1/bat-v2-source-ready/pir1-storeless-bat-v2-provider.service.in
@@ -1,0 +1,78 @@
+# Inert BAT V2 pir1 source-profile template. pir1 is the only plaintext clearing-key role.
+[Unit]
+Description=BitcoinPIR pir1 storeless BAT V2 provider (source template only)
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/etc/bitcoinpir/payment-v1/BAT-V2-SOURCE-PROFILE-RENDERED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/PIR1-BAT-V2-ACTIVATION-APPROVED
+
+[Service]
+Type=simple
+User=bitcoinpir-pir1-bat-v2
+Group=bitcoinpir-pir1-bat-v2
+UMask=0077
+StateDirectory=bitcoinpir-pir1-bat-v2
+StateDirectoryMode=0700
+WorkingDirectory=/var/lib/bitcoinpir-pir1-bat-v2
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/unified-server/@UNIFIED_SERVER_SHA256@/unified_server
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/bat-v2/pir1/unified-server.sha256
+ExecStart=/opt/bitcoinpir/unified-server/@UNIFIED_SERVER_SHA256@/unified_server \
+    --bind-address 127.0.0.1 \
+    --port 8191 \
+    --role primary \
+    --serve-hints \
+    --serve-queries \
+    --pool-size 8 \
+    --pool-dir /var/lib/bitcoinpir-pir1-bat-v2/hint-pool \
+    --config /etc/bitcoinpir/payment-v1/bat-v2/pir1/databases.toml \
+    --identity-key-path /etc/bitcoinpir/payment-v1/bat-v2/pir1/provider-identity.key \
+    --identity-cert-path /etc/bitcoinpir/payment-v1/bat-v2/pir1/provider-identity.cert \
+    --identity-server-id @PIR1_PROVIDER_SERVER_ID@ \
+    --require-service-auth-v1 \
+    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-current.bin \
+    --service-provider-id-hex @PIR1_PROVIDER_ID_HEX@ \
+    --service-policy-key-hex @PIR1_POLICY_VERIFYING_KEY_HEX@ \
+    --service-storeless-bat-v2-policy-digest-hex @PIR1_CURRENT_POLICY_DIGEST_HEX@ \
+    --service-storeless-bat-v2-retained-policy @PIR1_RETAINED_POLICY_DIGEST_HEX@=/etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-retained.bin \
+    --service-storeless-bat-v2-class @BAT_V2_CURRENT_CLASS_DIGEST_HEX@=/etc/bitcoinpir/payment-v1/bat-v2/public/classes/current.bin \
+    --service-storeless-bat-v2-class @BAT_V2_RETAINED_CLASS_DIGEST_HEX@=/etc/bitcoinpir/payment-v1/bat-v2/public/classes/retained.bin \
+    --service-storeless-bat-v2-accounting-authorization /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-authorization.bin \
+    --service-storeless-bat-v2-issuer-approval /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-approval.bin \
+    --service-storeless-bat-v2-operator-key-hex @PIR1_OPERATOR_VERIFYING_KEY_HEX@ \
+    --service-storeless-bat-v2-issuer-settlement-key-hex @ISSUER_SETTLEMENT_VERIFYING_KEY_HEX@ \
+    --service-storeless-bat-v2-pir1-clearing-key /etc/bitcoinpir/payment-v1/bat-v2/pir1/clearing-signing.key \
+    --service-storeless-bat-v2-minimum-authorization-epoch @PIR1_MINIMUM_AUTHORIZATION_EPOCH@ \
+    --max-connections 128 \
+    --service-max-concurrent-auth 16 \
+    --service-max-concurrent-online-v2full-auth 4 \
+    --websocket-handshake-timeout-ms 10000 \
+    --connection-idle-timeout-ms 30000 \
+    --service-pre-auth-timeout-ms 60000
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+LimitNOFILE=65535
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/bat-v2 /opt/bitcoinpir/unified-server/@UNIFIED_SERVER_SHA256@
+ReadWritePaths=/var/lib/bitcoinpir-pir1-bat-v2
+InaccessiblePaths=-/run/bitcoinpir-source-fair-edge
+
+# No ProviderStore, rollback, V1 shared/idempotency, Direct receipt, Standard
+# Cashu, ARC, or V1 BAT input is present. No [Install] section is provided.

--- a/deploy/payment-v1/bat-v2-source-ready/pir1-storeless-bat-v2-provider.service.in
+++ b/deploy/payment-v1/bat-v2-source-ready/pir1-storeless-bat-v2-provider.service.in
@@ -39,7 +39,7 @@ ExecStart=/opt/bitcoinpir/unified-server/@UNIFIED_SERVER_SHA256@/unified_server 
     --service-storeless-bat-v2-accounting-authorization /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-authorization.bin \
     --service-storeless-bat-v2-issuer-approval /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-approval.bin \
     --service-storeless-bat-v2-operator-key-hex @PIR1_OPERATOR_VERIFYING_KEY_HEX@ \
-    --service-storeless-bat-v2-issuer-settlement-key-hex @ISSUER_SETTLEMENT_VERIFYING_KEY_HEX@ \
+    --service-storeless-bat-v2-issuer-settlement-key-hex 248df8866b89b05dbb5d1a2ebec398e4281d9f0e152073570965cd2fbdc422b7 \
     --service-storeless-bat-v2-pir1-clearing-key /etc/bitcoinpir/payment-v1/bat-v2/pir1/clearing-signing.key \
     --service-storeless-bat-v2-minimum-authorization-epoch @PIR1_MINIMUM_AUTHORIZATION_EPOCH@ \
     --max-connections 128 \

--- a/deploy/payment-v1/bat-v2-source-ready/pir2-public-artifact-set.env.in
+++ b/deploy/payment-v1/bat-v2-source-ready/pir2-public-artifact-set.env.in
@@ -1,0 +1,7 @@
+schema=bitcoinpir-pir2-bat-v2-public-artifact-set-v1
+current_policy=@PIR2_CURRENT_POLICY_DIGEST_HEX@=@PIR2_CURRENT_POLICY_FILE_SHA256_HEX@=/etc/bitcoinpir/payment/service-policy.bin
+retained_policy=@PIR2_RETAINED_POLICY_DIGEST_HEX@=@PIR2_RETAINED_POLICY_FILE_SHA256_HEX@=/home/pir/data/pir2-sealed/public/policies/@PIR2_RETAINED_POLICY_DIGEST_HEX@.bin
+current_class=@BAT_V2_CURRENT_CLASS_DIGEST_HEX@=@BAT_V2_CURRENT_CLASS_FILE_SHA256_HEX@=/home/pir/data/pir2-sealed/public/classes/@BAT_V2_CURRENT_CLASS_DIGEST_HEX@.bin
+retained_class=@BAT_V2_RETAINED_CLASS_DIGEST_HEX@=@BAT_V2_RETAINED_CLASS_FILE_SHA256_HEX@=/home/pir/data/pir2-sealed/public/classes/@BAT_V2_RETAINED_CLASS_DIGEST_HEX@.bin
+accounting_authorization=@PIR2_ACCOUNTING_AUTHORIZATION_DIGEST_HEX@=@PIR2_ACCOUNTING_AUTHORIZATION_FILE_SHA256_HEX@=/home/pir/data/pir2-sealed/provider-accounting-authorization.bin
+accounting_approval=@PIR2_ACCOUNTING_APPROVAL_DIGEST_HEX@=@PIR2_ACCOUNTING_APPROVAL_FILE_SHA256_HEX@=/home/pir/data/pir2-sealed/issuer-accounting-approval.bin

--- a/deploy/payment-v1/bat-v2-source-ready/pir2-sealed-startup.env.in
+++ b/deploy/payment-v1/bat-v2-source-ready/pir2-sealed-startup.env.in
@@ -1,0 +1,10 @@
+schema=bitcoinpir-pir2-sealed-startup-v2
+profile=pir2-snp-sealed-v1
+phase=@PIR2_SEALED_PHASE@
+ordinal=@PIR2_SEALED_ORDINAL@
+verifier_nonce_hex=@PIR2_SEALED_VERIFIER_NONCE_HEX@
+current_policy_digest_hex=@PIR2_CURRENT_POLICY_DIGEST_HEX@
+class_digest_hex=@BAT_V2_CURRENT_CLASS_DIGEST_HEX@
+artifact_set_path=/home/pir/data/pir2-sealed/public-artifact-set.env
+artifact_set_sha256=@PIR2_PUBLIC_ARTIFACT_SET_SHA256_HEX@
+minimum_authorization_epoch=@PIR2_MINIMUM_AUTHORIZATION_EPOCH@

--- a/deploy/payment-v1/bat-v2-source-ready/source-profile.json.in
+++ b/deploy/payment-v1/bat-v2-source-ready/source-profile.json.in
@@ -3,7 +3,7 @@
   "profile": "issuer-pir1-pir2-storeless-v1",
   "issuer": {
     "issuerIdHex": "@BAT_V2_ISSUER_ID_HEX@",
-    "settlementVerifyingKeyHex": "@ISSUER_SETTLEMENT_VERIFYING_KEY_HEX@",
+    "settlementVerifyingKeyHex": "248df8866b89b05dbb5d1a2ebec398e4281d9f0e152073570965cd2fbdc422b7",
     "settlementSigningKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/issuer/issuer-settlement-signing.key",
     "unitPath": "deploy/payment-v1/bat-v2-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in",
     "policies": [
@@ -24,7 +24,7 @@
         "fileSha256Hex": "@PIR2_CURRENT_POLICY_FILE_SHA256_HEX@",
         "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-current.bin",
         "pir2RuntimePath": "/etc/bitcoinpir/payment/service-policy.bin",
-        "verifyingKeyHex": "@PIR2_POLICY_VERIFYING_KEY_HEX@",
+        "verifyingKeyHex": "73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5",
         "scopeIdHex": "@PIR2_CURRENT_SCOPE_ID_HEX@",
         "offerId": "@PIR2_CURRENT_OFFER_ID@"
       },
@@ -45,7 +45,7 @@
         "fileSha256Hex": "@PIR2_RETAINED_POLICY_FILE_SHA256_HEX@",
         "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-retained.bin",
         "pir2RuntimePath": "/home/pir/data/pir2-sealed/public/policies/@PIR2_RETAINED_POLICY_DIGEST_HEX@.bin",
-        "verifyingKeyHex": "@PIR2_POLICY_VERIFYING_KEY_HEX@",
+        "verifyingKeyHex": "73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5",
         "scopeIdHex": "@PIR2_RETAINED_SCOPE_ID_HEX@",
         "offerId": "@PIR2_RETAINED_OFFER_ID@"
       }
@@ -59,7 +59,7 @@
         "fileSha256Hex": "@BAT_V2_CURRENT_CLASS_FILE_SHA256_HEX@",
         "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/classes/current.bin",
         "pir2RuntimePath": "/home/pir/data/pir2-sealed/public/classes/@BAT_V2_CURRENT_CLASS_DIGEST_HEX@.bin",
-        "classVerifyingKeyHex": "@BAT_V2_CURRENT_CLASS_VERIFYING_KEY_HEX@",
+        "classVerifyingKeyHex": "@BAT_V2_CLASS_VERIFYING_KEY_HEX@",
         "batKeyIdHex": "@BAT_V2_CURRENT_KEY_ID_HEX@",
         "batSigningKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/issuer/bat-current.key",
         "memberPolicyDigestsHex": [
@@ -75,7 +75,7 @@
         "fileSha256Hex": "@BAT_V2_RETAINED_CLASS_FILE_SHA256_HEX@",
         "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/classes/retained.bin",
         "pir2RuntimePath": "/home/pir/data/pir2-sealed/public/classes/@BAT_V2_RETAINED_CLASS_DIGEST_HEX@.bin",
-        "classVerifyingKeyHex": "@BAT_V2_RETAINED_CLASS_VERIFYING_KEY_HEX@",
+        "classVerifyingKeyHex": "@BAT_V2_CLASS_VERIFYING_KEY_HEX@",
         "batKeyIdHex": "@BAT_V2_RETAINED_KEY_ID_HEX@",
         "batSigningKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/issuer/bat-retained.key",
         "memberPolicyDigestsHex": [
@@ -107,7 +107,7 @@
         "approvalPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir2-approval.bin",
         "pir2AuthorizationPath": "/home/pir/data/pir2-sealed/provider-accounting-authorization.bin",
         "pir2ApprovalPath": "/home/pir/data/pir2-sealed/issuer-accounting-approval.bin",
-        "operatorVerifyingKeyHex": "@PIR2_OPERATOR_VERIFYING_KEY_HEX@",
+        "operatorVerifyingKeyHex": "7ecb7900928f30efbf548a13c8d0b4fff5a580c7a145b003866580e42d9dc9cb",
         "operatorVerifyingKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/keys/pir2-operator-verifying.key",
         "minimumAuthorizationEpoch": "@PIR2_MINIMUM_AUTHORIZATION_EPOCH@"
       }
@@ -134,8 +134,8 @@
     },
     {
       "name": "pir2",
-      "providerIdHex": "@PIR2_PROVIDER_ID_HEX@",
-      "policyVerifyingKeyHex": "@PIR2_POLICY_VERIFYING_KEY_HEX@",
+      "providerIdHex": "85bfdd55b1408402bcad886568b732818a32472747226aa009839d45e0b96cac",
+      "policyVerifyingKeyHex": "73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5",
       "clearingKeySource": "snp-sealed-ready",
       "clearingVerifyingKeyHex": "@PIR2_CLEARING_VERIFYING_KEY_HEX@",
       "currentPolicyDigestHex": "@PIR2_CURRENT_POLICY_DIGEST_HEX@",
@@ -146,7 +146,7 @@
       ],
       "accountingAuthorizationDigestHex": "@PIR2_ACCOUNTING_AUTHORIZATION_DIGEST_HEX@",
       "accountingApprovalDigestHex": "@PIR2_ACCOUNTING_APPROVAL_DIGEST_HEX@",
-      "operatorVerifyingKeyHex": "@PIR2_OPERATOR_VERIFYING_KEY_HEX@",
+      "operatorVerifyingKeyHex": "7ecb7900928f30efbf548a13c8d0b4fff5a580c7a145b003866580e42d9dc9cb",
       "minimumAuthorizationEpoch": "@PIR2_MINIMUM_AUTHORIZATION_EPOCH@",
       "renderPath": "scripts/dracut/97bpir-tier3-init/unified-server-run.sh",
       "artifactSetPath": "deploy/payment-v1/bat-v2-source-ready/pir2-public-artifact-set.env.in",

--- a/deploy/payment-v1/bat-v2-source-ready/source-profile.json.in
+++ b/deploy/payment-v1/bat-v2-source-ready/source-profile.json.in
@@ -1,0 +1,156 @@
+{
+  "schema": "bitcoinpir-bat-v2-public-source-profile-v1",
+  "profile": "issuer-pir1-pir2-storeless-v1",
+  "issuer": {
+    "issuerIdHex": "@BAT_V2_ISSUER_ID_HEX@",
+    "settlementVerifyingKeyHex": "@ISSUER_SETTLEMENT_VERIFYING_KEY_HEX@",
+    "settlementSigningKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/issuer/issuer-settlement-signing.key",
+    "unitPath": "deploy/payment-v1/bat-v2-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in",
+    "policies": [
+      {
+        "state": "current",
+        "provider": "pir1",
+        "digestHex": "@PIR1_CURRENT_POLICY_DIGEST_HEX@",
+        "fileSha256Hex": "@PIR1_CURRENT_POLICY_FILE_SHA256_HEX@",
+        "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-current.bin",
+        "verifyingKeyHex": "@PIR1_POLICY_VERIFYING_KEY_HEX@",
+        "scopeIdHex": "@PIR1_CURRENT_SCOPE_ID_HEX@",
+        "offerId": "@PIR1_CURRENT_OFFER_ID@"
+      },
+      {
+        "state": "current",
+        "provider": "pir2",
+        "digestHex": "@PIR2_CURRENT_POLICY_DIGEST_HEX@",
+        "fileSha256Hex": "@PIR2_CURRENT_POLICY_FILE_SHA256_HEX@",
+        "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-current.bin",
+        "pir2RuntimePath": "/etc/bitcoinpir/payment/service-policy.bin",
+        "verifyingKeyHex": "@PIR2_POLICY_VERIFYING_KEY_HEX@",
+        "scopeIdHex": "@PIR2_CURRENT_SCOPE_ID_HEX@",
+        "offerId": "@PIR2_CURRENT_OFFER_ID@"
+      },
+      {
+        "state": "retained",
+        "provider": "pir1",
+        "digestHex": "@PIR1_RETAINED_POLICY_DIGEST_HEX@",
+        "fileSha256Hex": "@PIR1_RETAINED_POLICY_FILE_SHA256_HEX@",
+        "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-retained.bin",
+        "verifyingKeyHex": "@PIR1_POLICY_VERIFYING_KEY_HEX@",
+        "scopeIdHex": "@PIR1_RETAINED_SCOPE_ID_HEX@",
+        "offerId": "@PIR1_RETAINED_OFFER_ID@"
+      },
+      {
+        "state": "retained",
+        "provider": "pir2",
+        "digestHex": "@PIR2_RETAINED_POLICY_DIGEST_HEX@",
+        "fileSha256Hex": "@PIR2_RETAINED_POLICY_FILE_SHA256_HEX@",
+        "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-retained.bin",
+        "pir2RuntimePath": "/home/pir/data/pir2-sealed/public/policies/@PIR2_RETAINED_POLICY_DIGEST_HEX@.bin",
+        "verifyingKeyHex": "@PIR2_POLICY_VERIFYING_KEY_HEX@",
+        "scopeIdHex": "@PIR2_RETAINED_SCOPE_ID_HEX@",
+        "offerId": "@PIR2_RETAINED_OFFER_ID@"
+      }
+    ],
+    "classes": [
+      {
+        "state": "current",
+        "classIdHex": "@BAT_V2_CURRENT_CLASS_ID_HEX@",
+        "keyEpoch": "@BAT_V2_CURRENT_CLASS_KEY_EPOCH@",
+        "digestHex": "@BAT_V2_CURRENT_CLASS_DIGEST_HEX@",
+        "fileSha256Hex": "@BAT_V2_CURRENT_CLASS_FILE_SHA256_HEX@",
+        "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/classes/current.bin",
+        "pir2RuntimePath": "/home/pir/data/pir2-sealed/public/classes/@BAT_V2_CURRENT_CLASS_DIGEST_HEX@.bin",
+        "classVerifyingKeyHex": "@BAT_V2_CURRENT_CLASS_VERIFYING_KEY_HEX@",
+        "batKeyIdHex": "@BAT_V2_CURRENT_KEY_ID_HEX@",
+        "batSigningKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/issuer/bat-current.key",
+        "memberPolicyDigestsHex": [
+          "@PIR1_CURRENT_POLICY_DIGEST_HEX@",
+          "@PIR2_CURRENT_POLICY_DIGEST_HEX@"
+        ]
+      },
+      {
+        "state": "retained",
+        "classIdHex": "@BAT_V2_RETAINED_CLASS_ID_HEX@",
+        "keyEpoch": "@BAT_V2_RETAINED_CLASS_KEY_EPOCH@",
+        "digestHex": "@BAT_V2_RETAINED_CLASS_DIGEST_HEX@",
+        "fileSha256Hex": "@BAT_V2_RETAINED_CLASS_FILE_SHA256_HEX@",
+        "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/classes/retained.bin",
+        "pir2RuntimePath": "/home/pir/data/pir2-sealed/public/classes/@BAT_V2_RETAINED_CLASS_DIGEST_HEX@.bin",
+        "classVerifyingKeyHex": "@BAT_V2_RETAINED_CLASS_VERIFYING_KEY_HEX@",
+        "batKeyIdHex": "@BAT_V2_RETAINED_KEY_ID_HEX@",
+        "batSigningKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/issuer/bat-retained.key",
+        "memberPolicyDigestsHex": [
+          "@PIR1_RETAINED_POLICY_DIGEST_HEX@",
+          "@PIR2_RETAINED_POLICY_DIGEST_HEX@"
+        ]
+      }
+    ],
+    "accounting": [
+      {
+        "provider": "pir1",
+        "authorizationDigestHex": "@PIR1_ACCOUNTING_AUTHORIZATION_DIGEST_HEX@",
+        "authorizationFileSha256Hex": "@PIR1_ACCOUNTING_AUTHORIZATION_FILE_SHA256_HEX@",
+        "authorizationPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-authorization.bin",
+        "approvalDigestHex": "@PIR1_ACCOUNTING_APPROVAL_DIGEST_HEX@",
+        "approvalFileSha256Hex": "@PIR1_ACCOUNTING_APPROVAL_FILE_SHA256_HEX@",
+        "approvalPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-approval.bin",
+        "operatorVerifyingKeyHex": "@PIR1_OPERATOR_VERIFYING_KEY_HEX@",
+        "operatorVerifyingKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/keys/pir1-operator-verifying.key",
+        "minimumAuthorizationEpoch": "@PIR1_MINIMUM_AUTHORIZATION_EPOCH@"
+      },
+      {
+        "provider": "pir2",
+        "authorizationDigestHex": "@PIR2_ACCOUNTING_AUTHORIZATION_DIGEST_HEX@",
+        "authorizationFileSha256Hex": "@PIR2_ACCOUNTING_AUTHORIZATION_FILE_SHA256_HEX@",
+        "authorizationPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir2-authorization.bin",
+        "approvalDigestHex": "@PIR2_ACCOUNTING_APPROVAL_DIGEST_HEX@",
+        "approvalFileSha256Hex": "@PIR2_ACCOUNTING_APPROVAL_FILE_SHA256_HEX@",
+        "approvalPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir2-approval.bin",
+        "pir2AuthorizationPath": "/home/pir/data/pir2-sealed/provider-accounting-authorization.bin",
+        "pir2ApprovalPath": "/home/pir/data/pir2-sealed/issuer-accounting-approval.bin",
+        "operatorVerifyingKeyHex": "@PIR2_OPERATOR_VERIFYING_KEY_HEX@",
+        "operatorVerifyingKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/keys/pir2-operator-verifying.key",
+        "minimumAuthorizationEpoch": "@PIR2_MINIMUM_AUTHORIZATION_EPOCH@"
+      }
+    ]
+  },
+  "providers": [
+    {
+      "name": "pir1",
+      "providerIdHex": "@PIR1_PROVIDER_ID_HEX@",
+      "policyVerifyingKeyHex": "@PIR1_POLICY_VERIFYING_KEY_HEX@",
+      "clearingKeySource": "plaintext-pir1",
+      "clearingVerifyingKeyHex": "@PIR1_CLEARING_VERIFYING_KEY_HEX@",
+      "currentPolicyDigestHex": "@PIR1_CURRENT_POLICY_DIGEST_HEX@",
+      "retainedPolicyDigestsHex": ["@PIR1_RETAINED_POLICY_DIGEST_HEX@"],
+      "classDigestsHex": [
+        "@BAT_V2_CURRENT_CLASS_DIGEST_HEX@",
+        "@BAT_V2_RETAINED_CLASS_DIGEST_HEX@"
+      ],
+      "accountingAuthorizationDigestHex": "@PIR1_ACCOUNTING_AUTHORIZATION_DIGEST_HEX@",
+      "accountingApprovalDigestHex": "@PIR1_ACCOUNTING_APPROVAL_DIGEST_HEX@",
+      "operatorVerifyingKeyHex": "@PIR1_OPERATOR_VERIFYING_KEY_HEX@",
+      "minimumAuthorizationEpoch": "@PIR1_MINIMUM_AUTHORIZATION_EPOCH@",
+      "renderPath": "deploy/payment-v1/bat-v2-source-ready/pir1-storeless-bat-v2-provider.service.in"
+    },
+    {
+      "name": "pir2",
+      "providerIdHex": "@PIR2_PROVIDER_ID_HEX@",
+      "policyVerifyingKeyHex": "@PIR2_POLICY_VERIFYING_KEY_HEX@",
+      "clearingKeySource": "snp-sealed-ready",
+      "clearingVerifyingKeyHex": "@PIR2_CLEARING_VERIFYING_KEY_HEX@",
+      "currentPolicyDigestHex": "@PIR2_CURRENT_POLICY_DIGEST_HEX@",
+      "retainedPolicyDigestsHex": ["@PIR2_RETAINED_POLICY_DIGEST_HEX@"],
+      "classDigestsHex": [
+        "@BAT_V2_CURRENT_CLASS_DIGEST_HEX@",
+        "@BAT_V2_RETAINED_CLASS_DIGEST_HEX@"
+      ],
+      "accountingAuthorizationDigestHex": "@PIR2_ACCOUNTING_AUTHORIZATION_DIGEST_HEX@",
+      "accountingApprovalDigestHex": "@PIR2_ACCOUNTING_APPROVAL_DIGEST_HEX@",
+      "operatorVerifyingKeyHex": "@PIR2_OPERATOR_VERIFYING_KEY_HEX@",
+      "minimumAuthorizationEpoch": "@PIR2_MINIMUM_AUTHORIZATION_EPOCH@",
+      "renderPath": "scripts/dracut/97bpir-tier3-init/unified-server-run.sh",
+      "artifactSetPath": "deploy/payment-v1/bat-v2-source-ready/pir2-public-artifact-set.env.in",
+      "startupPath": "deploy/payment-v1/bat-v2-source-ready/pir2-sealed-startup.env.in"
+    }
+  ]
+}

--- a/scripts/dracut/97bpir-tier3-init/unified-server-finish.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-finish.sh
@@ -64,7 +64,7 @@ sealed_terminal_token_matches_current_boot() {
     token="$PIR2_SEALED_ATTEMPT_DIR/terminal-$boot_id_hex.env"
     [ -f "$token" ] && [ ! -L "$token" ] && [ -r "$token" ] || return 1
     token_lines=$(wc -l <"$token" | tr -d '[:space:]')
-    [ "$token_lines" = 11 ] || return 1
+    [ "$token_lines" = 12 ] || return 1
     token_schema=$(read_exact_attempt_token_value "$token" schema) || return 1
     token_kind=$(read_exact_attempt_token_value "$token" kind) || return 1
     token_phase=$(read_exact_attempt_token_value "$token" phase) || return 1
@@ -73,10 +73,11 @@ sealed_terminal_token_matches_current_boot() {
     token_nonce=$(read_exact_attempt_token_value "$token" verifier_nonce_hex) || return 1
     token_policy=$(read_exact_attempt_token_value "$token" current_policy_digest_hex) || return 1
     token_class=$(read_exact_attempt_token_value "$token" class_digest_hex) || return 1
+    token_artifact_set=$(read_exact_attempt_token_value "$token" artifact_set_sha256) || return 1
     token_minimum_epoch=$(read_exact_attempt_token_value "$token" minimum_authorization_epoch) || return 1
     token_receipt_digest=$(read_exact_attempt_token_value "$token" receipt_protocol_digest) || return 1
     token_receipt_sha256=$(read_exact_attempt_token_value "$token" receipt_file_sha256) || return 1
-    [ "$token_schema" = bitcoinpir-pir2-sealed-authoritative-attempt-v1 ] || return 1
+    [ "$token_schema" = bitcoinpir-pir2-sealed-authoritative-attempt-v2 ] || return 1
     [ "$token_kind" = terminal ] || return 1
     case "$token_phase" in observe|enroll|probe) ;; *) return 1 ;; esac
     [ "$token_boot_id" = "$boot_id_hex" ] || return 1
@@ -86,6 +87,7 @@ sealed_terminal_token_matches_current_boot() {
     canonical_nonzero_lower_hex "$token_nonce" 64 || return 1
     canonical_nonzero_lower_hex "$token_policy" 64 || return 1
     canonical_nonzero_lower_hex "$token_class" 64 || return 1
+    canonical_nonzero_lower_hex "$token_artifact_set" 64 || return 1
     canonical_nonzero_lower_hex "$token_receipt_digest" 64 || return 1
     canonical_nonzero_lower_hex "$token_receipt_sha256" 64 || return 1
 }

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -52,8 +52,10 @@ PIR2_SEALED_ATTEMPT_DIR=${BPIR_PIR2_SNP_SEALED_ATTEMPT_ROOT:-/run/bitcoinpir-pir
 PIR2_SEALED_IDENTITY_CERT_PATH="$PIR2_SEALED_ROOT/identity.cert"
 PIR2_SEALED_ACCOUNTING_AUTHORIZATION_PATH="$PIR2_SEALED_ROOT/provider-accounting-authorization.bin"
 PIR2_SEALED_ISSUER_APPROVAL_PATH="$PIR2_SEALED_ROOT/issuer-accounting-approval.bin"
-PIR2_SEALED_CLASS_PATH="$PIR2_SEALED_ROOT/bat-acceptance-class.bin"
 SERVICE_POLICY_PATH=/etc/bitcoinpir/payment/service-policy.bin
+PIR2_SEALED_ARTIFACT_SET_MAX_BYTES=8192
+PIR2_SEALED_ARTIFACT_SET_MAX_RETAINED_POLICIES=8
+PIR2_SEALED_ARTIFACT_SET_MAX_RETAINED_CLASSES=8
 PIR2_SEALED_INERT_SUCCESS_EXIT_CODE=42
 PIR2_SEALED_OPERATOR_KEY_HEX=7ecb7900928f30efbf548a13c8d0b4fff5a580c7a145b003866580e42d9dc9cb
 PIR2_SEALED_ISSUER_SETTLEMENT_KEY_HEX=248df8866b89b05dbb5d1a2ebec398e4281d9f0e152073570965cd2fbdc422b7
@@ -276,6 +278,8 @@ load_pir2_sealed_startup_config() {
         "${BPIR_PIR2_SNP_SEALED_VERIFIER_NONCE_HEX:-}" \
         "${BPIR_PIR2_SNP_SEALED_POLICY_DIGEST_HEX:-}" \
         "${BPIR_PIR2_SNP_SEALED_CLASS_DIGEST_HEX:-}" \
+        "${BPIR_PIR2_SNP_SEALED_ARTIFACT_SET_PATH:-}" \
+        "${BPIR_PIR2_SNP_SEALED_ARTIFACT_SET_SHA256:-}" \
         "${BPIR_PIR2_SNP_SEALED_MINIMUM_AUTHORIZATION_EPOCH:-}"; do
         [ -z "$env_value" ] || env_configured=true
     done
@@ -287,11 +291,14 @@ load_pir2_sealed_startup_config() {
         PIR2_SEALED_VERIFIER_NONCE_HEX=${BPIR_PIR2_SNP_SEALED_VERIFIER_NONCE_HEX:-}
         PIR2_SEALED_POLICY_DIGEST_HEX=${BPIR_PIR2_SNP_SEALED_POLICY_DIGEST_HEX:-}
         PIR2_SEALED_CLASS_DIGEST_HEX=${BPIR_PIR2_SNP_SEALED_CLASS_DIGEST_HEX:-}
+        PIR2_SEALED_ARTIFACT_SET_PATH=${BPIR_PIR2_SNP_SEALED_ARTIFACT_SET_PATH:-}
+        PIR2_SEALED_ARTIFACT_SET_SHA256=${BPIR_PIR2_SNP_SEALED_ARTIFACT_SET_SHA256:-}
         PIR2_SEALED_MINIMUM_AUTHORIZATION_EPOCH=${BPIR_PIR2_SNP_SEALED_MINIMUM_AUTHORIZATION_EPOCH:-}
         for env_value in \
             "$PIR2_SEALED_PROFILE" "$PIR2_SEALED_PHASE" "$PIR2_SEALED_ORDINAL" \
             "$PIR2_SEALED_VERIFIER_NONCE_HEX" "$PIR2_SEALED_POLICY_DIGEST_HEX" \
-            "$PIR2_SEALED_CLASS_DIGEST_HEX" "$PIR2_SEALED_MINIMUM_AUTHORIZATION_EPOCH"; do
+            "$PIR2_SEALED_CLASS_DIGEST_HEX" "$PIR2_SEALED_ARTIFACT_SET_PATH" \
+            "$PIR2_SEALED_ARTIFACT_SET_SHA256" "$PIR2_SEALED_MINIMUM_AUTHORIZATION_EPOCH"; do
             [ -n "$env_value" ] || fatal "partial pir2 sealed environment configuration"
         done
     else
@@ -299,14 +306,15 @@ load_pir2_sealed_startup_config() {
         unknown_config_key=$(awk -F= '
             $1 != "schema" && $1 != "profile" && $1 != "phase" && $1 != "ordinal" &&
             $1 != "verifier_nonce_hex" && $1 != "current_policy_digest_hex" &&
-            $1 != "class_digest_hex" && $1 != "minimum_authorization_epoch" {
+            $1 != "class_digest_hex" && $1 != "artifact_set_path" &&
+            $1 != "artifact_set_sha256" && $1 != "minimum_authorization_epoch" {
                 print $1; exit
             }
         ' "$PIR2_SEALED_STARTUP_CONFIG")
         [ -z "$unknown_config_key" ] \
             || fatal "sealed startup config contains unsupported key: $unknown_config_key"
         config_schema=$(read_exact_public_config_value schema)
-        [ "$config_schema" = bitcoinpir-pir2-sealed-startup-v1 ] \
+        [ "$config_schema" = bitcoinpir-pir2-sealed-startup-v2 ] \
             || fatal "sealed startup config has unsupported schema"
         PIR2_SEALED_PROFILE=$(read_exact_public_config_value profile)
         PIR2_SEALED_PHASE=$(read_exact_public_config_value phase)
@@ -314,6 +322,8 @@ load_pir2_sealed_startup_config() {
         PIR2_SEALED_VERIFIER_NONCE_HEX=$(read_exact_public_config_value verifier_nonce_hex)
         PIR2_SEALED_POLICY_DIGEST_HEX=$(read_exact_public_config_value current_policy_digest_hex)
         PIR2_SEALED_CLASS_DIGEST_HEX=$(read_exact_public_config_value class_digest_hex)
+        PIR2_SEALED_ARTIFACT_SET_PATH=$(read_exact_public_config_value artifact_set_path)
+        PIR2_SEALED_ARTIFACT_SET_SHA256=$(read_exact_public_config_value artifact_set_sha256)
         PIR2_SEALED_MINIMUM_AUTHORIZATION_EPOCH=$(read_exact_public_config_value minimum_authorization_epoch)
     fi
 
@@ -332,6 +342,191 @@ load_pir2_sealed_startup_config() {
     validate_lower_hex "$PIR2_SEALED_VERIFIER_NONCE_HEX" 64 "sealed verifier nonce"
     validate_lower_hex "$PIR2_SEALED_POLICY_DIGEST_HEX" 64 "sealed current policy digest"
     validate_lower_hex "$PIR2_SEALED_CLASS_DIGEST_HEX" 64 "sealed class digest"
+    validate_lower_hex "$PIR2_SEALED_ARTIFACT_SET_SHA256" 64 "sealed public artifact-set sha256"
+    [ "$PIR2_SEALED_ARTIFACT_SET_PATH" = "$PIR2_SEALED_ROOT/public-artifact-set.env" ] \
+        || fatal "sealed public artifact-set path is outside the fixed pir2 root"
+}
+
+validate_pir2_public_artifact_set() {
+    if [ ! -e "$PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH" ]; then
+        [ -f "$PIR2_SEALED_ARTIFACT_SET_PATH" ] && [ ! -L "$PIR2_SEALED_ARTIFACT_SET_PATH" ] \
+            || fatal "pir2 public artifact set must be a non-symlink regular file"
+        artifact_set_tmp="$PIR2_SEALED_ATTEMPT_DIR/.public-artifact-set-$PIR2_BOOT_ID_HEX.$$.tmp"
+        [ ! -e "$artifact_set_tmp" ] || fatal "pir2 trusted artifact-set temporary path exists"
+        umask 077
+        dd if="$PIR2_SEALED_ARTIFACT_SET_PATH" of="$artifact_set_tmp" bs=8192 count=2 2>/dev/null \
+            || fatal "failed to snapshot pir2 public artifact set"
+        chmod 600 "$artifact_set_tmp" || {
+            rm -f "$artifact_set_tmp"
+            fatal "failed to protect pir2 public artifact-set snapshot"
+        }
+        artifact_snapshot_size=$(wc -c <"$artifact_set_tmp" | tr -d '[:space:]') \
+            || fatal "failed to measure pir2 public artifact-set snapshot"
+        case "$artifact_snapshot_size" in
+            ''|*[!0-9]*) rm -f "$artifact_set_tmp"; fatal "pir2 public artifact-set snapshot size is invalid" ;;
+        esac
+        [ "$artifact_snapshot_size" -le "$PIR2_SEALED_ARTIFACT_SET_MAX_BYTES" ] || {
+            rm -f "$artifact_set_tmp"
+            fatal "pir2 public artifact set exceeds its byte bound"
+        }
+        artifact_snapshot_sha256=$(sha256sum "$artifact_set_tmp" | awk '{ print $1 }') \
+            || fatal "failed to hash pir2 public artifact-set snapshot"
+        [ "$artifact_snapshot_sha256" = "$PIR2_SEALED_ARTIFACT_SET_SHA256" ] || {
+            rm -f "$artifact_set_tmp"
+            fatal "pir2 public artifact set does not match startup sha256"
+        }
+        if ! ln "$artifact_set_tmp" "$PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH"; then
+            rm -f "$artifact_set_tmp"
+            fatal "failed to publish trusted pir2 public artifact-set snapshot"
+        fi
+        rm -f "$artifact_set_tmp" \
+            || fatal "failed to remove pir2 public artifact-set temporary path"
+    fi
+    [ -f "$PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH" ] \
+        && [ ! -L "$PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH" ] \
+        || fatal "trusted pir2 public artifact set is not a non-symlink regular file"
+    PIR2_ACTIVE_ARTIFACT_SET_PATH=$PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH
+    artifact_set_size=$(wc -c <"$PIR2_ACTIVE_ARTIFACT_SET_PATH" | tr -d '[:space:]') \
+        || fatal "failed to measure pir2 public artifact set"
+    case "$artifact_set_size" in
+        ''|*[!0-9]*) fatal "pir2 public artifact set size is invalid" ;;
+    esac
+    [ "$artifact_set_size" -le "$PIR2_SEALED_ARTIFACT_SET_MAX_BYTES" ] \
+        || fatal "pir2 public artifact set exceeds its byte bound"
+    artifact_set_sha256=$(sha256sum "$PIR2_ACTIVE_ARTIFACT_SET_PATH" | awk '{ print $1 }') \
+        || fatal "failed to hash pir2 public artifact set"
+    [ "$artifact_set_sha256" = "$PIR2_SEALED_ARTIFACT_SET_SHA256" ] \
+        || fatal "pir2 public artifact set does not match startup sha256"
+    awk -F= \
+        -v max_policies="$PIR2_SEALED_ARTIFACT_SET_MAX_RETAINED_POLICIES" \
+        -v max_classes="$PIR2_SEALED_ARTIFACT_SET_MAX_RETAINED_CLASSES" '
+        NR == 1 {
+            if ($0 != "schema=bitcoinpir-pir2-bat-v2-public-artifact-set-v1") exit 1
+            next
+        }
+        NF != 4 { exit 1 }
+        NR == 2 {
+            if ($1 != "current_policy") exit 1
+            stage = 1
+            next
+        }
+        $1 == "retained_policy" {
+            if (stage != 1 || (previous_policy != "" && $0 <= previous_policy)) exit 1
+            previous_policy = $0
+            retained_policies++
+            if (retained_policies > max_policies) exit 1
+            next
+        }
+        $1 == "current_class" {
+            if (stage != 1 || retained_policies < 1) exit 1
+            stage = 2
+            current_classes++
+            next
+        }
+        $1 == "retained_class" {
+            if (stage < 2 || current_classes != 1 || (previous_class != "" && $0 <= previous_class)) exit 1
+            stage = 3
+            previous_class = $0
+            retained_classes++
+            if (retained_classes > max_classes) exit 1
+            next
+        }
+        $1 == "accounting_authorization" {
+            if (stage != 3 || retained_classes < 1 || accounting_authorizations != 0) exit 1
+            stage = 4
+            accounting_authorizations++
+            next
+        }
+        $1 == "accounting_approval" {
+            if (stage != 4 || accounting_authorizations != 1 || accounting_approvals != 0) exit 1
+            stage = 5
+            accounting_approvals++
+            next
+        }
+        { exit 1 }
+        END {
+            if (NR < 7 || stage != 5 || retained_policies < 1 || current_classes != 1 || retained_classes < 1 || accounting_authorizations != 1 || accounting_approvals != 1) exit 1
+        }
+    ' "$PIR2_ACTIVE_ARTIFACT_SET_PATH" \
+        || fatal "pir2 public artifact set is not canonical or bounded"
+
+    artifact_seen_digests=" "
+    while IFS= read -r artifact_line; do
+        artifact_kind=${artifact_line%%=*}
+        [ "$artifact_kind" != schema ] || continue
+        artifact_spec=${artifact_line#*=}
+        artifact_digest=${artifact_spec%%=*}
+        artifact_remainder=${artifact_spec#*=}
+        artifact_file_sha256=${artifact_remainder%%=*}
+        artifact_path=${artifact_remainder#*=}
+        validate_lower_hex "$artifact_digest" 64 "pir2 public artifact protocol digest"
+        validate_lower_hex "$artifact_file_sha256" 64 "pir2 public artifact file sha256"
+        case "$artifact_seen_digests" in
+            *" $artifact_digest "*) fatal "pir2 public artifact set repeats a protocol digest" ;;
+        esac
+        artifact_seen_digests="$artifact_seen_digests$artifact_digest "
+        case "$artifact_path" in
+            *" "*|*"="*|*".."*) fatal "pir2 public artifact path is not canonical" ;;
+        esac
+        case "$artifact_kind:$artifact_path" in
+            current_policy:$SERVICE_POLICY_PATH) ;;
+            retained_policy:$PIR2_SEALED_ROOT/public/policies/$artifact_digest.bin) ;;
+            current_class:$PIR2_SEALED_ROOT/public/classes/$artifact_digest.bin) ;;
+            retained_class:$PIR2_SEALED_ROOT/public/classes/$artifact_digest.bin) ;;
+            accounting_authorization:$PIR2_SEALED_ACCOUNTING_AUTHORIZATION_PATH) ;;
+            accounting_approval:$PIR2_SEALED_ISSUER_APPROVAL_PATH) ;;
+            *) fatal "pir2 public artifact path is outside its role-specific root" ;;
+        esac
+        [ -f "$artifact_path" ] && [ ! -L "$artifact_path" ] \
+            || fatal "pir2 public artifact must be a non-symlink regular file: $artifact_path"
+        artifact_actual_sha256=$(sha256sum "$artifact_path" | awk '{ print $1 }') \
+            || fatal "failed to hash pir2 public artifact: $artifact_path"
+        [ "$artifact_actual_sha256" = "$artifact_file_sha256" ] \
+            || fatal "pir2 public artifact file sha256 mismatch: $artifact_path"
+        if [ "$artifact_kind" = current_policy ]; then
+            [ "$artifact_digest" = "$PIR2_SEALED_POLICY_DIGEST_HEX" ] \
+                || fatal "pir2 artifact set current policy does not match startup"
+        elif [ "$artifact_kind" = current_class ]; then
+            [ "$artifact_digest" = "$PIR2_SEALED_CLASS_DIGEST_HEX" ] \
+                || fatal "pir2 artifact set current class does not match startup"
+        fi
+    done <"$PIR2_ACTIVE_ARTIFACT_SET_PATH"
+}
+
+run_pir2_with_public_artifacts() {
+    artifact_execution_mode=$1
+    shift
+    [ -f "$PIR2_ACTIVE_ARTIFACT_SET_PATH" ] && [ ! -L "$PIR2_ACTIVE_ARTIFACT_SET_PATH" ] \
+        || fatal "trusted pir2 public artifact-set snapshot is unavailable"
+    while IFS= read -r artifact_line; do
+        artifact_kind=${artifact_line%%=*}
+        [ "$artifact_kind" != schema ] || continue
+        artifact_spec=${artifact_line#*=}
+        artifact_digest=${artifact_spec%%=*}
+        artifact_remainder=${artifact_spec#*=}
+        artifact_path=${artifact_remainder#*=}
+        case "$artifact_kind" in
+            current_policy)
+                set -- "$@" --service-storeless-bat-v2-policy-digest-hex "$artifact_digest"
+                ;;
+            retained_policy)
+                set -- "$@" --service-storeless-bat-v2-retained-policy "$artifact_digest=$artifact_path"
+                ;;
+            current_class|retained_class)
+                set -- "$@" --service-storeless-bat-v2-class "$artifact_digest=$artifact_path"
+                ;;
+            accounting_authorization|accounting_approval)
+                :
+                ;;
+            *) fatal "pir2 public artifact set changed after validation" ;;
+        esac
+    done <"$PIR2_ACTIVE_ARTIFACT_SET_PATH"
+    if [ "$artifact_execution_mode" = exec ]; then
+        exec "$@"
+    fi
+    [ "$artifact_execution_mode" = child ] \
+        || fatal "unsupported pir2 public artifact execution mode"
+    "$@"
 }
 
 read_pir2_current_boot() {
@@ -352,6 +547,7 @@ read_pir2_current_boot() {
     PIR2_SEALED_READY_RUNTIME_MARKER_PATH="$PIR2_SEALED_MARKER_DIR/ready-runtime-$PIR2_BOOT_ID_HEX.env"
     PIR2_SEALED_TERMINAL_TOKEN_PATH="$PIR2_SEALED_ATTEMPT_DIR/terminal-$PIR2_BOOT_ID_HEX.env"
     PIR2_SEALED_READY_PREFLIGHT_TOKEN_PATH="$PIR2_SEALED_ATTEMPT_DIR/ready-preflight-$PIR2_BOOT_ID_HEX.env"
+    PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH="$PIR2_SEALED_ATTEMPT_DIR/public-artifact-set-$PIR2_BOOT_ID_HEX.env"
 }
 
 prepare_pir2_sealed_attempt_dir() {
@@ -381,7 +577,7 @@ authoritative_attempt_token_matches_current_attempt() {
     [ -f "$attempt_token_path" ] && [ ! -L "$attempt_token_path" ] \
         || fatal "pir2 sealed authoritative attempt token is not a non-symlink regular file"
     attempt_token_lines=$(wc -l <"$attempt_token_path" | tr -d '[:space:]')
-    [ "$attempt_token_lines" = 11 ] \
+    [ "$attempt_token_lines" = 12 ] \
         || fatal "pir2 sealed authoritative attempt token has unexpected fields"
     attempt_token_schema=$(read_exact_attempt_token_value "$attempt_token_path" schema) \
         || fatal "pir2 sealed authoritative attempt token is malformed"
@@ -399,13 +595,15 @@ authoritative_attempt_token_matches_current_attempt() {
         || fatal "pir2 sealed authoritative attempt token is malformed"
     attempt_token_class=$(read_exact_attempt_token_value "$attempt_token_path" class_digest_hex) \
         || fatal "pir2 sealed authoritative attempt token is malformed"
+    attempt_token_artifact_set=$(read_exact_attempt_token_value "$attempt_token_path" artifact_set_sha256) \
+        || fatal "pir2 sealed authoritative attempt token is malformed"
     attempt_token_minimum_epoch=$(read_exact_attempt_token_value "$attempt_token_path" minimum_authorization_epoch) \
         || fatal "pir2 sealed authoritative attempt token is malformed"
     attempt_token_receipt_digest=$(read_exact_attempt_token_value "$attempt_token_path" receipt_protocol_digest) \
         || fatal "pir2 sealed authoritative attempt token is malformed"
     attempt_token_receipt_sha256=$(read_exact_attempt_token_value "$attempt_token_path" receipt_file_sha256) \
         || fatal "pir2 sealed authoritative attempt token is malformed"
-    [ "$attempt_token_schema" = bitcoinpir-pir2-sealed-authoritative-attempt-v1 ] \
+    [ "$attempt_token_schema" = bitcoinpir-pir2-sealed-authoritative-attempt-v2 ] \
         && [ "$attempt_token_kind" = "$expected_token_kind" ] \
         && [ "$attempt_token_phase" = "$expected_token_phase" ] \
         && [ "$attempt_token_boot_id" = "$PIR2_BOOT_ID_HEX" ] \
@@ -413,6 +611,7 @@ authoritative_attempt_token_matches_current_attempt() {
         && [ "$attempt_token_nonce" = "$PIR2_SEALED_VERIFIER_NONCE_HEX" ] \
         && [ "$attempt_token_policy" = "$PIR2_SEALED_POLICY_DIGEST_HEX" ] \
         && [ "$attempt_token_class" = "$PIR2_SEALED_CLASS_DIGEST_HEX" ] \
+        && [ "$attempt_token_artifact_set" = "$PIR2_SEALED_ARTIFACT_SET_SHA256" ] \
         && [ "$attempt_token_minimum_epoch" = "$PIR2_SEALED_MINIMUM_AUTHORIZATION_EPOCH" ] \
         || fatal "pir2 sealed authoritative attempt token does not match the current attempt"
     validate_lower_hex "$attempt_token_receipt_digest" 64 "authoritative receipt protocol digest"
@@ -461,7 +660,7 @@ write_authoritative_attempt_token() {
         || fatal "pir2 sealed authoritative attempt temporary path already exists"
     umask 077
     if ! {
-        printf 'schema=bitcoinpir-pir2-sealed-authoritative-attempt-v1\n'
+        printf 'schema=bitcoinpir-pir2-sealed-authoritative-attempt-v2\n'
         printf 'kind=%s\n' "$authoritative_token_kind"
         printf 'phase=%s\n' "$authoritative_token_phase"
         printf 'boot_id=%s\n' "$PIR2_BOOT_ID_HEX"
@@ -469,6 +668,7 @@ write_authoritative_attempt_token() {
         printf 'verifier_nonce_hex=%s\n' "$PIR2_SEALED_VERIFIER_NONCE_HEX"
         printf 'current_policy_digest_hex=%s\n' "$PIR2_SEALED_POLICY_DIGEST_HEX"
         printf 'class_digest_hex=%s\n' "$PIR2_SEALED_CLASS_DIGEST_HEX"
+        printf 'artifact_set_sha256=%s\n' "$PIR2_SEALED_ARTIFACT_SET_SHA256"
         printf 'minimum_authorization_epoch=%s\n' "$PIR2_SEALED_MINIMUM_AUTHORIZATION_EPOCH"
         printf 'receipt_protocol_digest=%s\n' "$PIR2_CHILD_RECEIPT_PROTOCOL_DIGEST"
         printf 'receipt_file_sha256=%s\n' "$PIR2_CHILD_RECEIPT_FILE_SHA256"
@@ -533,7 +733,7 @@ run_pir2_sealed_ready_preflight() {
         echo "[unified-server-run] reusing authoritative current-attempt pir2 sealed Ready-preflight success" >&2
         return 0
     fi
-    "$UNIFIED_SERVER" \
+    run_pir2_with_public_artifacts child "$UNIFIED_SERVER" \
         --port 8091 \
         --role secondary \
         --serve-queries \
@@ -549,8 +749,6 @@ run_pir2_sealed_ready_preflight() {
         --pir2-snp-sealed-identity-cert "$PIR2_SEALED_IDENTITY_CERT_PATH" \
         --pir2-snp-sealed-accounting-authorization "$PIR2_SEALED_ACCOUNTING_AUTHORIZATION_PATH" \
         --pir2-snp-sealed-issuer-approval "$PIR2_SEALED_ISSUER_APPROVAL_PATH" \
-        --service-storeless-bat-v2-policy-digest-hex "$PIR2_SEALED_POLICY_DIGEST_HEX" \
-        --service-storeless-bat-v2-class "$PIR2_SEALED_CLASS_DIGEST_HEX=$PIR2_SEALED_CLASS_PATH" \
         --service-storeless-bat-v2-accounting-authorization "$PIR2_SEALED_ACCOUNTING_AUTHORIZATION_PATH" \
         --service-storeless-bat-v2-issuer-approval "$PIR2_SEALED_ISSUER_APPROVAL_PATH" \
         --service-storeless-bat-v2-operator-key-hex "$PIR2_SEALED_OPERATOR_KEY_HEX" \
@@ -985,6 +1183,10 @@ observe|enroll|probe)
 ready)
     [ ! -e "$PIR2_SEALED_TERMINAL_TOKEN_PATH" ] \
         || fatal "terminal token already exists for this boot; refusing a phase change"
+    # Hash/canonicality validation happens immediately before the Ready child.
+    # The resulting exact set digest is part of the current-boot authoritative
+    # token; inert phases still avoid opening any policy/class artifact.
+    validate_pir2_public_artifact_set
     # The child process strictly opens the envelope, verifies all three public
     # authorizations, writes a separate current-boot receipt, drops both keys
     # on exit 42, and returns control here before any database/ORAM access.
@@ -1068,7 +1270,11 @@ start_unified_server_runtime_log
 
 # VPSBG is query-only and has no Harmony V2 hint pool, so the measured
 # invocation keeps online V2Full authorization disabled (limit 0).
-exec "$UNIFIED_SERVER" \
+# Revalidate the mutable-mount public bytes after the bounded ORAM build. The
+# Rust loader then repeats canonical/signature/digest/member/role-key checks in
+# the final Ready process; the audit receipt is evidence, not runtime authority.
+validate_pir2_public_artifact_set
+run_pir2_with_public_artifacts exec "$UNIFIED_SERVER" \
     --port 8091 \
     --role secondary \
     --serve-queries \
@@ -1101,8 +1307,6 @@ exec "$UNIFIED_SERVER" \
     --service-policy "$SERVICE_POLICY_PATH" \
     --service-provider-id-hex "$PIR2_SEALED_PROVIDER_ID_HEX" \
     --service-policy-key-hex "$PIR2_SEALED_POLICY_KEY_HEX" \
-    --service-storeless-bat-v2-policy-digest-hex "$PIR2_SEALED_POLICY_DIGEST_HEX" \
-    --service-storeless-bat-v2-class "$PIR2_SEALED_CLASS_DIGEST_HEX=$PIR2_SEALED_CLASS_PATH" \
     --service-storeless-bat-v2-accounting-authorization "$PIR2_SEALED_ACCOUNTING_AUTHORIZATION_PATH" \
     --service-storeless-bat-v2-issuer-approval "$PIR2_SEALED_ISSUER_APPROVAL_PATH" \
     --service-storeless-bat-v2-operator-key-hex "$PIR2_SEALED_OPERATOR_KEY_HEX" \

--- a/scripts/payment-bat-v2-source-profile-gate.mjs
+++ b/scripts/payment-bat-v2-source-profile-gate.mjs
@@ -1,0 +1,521 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const PROFILE_SCHEMA = "bitcoinpir-bat-v2-public-source-profile-v1";
+const SOURCE_ROOT = "deploy/payment-v1/bat-v2-source-ready";
+const MAX_RETAINED_PER_PROVIDER = 8;
+const MAX_POLICIES = 2 + (2 * MAX_RETAINED_PER_PROVIDER);
+const MAX_RETAINED_CLASSES = 8;
+const MAX_CLASSES = 1 + MAX_RETAINED_CLASSES;
+const PLACEHOLDER = /^@[A-Z0-9_]+@$/u;
+const LOWER_HEX_32 = /^[0-9a-f]{64}$/u;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function exactKeys(value, expected, label) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+    fail(`${label} fields must match the closed schema`);
+  }
+}
+
+function requireString(value, label) {
+  if (typeof value !== "string" || value.length === 0) fail(`${label} must be non-empty`);
+  return value;
+}
+
+function requireHexOrPlaceholder(value, label) {
+  requireString(value, label);
+  if (!LOWER_HEX_32.test(value) && !PLACEHOLDER.test(value)) {
+    fail(`${label} must be canonical nonzero 32-byte lowercase hex or one render placeholder`);
+  }
+  if (LOWER_HEX_32.test(value) && /^0+$/u.test(value)) fail(`${label} must not be all zero`);
+  return value;
+}
+
+function requireEpochOrPlaceholder(value, label) {
+  requireString(value, label);
+  if (!/^[1-9][0-9]*$/u.test(value) && !PLACEHOLDER.test(value)) {
+    fail(`${label} must be a nonzero decimal or one render placeholder`);
+  }
+  return value;
+}
+
+function requireAbsolutePath(value, prefix, label) {
+  requireString(value, label);
+  if (!value.startsWith(`${prefix}/`) || value.includes("..") || /[\s=]/u.test(value)) {
+    fail(`${label} is outside its closed absolute path root`);
+  }
+  return value;
+}
+
+function addUnique(set, value, label) {
+  if (set.has(value)) fail(`duplicate ${label}: ${value}`);
+  set.add(value);
+}
+
+function arrayBounded(value, min, max, label) {
+  if (!Array.isArray(value) || value.length < min || value.length > max) {
+    fail(`${label} must contain ${min}..${max} entries`);
+  }
+  return value;
+}
+
+function sameSet(actual, expected, label) {
+  const left = [...actual].sort();
+  const right = [...expected].sort();
+  if (JSON.stringify(left) !== JSON.stringify(right)) fail(`${label} does not match the manifest`);
+}
+
+function sameOrder(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) fail(`${label} order does not match the manifest`);
+}
+
+function requireStrictOrder(values, label) {
+  for (let index = 1; index < values.length; index += 1) {
+    if (values[index - 1] >= values[index]) fail(`${label} must use strict digest order`);
+  }
+}
+
+function valuesForFlag(command, flag) {
+  const tokens = command.trim().split(/\s+/u);
+  const values = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (tokens[index] === flag) {
+      if (index + 1 >= tokens.length || tokens[index + 1].startsWith("--")) {
+        fail(`${flag} requires an explicit value`);
+      }
+      values.push(tokens[index + 1]);
+    }
+  }
+  return values;
+}
+
+function oneValue(command, flag, label) {
+  const values = valuesForFlag(command, flag);
+  if (values.length !== 1) fail(`${label} must contain exactly one ${flag}`);
+  return values[0];
+}
+
+function execStart(source, label) {
+  if (/^\[Install\]$/mu.test(source)) fail(`${label} must remain inert without [Install]`);
+  const flattened = source.replace(/\\\r?\n[ \t]*/gu, " ");
+  const commands = [...flattened.matchAll(/^ExecStart=(.+)$/gmu)].map((match) => match[1]);
+  if (commands.length !== 1) fail(`${label} must contain exactly one ExecStart`);
+  return commands[0];
+}
+
+function validatePolicy(value, index, seenDigests, seenPaths) {
+  const label = `issuer.policies[${index}]`;
+  const expectedKeys = [
+    "state", "provider", "digestHex", "fileSha256Hex", "path", "verifyingKeyHex",
+    "scopeIdHex", "offerId",
+    ...(value.provider === "pir2" ? ["pir2RuntimePath"] : []),
+  ];
+  exactKeys(value, expectedKeys, label);
+  if (!new Set(["current", "retained"]).has(value.state)) fail(`${label}.state is invalid`);
+  if (!new Set(["pir1", "pir2"]).has(value.provider)) fail(`${label}.provider is invalid`);
+  requireHexOrPlaceholder(value.digestHex, `${label}.digestHex`);
+  requireHexOrPlaceholder(value.fileSha256Hex, `${label}.fileSha256Hex`);
+  requireHexOrPlaceholder(value.verifyingKeyHex, `${label}.verifyingKeyHex`);
+  requireHexOrPlaceholder(value.scopeIdHex, `${label}.scopeIdHex`);
+  requireEpochOrPlaceholder(value.offerId, `${label}.offerId`);
+  requireAbsolutePath(value.path, "/etc/bitcoinpir/payment-v1/bat-v2/public/policies", `${label}.path`);
+  if (value.provider === "pir2") {
+    if (value.state === "current") {
+      if (value.pir2RuntimePath !== "/etc/bitcoinpir/payment/service-policy.bin") {
+        fail(`${label}.pir2RuntimePath must use the measured current policy path`);
+      }
+    } else {
+      requireAbsolutePath(value.pir2RuntimePath, "/home/pir/data/pir2-sealed/public/policies", `${label}.pir2RuntimePath`);
+      if (value.pir2RuntimePath !== `/home/pir/data/pir2-sealed/public/policies/${value.digestHex}.bin`) {
+        fail(`${label}.pir2RuntimePath must be immutable by exact policy digest`);
+      }
+    }
+    addUnique(seenPaths, value.pir2RuntimePath, "pir2 runtime artifact path");
+  }
+  addUnique(seenDigests, value.digestHex, "policy digest");
+  addUnique(seenPaths, value.path, "public artifact path");
+}
+
+function validateClass(value, index, policyDigests, seenDigests, seenPaths, coverage) {
+  const label = `issuer.classes[${index}]`;
+  exactKeys(value, [
+    "state", "classIdHex", "keyEpoch", "digestHex", "fileSha256Hex", "path",
+    "pir2RuntimePath", "classVerifyingKeyHex", "batKeyIdHex", "batSigningKeyPath",
+    "memberPolicyDigestsHex",
+  ], label);
+  if (!new Set(["current", "retained"]).has(value.state)) fail(`${label}.state is invalid`);
+  for (const field of ["classIdHex", "digestHex", "fileSha256Hex", "classVerifyingKeyHex", "batKeyIdHex"]) {
+    requireHexOrPlaceholder(value[field], `${label}.${field}`);
+  }
+  requireEpochOrPlaceholder(value.keyEpoch, `${label}.keyEpoch`);
+  requireAbsolutePath(value.path, "/etc/bitcoinpir/payment-v1/bat-v2/public/classes", `${label}.path`);
+  requireAbsolutePath(value.pir2RuntimePath, "/home/pir/data/pir2-sealed/public/classes", `${label}.pir2RuntimePath`);
+  if (value.pir2RuntimePath !== `/home/pir/data/pir2-sealed/public/classes/${value.digestHex}.bin`) {
+    fail(`${label}.pir2RuntimePath must be immutable by exact class digest`);
+  }
+  requireAbsolutePath(value.batSigningKeyPath, "/etc/bitcoinpir/payment-v1/bat-v2/issuer", `${label}.batSigningKeyPath`);
+  addUnique(seenDigests, value.digestHex, "class digest");
+  addUnique(seenPaths, value.path, "public artifact path");
+  addUnique(seenPaths, value.pir2RuntimePath, "pir2 runtime artifact path");
+  addUnique(seenPaths, value.batSigningKeyPath, "issuer BAT signing-key path");
+  const members = arrayBounded(value.memberPolicyDigestsHex, 1, MAX_POLICIES, `${label}.memberPolicyDigestsHex`);
+  const local = new Set();
+  for (const digest of members) {
+    requireHexOrPlaceholder(digest, `${label}.memberPolicyDigestsHex[]`);
+    if (!policyDigests.has(digest)) fail(`${label} contains an unknown policy member`);
+    addUnique(local, digest, "class member");
+    coverage.set(digest, (coverage.get(digest) ?? 0) + 1);
+  }
+}
+
+function validateAccounting(value, index, seenPaths) {
+  const label = `issuer.accounting[${index}]`;
+  const expectedKeys = [
+    "provider", "authorizationDigestHex", "authorizationFileSha256Hex", "authorizationPath",
+    "approvalDigestHex", "approvalFileSha256Hex", "approvalPath", "operatorVerifyingKeyHex",
+    "operatorVerifyingKeyPath", "minimumAuthorizationEpoch",
+  ];
+  if (value.provider === "pir2") expectedKeys.push("pir2AuthorizationPath", "pir2ApprovalPath");
+  exactKeys(value, expectedKeys, label);
+  if (!new Set(["pir1", "pir2"]).has(value.provider)) fail(`${label}.provider is invalid`);
+  for (const field of [
+    "authorizationDigestHex", "authorizationFileSha256Hex", "approvalDigestHex",
+    "approvalFileSha256Hex", "operatorVerifyingKeyHex",
+  ]) requireHexOrPlaceholder(value[field], `${label}.${field}`);
+  requireEpochOrPlaceholder(value.minimumAuthorizationEpoch, `${label}.minimumAuthorizationEpoch`);
+  requireAbsolutePath(value.authorizationPath, "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting", `${label}.authorizationPath`);
+  requireAbsolutePath(value.approvalPath, "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting", `${label}.approvalPath`);
+  requireAbsolutePath(value.operatorVerifyingKeyPath, "/etc/bitcoinpir/payment-v1/bat-v2/public/keys", `${label}.operatorVerifyingKeyPath`);
+  for (const path of [value.authorizationPath, value.approvalPath, value.operatorVerifyingKeyPath]) {
+    addUnique(seenPaths, path, "public artifact path");
+  }
+  if (value.provider === "pir2") {
+    if (value.pir2AuthorizationPath !== "/home/pir/data/pir2-sealed/provider-accounting-authorization.bin") {
+      fail(`${label}.pir2AuthorizationPath must match the sealed Ready loader path`);
+    }
+    if (value.pir2ApprovalPath !== "/home/pir/data/pir2-sealed/issuer-accounting-approval.bin") {
+      fail(`${label}.pir2ApprovalPath must match the sealed Ready loader path`);
+    }
+    addUnique(seenPaths, value.pir2AuthorizationPath, "pir2 runtime artifact path");
+    addUnique(seenPaths, value.pir2ApprovalPath, "pir2 runtime artifact path");
+  }
+}
+
+export function validateSourceProfileV1(profile) {
+  exactKeys(profile, ["schema", "profile", "issuer", "providers"], "profile");
+  if (profile.schema !== PROFILE_SCHEMA) fail(`profile.schema must equal ${PROFILE_SCHEMA}`);
+  if (profile.profile !== "issuer-pir1-pir2-storeless-v1") fail("profile.profile is unsupported");
+  exactKeys(profile.issuer, [
+    "issuerIdHex", "settlementVerifyingKeyHex", "settlementSigningKeyPath", "unitPath",
+    "policies", "classes", "accounting",
+  ], "issuer");
+  requireHexOrPlaceholder(profile.issuer.issuerIdHex, "issuer.issuerIdHex");
+  requireHexOrPlaceholder(profile.issuer.settlementVerifyingKeyHex, "issuer.settlementVerifyingKeyHex");
+  requireAbsolutePath(profile.issuer.settlementSigningKeyPath, "/etc/bitcoinpir/payment-v1/bat-v2/issuer", "issuer.settlementSigningKeyPath");
+  if (profile.issuer.unitPath !== `${SOURCE_ROOT}/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in`) {
+    fail("issuer.unitPath is outside the versioned source profile");
+  }
+
+  const seenDigests = new Set();
+  const seenPaths = new Set();
+  const policies = arrayBounded(profile.issuer.policies, 4, MAX_POLICIES, "issuer.policies");
+  policies.forEach((value, index) => validatePolicy(value, index, seenDigests, seenPaths));
+  const policyDigests = new Set(policies.map((policy) => policy.digestHex));
+  const coverage = new Map();
+  const classes = arrayBounded(profile.issuer.classes, 2, MAX_CLASSES, "issuer.classes");
+  classes.forEach((value, index) => validateClass(value, index, policyDigests, seenDigests, seenPaths, coverage));
+  const classCoordinates = new Set();
+  for (const entry of classes) {
+    addUnique(classCoordinates, `${entry.classIdHex}:${entry.keyEpoch}`, "class coordinate");
+  }
+  for (const digest of policyDigests) {
+    if (!coverage.has(digest)) fail(`policy ${digest} must be covered by at least one configured class`);
+  }
+  if (classes.filter((value) => value.state === "current").length !== 1) fail("issuer must have exactly one current class");
+  if (!classes.some((value) => value.state === "retained")) fail("issuer must have retained class material");
+  requireStrictOrder(
+    classes.filter((value) => value.state === "retained").map((value) => value.digestHex),
+    "issuer retained classes",
+  );
+
+  const accounting = arrayBounded(profile.issuer.accounting, 2, 2, "issuer.accounting");
+  accounting.forEach((value, index) => validateAccounting(value, index, seenPaths));
+  sameSet(accounting.map((value) => value.provider), ["pir1", "pir2"], "issuer accounting providers");
+
+  const providers = arrayBounded(profile.providers, 2, 2, "providers");
+  const names = providers.map((provider) => provider.name);
+  sameSet(names, ["pir1", "pir2"], "provider roles");
+  const providerIds = new Set();
+  const roleKeys = new Map([[profile.issuer.settlementVerifyingKeyHex, "issuer settlement key"]]);
+  const classKeys = new Set();
+  const batKeyIds = new Set();
+  for (const value of classes) {
+    addUnique(classKeys, value.classVerifyingKeyHex, "class verifying key");
+    addUnique(batKeyIds, value.batKeyIdHex, "BAT key id");
+    if (roleKeys.has(value.classVerifyingKeyHex)) {
+      fail(`raw/public role-key reuse between ${roleKeys.get(value.classVerifyingKeyHex)} and class ${value.state} verifying key`);
+    }
+    roleKeys.set(value.classVerifyingKeyHex, `class ${value.state} verifying key`);
+  }
+
+  for (const [index, provider] of providers.entries()) {
+    const label = `providers[${index}]`;
+    const expectedKeys = [
+      "name", "providerIdHex", "policyVerifyingKeyHex", "clearingKeySource",
+      "clearingVerifyingKeyHex", "currentPolicyDigestHex", "retainedPolicyDigestsHex",
+      "classDigestsHex", "accountingAuthorizationDigestHex", "accountingApprovalDigestHex",
+      "operatorVerifyingKeyHex", "minimumAuthorizationEpoch", "renderPath",
+      ...(provider.name === "pir2" ? ["artifactSetPath", "startupPath"] : []),
+    ];
+    exactKeys(provider, expectedKeys, label);
+    if (!new Set(["pir1", "pir2"]).has(provider.name)) fail(`${label}.name is invalid`);
+    for (const field of [
+      "providerIdHex", "policyVerifyingKeyHex", "clearingVerifyingKeyHex",
+      "currentPolicyDigestHex", "accountingAuthorizationDigestHex",
+      "accountingApprovalDigestHex", "operatorVerifyingKeyHex",
+    ]) requireHexOrPlaceholder(provider[field], `${label}.${field}`);
+    requireEpochOrPlaceholder(provider.minimumAuthorizationEpoch, `${label}.minimumAuthorizationEpoch`);
+    addUnique(providerIds, provider.providerIdHex, "provider id");
+    const expectedSource = provider.name === "pir1" ? "plaintext-pir1" : "snp-sealed-ready";
+    if (provider.clearingKeySource !== expectedSource) fail(`${label} has the wrong clearing-key source`);
+    const providerPolicies = policies.filter((policy) => policy.provider === provider.name);
+    const current = providerPolicies.filter((policy) => policy.state === "current");
+    const retained = providerPolicies.filter((policy) => policy.state === "retained");
+    if (current.length !== 1) fail(`${label} must have exactly one current signed policy`);
+    arrayBounded(retained, 1, MAX_RETAINED_PER_PROVIDER, `${label} retained policies`);
+    requireStrictOrder(retained.map((policy) => policy.digestHex), `${label} retained policies`);
+    if (providerPolicies.some((policy) => policy.verifyingKeyHex !== provider.policyVerifyingKeyHex)) {
+      fail(`${label} policy verifying key is inconsistent with its signed-policy set`);
+    }
+    if (provider.currentPolicyDigestHex !== current[0].digestHex) fail(`${label} current policy is inconsistent`);
+    sameSet(provider.retainedPolicyDigestsHex, retained.map((policy) => policy.digestHex), `${label} retained policies`);
+    const expectedClassDigests = classes
+      .filter((entry) => entry.memberPolicyDigestsHex.some((digest) => providerPolicies.some((policy) => policy.digestHex === digest)))
+      .map((entry) => entry.digestHex);
+    sameSet(provider.classDigestsHex, expectedClassDigests, `${label} classes`);
+    const relation = accounting.find((entry) => entry.provider === provider.name);
+    if (provider.accountingAuthorizationDigestHex !== relation.authorizationDigestHex
+      || provider.accountingApprovalDigestHex !== relation.approvalDigestHex
+      || provider.operatorVerifyingKeyHex !== relation.operatorVerifyingKeyHex
+      || provider.minimumAuthorizationEpoch !== relation.minimumAuthorizationEpoch) {
+      fail(`${label} current accounting relationship is inconsistent`);
+    }
+    for (const [key, role] of [
+      [provider.policyVerifyingKeyHex, `${provider.name} policy key`],
+      [provider.clearingVerifyingKeyHex, `${provider.name} clearing key`],
+      [provider.operatorVerifyingKeyHex, `${provider.name} operator key`],
+    ]) {
+      if (roleKeys.has(key)) fail(`raw/public role-key reuse between ${roleKeys.get(key)} and ${role}`);
+      roleKeys.set(key, role);
+    }
+    const expectedRender = provider.name === "pir1"
+      ? `${SOURCE_ROOT}/pir1-storeless-bat-v2-provider.service.in`
+      : "scripts/dracut/97bpir-tier3-init/unified-server-run.sh";
+    if (provider.renderPath !== expectedRender) fail(`${label}.renderPath is unsupported`);
+    if (provider.name === "pir2") {
+      if (provider.artifactSetPath !== `${SOURCE_ROOT}/pir2-public-artifact-set.env.in`
+        || provider.startupPath !== `${SOURCE_ROOT}/pir2-sealed-startup.env.in`) {
+        fail("pir2 render inputs must use the reviewed versioned artifact/startup templates");
+      }
+    }
+  }
+  return profile;
+}
+
+function forbid(command, patterns, label) {
+  for (const [pattern, description] of patterns) {
+    if (pattern.test(command)) fail(`${label} contains forbidden ${description}`);
+  }
+}
+
+export function validateIssuerUnitV1(source, profile) {
+  const command = execStart(source, "BAT V2 issuer unit");
+  for (const sentinel of [
+    "ConditionPathExists=/etc/bitcoinpir/payment-v1/BAT-V2-SOURCE-PROFILE-RENDERED",
+    "ConditionPathExists=/etc/bitcoinpir/payment-v1/MAINNET-BAT-V2-ACTIVATION-APPROVED",
+  ]) {
+    if (!source.includes(sentinel)) fail(`BAT V2 issuer unit is missing ${sentinel}`);
+  }
+  if (source.includes("MAINNET-LIGHTNING-V1-ACTIVATION-APPROVED")) {
+    fail("BAT V2 issuer unit must not reuse the V1 activation approval");
+  }
+  if (!command.startsWith("/opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@/payment-issuer serve-cln ")) {
+    fail("BAT V2 issuer unit has the wrong executable or backend");
+  }
+  forbid(command, [
+    [/--receipt-signing-key(?:\s|$)/u, "Direct receipt key"],
+    [/--clearing-(?:authorization|approval|provider-request-verifying-key)(?:\s|$)/u, "V1 clearing"],
+    [/--redeem-response-derivation-key(?:\s|$)/u, "V1 idempotency derivation"],
+    [/--(?:arc-key|allow-experimental-arc)(?:\s|$)/u, "ARC"],
+    [/--retained-issuer-settlement-verifying-key(?:\s|$)/u, "retained accounting runtime"],
+  ], "BAT V2 issuer unit");
+  sameSet(valuesForFlag(command, "--service-policy"), profile.issuer.policies.map((policy) => `${policy.path}=${policy.verifyingKeyHex}`), "issuer policy argv");
+  sameSet(valuesForFlag(command, "--bat-v2-class"), profile.issuer.classes.map((entry) => entry.path), "issuer class argv");
+  sameSet(valuesForFlag(command, "--bat-key"), profile.issuer.classes.map((entry) => entry.batSigningKeyPath), "issuer BAT key argv");
+  sameOrder(valuesForFlag(command, "--bat-v2-accounting-authorization"), profile.issuer.accounting.map((entry) => entry.authorizationPath), "issuer accounting authorization argv");
+  sameOrder(valuesForFlag(command, "--bat-v2-accounting-approval"), profile.issuer.accounting.map((entry) => entry.approvalPath), "issuer accounting approval argv");
+  sameOrder(valuesForFlag(command, "--bat-v2-accounting-operator-verifying-key"), profile.issuer.accounting.map((entry) => entry.operatorVerifyingKeyPath), "issuer operator-key argv");
+  if (oneValue(command, "--issuer-settlement-signing-key", "BAT V2 issuer unit") !== profile.issuer.settlementSigningKeyPath) {
+    fail("issuer settlement signing-key path does not match the profile");
+  }
+}
+
+export function validatePir1UnitV1(source, profile) {
+  const command = execStart(source, "pir1 BAT V2 unit");
+  for (const sentinel of [
+    "ConditionPathExists=/etc/bitcoinpir/payment-v1/BAT-V2-SOURCE-PROFILE-RENDERED",
+    "ConditionPathExists=/etc/bitcoinpir/payment-v1/PIR1-BAT-V2-ACTIVATION-APPROVED",
+  ]) {
+    if (!source.includes(sentinel)) fail(`pir1 BAT V2 unit is missing ${sentinel}`);
+  }
+  const provider = profile.providers.find((entry) => entry.name === "pir1");
+  const policies = profile.issuer.policies.filter((entry) => entry.provider === "pir1");
+  const current = policies.find((entry) => entry.state === "current");
+  const retained = policies.filter((entry) => entry.state === "retained");
+  const classes = profile.issuer.classes.filter((entry) => provider.classDigestsHex.includes(entry.digestHex));
+  const accounting = profile.issuer.accounting.find((entry) => entry.provider === "pir1");
+  forbid(command, [
+    [/--service-store(?:\s|$)/u, "ProviderStore"],
+    [/--service-(?:remote-)?rollback-authority(?:\s|$)/u, "rollback authority"],
+    [/--service-shared-/u, "V1 shared clearing"],
+    [/--service-(?:bat-key|arc-key|cashu-)/u, "V1 BAT/ARC/Standard Cashu"],
+    [/--service-retained-policy(?:\s|$)/u, "V1 retained policy"],
+    [/--(?:allow-experimental-arc|require-arc|require-cashu)(?:\s|$)/u, "legacy paid gate"],
+  ], "pir1 BAT V2 unit");
+  const serviceFlags = [...command.matchAll(/--service-[a-z0-9-]+/gu)].map((match) => match[0]);
+  const allowedBase = new Set([
+    "--service-policy", "--service-provider-id-hex", "--service-policy-key-hex",
+    "--service-max-concurrent-auth", "--service-max-concurrent-online-v2full-auth",
+    "--service-pre-auth-timeout-ms",
+  ]);
+  for (const flag of serviceFlags) {
+    if (!allowedBase.has(flag) && !flag.startsWith("--service-storeless-bat-v2-")) {
+      fail(`pir1 BAT V2 unit uses unsupported service flag ${flag}`);
+    }
+  }
+  if (oneValue(command, "--service-policy", "pir1 BAT V2 unit") !== current.path
+    || oneValue(command, "--service-provider-id-hex", "pir1 BAT V2 unit") !== provider.providerIdHex
+    || oneValue(command, "--service-policy-key-hex", "pir1 BAT V2 unit") !== provider.policyVerifyingKeyHex
+    || oneValue(command, "--service-storeless-bat-v2-policy-digest-hex", "pir1 BAT V2 unit") !== current.digestHex) {
+    fail("pir1 current policy argv does not match the profile");
+  }
+  sameSet(valuesForFlag(command, "--service-storeless-bat-v2-retained-policy"), retained.map((entry) => `${entry.digestHex}=${entry.path}`), "pir1 retained policy argv");
+  sameSet(valuesForFlag(command, "--service-storeless-bat-v2-class"), classes.map((entry) => `${entry.digestHex}=${entry.path}`), "pir1 class argv");
+  if (oneValue(command, "--service-storeless-bat-v2-accounting-authorization", "pir1 BAT V2 unit") !== accounting.authorizationPath
+    || oneValue(command, "--service-storeless-bat-v2-issuer-approval", "pir1 BAT V2 unit") !== accounting.approvalPath
+    || oneValue(command, "--service-storeless-bat-v2-operator-key-hex", "pir1 BAT V2 unit") !== provider.operatorVerifyingKeyHex
+    || oneValue(command, "--service-storeless-bat-v2-issuer-settlement-key-hex", "pir1 BAT V2 unit") !== profile.issuer.settlementVerifyingKeyHex
+    || oneValue(command, "--service-storeless-bat-v2-minimum-authorization-epoch", "pir1 BAT V2 unit") !== provider.minimumAuthorizationEpoch) {
+    fail("pir1 current accounting argv does not match the profile");
+  }
+  oneValue(command, "--service-storeless-bat-v2-pir1-clearing-key", "pir1 BAT V2 unit");
+}
+
+function parseEnv(source, label) {
+  if (!source.endsWith("\n") || source.includes("\r")) fail(`${label} must be canonical LF text`);
+  const entries = [];
+  for (const [index, line] of source.trimEnd().split("\n").entries()) {
+    const split = line.indexOf("=");
+    if (split <= 0 || split === line.length - 1) fail(`${label} line ${index + 1} is malformed`);
+    entries.push([line.slice(0, split), line.slice(split + 1)]);
+  }
+  return entries;
+}
+
+export function validatePir2RenderInputsV1(artifactSource, startupSource, runSource, profile) {
+  const provider = profile.providers.find((entry) => entry.name === "pir2");
+  const policies = profile.issuer.policies.filter((entry) => entry.provider === "pir2");
+  const currentPolicy = policies.find((entry) => entry.state === "current");
+  const retainedPolicies = policies.filter((entry) => entry.state === "retained");
+  const classes = profile.issuer.classes.filter((entry) => provider.classDigestsHex.includes(entry.digestHex));
+  const currentClass = classes.find((entry) => entry.state === "current");
+  const retainedClasses = classes.filter((entry) => entry.state === "retained");
+  const accounting = profile.issuer.accounting.find((entry) => entry.provider === "pir2");
+  const artifact = parseEnv(artifactSource, "pir2 artifact set");
+  if (artifact.length < 7 || artifact.length > 4 + MAX_RETAINED_PER_PROVIDER + MAX_CLASSES) {
+    fail("pir2 artifact set is outside its bounded entry count");
+  }
+  if (artifact[0][0] !== "schema" || artifact[0][1] !== "bitcoinpir-pir2-bat-v2-public-artifact-set-v1") {
+    fail("pir2 artifact set schema is unsupported");
+  }
+  const expectedArtifact = [
+    ["current_policy", `${currentPolicy.digestHex}=${currentPolicy.fileSha256Hex}=${currentPolicy.pir2RuntimePath}`],
+    ...retainedPolicies.map((entry) => ["retained_policy", `${entry.digestHex}=${entry.fileSha256Hex}=${entry.pir2RuntimePath}`]),
+    ["current_class", `${currentClass.digestHex}=${currentClass.fileSha256Hex}=${currentClass.pir2RuntimePath}`],
+    ...retainedClasses.map((entry) => ["retained_class", `${entry.digestHex}=${entry.fileSha256Hex}=${entry.pir2RuntimePath}`]),
+    ["accounting_authorization", `${accounting.authorizationDigestHex}=${accounting.authorizationFileSha256Hex}=${accounting.pir2AuthorizationPath}`],
+    ["accounting_approval", `${accounting.approvalDigestHex}=${accounting.approvalFileSha256Hex}=${accounting.pir2ApprovalPath}`],
+  ];
+  if (JSON.stringify(artifact.slice(1)) !== JSON.stringify(expectedArtifact)) {
+    fail("pir2 artifact set entries do not match the profile in canonical order");
+  }
+  const startup = parseEnv(startupSource, "pir2 startup config");
+  const startupKeys = startup.map(([key]) => key);
+  const expectedKeys = [
+    "schema", "profile", "phase", "ordinal", "verifier_nonce_hex",
+    "current_policy_digest_hex", "class_digest_hex", "artifact_set_path",
+    "artifact_set_sha256", "minimum_authorization_epoch",
+  ];
+  if (JSON.stringify(startupKeys) !== JSON.stringify(expectedKeys)) fail("pir2 startup config fields/order are not canonical v2");
+  const startupMap = new Map(startup);
+  if (startupMap.get("schema") !== "bitcoinpir-pir2-sealed-startup-v2"
+    || startupMap.get("profile") !== "pir2-snp-sealed-v1"
+    || startupMap.get("current_policy_digest_hex") !== currentPolicy.digestHex
+    || startupMap.get("class_digest_hex") !== currentClass.digestHex
+    || startupMap.get("artifact_set_path") !== "/home/pir/data/pir2-sealed/public-artifact-set.env"
+    || startupMap.get("minimum_authorization_epoch") !== provider.minimumAuthorizationEpoch) {
+    fail("pir2 startup config does not bind the profile");
+  }
+  for (const required of [
+    "bitcoinpir-pir2-sealed-startup-v2", "artifact_set_path", "artifact_set_sha256",
+    "PIR2_SEALED_ARTIFACT_SET_SHA256", "validate_pir2_public_artifact_set",
+    "PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH", "PIR2_ACTIVE_ARTIFACT_SET_PATH",
+    "artifact_set_sha256=", "--service-storeless-bat-v2-retained-policy",
+    "--service-storeless-bat-v2-class",
+  ]) {
+    if (!runSource.includes(required)) fail(`pir2 measured run path is missing ${required}`);
+  }
+  if (/--service-storeless-bat-v2-pir1-clearing-key/u.test(runSource)
+    || /--service-shared-(?:clearing|idempotency)/u.test(runSource)) {
+    fail("pir2 measured run path contains a plaintext or V1 clearing fallback");
+  }
+}
+
+export function validateRepository(root) {
+  const sourceRoot = join(root, SOURCE_ROOT);
+  const profile = validateSourceProfileV1(JSON.parse(readFileSync(join(sourceRoot, "source-profile.json.in"), "utf8")));
+  validateIssuerUnitV1(readFileSync(join(sourceRoot, "issuer-lightning-mainnet-bat-v2-payment-issuer.service.in"), "utf8"), profile);
+  validatePir1UnitV1(readFileSync(join(sourceRoot, "pir1-storeless-bat-v2-provider.service.in"), "utf8"), profile);
+  validatePir2RenderInputsV1(
+    readFileSync(join(sourceRoot, "pir2-public-artifact-set.env.in"), "utf8"),
+    readFileSync(join(sourceRoot, "pir2-sealed-startup.env.in"), "utf8"),
+    readFileSync(join(root, "scripts/dracut/97bpir-tier3-init/unified-server-run.sh"), "utf8"),
+    profile,
+  );
+  return { schema: PROFILE_SCHEMA, result: "PASS" };
+}
+
+const isMain = process.argv[1] !== undefined
+  && pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
+if (isMain) {
+  const repository = process.argv[2]
+    ? resolve(process.argv[2])
+    : resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  try {
+    process.stdout.write(`${JSON.stringify(validateRepository(repository))}\n`);
+  } catch (error) {
+    process.stderr.write(`payment-bat-v2-source-profile-gate: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/payment-bat-v2-source-profile-gate.mjs
+++ b/scripts/payment-bat-v2-source-profile-gate.mjs
@@ -147,7 +147,7 @@ function validatePolicy(value, index, seenDigests, seenPaths) {
   addUnique(seenPaths, value.path, "public artifact path");
 }
 
-function validateClass(value, index, policyDigests, seenDigests, seenPaths, coverage) {
+function validateClass(value, index, policyDigests, seenDigests, seenPaths, seenSecretPaths, coverage) {
   const label = `issuer.classes[${index}]`;
   exactKeys(value, [
     "state", "classIdHex", "keyEpoch", "digestHex", "fileSha256Hex", "path",
@@ -168,7 +168,7 @@ function validateClass(value, index, policyDigests, seenDigests, seenPaths, cove
   addUnique(seenDigests, value.digestHex, "class digest");
   addUnique(seenPaths, value.path, "public artifact path");
   addUnique(seenPaths, value.pir2RuntimePath, "pir2 runtime artifact path");
-  addUnique(seenPaths, value.batSigningKeyPath, "issuer BAT signing-key path");
+  addUnique(seenSecretPaths, value.batSigningKeyPath, "private signing-key path");
   const members = arrayBounded(value.memberPolicyDigestsHex, 1, MAX_POLICIES, `${label}.memberPolicyDigestsHex`);
   const local = new Set();
   for (const digest of members) {
@@ -229,12 +229,16 @@ export function validateSourceProfileV1(profile) {
 
   const seenDigests = new Set();
   const seenPaths = new Set();
+  const seenSecretPaths = new Set();
+  addUnique(seenSecretPaths, profile.issuer.settlementSigningKeyPath, "private signing-key path");
   const policies = arrayBounded(profile.issuer.policies, 4, MAX_POLICIES, "issuer.policies");
   policies.forEach((value, index) => validatePolicy(value, index, seenDigests, seenPaths));
   const policyDigests = new Set(policies.map((policy) => policy.digestHex));
   const coverage = new Map();
   const classes = arrayBounded(profile.issuer.classes, 2, MAX_CLASSES, "issuer.classes");
-  classes.forEach((value, index) => validateClass(value, index, policyDigests, seenDigests, seenPaths, coverage));
+  classes.forEach((value, index) => validateClass(
+    value, index, policyDigests, seenDigests, seenPaths, seenSecretPaths, coverage,
+  ));
   const classCoordinates = new Set();
   for (const entry of classes) {
     addUnique(classCoordinates, `${entry.classIdHex}:${entry.keyEpoch}`, "class coordinate");
@@ -258,15 +262,17 @@ export function validateSourceProfileV1(profile) {
   sameSet(names, ["pir1", "pir2"], "provider roles");
   const providerIds = new Set();
   const roleKeys = new Map([[profile.issuer.settlementVerifyingKeyHex, "issuer settlement key"]]);
-  const classKeys = new Set();
   const batKeyIds = new Set();
+  const classSigner = classes[0].classVerifyingKeyHex;
+  if (classes.some((value) => value.classVerifyingKeyHex !== classSigner)) {
+    fail("all BAT V2 classes for one issuer must use the same class artifact signer");
+  }
+  if (roleKeys.has(classSigner)) {
+    fail(`raw/public role-key reuse between ${roleKeys.get(classSigner)} and class artifact signer`);
+  }
+  roleKeys.set(classSigner, "class artifact signer");
   for (const value of classes) {
-    addUnique(classKeys, value.classVerifyingKeyHex, "class verifying key");
     addUnique(batKeyIds, value.batKeyIdHex, "BAT key id");
-    if (roleKeys.has(value.classVerifyingKeyHex)) {
-      fail(`raw/public role-key reuse between ${roleKeys.get(value.classVerifyingKeyHex)} and class ${value.state} verifying key`);
-    }
-    roleKeys.set(value.classVerifyingKeyHex, `class ${value.state} verifying key`);
   }
 
   for (const [index, provider] of providers.entries()) {
@@ -422,6 +428,29 @@ export function validatePir1UnitV1(source, profile) {
   oneValue(command, "--service-storeless-bat-v2-pir1-clearing-key", "pir1 BAT V2 unit");
 }
 
+export function validatePrivateSecretPathsV1(issuerSource, pir1Source, profile) {
+  const issuerCommand = execStart(issuerSource, "BAT V2 issuer unit");
+  const pir1Command = execStart(pir1Source, "pir1 BAT V2 unit");
+  const privatePaths = [
+    [oneValue(issuerCommand, "--issuer-settlement-signing-key", "BAT V2 issuer unit"), "issuer settlement signing key"],
+    ...valuesForFlag(issuerCommand, "--bat-key").map((value) => [value, "issuer BAT scalar"]),
+    [oneValue(issuerCommand, "--quote-signing-key", "BAT V2 issuer unit"), "issuer quote signing key"],
+    [oneValue(issuerCommand, "--credential-derivation-key", "BAT V2 issuer unit"), "issuer credential derivation key"],
+    [oneValue(pir1Command, "--identity-key-path", "pir1 BAT V2 unit"), "pir1 identity signing key"],
+    [oneValue(pir1Command, "--service-storeless-bat-v2-pir1-clearing-key", "pir1 BAT V2 unit"), "pir1 clearing signing key"],
+  ];
+  const seen = new Set();
+  for (const [value, label] of privatePaths) {
+    requireAbsolutePath(value, "/etc/bitcoinpir/payment-v1/bat-v2", label);
+    addUnique(seen, value, "private signing-key path");
+  }
+  sameSet(
+    valuesForFlag(issuerCommand, "--bat-key"),
+    profile.issuer.classes.map((entry) => entry.batSigningKeyPath),
+    "issuer BAT private-path set",
+  );
+}
+
 function parseEnv(source, label) {
   if (!source.endsWith("\n") || source.includes("\r")) fail(`${label} must be canonical LF text`);
   const entries = [];
@@ -433,6 +462,13 @@ function parseEnv(source, label) {
   return entries;
 }
 
+function measuredHexConstant(runSource, name) {
+  const pattern = new RegExp(`^${name}=([0-9a-f]{64})$`, "gmu");
+  const matches = [...runSource.matchAll(pattern)];
+  if (matches.length !== 1) fail(`pir2 measured run path must define exactly one ${name}`);
+  return matches[0][1];
+}
+
 export function validatePir2RenderInputsV1(artifactSource, startupSource, runSource, profile) {
   const provider = profile.providers.find((entry) => entry.name === "pir2");
   const policies = profile.issuer.policies.filter((entry) => entry.provider === "pir2");
@@ -442,6 +478,16 @@ export function validatePir2RenderInputsV1(artifactSource, startupSource, runSou
   const currentClass = classes.find((entry) => entry.state === "current");
   const retainedClasses = classes.filter((entry) => entry.state === "retained");
   const accounting = profile.issuer.accounting.find((entry) => entry.provider === "pir2");
+  for (const [actual, constantName, label] of [
+    [provider.providerIdHex, "PIR2_SEALED_PROVIDER_ID_HEX", "provider id"],
+    [provider.policyVerifyingKeyHex, "PIR2_SEALED_POLICY_KEY_HEX", "policy key"],
+    [provider.operatorVerifyingKeyHex, "PIR2_SEALED_OPERATOR_KEY_HEX", "operator key"],
+    [profile.issuer.settlementVerifyingKeyHex, "PIR2_SEALED_ISSUER_SETTLEMENT_KEY_HEX", "issuer settlement key"],
+  ]) {
+    if (actual !== measuredHexConstant(runSource, constantName)) {
+      fail(`pir2 ${label} does not match measured source constant ${constantName}`);
+    }
+  }
   const artifact = parseEnv(artifactSource, "pir2 artifact set");
   if (artifact.length < 7 || artifact.length > 4 + MAX_RETAINED_PER_PROVIDER + MAX_CLASSES) {
     fail("pir2 artifact set is outside its bounded entry count");
@@ -495,8 +541,11 @@ export function validatePir2RenderInputsV1(artifactSource, startupSource, runSou
 export function validateRepository(root) {
   const sourceRoot = join(root, SOURCE_ROOT);
   const profile = validateSourceProfileV1(JSON.parse(readFileSync(join(sourceRoot, "source-profile.json.in"), "utf8")));
-  validateIssuerUnitV1(readFileSync(join(sourceRoot, "issuer-lightning-mainnet-bat-v2-payment-issuer.service.in"), "utf8"), profile);
-  validatePir1UnitV1(readFileSync(join(sourceRoot, "pir1-storeless-bat-v2-provider.service.in"), "utf8"), profile);
+  const issuerSource = readFileSync(join(sourceRoot, "issuer-lightning-mainnet-bat-v2-payment-issuer.service.in"), "utf8");
+  const pir1Source = readFileSync(join(sourceRoot, "pir1-storeless-bat-v2-provider.service.in"), "utf8");
+  validateIssuerUnitV1(issuerSource, profile);
+  validatePir1UnitV1(pir1Source, profile);
+  validatePrivateSecretPathsV1(issuerSource, pir1Source, profile);
   validatePir2RenderInputsV1(
     readFileSync(join(sourceRoot, "pir2-public-artifact-set.env.in"), "utf8"),
     readFileSync(join(sourceRoot, "pir2-sealed-startup.env.in"), "utf8"),

--- a/scripts/payment-bat-v2-source-profile-gate.test.mjs
+++ b/scripts/payment-bat-v2-source-profile-gate.test.mjs
@@ -9,6 +9,7 @@ import {
   validateIssuerUnitV1,
   validatePir1UnitV1,
   validatePir2RenderInputsV1,
+  validatePrivateSecretPathsV1,
   validateRepository,
   validateSourceProfileV1,
 } from "./payment-bat-v2-source-profile-gate.mjs";
@@ -74,7 +75,33 @@ test("class membership covers every policy and is coordinate-fork-free", () => {
 
   const reusedBatPath = profile();
   reusedBatPath.issuer.classes[1].batSigningKeyPath = reusedBatPath.issuer.classes[0].batSigningKeyPath;
-  assert.throws(() => validateSourceProfileV1(reusedBatPath), /duplicate issuer BAT signing-key path/u);
+  assert.throws(() => validateSourceProfileV1(reusedBatPath), /duplicate private signing-key path/u);
+
+  const divergentSigner = profile();
+  divergentSigner.issuer.classes[1].classVerifyingKeyHex = "@OTHER_CLASS_VERIFYING_KEY_HEX@";
+  assert.throws(
+    () => validateSourceProfileV1(divergentSigner),
+    /same class artifact signer/u,
+  );
+});
+
+test("every explicit private signing-key path is unique across issuer and pir1", () => {
+  const settlementReusesBat = profile();
+  settlementReusesBat.issuer.settlementSigningKeyPath =
+    settlementReusesBat.issuer.classes[0].batSigningKeyPath;
+  assert.throws(
+    () => validateSourceProfileV1(settlementReusesBat),
+    /duplicate private signing-key path/u,
+  );
+
+  const clearingReusesIdentity = pir1Source.replace(
+    "/etc/bitcoinpir/payment-v1/bat-v2/pir1/clearing-signing.key",
+    "/etc/bitcoinpir/payment-v1/bat-v2/pir1/provider-identity.key",
+  );
+  assert.throws(
+    () => validatePrivateSecretPathsV1(issuerSource, clearingReusesIdentity, profile()),
+    /duplicate private signing-key path/u,
+  );
 });
 
 test("provider ids, policy roots, and role keys cannot be reused", () => {
@@ -202,5 +229,17 @@ test("pir2 render input is canonical, bounded, and SHA/token bound", () => {
   assert.throws(
     () => validateSourceProfileV1(reusedRuntimePath),
     /immutable by exact class digest|duplicate pir2 runtime artifact path/u,
+  );
+
+  const mutatedProviderId = profile();
+  mutatedProviderId.providers[1].providerIdHex = "a".repeat(64);
+  assert.throws(
+    () => validatePir2RenderInputsV1(
+      artifactSource,
+      startupSource,
+      runSource,
+      validateSourceProfileV1(mutatedProviderId),
+    ),
+    /provider id does not match measured source constant/u,
   );
 });

--- a/scripts/payment-bat-v2-source-profile-gate.test.mjs
+++ b/scripts/payment-bat-v2-source-profile-gate.test.mjs
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  PROFILE_SCHEMA,
+  validateIssuerUnitV1,
+  validatePir1UnitV1,
+  validatePir2RenderInputsV1,
+  validateRepository,
+  validateSourceProfileV1,
+} from "./payment-bat-v2-source-profile-gate.mjs";
+
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const sourceRoot = join(repository, "deploy/payment-v1/bat-v2-source-ready");
+const profileSource = readFileSync(join(sourceRoot, "source-profile.json.in"), "utf8");
+const issuerSource = readFileSync(
+  join(sourceRoot, "issuer-lightning-mainnet-bat-v2-payment-issuer.service.in"),
+  "utf8",
+);
+const pir1Source = readFileSync(
+  join(sourceRoot, "pir1-storeless-bat-v2-provider.service.in"),
+  "utf8",
+);
+const artifactSource = readFileSync(join(sourceRoot, "pir2-public-artifact-set.env.in"), "utf8");
+const startupSource = readFileSync(join(sourceRoot, "pir2-sealed-startup.env.in"), "utf8");
+const runSource = readFileSync(
+  join(repository, "scripts/dracut/97bpir-tier3-init/unified-server-run.sh"),
+  "utf8",
+);
+
+function profile() {
+  return JSON.parse(profileSource);
+}
+
+test("checked-in BAT V2 source profile and all three render roles pass", () => {
+  assert.deepEqual(validateRepository(repository), { schema: PROFILE_SCHEMA, result: "PASS" });
+  const stdout = execFileSync(
+    process.execPath,
+    [join(repository, "scripts/payment-bat-v2-source-profile-gate.mjs"), repository],
+    { encoding: "utf8" },
+  );
+  assert.deepEqual(JSON.parse(stdout), { schema: PROFILE_SCHEMA, result: "PASS" });
+});
+
+test("profile schema is closed and retained material is mandatory", () => {
+  const unknown = profile();
+  unknown.issuer.retainedAccounting = [];
+  assert.throws(() => validateSourceProfileV1(unknown), /fields must match the closed schema/u);
+
+  const noRetained = profile();
+  noRetained.issuer.policies = noRetained.issuer.policies.filter((entry) => entry.state === "current");
+  assert.throws(() => validateSourceProfileV1(noRetained), /issuer\.policies must contain 4/u);
+
+  const tooManyRetainedClasses = profile();
+  tooManyRetainedClasses.issuer.classes.push(...Array.from({ length: 8 }, () => ({})));
+  assert.throws(
+    () => validateSourceProfileV1(tooManyRetainedClasses),
+    /issuer\.classes must contain 2\.\.9 entries/u,
+  );
+});
+
+test("class membership covers every policy and is coordinate-fork-free", () => {
+  const missing = profile();
+  missing.issuer.classes[1].memberPolicyDigestsHex.pop();
+  assert.throws(() => validateSourceProfileV1(missing), /covered by at least one configured class/u);
+
+  const fork = profile();
+  fork.issuer.classes[1].classIdHex = fork.issuer.classes[0].classIdHex;
+  fork.issuer.classes[1].keyEpoch = fork.issuer.classes[0].keyEpoch;
+  assert.throws(() => validateSourceProfileV1(fork), /duplicate class coordinate/u);
+
+  const reusedBatPath = profile();
+  reusedBatPath.issuer.classes[1].batSigningKeyPath = reusedBatPath.issuer.classes[0].batSigningKeyPath;
+  assert.throws(() => validateSourceProfileV1(reusedBatPath), /duplicate issuer BAT signing-key path/u);
+});
+
+test("provider ids, policy roots, and role keys cannot be reused", () => {
+  const duplicateProvider = profile();
+  duplicateProvider.providers[1].providerIdHex = duplicateProvider.providers[0].providerIdHex;
+  assert.throws(() => validateSourceProfileV1(duplicateProvider), /duplicate provider id/u);
+
+  const wrongPolicyRoot = profile();
+  wrongPolicyRoot.providers[0].policyVerifyingKeyHex = "@PIR1_OTHER_POLICY_VERIFYING_KEY_HEX@";
+  assert.throws(() => validateSourceProfileV1(wrongPolicyRoot), /policy verifying key is inconsistent/u);
+
+  const roleReuse = profile();
+  roleReuse.providers[1].operatorVerifyingKeyHex = roleReuse.issuer.settlementVerifyingKeyHex;
+  roleReuse.issuer.accounting[1].operatorVerifyingKeyHex = roleReuse.issuer.settlementVerifyingKeyHex;
+  assert.throws(() => validateSourceProfileV1(roleReuse), /role-key reuse/u);
+});
+
+test("issuer argv rejects V1 redemption and keeps exact V2 artifact sets", () => {
+  const checked = validateSourceProfileV1(profile());
+  assert.throws(
+    () => validateIssuerUnitV1(
+      issuerSource.replace(
+        "    --bat-v2-class /etc/bitcoinpir/payment-v1/bat-v2/public/classes/current.bin \\\n",
+        "    --receipt-signing-key /tmp/direct.key \\\n    --bat-v2-class /etc/bitcoinpir/payment-v1/bat-v2/public/classes/current.bin \\\n",
+      ),
+      checked,
+    ),
+    /forbidden Direct receipt key/u,
+  );
+  assert.throws(
+    () => validateIssuerUnitV1(
+      issuerSource.replace(
+        "    --bat-v2-class /etc/bitcoinpir/payment-v1/bat-v2/public/classes/retained.bin \\\n",
+        "",
+      ),
+      checked,
+    ),
+    /issuer class argv does not match/u,
+  );
+  const swappedApprovals = issuerSource
+    .replace("/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-approval.bin", "@SWAP_APPROVAL@")
+    .replace("/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir2-approval.bin", "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-approval.bin")
+    .replace("@SWAP_APPROVAL@", "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir2-approval.bin");
+  assert.throws(
+    () => validateIssuerUnitV1(swappedApprovals, checked),
+    /issuer accounting approval argv order does not match/u,
+  );
+});
+
+test("pir1 argv is storeless and has one complete current accounting group", () => {
+  const checked = validateSourceProfileV1(profile());
+  assert.throws(
+    () => validatePir1UnitV1(
+      pir1Source.replace(
+        "    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-current.bin \\\n",
+        "    --service-store /tmp/provider.sqlite3 \\\n    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-current.bin \\\n",
+      ),
+      checked,
+    ),
+    /forbidden ProviderStore/u,
+  );
+  assert.throws(
+    () => validatePir1UnitV1(
+      pir1Source.replace(
+        /    --service-storeless-bat-v2-issuer-approval .*\\\n/u,
+        "",
+      ),
+      checked,
+    ),
+    /exactly one --service-storeless-bat-v2-issuer-approval/u,
+  );
+  assert.throws(
+    () => validatePir1UnitV1(
+      pir1Source.replace(
+        /    --service-storeless-bat-v2-class @BAT_V2_RETAINED_CLASS_DIGEST_HEX@=.*\\\n/u,
+        "",
+      ),
+      checked,
+    ),
+    /pir1 class argv does not match/u,
+  );
+});
+
+test("pir2 render input is canonical, bounded, and SHA/token bound", () => {
+  const checked = validateSourceProfileV1(profile());
+  assert.throws(
+    () => validatePir2RenderInputsV1(
+      artifactSource.replace("retained_policy=", "unknown_policy="),
+      startupSource,
+      runSource,
+      checked,
+    ),
+    /entries do not match/u,
+  );
+  assert.throws(
+    () => validatePir2RenderInputsV1(
+      artifactSource,
+      startupSource.replace("bitcoinpir-pir2-sealed-startup-v2", "bitcoinpir-pir2-sealed-startup-v1"),
+      runSource,
+      checked,
+    ),
+    /does not bind the profile/u,
+  );
+  assert.throws(
+    () => validatePir2RenderInputsV1(
+      artifactSource,
+      startupSource,
+      runSource.replaceAll("artifact_set_sha256=", "artifact_set_unbound="),
+      checked,
+    ),
+    /missing artifact_set_sha256=/u,
+  );
+  assert.throws(
+    () => validatePir2RenderInputsV1(
+      artifactSource,
+      startupSource,
+      `${runSource}\n--service-storeless-bat-v2-pir1-clearing-key /tmp/plaintext\n`,
+      checked,
+    ),
+    /plaintext or V1 clearing fallback/u,
+  );
+  const reusedRuntimePath = profile();
+  reusedRuntimePath.issuer.classes[1].pir2RuntimePath =
+    reusedRuntimePath.issuer.classes[0].pir2RuntimePath;
+  assert.throws(
+    () => validateSourceProfileV1(reusedRuntimePath),
+    /immutable by exact class digest|duplicate pir2 runtime artifact path/u,
+  );
+});

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -26,9 +26,9 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "1d32d99f837ff0b0579c566bf8015b7ae684c4509856ec9c78a223255780be6a",
+    "4ac1a58416dbf82266852fce7b7e244b2b8e58b22f7f693c0071229206c73745",
   "scripts/dracut/97bpir-tier3-init/unified-server-finish.sh":
-    "06b763099ce2828603763ec45e1cdcec406659a3fb0cd413c28ac85af9cf6444",
+    "361d6a52a2e61482d8e766823a17c3b12187f96805c7e1f9d0f785e27ae64ef9",
   "scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh":
     "571fd7005f5941abaeecdbcf4e363bb0bcd6ff005f471d3d4f0402306c0b8181",
 });
@@ -107,6 +107,14 @@ export const REQUIRED_PREPARATION_FILES = Object.freeze([
   "deploy/payment-v1/db1-free-pow-bat/README.md",
   "deploy/payment-v1/db1-free-pow-bat/pir1-service-policy.toml.in",
   "deploy/payment-v1/db1-free-pow-bat/pir2-service-policy.toml.in",
+  "deploy/payment-v1/bat-v2-source-ready/README.md",
+  "deploy/payment-v1/bat-v2-source-ready/bat-v2-class.toml.in",
+  "deploy/payment-v1/bat-v2-source-ready/provider-accounting-authorization.toml.in",
+  "deploy/payment-v1/bat-v2-source-ready/source-profile.json.in",
+  "deploy/payment-v1/bat-v2-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in",
+  "deploy/payment-v1/bat-v2-source-ready/pir1-storeless-bat-v2-provider.service.in",
+  "deploy/payment-v1/bat-v2-source-ready/pir2-public-artifact-set.env.in",
+  "deploy/payment-v1/bat-v2-source-ready/pir2-sealed-startup.env.in",
   "deploy/payment-v1/directory-relay.toml.example",
   "deploy/payment-v1/relay-selection.toml.example",
   "deploy/payment-v1/edge/README.md",
@@ -2422,6 +2430,62 @@ function requireMeasuredPublicHex(value, flag, label) {
  */
 export function validateVpsbgPremiumFreePowMeasuredFinalExec(text) {
   const label = "VPSBG Premium + Free-PoW measured final exec";
+  if (/^VPSBG_RUNTIME_PROFILE=pir2-snp-sealed-v1$/mu.test(text)) {
+    const logicalLines = measuredShellLogicalLines(text, label);
+    const finalLines = logicalLines.filter((line) =>
+      /^run_pir2_with_public_artifacts exec "\$UNIFIED_SERVER"(?:\s|$)/u.test(line),
+    );
+    if (finalLines.length !== 1 || !finalLines[0].includes("--direct-oram-db")) {
+      fail(`${label} must contain exactly one sealed Direct ORAM final invocation`);
+    }
+    const finalLine = finalLines[0];
+    for (const required of [
+      "--pir2-snp-sealed-require-ready",
+      "--require-service-auth-v1",
+      "--service-policy \"$SERVICE_POLICY_PATH\"",
+      "--service-provider-id-hex \"$PIR2_SEALED_PROVIDER_ID_HEX\"",
+      "--service-policy-key-hex \"$PIR2_SEALED_POLICY_KEY_HEX\"",
+      "--service-storeless-bat-v2-accounting-authorization",
+      "--service-storeless-bat-v2-issuer-approval",
+      "--service-storeless-bat-v2-operator-key-hex",
+      "--service-storeless-bat-v2-issuer-settlement-key-hex",
+      "--service-storeless-bat-v2-minimum-authorization-epoch",
+      "--connection-idle-timeout-ms 300000",
+      "--service-pre-auth-timeout-ms 300000",
+    ]) requireText(finalLine, required, label);
+    for (const [name, value] of [
+      ["PIR2_SEALED_OPERATOR_KEY_HEX", /^PIR2_SEALED_OPERATOR_KEY_HEX=([0-9a-f]{64})$/mu.exec(text)?.[1]],
+      ["PIR2_SEALED_ISSUER_SETTLEMENT_KEY_HEX", /^PIR2_SEALED_ISSUER_SETTLEMENT_KEY_HEX=([0-9a-f]{64})$/mu.exec(text)?.[1]],
+      ["PIR2_SEALED_PROVIDER_ID_HEX", /^PIR2_SEALED_PROVIDER_ID_HEX=([0-9a-f]{64})$/mu.exec(text)?.[1]],
+      ["PIR2_SEALED_POLICY_KEY_HEX", /^PIR2_SEALED_POLICY_KEY_HEX=([0-9a-f]{64})$/mu.exec(text)?.[1]],
+    ]) requireMeasuredPublicHex(value ?? "", name, label);
+    rejectPattern(text, /@[A-Z][A-Z0-9_]*@/u, label, "placeholder value");
+    for (const [pattern, description] of [
+      [/--service-storeless-free-pow-policy-digest-hex/u, "storeless policy digest"],
+      [/--service-remote-rollback-authority-config/u, "remote rollback authority"],
+      [/--service-bat-key/u, "provider-local BAT key"],
+      [/--service-arc-key/u, "provider-local ARC key"],
+      [/--service-store(?:\s|=)/u, "ProviderStore"],
+      [/--service-shared-/u, "V1 shared clearing"],
+      [/--service-storeless-bat-v2-pir1-clearing-key/u, "plaintext pir1 clearing key"],
+    ]) rejectPattern(text, pattern, label, description);
+    for (const [needle, description] of [
+      ["--connection-idle-timeout-ms 300000", "connection idle timeout"],
+      ["--service-pre-auth-timeout-ms 300000", "service pre-auth timeout"],
+    ]) {
+      if (finalLine.split(needle).length !== 2) {
+        fail(`${label} must contain ${description} exactly once in the final invocation`);
+      }
+    }
+    for (const required of [
+      "bitcoinpir-pir2-sealed-startup-v2",
+      "PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH",
+      "artifact_set_sha256=",
+      "--service-storeless-bat-v2-retained-policy",
+      "--service-storeless-bat-v2-class",
+    ]) requireText(text, required, label);
+    return;
+  }
   const execLines = measuredShellLogicalLines(text, label).filter((line) =>
     /^exec\s+"\$UNIFIED_SERVER"(?:\s|$)/u.test(line),
   );
@@ -3146,6 +3210,7 @@ function validateTemplateTreeShape(root) {
       !rel.endsWith(".fragment.in") &&
       !rel.endsWith(".cfg.in") &&
       !rel.endsWith(".conf.in") &&
+      !rel.endsWith(".env.in") &&
       !rel.endsWith(".json.in") &&
       !rel.endsWith(".sh.in") &&
       !rel.endsWith(".toml.in") &&
@@ -3166,6 +3231,25 @@ function validateActiveBaselines(root) {
     const actual = sha256File(absolute);
     if (actual !== expected) {
       fail(`active deployment file changed outside this slice: ${relativePath}`);
+    }
+    if (
+      relativePath === VPSBG_MEASURED_RUN_PATH &&
+      /^VPSBG_RUNTIME_PROFILE=pir2-snp-sealed-v1$/mu.test(text)
+    ) {
+      for (const required of [
+        "bitcoinpir-pir2-sealed-startup-v2",
+        "PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH",
+        "artifact_set_sha256=",
+        "run_pir2_with_public_artifacts exec",
+        "--service-storeless-bat-v2-retained-policy",
+      ]) requireText(text, required, relativePath);
+      rejectPattern(
+        text,
+        /--service-storeless-bat-v2-pir1-clearing-key|--service-shared-(?:clearing|idempotency)/u,
+        relativePath,
+        "plaintext or V1 clearing fallback",
+      );
+      continue;
     }
     if (
       relativePath === VPSBG_MEASURED_RUN_PATH &&

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -13,6 +13,7 @@ import {
   validateBuildManifestV1,
   validateClosedHaproxyConfigV1,
 } from "./payment-v1-directory-public-haproxy-artifact-gate.mjs";
+import { validateRepository as validateBatV2SourceProfileRepository } from "./payment-bat-v2-source-profile-gate.mjs";
 
 export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/pir-primary.service":
@@ -3285,6 +3286,7 @@ export function validateDeploymentTree(rootInput) {
   validateTemplateTreeShape(root);
   validateActiveBaselines(root);
   validatePublisherNetnsTree(root);
+  validateBatV2SourceProfileRepository(root);
 
   const provider = readRequired(
     root,

--- a/scripts/payment-v1-deployment-template-gate.test.mjs
+++ b/scripts/payment-v1-deployment-template-gate.test.mjs
@@ -701,7 +701,7 @@ test("db1 product policies keep every role-local scope on Free-PoW plus shared B
   }
 });
 
-test("VPSBG measured final exec fixes the premium suffix while accepting rendered public keys", () => {
+test("VPSBG measured final exec fixes the sealed BAT V2 suffix while accepting reviewed public keys", () => {
   const measuredRunPath =
     "scripts/dracut/97bpir-tier3-init/unified-server-run.sh";
   const measuredRun = readFileSync(join(REPOSITORY, measuredRunPath), "utf8");
@@ -720,13 +720,13 @@ test("VPSBG measured final exec fixes the premium suffix while accepting rendere
   );
 
   const dpfOnlyRun = measuredRun.replace(
-    "VPSBG_RUNTIME_PROFILE=direct-oram-v1",
+    "VPSBG_RUNTIME_PROFILE=pir2-snp-sealed-v1",
     "VPSBG_RUNTIME_PROFILE=dpf-only-functional-beta-v1",
   );
   assert.notEqual(dpfOnlyRun, measuredRun);
   assert.throws(
     () => validateVpsbgPremiumFreePowMeasuredFinalExec(dpfOnlyRun),
-    /must select the reviewed Direct ORAM runtime profile/,
+    /must contain exactly one db0 DPF-only and one Direct ORAM fallback exec/,
   );
 });
 
@@ -741,7 +741,7 @@ test("VPSBG measured final exec rejects placeholders and forbidden payment mater
   );
   assert.throws(
     () => validateVpsbgPremiumFreePowMeasuredFinalExec(placeholder),
-    /placeholder value/,
+    /non-placeholder 64-hex public value|placeholder value/,
   );
 
   const suffixEnd = [
@@ -781,12 +781,12 @@ test("VPSBG measured final exec rejects placeholders and forbidden payment mater
     );
   }
 
-  const idleLine = "        --connection-idle-timeout-ms 300000 \\";
+  const idleLine = "    --connection-idle-timeout-ms 300000 \\";
   const missingIdleTimeout = measuredRun.replace(idleLine + "\n", "");
   assert.notEqual(missingIdleTimeout, measuredRun);
   assert.throws(
     () => validateVpsbgPremiumFreePowMeasuredFinalExec(missingIdleTimeout),
-    /must contain --connection-idle-timeout-ms exactly once and in canonical order/,
+    /connection idle timeout exactly once|--connection-idle-timeout-ms 300000/,
   );
 });
 

--- a/scripts/payment-v1-deployment-template-gate.test.mjs
+++ b/scripts/payment-v1-deployment-template-gate.test.mjs
@@ -108,6 +108,23 @@ test("repository deployment preparation passes its fail-closed gate", () => {
   assert.equal(validateDeploymentTree(REPOSITORY), true);
 });
 
+test("default deployment gate executes the BAT V2 source-profile validator", () => {
+  withFixture((root) => {
+    mutate(
+      root,
+      "deploy/payment-v1/bat-v2-source-ready/source-profile.json.in",
+      (text) => text.replace(
+        "85bfdd55b1408402bcad886568b732818a32472747226aa009839d45e0b96cac",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ),
+    );
+    assert.throws(
+      () => validateDeploymentTree(root),
+      /provider id does not match measured source constant/u,
+    );
+  });
+});
+
 test("a copied fixture ignores Finder metadata but rejects adjacent unexpected files", () => {
   withFixture((root) => {
     const deploymentRoot = join(root, "deploy/payment-v1");

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -86,16 +86,44 @@ function run(command, args, options = {}) {
   return result;
 }
 
-function writeSealedStartup(root, phase, ordinal = 1) {
+function writeSealedStartup(
+  root,
+  phase,
+  ordinal = 1,
+  servicePolicyPath = path.join(root, "service-policy.bin"),
+) {
+  const retainedPolicyPath = path.join(root, `public/policies/${"47".repeat(32)}.bin`);
+  const currentClassPath = path.join(root, `public/classes/${"43".repeat(32)}.bin`);
+  const retainedClassPath = path.join(root, `public/classes/${"48".repeat(32)}.bin`);
+  const accountingAuthorizationPath = path.join(root, "provider-accounting-authorization.bin");
+  const accountingApprovalPath = path.join(root, "issuer-accounting-approval.bin");
+  if (!existsSync(servicePolicyPath)) write(servicePolicyPath, "fixture current policy\n");
+  write(retainedPolicyPath, "fixture retained policy\n");
+  write(currentClassPath, "fixture current class\n");
+  write(retainedClassPath, "fixture retained class\n");
+  write(accountingAuthorizationPath, "provider-accounting-authorization.bin fixture\n");
+  write(accountingApprovalPath, "issuer-accounting-approval.bin fixture\n");
+  const artifactSet = `schema=bitcoinpir-pir2-bat-v2-public-artifact-set-v1
+current_policy=${"42".repeat(32)}=${sha256(readFileSync(servicePolicyPath))}=${servicePolicyPath}
+retained_policy=${"47".repeat(32)}=${sha256(readFileSync(retainedPolicyPath))}=${retainedPolicyPath}
+current_class=${"43".repeat(32)}=${sha256(readFileSync(currentClassPath))}=${currentClassPath}
+retained_class=${"48".repeat(32)}=${sha256(readFileSync(retainedClassPath))}=${retainedClassPath}
+accounting_authorization=${"49".repeat(32)}=${sha256(readFileSync(accountingAuthorizationPath))}=${accountingAuthorizationPath}
+accounting_approval=${"4a".repeat(32)}=${sha256(readFileSync(accountingApprovalPath))}=${accountingApprovalPath}
+`;
+  const artifactSetPath = path.join(root, "public-artifact-set.env");
+  write(artifactSetPath, artifactSet);
   write(
     path.join(root, "startup.env"),
-    `schema=bitcoinpir-pir2-sealed-startup-v1
+    `schema=bitcoinpir-pir2-sealed-startup-v2
 profile=pir2-snp-sealed-v1
 phase=${phase}
 ordinal=${ordinal}
 verifier_nonce_hex=${"41".repeat(32)}
 current_policy_digest_hex=${"42".repeat(32)}
 class_digest_hex=${"43".repeat(32)}
+artifact_set_path=${artifactSetPath}
+artifact_set_sha256=${sha256(artifactSet)}
 minimum_authorization_epoch=7
 `,
   );
@@ -109,11 +137,12 @@ function authoritativeAttemptToken({
   nonce = "41".repeat(32),
   policy = "42".repeat(32),
   classDigest = "43".repeat(32),
+  artifactSetSha256 = "49".repeat(32),
   minimumAuthorizationEpoch = 7,
   receiptProtocolDigest = "44".repeat(32),
   receiptFileSha256 = "45".repeat(32),
 }) {
-  return `schema=bitcoinpir-pir2-sealed-authoritative-attempt-v1
+  return `schema=bitcoinpir-pir2-sealed-authoritative-attempt-v2
 kind=${kind}
 phase=${phase}
 boot_id=${bootIdHex}
@@ -121,6 +150,7 @@ ordinal=${ordinal}
 verifier_nonce_hex=${nonce}
 current_policy_digest_hex=${policy}
 class_digest_hex=${classDigest}
+artifact_set_sha256=${artifactSetSha256}
 minimum_authorization_epoch=${minimumAuthorizationEpoch}
 receipt_protocol_digest=${receiptProtocolDigest}
 receipt_file_sha256=${receiptFileSha256}
@@ -157,8 +187,13 @@ try {
   assert.match(tier3RunText, /ready-runtime-\$PIR2_BOOT_ID_HEX\.bin/);
   assert.match(
     tier3RunText,
-    /--pir2-snp-sealed-require-ready[\s\S]*--service-storeless-bat-v2-policy-digest-hex/,
-    "final serving must use sealed Ready plus the payment-storeless BAT V2 profile",
+    /validate_pir2_public_artifact_set[\s\S]*run_pir2_with_public_artifacts exec[\s\S]*--pir2-snp-sealed-require-ready/,
+    "final serving must use sealed Ready plus the validated public BAT V2 artifact set",
+  );
+  assert.match(
+    tier3RunText,
+    /run_pir2_with_public_artifacts\(\)[\s\S]*--service-storeless-bat-v2-policy-digest-hex[\s\S]*--service-storeless-bat-v2-retained-policy[\s\S]*--service-storeless-bat-v2-class/,
+    "the bounded artifact runner must project current, retained, and class flags",
   );
   assert.doesNotMatch(
     tier3ModuleSetupText,
@@ -471,7 +506,7 @@ exit 0
   createProofV1(mismatchData, "proof-v1-db0");
   createProofV1(mismatchData, "proof-v1-db1");
   write(path.join(mismatchData, "proof-v2-db0/server-db/MANIFEST.toml"), "proof manifest\n");
-  writeSealedStartup(path.join(mismatchData, "pir2-sealed"), "ready");
+  writeSealedStartup(path.join(mismatchData, "pir2-sealed"), "ready", 1, mismatchServicePolicy);
   write(
     path.join(mismatchData, "databases.toml"),
     `[[database]]\nname = "main"\ntype = "full"\npath = "runtime-db0"\nproof_dir = "proof-v1-db0"\nproof_v2_dir = "proof-v2-db0"\nbase_height = 0\nheight = 948454\n\n[[database]]\nname = "delta"\ntype = "delta"\npath = "runtime-db1"\nproof_dir = "proof-v1-db1"\nproof_v2_dir = "proof-v2-db1"\nbase_height = 940611\nheight = 948454\n`,
@@ -555,7 +590,7 @@ exit 0
   const directSealedRoot = path.join(directData, "pir2-sealed");
   write(directServicePolicy, "fixture policy\n");
   write(directSwaps, "Filename\tType\tSize\tUsed\tPriority\n");
-  writeSealedStartup(directSealedRoot, "ready");
+  writeSealedStartup(directSealedRoot, "ready", 1, directServicePolicy);
   for (const relative of [
     "release.bin",
     "credentials.envelope.bin",
@@ -740,6 +775,11 @@ exit 1
   assert.match(finalArgs, /--direct-oram-db\n1=.*db1-delta-940611-948454/);
   assert.match(finalArgs, /--pir2-snp-sealed-require-ready/);
   assert.match(finalArgs, /--service-storeless-bat-v2-policy-digest-hex/);
+  assert.equal(
+    (finalArgs.match(/--service-storeless-bat-v2-retained-policy/g) ?? []).length,
+    1,
+  );
+  assert.equal((finalArgs.match(/--service-storeless-bat-v2-class/g) ?? []).length, 2);
   assert.doesNotMatch(finalArgs, /(?:--identity-key-path|--service-shared-clearing-key|--service-storeless-bat-v2-pir1-clearing-key)/);
   assert.deepEqual(
     readFileSync(directEvents, "utf8").trim().split("\n").map((event) =>
@@ -777,6 +817,17 @@ exit 1
   );
   const readyPreflightTokenText = readFileSync(readyPreflightToken, "utf8");
   assert.match(readyPreflightTokenText, /kind=ready-preflight\nphase=ready\n/);
+  const directArtifactSet = path.join(directSealedRoot, "public-artifact-set.env");
+  assert.match(
+    readyPreflightTokenText,
+    new RegExp(`artifact_set_sha256=${sha256(readFileSync(directArtifactSet))}`),
+  );
+  const trustedArtifactSet = path.join(
+    directEnv.BPIR_PIR2_SNP_SEALED_ATTEMPT_ROOT,
+    `public-artifact-set-${firstBootHex}.env`,
+  );
+  assert.equal(readFileSync(trustedArtifactSet, "utf8"), readFileSync(directArtifactSet, "utf8"));
+  assert.equal(statSync(trustedArtifactSet).mode & 0o777, 0o600);
   assert.match(
     readyPreflightTokenText,
     new RegExp(`receipt_file_sha256=${sha256(readFileSync(readyPreflightReceipt))}`),


### PR DESCRIPTION
## What changed

- add a versioned BAT V2 source manifest for the issuer, pir1 storeless provider and pir2 SNP-sealed provider
- add inert issuer and pir1 systemd source templates with exact current/retained policy, class and current accounting inputs
- extend the measured pir2 Ready path to validate a bounded canonical public artifact set, bind its SHA-256 to current-boot attempt tokens, and pass exact retained policy/class arguments in both preflight and final execution
- add a dedicated source-profile validator and wire it into the existing deployment gate

## Safety properties

The provider profiles reject ProviderStore, payment rollback, V1 shared/idempotency, Direct receipt, Standard Cashu, ARC and V1 BAT inputs. pir1 is the only plaintext clearing-key role; pir2 accepts only the sealed Ready key. The gate enforces one issuer class signer, fresh BAT key IDs and secret paths, aligned accounting triples, exact policy/class coverage, measured pir2 identity/key pins, canonical bounded artifact sets and role-key separation.

These are inert source/render inputs. This PR does not materialize private keys, build a UKI, upload or switch a VPSBG image, provision funds, install a unit or activate production.

## Validation

- source plus Tier3 focused suite: 14 passed
- deployment template gate suite: 32 passed
- pir2 Tier3 generation fixture: passed
- `sh -n` on measured run and finish scripts
- `git diff --check`

Independent P0/P1 review initially found four gate defects; all were fixed and the follow-up review passed.