### PR TITLE
feat(pir2): expose bounded inert receipt recovery

### DIFF
--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -57,6 +57,19 @@ PIR2_SEALED_ARTIFACT_SET_MAX_BYTES=8192
 PIR2_SEALED_ARTIFACT_SET_MAX_RETAINED_POLICIES=8
 PIR2_SEALED_ARTIFACT_SET_MAX_RETAINED_CLASSES=8
 PIR2_SEALED_INERT_SUCCESS_EXIT_CODE=42
+# Inert Observe/Enroll/Probe runs leave no listener behind.  VPSBG currently
+# has no console or file-extraction API, so expose only the canonical receipt
+# briefly through the already configured cloudflared origin.  This is a
+# distinct schema/root from the Direct ORAM progress API below.
+PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT=/run/bitcoinpir-pir2-sealed-receipt-api
+PIR2_SEALED_RECEIPT_RECOVERY_FILE="$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT/pir2-sealed-receipt.bin"
+PIR2_SEALED_RECEIPT_RECOVERY_STATUS_FILE="$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT/status.json"
+PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID_FILE=/run/bitcoinpir-pir2-sealed-receipt-api.pid
+PIR2_SEALED_RECEIPT_RECOVERY_HTTPD=/usr/bin/busybox
+PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_HOST=127.0.0.1
+PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PORT=8091
+PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID=
+PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS=600
 PIR2_SEALED_OPERATOR_KEY_HEX=30e02d80704f77099ae342a428ab22e1176baf61b4a0593b1783289e5cb5b63c
 PIR2_SEALED_ISSUER_SETTLEMENT_KEY_HEX=9ab315056cdabf821c41d2bb57a8ab180481436f439c5ef4131c000b448c2763
 PIR2_SEALED_PROVIDER_ID_HEX=a6465c49877dcc7062f383085ddf0479c76af8b2aee28bf3d3a40f4f202d888d
@@ -700,6 +713,86 @@ prepare_pir2_sealed_output_dirs() {
         || fatal "failed to protect pir2 sealed output directories"
 }
 
