### PR TITLE
fix(deploy): allow genesis pir2 artifact set

### DIFF
--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -418,7 +418,7 @@ validate_pir2_public_artifact_set() {
             next
         }
         $1 == "current_class" {
-            if (stage != 1 || retained_policies < 1) exit 1
+            if (stage != 1) exit 1
             stage = 2
             current_classes++
             next
@@ -432,7 +432,7 @@ validate_pir2_public_artifact_set() {
             next
         }
         $1 == "accounting_authorization" {
-            if (stage != 3 || retained_classes < 1 || accounting_authorizations != 0) exit 1
+            if ((stage != 2 && stage != 3) || current_classes != 1 || accounting_authorizations != 0) exit 1
             stage = 4
             accounting_authorizations++
             next
@@ -445,7 +445,7 @@ validate_pir2_public_artifact_set() {
         }
         { exit 1 }
         END {
-            if (NR < 7 || stage != 5 || retained_policies < 1 || current_classes != 1 || retained_classes < 1 || accounting_authorizations != 1 || accounting_approvals != 1) exit 1
+            if (NR < 5 || stage != 5 || current_classes != 1 || accounting_authorizations != 1 || accounting_approvals != 1) exit 1
         }
     ' "$PIR2_ACTIVE_ARTIFACT_SET_PATH" \
         || fatal "pir2 public artifact set is not canonical or bounded"

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -92,22 +92,16 @@ function writeSealedStartup(
   ordinal = 1,
   servicePolicyPath = path.join(root, "service-policy.bin"),
 ) {
-  const retainedPolicyPath = path.join(root, `public/policies/${"47".repeat(32)}.bin`);
   const currentClassPath = path.join(root, `public/classes/${"43".repeat(32)}.bin`);
-  const retainedClassPath = path.join(root, `public/classes/${"48".repeat(32)}.bin`);
   const accountingAuthorizationPath = path.join(root, "provider-accounting-authorization.bin");
   const accountingApprovalPath = path.join(root, "issuer-accounting-approval.bin");
   if (!existsSync(servicePolicyPath)) write(servicePolicyPath, "fixture current policy\n");
-  write(retainedPolicyPath, "fixture retained policy\n");
   write(currentClassPath, "fixture current class\n");
-  write(retainedClassPath, "fixture retained class\n");
   write(accountingAuthorizationPath, "provider-accounting-authorization.bin fixture\n");
   write(accountingApprovalPath, "issuer-accounting-approval.bin fixture\n");
   const artifactSet = `schema=bitcoinpir-pir2-bat-v2-public-artifact-set-v1
 current_policy=${"42".repeat(32)}=${sha256(readFileSync(servicePolicyPath))}=${servicePolicyPath}
-retained_policy=${"47".repeat(32)}=${sha256(readFileSync(retainedPolicyPath))}=${retainedPolicyPath}
 current_class=${"43".repeat(32)}=${sha256(readFileSync(currentClassPath))}=${currentClassPath}
-retained_class=${"48".repeat(32)}=${sha256(readFileSync(retainedClassPath))}=${retainedClassPath}
 accounting_authorization=${"49".repeat(32)}=${sha256(readFileSync(accountingAuthorizationPath))}=${accountingAuthorizationPath}
 accounting_approval=${"4a".repeat(32)}=${sha256(readFileSync(accountingApprovalPath))}=${accountingApprovalPath}
 `;
@@ -792,9 +786,9 @@ exit 1
   assert.match(finalArgs, /--service-storeless-bat-v2-policy-digest-hex/);
   assert.equal(
     (finalArgs.match(/--service-storeless-bat-v2-retained-policy/g) ?? []).length,
-    1,
+    0,
   );
-  assert.equal((finalArgs.match(/--service-storeless-bat-v2-class/g) ?? []).length, 2);
+  assert.equal((finalArgs.match(/--service-storeless-bat-v2-class/g) ?? []).length, 1);
   assert.doesNotMatch(finalArgs, /(?:--identity-key-path|--service-shared-clearing-key|--service-storeless-bat-v2-pir1-clearing-key)/);
   assert.deepEqual(
     readFileSync(directEvents, "utf8").trim().split("\n").map((event) =>


### PR DESCRIPTION
## Summary
- allow the measured pir2 Ready validator to accept the genesis artifact set with zero retained policies/classes
- keep canonical ordering, retained bounds, and exact current/accounting entries
- exercise the real initramfs shell validator with the existing Tier3 generation fixture

## Validation
- `sh -n scripts/dracut/97bpir-tier3-init/unified-server-run.sh`
- `node scripts/vpsbg-tier3-generation.test.mjs`
- `git diff --check`

The dynamic fixture is retained because the source-profile unit gate does not execute the initramfs awk validator that caused this production Ready mismatch.