### PR TITLE
Add one-shot pir2 sealed provisioner UKI

### DIFF
--- a/scripts/build_uki_pir2_sealed_provisioner.sh
+++ b/scripts/build_uki_pir2_sealed_provisioner.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Build the deliberately small, offline, one-shot pir2 sealed provisioner UKI.
+set -euo pipefail
+
+[ "${EUID}" = 0 ] || { echo "error: must run as root" >&2; exit 1; }
+for tool in dracut ukify sha256sum; do command -v "$tool" >/dev/null || { echo "error: missing $tool" >&2; exit 1; }; done
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+MODULE_SRC="$SCRIPT_DIR/dracut/97bpir-pir2-sealed-provisioner"
+PAYLOAD_DIR=${BPIR_PIR2_SEALED_PROVISIONER_PAYLOAD_DIR:?error: set BPIR_PIR2_SEALED_PROVISIONER_PAYLOAD_DIR}
+MANIFEST=${BPIR_PIR2_SEALED_PROVISIONER_MANIFEST:?error: set BPIR_PIR2_SEALED_PROVISIONER_MANIFEST}
+KERNEL=${KERNEL:-}
+OUT=${OUT:-/tmp/bpir-pir2-sealed-provisioner.efi}
+INITRD=${INITRD:-/tmp/bpir-pir2-sealed-provisioner.img}
+
+[ -d "$PAYLOAD_DIR" ] || { echo "error: payload dir missing" >&2; exit 1; }
+[ -r "$MANIFEST" ] || { echo "error: manifest missing" >&2; exit 1; }
+[ -d "$MODULE_SRC" ] || { echo "error: module missing" >&2; exit 1; }
+if [ -z "$KERNEL" ]; then KERNEL=$(ls -1 /boot/vmlinuz-*-generic 2>/dev/null | sort -V | tail -1); fi
+[ -r "$KERNEL" ] || { echo "error: kernel unreadable" >&2; exit 1; }
+KVER=$(basename "$KERNEL" | sed 's/^vmlinuz-//')
+[ -d "/usr/lib/modules/$KVER" ] || { echo "error: modules missing for $KVER" >&2; exit 1; }
+
+dst=/usr/lib/dracut/modules.d/97bpir-pir2-sealed-provisioner
+mkdir -p "$dst"
+cp -fp "$MODULE_SRC"/* "$dst/"
+chmod 0755 "$dst"/*
+find "$dst" -type f -exec touch -d @0 {} +
+export BPIR_PIR2_SEALED_PROVISIONER_PAYLOAD_DIR="$PAYLOAD_DIR"
+export BPIR_PIR2_SEALED_PROVISIONER_MANIFEST="$MANIFEST"
+
+SOURCE_DATE_EPOCH=0 dracut --force --no-hostonly --reproducible \
+    --add bpir-pir2-sealed-provisioner --add-drivers " virtio_blk " \
+    --kver "$KVER" "$INITRD"
+ukify build --linux="$KERNEL" --initrd="$INITRD" \
+    --cmdline="rdinit=/sbin/bpir-pir2-sealed-provisioner-init quiet" --output="$OUT"
+printf 'wrote %s\nsha256 %s\n' "$OUT" "$(sha256sum "$OUT" | awk '{print $1}')"

--- a/scripts/dracut/97bpir-pir2-sealed-provisioner/bpir-pir2-sealed-provisioner-init.sh
+++ b/scripts/dracut/97bpir-pir2-sealed-provisioner/bpir-pir2-sealed-provisioner-init.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+# Offline one-shot installer for the pre-validated sealed release payload.
+# The manifest is the complete write plan: action<TAB>relative path<TAB>sha256.
+
+set -eu
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
+
+payload=${BPIR_SEALED_PROVISIONER_TEST_PAYLOAD:-/usr/share/bitcoinpir/pir2-sealed-provisioner/payload}
+manifest=${BPIR_SEALED_PROVISIONER_TEST_MANIFEST:-/usr/share/bitcoinpir/pir2-sealed-provisioner/manifest.tsv}
+test_root=${BPIR_SEALED_PROVISIONER_TEST_ROOT:-}
+
+fail() {
+    echo "[pir2-sealed-provisioner] FATAL: $*" >&2
+    if [ -n "$test_root" ]; then
+        return 1
+    fi
+    sync || true
+    poweroff -f
+    while :; do sleep 1; done
+}
+
+allowed() {
+    case "$1:$2" in
+        replace:startup.env) return 0 ;;
+        replay:release.bin|replay:public-artifact-set.env|replay:identity.cert|\
+        replay:provider-accounting-authorization.bin|replay:issuer-accounting-approval.bin) return 0 ;;
+        replay:public/classes/*)
+            class=${2#public/classes/}
+            stem=${class%.bin}
+            [ "$class" = "$stem.bin" ] && [ "${#stem}" -eq 64 ] || return 1
+            case "$stem" in *[!0123456789abcdef]*|'') return 1 ;; esac
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+sha256() { sha256sum "$1" | awk '{print $1}'; }
+
+if [ -n "$test_root" ]; then
+    target="$test_root/home/pir/data/pir2-sealed"
+else
+    mount -t proc proc /proc 2>/dev/null || true
+    mount -t sysfs sysfs /sys 2>/dev/null || true
+    mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
+    modprobe virtio_blk 2>/dev/null || true
+    modprobe ext4 2>/dev/null || true
+    mkdir -p /sysroot
+    root_label=${BPIR_PIR2_SEALED_PROVISIONER_ROOT_LABEL:-cloudimg-rootfs}
+    mount -L "$root_label" -o rw /sysroot || fail "cannot mount rootfs label $root_label"
+    target=/sysroot/home/pir/data/pir2-sealed
+fi
+
+[ -r "$manifest" ] || fail "manifest unavailable"
+[ -d "$payload" ] || fail "payload unavailable"
+mkdir -p "$target"
+chmod 0700 "$target"
+
+# First validate every line and every embedded byte.  No destination write is
+# attempted until the payload is complete and matches the baked manifest.
+tab=$(printf '\t')
+while IFS="$tab" read -r action rel expected extra; do
+    [ -n "$action" ] || continue
+    [ -z "$extra" ] || fail "invalid manifest fields"
+    allowed "$action" "$rel" || fail "manifest path is not allowlisted: $action $rel"
+    case "$expected" in [0123456789abcdef][0123456789abcdef][0123456789abcdef][0123456789abcdef][0123456789abcdef][0123456789abcdef][0123456789abcdef][0123456789abcdef]*) ;; *) fail "invalid manifest sha256" ;; esac
+    [ "${#expected}" -eq 64 ] || fail "invalid manifest sha256 length"
+    src="$payload/$rel"
+    [ -f "$src" ] && [ ! -L "$src" ] || fail "payload file missing: $rel"
+    [ "$(sha256 "$src")" = "$expected" ] || fail "payload hash mismatch: $rel"
+done < "$manifest"
+
+while IFS="$tab" read -r action rel expected extra; do
+    [ -n "$action" ] || continue
+    dest="$target/$rel"
+    src="$payload/$rel"
+    mkdir -p "$(dirname "$dest")"
+    chmod 0700 "$(dirname "$dest")"
+    case "$action" in
+        replace)
+            tmp="$dest.tmp.$$"
+            rm -f "$tmp"
+            cp "$src" "$tmp" || fail "cannot stage replacement: $rel"
+            chmod 0600 "$tmp"
+            mv -f "$tmp" "$dest" || fail "cannot replace: $rel"
+            ;;
+        replay)
+            if [ -e "$dest" ] || [ -L "$dest" ]; then
+                [ ! -L "$dest" ] && [ -f "$dest" ] || fail "replay destination is not a regular file: $rel"
+                cmp -s "$src" "$dest" || fail "replay conflict: $rel"
+            else
+                tmp="$dest.tmp.$$"
+                rm -f "$tmp"
+                cp "$src" "$tmp" || fail "cannot stage replay: $rel"
+                chmod 0600 "$tmp"
+                if ! ln "$tmp" "$dest" 2>/dev/null; then
+                    rm -f "$tmp"
+                    [ -e "$dest" ] && cmp -s "$src" "$dest" || fail "replay conflict: $rel"
+                else
+                    rm -f "$tmp"
+                fi
+            fi
+            ;;
+        *) fail "unsupported manifest action" ;;
+    esac
+done < "$manifest"
+
+manifest_sha=$(sha256 "$manifest")
+markers="$target/markers"
+mkdir -p "$markers"
+chmod 0700 "$markers"
+marker="$markers/provision-$manifest_sha.env"
+marker_tmp="$marker.tmp.$$"
+printf 'sealed-provisioner-manifest-sha256=%s\n' "$manifest_sha" > "$marker_tmp"
+chmod 0600 "$marker_tmp"
+if ! ln "$marker_tmp" "$marker" 2>/dev/null; then
+    rm -f "$marker_tmp"
+    [ -f "$marker" ] && [ ! -L "$marker" ] \
+        && [ "$(cat "$marker")" = "sealed-provisioner-manifest-sha256=$manifest_sha" ] \
+        || fail "marker conflict"
+else
+    rm -f "$marker_tmp"
+fi
+sync
+echo "[pir2-sealed-provisioner] complete"
+[ -n "$test_root" ] && exit 0
+poweroff -f
+while :; do sleep 1; done

--- a/scripts/dracut/97bpir-pir2-sealed-provisioner/module-setup.sh
+++ b/scripts/dracut/97bpir-pir2-sealed-provisioner/module-setup.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# One-shot, offline pir2 sealed-state provisioner.  It deliberately contains
+# no network, SSH, service manager, ORAM, builder, or SEV component.
+
+check() {
+    local name
+    for name in BPIR_PIR2_SEALED_PROVISIONER_PAYLOAD_DIR \
+        BPIR_PIR2_SEALED_PROVISIONER_MANIFEST; do
+        [ -n "${!name:-}" ] || {
+            derror "bpir-pir2-sealed-provisioner: missing $name"
+            return 1
+        }
+    done
+    [ -d "$BPIR_PIR2_SEALED_PROVISIONER_PAYLOAD_DIR" ] || return 1
+    [ -r "$BPIR_PIR2_SEALED_PROVISIONER_MANIFEST" ] || return 1
+    [ -x /usr/bin/busybox ] || return 1
+    return 0
+}
+
+depends() {
+    echo "busybox base"
+    return 0
+}
+
+install() {
+    local payload=$BPIR_PIR2_SEALED_PROVISIONER_PAYLOAD_DIR
+    local manifest=$BPIR_PIR2_SEALED_PROVISIONER_MANIFEST
+
+    inst_multiple awk basename cat chmod cmp dirname find ln mkdir mount modprobe mv \
+        rm sha256sum sleep sync
+    inst_simple /usr/bin/busybox
+    ln_r /usr/bin/busybox /sbin/poweroff
+    inst_simple "$moddir/bpir-pir2-sealed-provisioner-init.sh" \
+        /sbin/bpir-pir2-sealed-provisioner-init
+    inst_dir /usr/share/bitcoinpir/pir2-sealed-provisioner/payload
+    local tab action rel expected extra source destination
+    tab=$(printf '\t')
+    while IFS="$tab" read -r action rel expected extra; do
+        [ -n "$action" ] || continue
+        [ -z "$extra" ] || {
+            derror "bpir-pir2-sealed-provisioner: invalid manifest fields"
+            return 1
+        }
+        case "$rel" in ''|/*|..|../*|*/../*|*/..) derror "bpir-pir2-sealed-provisioner: unsafe manifest path"; return 1 ;; esac
+        source="$payload/$rel"
+        [ -f "$source" ] && [ ! -L "$source" ] && [ -r "$source" ] || {
+            derror "bpir-pir2-sealed-provisioner: unreadable regular payload source: $rel"
+            return 1
+        }
+        destination="/usr/share/bitcoinpir/pir2-sealed-provisioner/payload/$rel"
+        inst_dir "$(dirname "$destination")"
+        inst_simple "$source" "$destination"
+    done < "$manifest"
+    inst_simple "$manifest" \
+        /usr/share/bitcoinpir/pir2-sealed-provisioner/manifest.tsv
+    chmod 0755 "$initdir/sbin/bpir-pir2-sealed-provisioner-init"
+    chmod 0444 "$initdir/usr/share/bitcoinpir/pir2-sealed-provisioner/manifest.tsv"
+}

