### PR TITLE
chore(deploy): lock pir2 genesis policy

### DIFF
--- a/scripts/build_uki_tier3.sh
+++ b/scripts/build_uki_tier3.sh
@@ -48,7 +48,7 @@ CUSTOM_INITRD=/tmp/bpir-tier3-initrd.img
 # The currently deployed image accepts service-policy epoch 8 with this exact
 # digest. A policy rotation is a production behavior change and must update
 # this reviewed lock in source before a new UKI can be emitted.
-TIER3_SERVICE_POLICY_SHA256=ef076d5fcb4ccc89c7ad4b883d332005ef59cfa09617e1ea66359d37f962dc14
+TIER3_SERVICE_POLICY_SHA256=5e57ed6b5313ebf89f8f00b24d9ad78452be24e9e59bc88c96d56203f4a26092
 
 # Resolve dracut module dir relative to this script.
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)

--- a/scripts/tier3-uki-policy-contract.test.mjs
+++ b/scripts/tier3-uki-policy-contract.test.mjs
@@ -17,7 +17,7 @@ const runPath = resolve(
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh",
 );
 const reviewedPolicySha256 =
-  "ef076d5fcb4ccc89c7ad4b883d332005ef59cfa09617e1ea66359d37f962dc14";
+  "5e57ed6b5313ebf89f8f00b24d9ad78452be24e9e59bc88c96d56203f4a26092";
 
 function validateBuildContract(source) {
   const policyRequirement = source.indexOf(


### PR DESCRIPTION
## Summary

- lock the production Tier3 UKI builder to the canonical pir2 genesis policy bytes
- update the existing policy-lock contract fixture to the same SHA-256
- preserve the image-265 release record unchanged

## Focused validation

- `node --test scripts/tier3-uki-policy-contract.test.mjs` (5/5)
- `sh -n scripts/build_uki_tier3.sh`
- `git diff --check`

No UKI build, upload, switch, reboot, service mutation, or funds operation is included.