### PR TITLE
feat(deploy): add BAT V2 genesis source profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,13 @@ deploy/payment-v1/bat-v2-source-ready/*
 !deploy/payment-v1/bat-v2-source-ready/pir1-storeless-bat-v2-provider.service.in
 !deploy/payment-v1/bat-v2-source-ready/pir2-public-artifact-set.env.in
 !deploy/payment-v1/bat-v2-source-ready/pir2-sealed-startup.env.in
+!deploy/payment-v1/bat-v2-genesis-source-ready/
+deploy/payment-v1/bat-v2-genesis-source-ready/*
+!deploy/payment-v1/bat-v2-genesis-source-ready/source-profile.json.in
+!deploy/payment-v1/bat-v2-genesis-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in
+!deploy/payment-v1/bat-v2-genesis-source-ready/pir1-storeless-bat-v2-provider.service.in
+!deploy/payment-v1/bat-v2-genesis-source-ready/pir2-public-artifact-set.env.in
+!deploy/payment-v1/bat-v2-genesis-source-ready/pir2-sealed-startup.env.in
 !deploy/payment-v1/systemd/
 deploy/payment-v1/systemd/*
 !deploy/payment-v1/systemd/bhtm-caddy.directory-public-edge.conf.in

--- a/deploy/payment-v1/bat-v2-genesis-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in
+++ b/deploy/payment-v1/bat-v2-genesis-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in
@@ -1,0 +1,72 @@
+# Inert BAT V2 genesis source-profile template. Rendering and activation are separate approvals.
+[Unit]
+Description=BitcoinPIR Mainnet Lightning BAT V2 genesis issuer (source template only)
+After=network-online.target bitcoinpir-mainnet-lightning-v1-core.service bitcoinpir-mainnet-lightning-v1-preflight.service bitcoinpir-mainnet-lightning-v1-cln-rpc-guard.service
+Wants=network-online.target
+Requisite=bitcoinpir-mainnet-lightning-v1-core.service
+Requires=bitcoinpir-mainnet-lightning-v1-preflight.service bitcoinpir-mainnet-lightning-v1-cln-rpc-guard.service
+BindsTo=bitcoinpir-mainnet-lightning-v1-preflight.service bitcoinpir-mainnet-lightning-v1-cln-rpc-guard.service
+ConditionPathExists=/etc/bitcoinpir/payment-v1/BAT-V2-SOURCE-PROFILE-RENDERED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/MAINNET-BAT-V2-ACTIVATION-APPROVED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/LIGHTNING-CUSTODY-APPROVED
+
+[Service]
+Type=simple
+User=bitcoinpir-mainnet-issuer
+Group=bitcoinpir-mainnet-issuer
+UMask=0077
+StateDirectory=bitcoinpir-mainnet-bat-v2-issuer
+StateDirectoryMode=0700
+WorkingDirectory=/var/lib/bitcoinpir-mainnet-bat-v2-issuer
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@/payment-issuer
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/bat-v2/issuer/payment-issuer.sha256
+ExecStart=/opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@/payment-issuer serve-cln \
+    --bind 127.0.0.1:5610 \
+    --max-connections 128 \
+    --allow-origin @BITCOINPIR_WEB_ORIGIN@ \
+    --store /var/lib/bitcoinpir-mainnet-bat-v2-issuer/issuer.sqlite3 \
+    --remote-rollback-authority-config /etc/bitcoinpir/payment-v1/bat-v2/issuer/remote-rollback-authority.toml \
+    --quote-delegation /etc/bitcoinpir/payment-v1/mainnet-lightning-v1/quote-delegation.bin \
+    --quote-signing-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/quote-signing.key \
+    --credential-derivation-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/credential-derivation.key \
+    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-current.bin=@PIR1_POLICY_VERIFYING_KEY_HEX@ \
+    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-current.bin=73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5 \
+    --bat-v2-class /etc/bitcoinpir/payment-v1/bat-v2/public/classes/current.bin \
+    --bat-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/bat-current.key \
+    --bat-v2-accounting-authorization /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-authorization.bin \
+    --bat-v2-accounting-approval /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-approval.bin \
+    --bat-v2-accounting-operator-verifying-key /etc/bitcoinpir/payment-v1/bat-v2/public/keys/pir1-operator-verifying.key \
+    --bat-v2-accounting-authorization /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir2-authorization.bin \
+    --bat-v2-accounting-approval /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir2-approval.bin \
+    --bat-v2-accounting-operator-verifying-key /etc/bitcoinpir/payment-v1/bat-v2/public/keys/pir2-operator-verifying.key \
+    --issuer-settlement-signing-key /etc/bitcoinpir/payment-v1/bat-v2/issuer/issuer-settlement-signing.key \
+    --cln-rpc-socket /run/bitcoinpir-mainnet-cln-rpc-guard/issuer/issuer-rpc \
+    --cln-rpc-expected-uid @CLN_GUARD_UID@ \
+    --cln-rpc-expected-gid @ISSUER_GID@ \
+    --cln-rpc-timeout-seconds 10
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/bat-v2 /etc/bitcoinpir/payment-v1/mainnet-lightning-v1 /run/bitcoinpir-mainnet-cln-rpc-guard/issuer /opt/bitcoinpir/payment-issuer/@PAYMENT_ISSUER_SHA256@
+ReadWritePaths=/var/lib/bitcoinpir-mainnet-bat-v2-issuer
+InaccessiblePaths=-/srv/lightning -/srv/bitcoin -/run/bitcoinpir-source-fair-edge
+
+# No [Install] section: this checked-in file is not an activation artifact.

--- a/deploy/payment-v1/bat-v2-genesis-source-ready/pir1-storeless-bat-v2-provider.service.in
+++ b/deploy/payment-v1/bat-v2-genesis-source-ready/pir1-storeless-bat-v2-provider.service.in
@@ -1,0 +1,76 @@
+# Inert BAT V2 genesis source-profile template. pir1 is the only plaintext clearing-key role.
+[Unit]
+Description=BitcoinPIR pir1 storeless BAT V2 genesis provider (source template only)
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/etc/bitcoinpir/payment-v1/BAT-V2-SOURCE-PROFILE-RENDERED
+ConditionPathExists=/etc/bitcoinpir/payment-v1/PIR1-BAT-V2-ACTIVATION-APPROVED
+
+[Service]
+Type=simple
+User=bitcoinpir-pir1-bat-v2
+Group=bitcoinpir-pir1-bat-v2
+UMask=0077
+StateDirectory=bitcoinpir-pir1-bat-v2
+StateDirectoryMode=0700
+WorkingDirectory=/var/lib/bitcoinpir-pir1-bat-v2
+ExecStartPre=/usr/bin/test -x /opt/bitcoinpir/unified-server/@UNIFIED_SERVER_SHA256@/unified_server
+ExecStartPre=/usr/bin/sha256sum --check --strict /etc/bitcoinpir/payment-v1/bat-v2/pir1/unified-server.sha256
+ExecStart=/opt/bitcoinpir/unified-server/@UNIFIED_SERVER_SHA256@/unified_server \
+    --bind-address 127.0.0.1 \
+    --port 8191 \
+    --role primary \
+    --serve-hints \
+    --serve-queries \
+    --pool-size 8 \
+    --pool-dir /var/lib/bitcoinpir-pir1-bat-v2/hint-pool \
+    --config /etc/bitcoinpir/payment-v1/bat-v2/pir1/databases.toml \
+    --identity-key-path /etc/bitcoinpir/payment-v1/bat-v2/pir1/provider-identity.key \
+    --identity-cert-path /etc/bitcoinpir/payment-v1/bat-v2/pir1/provider-identity.cert \
+    --identity-server-id @PIR1_PROVIDER_SERVER_ID@ \
+    --require-service-auth-v1 \
+    --service-policy /etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-current.bin \
+    --service-provider-id-hex @PIR1_PROVIDER_ID_HEX@ \
+    --service-policy-key-hex @PIR1_POLICY_VERIFYING_KEY_HEX@ \
+    --service-storeless-bat-v2-policy-digest-hex @PIR1_CURRENT_POLICY_DIGEST_HEX@ \
+    --service-storeless-bat-v2-class @BAT_V2_CURRENT_CLASS_DIGEST_HEX@=/etc/bitcoinpir/payment-v1/bat-v2/public/classes/current.bin \
+    --service-storeless-bat-v2-accounting-authorization /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-authorization.bin \
+    --service-storeless-bat-v2-issuer-approval /etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-approval.bin \
+    --service-storeless-bat-v2-operator-key-hex @PIR1_OPERATOR_VERIFYING_KEY_HEX@ \
+    --service-storeless-bat-v2-issuer-settlement-key-hex 248df8866b89b05dbb5d1a2ebec398e4281d9f0e152073570965cd2fbdc422b7 \
+    --service-storeless-bat-v2-pir1-clearing-key /etc/bitcoinpir/payment-v1/bat-v2/pir1/clearing-signing.key \
+    --service-storeless-bat-v2-minimum-authorization-epoch @PIR1_MINIMUM_AUTHORIZATION_EPOCH@ \
+    --max-connections 128 \
+    --service-max-concurrent-auth 16 \
+    --service-max-concurrent-online-v2full-auth 4 \
+    --websocket-handshake-timeout-ms 10000 \
+    --connection-idle-timeout-ms 30000 \
+    --service-pre-auth-timeout-ms 60000
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+LimitNOFILE=65535
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+ReadOnlyPaths=/etc/bitcoinpir/payment-v1/bat-v2 /opt/bitcoinpir/unified-server/@UNIFIED_SERVER_SHA256@
+ReadWritePaths=/var/lib/bitcoinpir-pir1-bat-v2
+InaccessiblePaths=-/run/bitcoinpir-source-fair-edge
+
+# No ProviderStore, rollback, V1 shared/idempotency, Direct receipt, Standard
+# Cashu, ARC, or V1 BAT input is present. No [Install] section is provided.

--- a/deploy/payment-v1/bat-v2-genesis-source-ready/pir2-public-artifact-set.env.in
+++ b/deploy/payment-v1/bat-v2-genesis-source-ready/pir2-public-artifact-set.env.in
@@ -1,0 +1,5 @@
+schema=bitcoinpir-pir2-bat-v2-public-artifact-set-v1
+current_policy=@PIR2_CURRENT_POLICY_DIGEST_HEX@=@PIR2_CURRENT_POLICY_FILE_SHA256_HEX@=/etc/bitcoinpir/payment/service-policy.bin
+current_class=@BAT_V2_CURRENT_CLASS_DIGEST_HEX@=@BAT_V2_CURRENT_CLASS_FILE_SHA256_HEX@=/home/pir/data/pir2-sealed/public/classes/@BAT_V2_CURRENT_CLASS_DIGEST_HEX@.bin
+accounting_authorization=@PIR2_ACCOUNTING_AUTHORIZATION_DIGEST_HEX@=@PIR2_ACCOUNTING_AUTHORIZATION_FILE_SHA256_HEX@=/home/pir/data/pir2-sealed/provider-accounting-authorization.bin
+accounting_approval=@PIR2_ACCOUNTING_APPROVAL_DIGEST_HEX@=@PIR2_ACCOUNTING_APPROVAL_FILE_SHA256_HEX@=/home/pir/data/pir2-sealed/issuer-accounting-approval.bin

--- a/deploy/payment-v1/bat-v2-genesis-source-ready/pir2-sealed-startup.env.in
+++ b/deploy/payment-v1/bat-v2-genesis-source-ready/pir2-sealed-startup.env.in
@@ -1,0 +1,10 @@
+schema=bitcoinpir-pir2-sealed-startup-v2
+profile=pir2-snp-sealed-v1
+phase=@PIR2_SEALED_PHASE@
+ordinal=@PIR2_SEALED_ORDINAL@
+verifier_nonce_hex=@PIR2_SEALED_VERIFIER_NONCE_HEX@
+current_policy_digest_hex=@PIR2_CURRENT_POLICY_DIGEST_HEX@
+class_digest_hex=@BAT_V2_CURRENT_CLASS_DIGEST_HEX@
+artifact_set_path=/home/pir/data/pir2-sealed/public-artifact-set.env
+artifact_set_sha256=@PIR2_PUBLIC_ARTIFACT_SET_SHA256_HEX@
+minimum_authorization_epoch=@PIR2_MINIMUM_AUTHORIZATION_EPOCH@

--- a/deploy/payment-v1/bat-v2-genesis-source-ready/source-profile.json.in
+++ b/deploy/payment-v1/bat-v2-genesis-source-ready/source-profile.json.in
@@ -1,0 +1,113 @@
+{
+  "schema": "bitcoinpir-bat-v2-public-genesis-source-profile-v1",
+  "profile": "issuer-pir1-pir2-storeless-genesis-v1",
+  "issuer": {
+    "issuerIdHex": "@BAT_V2_ISSUER_ID_HEX@",
+    "settlementVerifyingKeyHex": "248df8866b89b05dbb5d1a2ebec398e4281d9f0e152073570965cd2fbdc422b7",
+    "settlementSigningKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/issuer/issuer-settlement-signing.key",
+    "unitPath": "deploy/payment-v1/bat-v2-genesis-source-ready/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in",
+    "policies": [
+      {
+        "state": "current",
+        "provider": "pir1",
+        "digestHex": "@PIR1_CURRENT_POLICY_DIGEST_HEX@",
+        "fileSha256Hex": "@PIR1_CURRENT_POLICY_FILE_SHA256_HEX@",
+        "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir1-current.bin",
+        "verifyingKeyHex": "@PIR1_POLICY_VERIFYING_KEY_HEX@",
+        "scopeIdHex": "@PIR1_CURRENT_SCOPE_ID_HEX@",
+        "offerId": "@PIR1_CURRENT_OFFER_ID@"
+      },
+      {
+        "state": "current",
+        "provider": "pir2",
+        "digestHex": "@PIR2_CURRENT_POLICY_DIGEST_HEX@",
+        "fileSha256Hex": "@PIR2_CURRENT_POLICY_FILE_SHA256_HEX@",
+        "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/policies/pir2-current.bin",
+        "pir2RuntimePath": "/etc/bitcoinpir/payment/service-policy.bin",
+        "verifyingKeyHex": "73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5",
+        "scopeIdHex": "@PIR2_CURRENT_SCOPE_ID_HEX@",
+        "offerId": "@PIR2_CURRENT_OFFER_ID@"
+      }
+    ],
+    "classes": [
+      {
+        "state": "current",
+        "classIdHex": "@BAT_V2_CURRENT_CLASS_ID_HEX@",
+        "keyEpoch": "@BAT_V2_CURRENT_CLASS_KEY_EPOCH@",
+        "digestHex": "@BAT_V2_CURRENT_CLASS_DIGEST_HEX@",
+        "fileSha256Hex": "@BAT_V2_CURRENT_CLASS_FILE_SHA256_HEX@",
+        "path": "/etc/bitcoinpir/payment-v1/bat-v2/public/classes/current.bin",
+        "pir2RuntimePath": "/home/pir/data/pir2-sealed/public/classes/@BAT_V2_CURRENT_CLASS_DIGEST_HEX@.bin",
+        "classVerifyingKeyHex": "@BAT_V2_CLASS_VERIFYING_KEY_HEX@",
+        "batKeyIdHex": "@BAT_V2_CURRENT_KEY_ID_HEX@",
+        "batSigningKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/issuer/bat-current.key",
+        "memberPolicyDigestsHex": [
+          "@PIR1_CURRENT_POLICY_DIGEST_HEX@",
+          "@PIR2_CURRENT_POLICY_DIGEST_HEX@"
+        ]
+      }
+    ],
+    "accounting": [
+      {
+        "provider": "pir1",
+        "authorizationDigestHex": "@PIR1_ACCOUNTING_AUTHORIZATION_DIGEST_HEX@",
+        "authorizationFileSha256Hex": "@PIR1_ACCOUNTING_AUTHORIZATION_FILE_SHA256_HEX@",
+        "authorizationPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-authorization.bin",
+        "approvalDigestHex": "@PIR1_ACCOUNTING_APPROVAL_DIGEST_HEX@",
+        "approvalFileSha256Hex": "@PIR1_ACCOUNTING_APPROVAL_FILE_SHA256_HEX@",
+        "approvalPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir1-approval.bin",
+        "operatorVerifyingKeyHex": "@PIR1_OPERATOR_VERIFYING_KEY_HEX@",
+        "operatorVerifyingKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/keys/pir1-operator-verifying.key",
+        "minimumAuthorizationEpoch": "@PIR1_MINIMUM_AUTHORIZATION_EPOCH@"
+      },
+      {
+        "provider": "pir2",
+        "authorizationDigestHex": "@PIR2_ACCOUNTING_AUTHORIZATION_DIGEST_HEX@",
+        "authorizationFileSha256Hex": "@PIR2_ACCOUNTING_AUTHORIZATION_FILE_SHA256_HEX@",
+        "authorizationPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir2-authorization.bin",
+        "approvalDigestHex": "@PIR2_ACCOUNTING_APPROVAL_DIGEST_HEX@",
+        "approvalFileSha256Hex": "@PIR2_ACCOUNTING_APPROVAL_FILE_SHA256_HEX@",
+        "approvalPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/accounting/pir2-approval.bin",
+        "pir2AuthorizationPath": "/home/pir/data/pir2-sealed/provider-accounting-authorization.bin",
+        "pir2ApprovalPath": "/home/pir/data/pir2-sealed/issuer-accounting-approval.bin",
+        "operatorVerifyingKeyHex": "7ecb7900928f30efbf548a13c8d0b4fff5a580c7a145b003866580e42d9dc9cb",
+        "operatorVerifyingKeyPath": "/etc/bitcoinpir/payment-v1/bat-v2/public/keys/pir2-operator-verifying.key",
+        "minimumAuthorizationEpoch": "@PIR2_MINIMUM_AUTHORIZATION_EPOCH@"
+      }
+    ]
+  },
+  "providers": [
+    {
+      "name": "pir1",
+      "providerIdHex": "@PIR1_PROVIDER_ID_HEX@",
+      "policyVerifyingKeyHex": "@PIR1_POLICY_VERIFYING_KEY_HEX@",
+      "clearingKeySource": "plaintext-pir1",
+      "clearingVerifyingKeyHex": "@PIR1_CLEARING_VERIFYING_KEY_HEX@",
+      "currentPolicyDigestHex": "@PIR1_CURRENT_POLICY_DIGEST_HEX@",
+      "retainedPolicyDigestsHex": [],
+      "classDigestsHex": ["@BAT_V2_CURRENT_CLASS_DIGEST_HEX@"],
+      "accountingAuthorizationDigestHex": "@PIR1_ACCOUNTING_AUTHORIZATION_DIGEST_HEX@",
+      "accountingApprovalDigestHex": "@PIR1_ACCOUNTING_APPROVAL_DIGEST_HEX@",
+      "operatorVerifyingKeyHex": "@PIR1_OPERATOR_VERIFYING_KEY_HEX@",
+      "minimumAuthorizationEpoch": "@PIR1_MINIMUM_AUTHORIZATION_EPOCH@",
+      "renderPath": "deploy/payment-v1/bat-v2-genesis-source-ready/pir1-storeless-bat-v2-provider.service.in"
+    },
+    {
+      "name": "pir2",
+      "providerIdHex": "85bfdd55b1408402bcad886568b732818a32472747226aa009839d45e0b96cac",
+      "policyVerifyingKeyHex": "73c5889ee3bb11b79a7628bad1aa24be927f6e047abadd6dd6ce38e45bb0cfd5",
+      "clearingKeySource": "snp-sealed-ready",
+      "clearingVerifyingKeyHex": "@PIR2_CLEARING_VERIFYING_KEY_HEX@",
+      "currentPolicyDigestHex": "@PIR2_CURRENT_POLICY_DIGEST_HEX@",
+      "retainedPolicyDigestsHex": [],
+      "classDigestsHex": ["@BAT_V2_CURRENT_CLASS_DIGEST_HEX@"],
+      "accountingAuthorizationDigestHex": "@PIR2_ACCOUNTING_AUTHORIZATION_DIGEST_HEX@",
+      "accountingApprovalDigestHex": "@PIR2_ACCOUNTING_APPROVAL_DIGEST_HEX@",
+      "operatorVerifyingKeyHex": "7ecb7900928f30efbf548a13c8d0b4fff5a580c7a145b003866580e42d9dc9cb",
+      "minimumAuthorizationEpoch": "@PIR2_MINIMUM_AUTHORIZATION_EPOCH@",
+      "renderPath": "scripts/dracut/97bpir-tier3-init/unified-server-run.sh",
+      "artifactSetPath": "deploy/payment-v1/bat-v2-genesis-source-ready/pir2-public-artifact-set.env.in",
+      "startupPath": "deploy/payment-v1/bat-v2-genesis-source-ready/pir2-sealed-startup.env.in"
+    }
+  ]
+}

--- a/deploy/payment-v1/bat-v2-source-ready/README.md
+++ b/deploy/payment-v1/bat-v2-source-ready/README.md
@@ -39,6 +39,17 @@ continuity contract, not permission to fabricate history: retained entries
 must be real, previously issued canonical artifacts. A deployment with no real
 retained epoch stays blocked until a new profile version explicitly permits it.
 
+## First production epoch
+
+`../bat-v2-genesis-source-ready/` is the only versioned first-epoch profile.
+Its distinct `bitcoinpir-bat-v2-public-genesis-source-profile-v1` schema permits
+exactly two current policies, one current class covering both providers, and
+empty `retainedPolicyDigestsHex` arrays. It retains the same issuer, role/path,
+accounting, pir1 plaintext-clearing, and pir2 sealed-Ready constraints as the
+rotation profile. It is only for a first real production epoch: after an epoch
+exists, every subsequent render must use this directory's retained-material
+rotation profile. Neither profile permits invented retained artifacts.
+
 The schema accepts at most eight retained policies per provider and eight
 retained classes. Every pir2 retained artifact has its own digest-derived
 immutable runtime path and file SHA-256; the canonical artifact-set file is

--- a/scripts/payment-bat-v2-source-profile-gate.mjs
+++ b/scripts/payment-bat-v2-source-profile-gate.mjs
@@ -5,7 +5,9 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 export const PROFILE_SCHEMA = "bitcoinpir-bat-v2-public-source-profile-v1";
+export const GENESIS_PROFILE_SCHEMA = "bitcoinpir-bat-v2-public-genesis-source-profile-v1";
 const SOURCE_ROOT = "deploy/payment-v1/bat-v2-source-ready";
+const GENESIS_SOURCE_ROOT = "deploy/payment-v1/bat-v2-genesis-source-ready";
 const MAX_RETAINED_PER_PROVIDER = 8;
 const MAX_POLICIES = 2 + (2 * MAX_RETAINED_PER_PROVIDER);
 const MAX_RETAINED_CLASSES = 8;
@@ -212,10 +214,10 @@ function validateAccounting(value, index, seenPaths) {
   }
 }
 
-export function validateSourceProfileV1(profile) {
+function validateSourceProfile(profile, definition) {
   exactKeys(profile, ["schema", "profile", "issuer", "providers"], "profile");
-  if (profile.schema !== PROFILE_SCHEMA) fail(`profile.schema must equal ${PROFILE_SCHEMA}`);
-  if (profile.profile !== "issuer-pir1-pir2-storeless-v1") fail("profile.profile is unsupported");
+  if (profile.schema !== definition.schema) fail(`profile.schema must equal ${definition.schema}`);
+  if (profile.profile !== definition.profile) fail("profile.profile is unsupported");
   exactKeys(profile.issuer, [
     "issuerIdHex", "settlementVerifyingKeyHex", "settlementSigningKeyPath", "unitPath",
     "policies", "classes", "accounting",
@@ -223,7 +225,7 @@ export function validateSourceProfileV1(profile) {
   requireHexOrPlaceholder(profile.issuer.issuerIdHex, "issuer.issuerIdHex");
   requireHexOrPlaceholder(profile.issuer.settlementVerifyingKeyHex, "issuer.settlementVerifyingKeyHex");
   requireAbsolutePath(profile.issuer.settlementSigningKeyPath, "/etc/bitcoinpir/payment-v1/bat-v2/issuer", "issuer.settlementSigningKeyPath");
-  if (profile.issuer.unitPath !== `${SOURCE_ROOT}/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in`) {
+  if (profile.issuer.unitPath !== `${definition.sourceRoot}/issuer-lightning-mainnet-bat-v2-payment-issuer.service.in`) {
     fail("issuer.unitPath is outside the versioned source profile");
   }
 
@@ -231,14 +233,20 @@ export function validateSourceProfileV1(profile) {
   const seenPaths = new Set();
   const seenSecretPaths = new Set();
   addUnique(seenSecretPaths, profile.issuer.settlementSigningKeyPath, "private signing-key path");
-  const policies = arrayBounded(profile.issuer.policies, 4, MAX_POLICIES, "issuer.policies");
+  const policies = arrayBounded(profile.issuer.policies, definition.minimumPolicies, MAX_POLICIES, "issuer.policies");
   policies.forEach((value, index) => validatePolicy(value, index, seenDigests, seenPaths));
+  if (!definition.requiresRetained && policies.some((value) => value.state === "retained")) {
+    fail("genesis issuer must not contain retained policy material");
+  }
   const policyDigests = new Set(policies.map((policy) => policy.digestHex));
   const coverage = new Map();
-  const classes = arrayBounded(profile.issuer.classes, 2, MAX_CLASSES, "issuer.classes");
+  const classes = arrayBounded(profile.issuer.classes, definition.minimumClasses, MAX_CLASSES, "issuer.classes");
   classes.forEach((value, index) => validateClass(
     value, index, policyDigests, seenDigests, seenPaths, seenSecretPaths, coverage,
   ));
+  if (!definition.requiresRetained && classes.some((value) => value.state === "retained")) {
+    fail("genesis issuer must not contain retained class material");
+  }
   const classCoordinates = new Set();
   for (const entry of classes) {
     addUnique(classCoordinates, `${entry.classIdHex}:${entry.keyEpoch}`, "class coordinate");
@@ -247,11 +255,11 @@ export function validateSourceProfileV1(profile) {
     if (!coverage.has(digest)) fail(`policy ${digest} must be covered by at least one configured class`);
   }
   if (classes.filter((value) => value.state === "current").length !== 1) fail("issuer must have exactly one current class");
-  if (!classes.some((value) => value.state === "retained")) fail("issuer must have retained class material");
-  requireStrictOrder(
-    classes.filter((value) => value.state === "retained").map((value) => value.digestHex),
-    "issuer retained classes",
-  );
+  const retainedClasses = classes.filter((value) => value.state === "retained");
+  if (definition.requiresRetained) {
+    if (retainedClasses.length === 0) fail("issuer must have retained class material");
+    requireStrictOrder(retainedClasses.map((value) => value.digestHex), "issuer retained classes");
+  }
 
   const accounting = arrayBounded(profile.issuer.accounting, 2, 2, "issuer.accounting");
   accounting.forEach((value, index) => validateAccounting(value, index, seenPaths));
@@ -299,8 +307,6 @@ export function validateSourceProfileV1(profile) {
     const current = providerPolicies.filter((policy) => policy.state === "current");
     const retained = providerPolicies.filter((policy) => policy.state === "retained");
     if (current.length !== 1) fail(`${label} must have exactly one current signed policy`);
-    arrayBounded(retained, 1, MAX_RETAINED_PER_PROVIDER, `${label} retained policies`);
-    requireStrictOrder(retained.map((policy) => policy.digestHex), `${label} retained policies`);
     if (providerPolicies.some((policy) => policy.verifyingKeyHex !== provider.policyVerifyingKeyHex)) {
       fail(`${label} policy verifying key is inconsistent with its signed-policy set`);
     }
@@ -325,18 +331,46 @@ export function validateSourceProfileV1(profile) {
       if (roleKeys.has(key)) fail(`raw/public role-key reuse between ${roleKeys.get(key)} and ${role}`);
       roleKeys.set(key, role);
     }
+    if (definition.requiresRetained) {
+      arrayBounded(retained, 1, MAX_RETAINED_PER_PROVIDER, `${label} retained policies`);
+      requireStrictOrder(retained.map((policy) => policy.digestHex), `${label} retained policies`);
+    } else if (retained.length !== 0) {
+      fail(`${label} genesis profile must not contain retained policies`);
+    }
     const expectedRender = provider.name === "pir1"
-      ? `${SOURCE_ROOT}/pir1-storeless-bat-v2-provider.service.in`
+      ? `${definition.sourceRoot}/pir1-storeless-bat-v2-provider.service.in`
       : "scripts/dracut/97bpir-tier3-init/unified-server-run.sh";
     if (provider.renderPath !== expectedRender) fail(`${label}.renderPath is unsupported`);
     if (provider.name === "pir2") {
-      if (provider.artifactSetPath !== `${SOURCE_ROOT}/pir2-public-artifact-set.env.in`
-        || provider.startupPath !== `${SOURCE_ROOT}/pir2-sealed-startup.env.in`) {
+      if (provider.artifactSetPath !== `${definition.sourceRoot}/pir2-public-artifact-set.env.in`
+        || provider.startupPath !== `${definition.sourceRoot}/pir2-sealed-startup.env.in`) {
         fail("pir2 render inputs must use the reviewed versioned artifact/startup templates");
       }
     }
   }
   return profile;
+}
+
+export function validateSourceProfileV1(profile) {
+  return validateSourceProfile(profile, {
+    schema: PROFILE_SCHEMA,
+    profile: "issuer-pir1-pir2-storeless-v1",
+    sourceRoot: SOURCE_ROOT,
+    minimumPolicies: 4,
+    minimumClasses: 2,
+    requiresRetained: true,
+  });
+}
+
+export function validateSourceProfileGenesisV1(profile) {
+  return validateSourceProfile(profile, {
+    schema: GENESIS_PROFILE_SCHEMA,
+    profile: "issuer-pir1-pir2-storeless-genesis-v1",
+    sourceRoot: GENESIS_SOURCE_ROOT,
+    minimumPolicies: 2,
+    minimumClasses: 1,
+    requiresRetained: false,
+  });
 }
 
 function forbid(command, patterns, label) {
@@ -489,7 +523,7 @@ export function validatePir2RenderInputsV1(artifactSource, startupSource, runSou
     }
   }
   const artifact = parseEnv(artifactSource, "pir2 artifact set");
-  if (artifact.length < 7 || artifact.length > 4 + MAX_RETAINED_PER_PROVIDER + MAX_CLASSES) {
+  if (artifact.length < 5 || artifact.length > 4 + MAX_RETAINED_PER_PROVIDER + MAX_CLASSES) {
     fail("pir2 artifact set is outside its bounded entry count");
   }
   if (artifact[0][0] !== "schema" || artifact[0][1] !== "bitcoinpir-pir2-bat-v2-public-artifact-set-v1") {
@@ -551,6 +585,27 @@ export function validateRepository(root) {
     readFileSync(join(sourceRoot, "pir2-sealed-startup.env.in"), "utf8"),
     readFileSync(join(root, "scripts/dracut/97bpir-tier3-init/unified-server-run.sh"), "utf8"),
     profile,
+  );
+  const genesisRoot = join(root, GENESIS_SOURCE_ROOT);
+  const genesisProfile = validateSourceProfileGenesisV1(
+    JSON.parse(readFileSync(join(genesisRoot, "source-profile.json.in"), "utf8")),
+  );
+  const genesisIssuerSource = readFileSync(
+    join(genesisRoot, "issuer-lightning-mainnet-bat-v2-payment-issuer.service.in"),
+    "utf8",
+  );
+  const genesisPir1Source = readFileSync(
+    join(genesisRoot, "pir1-storeless-bat-v2-provider.service.in"),
+    "utf8",
+  );
+  validateIssuerUnitV1(genesisIssuerSource, genesisProfile);
+  validatePir1UnitV1(genesisPir1Source, genesisProfile);
+  validatePrivateSecretPathsV1(genesisIssuerSource, genesisPir1Source, genesisProfile);
+  validatePir2RenderInputsV1(
+    readFileSync(join(genesisRoot, "pir2-public-artifact-set.env.in"), "utf8"),
+    readFileSync(join(genesisRoot, "pir2-sealed-startup.env.in"), "utf8"),
+    readFileSync(join(root, "scripts/dracut/97bpir-tier3-init/unified-server-run.sh"), "utf8"),
+    genesisProfile,
   );
   return { schema: PROFILE_SCHEMA, result: "PASS" };
 }

--- a/scripts/payment-bat-v2-source-profile-gate.test.mjs
+++ b/scripts/payment-bat-v2-source-profile-gate.test.mjs
@@ -5,18 +5,22 @@ import { dirname, join, resolve } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
+  GENESIS_PROFILE_SCHEMA,
   PROFILE_SCHEMA,
   validateIssuerUnitV1,
   validatePir1UnitV1,
   validatePir2RenderInputsV1,
   validatePrivateSecretPathsV1,
   validateRepository,
+  validateSourceProfileGenesisV1,
   validateSourceProfileV1,
 } from "./payment-bat-v2-source-profile-gate.mjs";
 
 const repository = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const sourceRoot = join(repository, "deploy/payment-v1/bat-v2-source-ready");
 const profileSource = readFileSync(join(sourceRoot, "source-profile.json.in"), "utf8");
+const genesisSourceRoot = join(repository, "deploy/payment-v1/bat-v2-genesis-source-ready");
+const genesisProfileSource = readFileSync(join(genesisSourceRoot, "source-profile.json.in"), "utf8");
 const issuerSource = readFileSync(
   join(sourceRoot, "issuer-lightning-mainnet-bat-v2-payment-issuer.service.in"),
   "utf8",
@@ -34,6 +38,10 @@ const runSource = readFileSync(
 
 function profile() {
   return JSON.parse(profileSource);
+}
+
+function genesisProfile() {
+  return JSON.parse(genesisProfileSource);
 }
 
 test("checked-in BAT V2 source profile and all three render roles pass", () => {
@@ -61,6 +69,34 @@ test("profile schema is closed and retained material is mandatory", () => {
     () => validateSourceProfileV1(tooManyRetainedClasses),
     /issuer\.classes must contain 2\.\.9 entries/u,
   );
+});
+
+test("genesis profile is current-only and cannot be confused with rotation", () => {
+  const checked = validateSourceProfileGenesisV1(genesisProfile());
+  assert.equal(checked.schema, GENESIS_PROFILE_SCHEMA);
+  assert.deepEqual(
+    checked.providers.map((provider) => provider.retainedPolicyDigestsHex),
+    [[], []],
+  );
+
+  const retainedPolicy = genesisProfile();
+  retainedPolicy.issuer.policies[0].state = "retained";
+  assert.throws(
+    () => validateSourceProfileGenesisV1(retainedPolicy),
+    /genesis issuer must not contain retained policy material/u,
+  );
+
+  const retainedClass = genesisProfile();
+  retainedClass.issuer.classes[0].state = "retained";
+  assert.throws(
+    () => validateSourceProfileGenesisV1(retainedClass),
+    /genesis issuer must not contain retained class material/u,
+  );
+
+  const wrongProfile = genesisProfile();
+  wrongProfile.profile = "issuer-pir1-pir2-storeless-v1";
+  assert.throws(() => validateSourceProfileGenesisV1(wrongProfile), /profile\.profile is unsupported/u);
+  assert.throws(() => validateSourceProfileV1(genesisProfile()), /profile\.schema must equal/u);
 });
 
 test("class membership covers every policy and is coordinate-fork-free", () => {


### PR DESCRIPTION
## Summary
- add an explicit first-production-epoch BAT V2 source profile with current-only policies/classes
- preserve the existing rotation profile requirement for real retained policy/class artifacts
- keep issuer, pir1, and measured pir2 templates inert and closed over the existing storeless/sealed constraints

## Validation
- `node scripts/payment-bat-v2-source-profile-gate.mjs`
- `node --test scripts/payment-bat-v2-source-profile-gate.test.mjs` (9 passed)
- `git diff --check`

## Scope
Source templates and their existing gate only. No runtime, key material, host installation, service activation, VPSBG change, publication, or funds.