--- a/scripts/pir2-sealed-provisioner.test.mjs
+++ b/scripts/pir2-sealed-provisioner.test.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const repo = new URL('.', import.meta.url).pathname;
+const init = join(repo, 'dracut/97bpir-pir2-sealed-provisioner/bpir-pir2-sealed-provisioner-init.sh');
+const root = await mkdtemp(join(tmpdir(), 'bpir-sealed-provisioner-'));
+const payload = join(root, 'payload');
+const target = join(root, 'target');
+const hash = value => createHash('sha256').update(value).digest('hex');
+const files = {
+  'startup.env': 'startup=v1\n',
+  'release.bin': 'release\n',
+  'public-artifact-set.env': 'public-set\n',
+  'identity.cert': 'cert\n',
+  'provider-accounting-authorization.bin': 'provider-auth\n',
+  'issuer-accounting-approval.bin': 'issuer-approval\n',
+  ['public/classes/' + 'a'.repeat(64) + '.bin']: 'class\n',
+};
+try {
+  for (const [rel, value] of Object.entries(files)) {
+    await mkdir(join(payload, rel, '..'), { recursive: true });
+    await writeFile(join(payload, rel), value);
+  }
+  const manifest = Object.entries(files).map(([rel, value]) =>
+    `${rel === 'startup.env' ? 'replace' : 'replay'}\t${rel}\t${hash(value)}\n`).join('');
+  const manifestPath = join(root, 'manifest.tsv');
+  await writeFile(manifestPath, manifest);
+  const run = () => execFileSync('/bin/sh', [init], { env: { ...process.env,
+    BPIR_SEALED_PROVISIONER_TEST_ROOT: target,
+    BPIR_SEALED_PROVISIONER_TEST_PAYLOAD: payload,
+    BPIR_SEALED_PROVISIONER_TEST_MANIFEST: manifestPath,
+  }, stdio: 'pipe' });
+  run(); // first install
+  const installed = join(target, 'home/pir/data/pir2-sealed');
+  if (await readFile(join(installed, 'release.bin'), 'utf8') !== files['release.bin']) throw new Error('first install');
+  await writeFile(join(payload, 'startup.env'), 'startup=v2\n');
+  await writeFile(manifestPath, manifest.replace(hash(files['startup.env']), hash('startup=v2\n')));
+  run(); // startup replacement
+  if (await readFile(join(installed, 'startup.env'), 'utf8') !== 'startup=v2\n') throw new Error('startup replace');
+  const marker = join(installed, 'markers', `provision-${hash(await readFile(manifestPath))}.env`);
+  if (((await stat(installed)).mode & 0o777) !== 0o700 ||
+      ((await stat(join(installed, 'markers'))).mode & 0o777) !== 0o700 ||
+      ((await stat(marker)).mode & 0o777) !== 0o600) throw new Error('sealed permissions or marker');
+  run(); // exact replay accepted
+  await writeFile(join(installed, 'release.bin'), 'conflict\n');
+  let conflicted = false;
+  try { run(); } catch { conflicted = true; }
+  if (!conflicted || await readFile(join(installed, 'release.bin'), 'utf8') !== 'conflict\n') throw new Error('replay conflict overwrite');
+  console.log('pir2 sealed provisioner: ok');
+} finally { await rm(root, { recursive: true, force: true }); }


### PR DESCRIPTION
## Summary
- add an offline one-shot UKI that mounts the VPSBG data disk and writes only manifest-allowlisted pir2 sealed ceremony files
- make startup.env the only replaceable input; require exact replay or atomic first publication for release and Ready public artifacts
- power off after a durable manifest-bound marker, with no SSH, network, service, ORAM, builder, or SEV runtime

## Focused validation
- sh -n on the build and init scripts
- node scripts/pir2-sealed-provisioner.test.mjs
- git diff --check

The shell test executes the real init script because ordinary parser units cannot cover same-filesystem atomic publish, exact replay, conflict non-overwrite, file mode, and marker behavior.