+pir2_sealed_receipt_recovery_window_seconds() {
+    # This override exists only for the repository fixture.  Production always
+    # uses the measured, finite 600-second window above.
+    if [ -n "${BPIR_TEST_PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS:-}" ]; then
+        case "$BPIR_TEST_PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS" in
+            ''|*[!0-9]*|0) fatal "fixture receipt recovery window must be a positive integer" ;;
+        esac
+        [ "$BPIR_TEST_PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS" -le 60 ] \
+            || fatal "fixture receipt recovery window exceeds 60 seconds"
+        printf '%s\n' "$BPIR_TEST_PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS"
+        return 0
+    fi
+    printf '%s\n' "$PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS"
+}
+
+prepare_pir2_sealed_receipt_recovery_api() {
+    case "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" in
+        /run/bitcoinpir-pir2-sealed-receipt-api) ;;
+        *) fatal "unsupported pir2 sealed receipt recovery root" ;;
+    esac
+    rm -rf "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" \
+        || fatal "failed to clear pir2 sealed receipt recovery root"
+    mkdir -p "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" \
+        || fatal "failed to create pir2 sealed receipt recovery root"
+    chmod 700 "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" \
+        || fatal "failed to protect pir2 sealed receipt recovery root"
+}
+
+stop_pir2_sealed_receipt_recovery_api() {
+    [ -n "${PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID:-}" ] || return 0
+    kill "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID" 2>/dev/null || true
+    wait "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID" 2>/dev/null || true
+    PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID=
+    rm -f "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID_FILE"
+}
+
+remove_pir2_sealed_receipt_recovery_api_root() {
+    case "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" in
+        /run/bitcoinpir-pir2-sealed-receipt-api) rm -rf "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" || return 1 ;;
+        *) return 1 ;;
+    esac
+}
+
+publish_pir2_sealed_receipt_recovery_window() {
+    recovery_window_seconds=$(pir2_sealed_receipt_recovery_window_seconds)
+    prepare_pir2_sealed_receipt_recovery_api
+    receipt_tmp="$PIR2_SEALED_RECEIPT_RECOVERY_FILE.tmp.$$"
+    status_tmp="$PIR2_SEALED_RECEIPT_RECOVERY_STATUS_FILE.tmp.$$"
+    umask 077
+    cp "$PIR2_SEALED_RECEIPT_PATH" "$receipt_tmp" \
+        || fatal "failed to stage canonical pir2 sealed receipt for recovery"
+    chmod 600 "$receipt_tmp" || fatal "failed to protect staged pir2 sealed receipt"
+    mv "$receipt_tmp" "$PIR2_SEALED_RECEIPT_RECOVERY_FILE" \
+        || fatal "failed to publish canonical pir2 sealed receipt"
+    {
+        printf '{"schema_version":1,"phase":"%s","ordinal":%s,' \
+            "$PIR2_SEALED_PHASE" "$PIR2_SEALED_ORDINAL"
+        printf '"boot_id":"%s","receipt_sha256":"%s"}\n' \
+            "$PIR2_BOOT_ID_HEX" "$PIR2_CHILD_RECEIPT_FILE_SHA256"
+    } >"$status_tmp" || fatal "failed to stage pir2 sealed receipt recovery status"
+    chmod 600 "$status_tmp" || fatal "failed to protect pir2 sealed receipt recovery status"
+    mv "$status_tmp" "$PIR2_SEALED_RECEIPT_RECOVERY_STATUS_FILE" \
+        || fatal "failed to publish pir2 sealed receipt recovery status"
+    [ -x "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD" ] \
+        || fatal "BusyBox httpd missing from UKI"
+    "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD" httpd -f \
+        -p "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_HOST:$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PORT" \
+        -h "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" </dev/null >/dev/null 2>&1 &
+    PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID=$!
+    printf '%s\n' "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID" >"$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID_FILE" \
+        || fatal "failed to record pir2 sealed receipt recovery process"
+    chmod 600 "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID_FILE" \
+        || fatal "failed to protect pir2 sealed receipt recovery process"
+    sleep "$recovery_window_seconds"
+    stop_pir2_sealed_receipt_recovery_api \
+        || fatal "failed to stop pir2 sealed receipt recovery API"
+    remove_pir2_sealed_receipt_recovery_api_root \
+        || fatal "failed to remove pir2 sealed receipt recovery root"
+}
+
 run_pir2_sealed_inert_phase() {
     if [ "$PIR2_SEALED_PHASE" = observe ]; then
         "$UNIFIED_SERVER" \
@@ -735,6 +828,7 @@ run_pir2_sealed_inert_phase() {
         || fatal "pir2 sealed $PIR2_SEALED_PHASE dispatcher failed with exit $sealed_status"
     read_child_audit_evidence \
         "$PIR2_SEALED_RECEIPT_PATH" "$PIR2_SEALED_MARKER_PATH" "$PIR2_SEALED_PHASE"
+    publish_pir2_sealed_receipt_recovery_window
     write_authoritative_attempt_token \
         "$PIR2_SEALED_TERMINAL_TOKEN_PATH" terminal "$PIR2_SEALED_PHASE"
     authoritative_attempt_token_matches_current_attempt \

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -303,6 +303,26 @@ try {
   const inertBootId = path.join(inertRoot, "boot_id");
   const inertSwaps = path.join(inertRoot, "swaps");
   const inertCalls = path.join(inertRoot, "unified-server.calls");
+  const inertBusybox = path.join(inertRoot, "busybox");
+  write(
+    inertBusybox,
+    `#!/bin/sh
+[ "$1" = httpd ] || exit 2
+shift
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -f) shift ;;
+    -p) address=$2; shift 2 ;;
+    -h) root=$2; shift 2 ;;
+    *) exit 2 ;;
+  esac
+done
+host=\${address%:*}
+port=\${address##*:}
+exec python3 -m http.server "$port" --bind "$host" --directory "$root"
+`,
+  );
+  chmodSync(inertBusybox, 0o755);
   write(inertSwaps, "Filename\tType\tSize\tUsed\tPriority\n");
   write(
     inertBinary,
@@ -346,6 +366,8 @@ exit 42
     inertRunScript,
     tier3RunText
       .replace("UNIFIED_SERVER=/usr/local/bin/unified_server", `UNIFIED_SERVER=${inertBinary}`)
+      .replace("PIR2_SEALED_RECEIPT_RECOVERY_HTTPD=/usr/bin/busybox", `PIR2_SEALED_RECEIPT_RECOVERY_HTTPD=${inertBusybox}`)
+      .replaceAll("/run/bitcoinpir-pir2-sealed-receipt-api", `${inertRoot}/receipt-recovery-api`)
       .replaceAll("sleep 5", ":"),
   );
   chmodSync(inertRunScript, 0o755);
@@ -366,6 +388,7 @@ exit 42
       BPIR_PIR2_PROC_SWAPS: inertSwaps,
       BPIR_PIR2_SNP_SEALED_ROOT: phaseRoot,
       BPIR_PIR2_SNP_SEALED_ATTEMPT_ROOT: path.join(phaseRoot, "trusted-attempt"),
+      BPIR_TEST_PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS: "1",
     };
     const inert = run("sh", [inertRunScript], { env: inertEnv });
     assert.equal(inert.status, 42, inert.stdout + inert.stderr);
@@ -389,6 +412,66 @@ exit 42
     assert.equal(readFileSync(inertCalls, "utf8"), callsBeforeRetry);
     writeFileSync(startupPath, originalStartup);
   }
+
+  // Exercise the bounded endpoint through the same BusyBox-httpd invocation
+  // shape as the UKI: the canonical receipt and minimal status are readable
+  // during the one-second fixture window, then the inert attempt stays 42.
+  const recoveryRoot = path.join(inertRoot, "recovery-window");
+  writeSealedStartup(recoveryRoot, "observe", 77);
+  writeFileSync(inertBootId, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb\n");
+  const recoveryApiRoot = path.join(inertRoot, "receipt-recovery-api");
+  const recoveryReceiptOutput = path.join(inertRoot, "recovered-receipt.bin");
+  const recoveryStatusOutput = path.join(inertRoot, "recovered-status.json");
+  const recoveryRunner = `
+"$1" >"$2" 2>"$3" &
+pid=$!
+i=0
+while [ ! -f "$4/status.json" ]; do
+  [ "$i" -lt 100 ] || exit 3
+  sleep 0.02
+  i=$((i + 1))
+done
+j=0
+until curl -fsS "http://127.0.0.1:8091/pir2-sealed-receipt.bin" >"$5"; do
+  [ "$j" -lt 50 ] || exit 4
+  sleep 0.02
+  j=$((j + 1))
+done
+curl -fsS "http://127.0.0.1:8091/status.json" >"$6" || exit 5
+wait "$pid"
+exit $?
+`;
+  const recovery = run(
+    "sh",
+    [
+      "-c",
+      recoveryRunner,
+      "fixture",
+      inertRunScript,
+      path.join(inertRoot, "recovery.stdout"),
+      path.join(inertRoot, "recovery.stderr"),
+      recoveryApiRoot,
+      recoveryReceiptOutput,
+      recoveryStatusOutput,
+    ],
+    {
+      env: {
+        ...process.env,
+        BPIR_ORAM_BOOT_ID_FILE: inertBootId,
+        BPIR_PIR2_PROC_SWAPS: inertSwaps,
+        BPIR_PIR2_SNP_SEALED_ROOT: recoveryRoot,
+        BPIR_PIR2_SNP_SEALED_ATTEMPT_ROOT: path.join(recoveryRoot, "trusted-attempt"),
+        BPIR_TEST_PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS: "1",
+      },
+    },
+  );
+  assert.equal(recovery.status, 42, recovery.stdout + recovery.stderr);
+  assert.equal(readFileSync(recoveryReceiptOutput, "utf8"), "fixture receipt\n");
+  assert.match(
+    readFileSync(recoveryStatusOutput, "utf8"),
+    /"phase":"observe","ordinal":77,"boot_id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","receipt_sha256":"[0-9a-f]{64}"/,
+  );
+  assert.equal(existsSync(recoveryApiRoot), false, "receipt recovery root must be removed after its bounded window");
 
   const forgedRoot = path.join(inertRoot, "forged-persistent");
   const forgedAttemptRoot = path.join(forgedRoot, "trusted-attempt");


### PR DESCRIPTION
## Summary
- expose the canonical Observe/Enroll/Probe receipt for a fixed 600-second window through the existing cloudflared origin on port 8091
- publish only the receipt plus phase, ordinal, boot id, and receipt SHA-256
- stop the temporary BusyBox HTTP server and remove its runtime root before the existing terminal token and exit-42 flow

## Validation
- `sh -n scripts/dracut/97bpir-tier3-init/unified-server-run.sh`
- `node scripts/vpsbg-tier3-generation.test.mjs`
- `git diff --check`

The existing dynamic fixture is necessary here because source-profile unit checks cannot execute the initramfs/runit HTTP window that is required to recover the real SNP observation receipt.