### PR TITLE
Expose sealed preflight failures briefly

### DIFF
--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -70,6 +70,15 @@ PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_HOST=127.0.0.1
 PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PORT=8091
 PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID=
 PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS=600
+# A failed sealed preflight has no receipt, but VPSBG has no console or file
+# extraction API.  Reuse the same short-lived recovery origin for a minimal
+# failure status before runit retries the service.
+PIR2_SEALED_FAILURE_RECOVERY_ENABLED=false
+PIR2_SEALED_FAILURE_RECOVERY_ACTIVE=false
+PIR2_SEALED_FAILURE_RECOVERY_PUBLISHING=false
+PIR2_SEALED_SUCCESS_RECOVERY_LISTENER_STARTED=false
+PIR2_SEALED_FAILURE_STAGE=startup-config
+PIR2_SEALED_FAILURE_STDERR_FILE=/run/bitcoinpir-pir2-sealed-preflight.stderr
 PIR2_SEALED_OPERATOR_KEY_HEX=30e02d80704f77099ae342a428ab22e1176baf61b4a0593b1783289e5cb5b63c
 PIR2_SEALED_ISSUER_SETTLEMENT_KEY_HEX=9ab315056cdabf821c41d2bb57a8ab180481436f439c5ef4131c000b448c2763
 PIR2_SEALED_PROVIDER_ID_HEX=a6465c49877dcc7062f383085ddf0479c76af8b2aee28bf3d3a40f4f202d888d
@@ -139,6 +148,10 @@ DELTA_EXPECTED_INDEX_SHA256=e06fc3dedf30096124888acef3024f21a9c049d59fd8c7d518aa
 DELTA_EXPECTED_CHUNKS_SHA256=536acb605396056118c7c0836988f369c5abbfc3f7e90732ad93e819d5188e0a
 
 fatal() {
+    if [ "${PIR2_SEALED_FAILURE_RECOVERY_ENABLED:-false}" = true ] \
+        && [ "${PIR2_SEALED_SUCCESS_RECOVERY_LISTENER_STARTED:-false}" != true ]; then
+        publish_pir2_sealed_failure_recovery_window "$PIR2_SEALED_FAILURE_STAGE" "$1" || true
+    fi
     if [ -n "${ORAM_STATUS_STARTED_AT_EPOCH:-}" ] && [ -d "$ORAM_STATUS_HTTP_ROOT" ]; then
         write_direct_oram_status_json failed "${2:-$ORAM_TOTAL_MAX_SECONDS}" "${3:-bootstrap-failed}" || true
     fi
@@ -728,6 +741,78 @@ pir2_sealed_receipt_recovery_window_seconds() {
     printf '%s\n' "$PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS"
 }
 
+pir2_sealed_failure_detail_hex() {
+    failure_detail=$1
+    printf '%s' "$failure_detail" | tail -c 512 | od -An -tx1 -v | tr -d ' \n'
+}
+
+pir2_sealed_failure_stderr_detail_hex() {
+    [ -f "$PIR2_SEALED_FAILURE_STDERR_FILE" ] || return 1
+    tail -c 512 "$PIR2_SEALED_FAILURE_STDERR_FILE" | od -An -tx1 -v | tr -d ' \n'
+}
+
+publish_pir2_sealed_failure_recovery_window() {
+    failure_stage=$1
+    failure_detail=$2
+    case "$failure_stage" in process-controls|startup-config|attempt|dispatcher) ;; *) return 1 ;; esac
+    failure_phase=unknown
+    failure_ordinal=0
+    case "${PIR2_SEALED_PHASE:-}:${PIR2_SEALED_ORDINAL:-}" in
+        observe:[1-9]*|enroll:[1-9]*|probe:[1-9]*|ready:[1-9]*)
+            case "${PIR2_SEALED_ORDINAL:-}" in *[!0-9]*) ;; *)
+                failure_phase=$PIR2_SEALED_PHASE
+                failure_ordinal=$PIR2_SEALED_ORDINAL
+                ;;
+            esac
+            ;;
+    esac
+    [ "${PIR2_SEALED_FAILURE_RECOVERY_ACTIVE:-false}" != true ] || return 1
+    [ "${PIR2_SEALED_FAILURE_RECOVERY_PUBLISHING:-false}" != true ] || return 1
+    [ -z "${PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID:-}" ] || return 1
+
+    PIR2_SEALED_FAILURE_RECOVERY_PUBLISHING=true
+    recovery_window_seconds=$(pir2_sealed_receipt_recovery_window_seconds) || return 1
+    case "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" in
+        /run/bitcoinpir-pir2-sealed-receipt-api) ;;
+        *) return 1 ;;
+    esac
+    rm -rf "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" || return 1
+    mkdir -p "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" || return 1
+    chmod 700 "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" || return 1
+    failure_detail_hex=$(pir2_sealed_failure_stderr_detail_hex 2>/dev/null || true)
+    [ -n "$failure_detail_hex" ] || failure_detail_hex=$(pir2_sealed_failure_detail_hex "$failure_detail")
+    status_tmp="$PIR2_SEALED_RECEIPT_RECOVERY_STATUS_FILE.tmp.$$"
+    umask 077
+    {
+        printf '{"schema_version":1,"status":"failed","stage":"%s",' "$failure_stage"
+        printf '"phase":"%s","ordinal":%s,"detail_hex":"%s"}\n' \
+            "$failure_phase" "$failure_ordinal" "$failure_detail_hex"
+    } >"$status_tmp" || return 1
+    chmod 600 "$status_tmp" || return 1
+    mv "$status_tmp" "$PIR2_SEALED_RECEIPT_RECOVERY_STATUS_FILE" || return 1
+    [ -x "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD" ] || return 1
+    "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD" httpd -f \
+        -p "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_HOST:$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PORT" \
+        -h "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" </dev/null >/dev/null 2>&1 &
+    PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID=$!
+    PIR2_SEALED_FAILURE_RECOVERY_ACTIVE=true
+    sleep "$recovery_window_seconds"
+    stop_pir2_sealed_receipt_recovery_api || return 1
+    remove_pir2_sealed_receipt_recovery_api_root || return 1
+    PIR2_SEALED_FAILURE_RECOVERY_ACTIVE=false
+    PIR2_SEALED_FAILURE_RECOVERY_PUBLISHING=false
+}
+
+capture_pir2_sealed_preflight_stderr() {
+    umask 077
+    : >"$PIR2_SEALED_FAILURE_STDERR_FILE" || return 1
+    chmod 600 "$PIR2_SEALED_FAILURE_STDERR_FILE" || return 1
+    "$@" 2>"$PIR2_SEALED_FAILURE_STDERR_FILE"
+    captured_status=$?
+    cat "$PIR2_SEALED_FAILURE_STDERR_FILE" >&2 || true
+    return "$captured_status"
+}
+
 prepare_pir2_sealed_receipt_recovery_api() {
     case "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" in
         /run/bitcoinpir-pir2-sealed-receipt-api) ;;
@@ -782,6 +867,7 @@ publish_pir2_sealed_receipt_recovery_window() {
         -p "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_HOST:$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PORT" \
         -h "$PIR2_SEALED_RECEIPT_RECOVERY_HTTP_ROOT" </dev/null >/dev/null 2>&1 &
     PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID=$!
+    PIR2_SEALED_SUCCESS_RECOVERY_LISTENER_STARTED=true
     printf '%s\n' "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID" >"$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID_FILE" \
         || fatal "failed to record pir2 sealed receipt recovery process"
     chmod 600 "$PIR2_SEALED_RECEIPT_RECOVERY_HTTPD_PID_FILE" \
@@ -794,8 +880,9 @@ publish_pir2_sealed_receipt_recovery_window() {
 }
 
 run_pir2_sealed_inert_phase() {
+    PIR2_SEALED_FAILURE_STAGE=dispatcher
     if [ "$PIR2_SEALED_PHASE" = observe ]; then
-        "$UNIFIED_SERVER" \
+        capture_pir2_sealed_preflight_stderr "$UNIFIED_SERVER" \
             --port 8091 \
             --role secondary \
             --serve-queries \
@@ -809,7 +896,7 @@ run_pir2_sealed_inert_phase() {
             --pir2-snp-sealed-current-boot-id-hex "$PIR2_BOOT_ID_HEX"
     else
         require_file "$PIR2_SEALED_RELEASE_PATH"
-        "$UNIFIED_SERVER" \
+        capture_pir2_sealed_preflight_stderr "$UNIFIED_SERVER" \
             --port 8091 \
             --role secondary \
             --serve-queries \
@@ -843,7 +930,8 @@ run_pir2_sealed_ready_preflight() {
         echo "[unified-server-run] reusing authoritative current-attempt pir2 sealed Ready-preflight success" >&2
         return 0
     fi
-    run_pir2_with_public_artifacts child "$UNIFIED_SERVER" \
+    PIR2_SEALED_FAILURE_STAGE=dispatcher
+    capture_pir2_sealed_preflight_stderr run_pir2_with_public_artifacts child "$UNIFIED_SERVER" \
         --port 8091 \
         --role secondary \
         --serve-queries \
@@ -1263,17 +1351,21 @@ verify_direct_oram_publish() {
     echo "[unified-server-run] verified published $db_label direct ORAM paths" >&2
 }
 
+PIR2_SEALED_FAILURE_RECOVERY_ENABLED=true
+PIR2_SEALED_FAILURE_STAGE=startup-config
+load_pir2_sealed_startup_config
 [ -x "$UNIFIED_SERVER" ] || fatal "$UNIFIED_SERVER missing from UKI"
 # BusyBox ash provides the required ulimit builtin in the measured initramfs.
 # shellcheck disable=SC3045
+PIR2_SEALED_FAILURE_STAGE=process-controls
 ulimit -c 0 || fatal "failed to disable core dumps before pir2 sealed startup"
 PIR2_PROC_SWAPS=${BPIR_PIR2_PROC_SWAPS:-/proc/swaps}
 require_file "$PIR2_PROC_SWAPS"
 active_swap_rows=$(awk 'NR > 1 { count++ } END { print count + 0 }' "$PIR2_PROC_SWAPS") \
     || fatal "failed to inspect active swap before pir2 sealed startup"
 [ "$active_swap_rows" = 0 ] || fatal "active swap is forbidden for pir2 sealed startup"
+PIR2_SEALED_FAILURE_STAGE=attempt
 read_pir2_current_boot
-load_pir2_sealed_startup_config
 prepare_pir2_sealed_output_dirs
 prepare_pir2_sealed_attempt_dir
 case "$PIR2_SEALED_PHASE" in

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -343,6 +343,10 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 printf '%s:%s\n' "$phase" "$release_seen" >> "${inertCalls}"
+[ "\${BPIR_TEST_CHILD_EXIT_ONE:-false}" = true ] && {
+  printf 'fixture child exit one\n' >&2
+  exit 1
+}
 [ ! -e "$receipt" ] || exit 2
 [ ! -e "$marker" ] || exit 2
 printf 'fixture receipt\n' > "$receipt"
@@ -367,7 +371,9 @@ exit 42
     tier3RunText
       .replace("UNIFIED_SERVER=/usr/local/bin/unified_server", `UNIFIED_SERVER=${inertBinary}`)
       .replace("PIR2_SEALED_RECEIPT_RECOVERY_HTTPD=/usr/bin/busybox", `PIR2_SEALED_RECEIPT_RECOVERY_HTTPD=${inertBusybox}`)
+      .replace("PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS=600", "PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS=1")
       .replaceAll("/run/bitcoinpir-pir2-sealed-receipt-api", `${inertRoot}/receipt-recovery-api`)
+      .replaceAll("/run/bitcoinpir-pir2-sealed-preflight.stderr", `${inertRoot}/preflight.stderr`)
       .replaceAll("sleep 5", ":"),
   );
   chmodSync(inertRunScript, 0o755);
@@ -472,6 +478,56 @@ exit $?
     /"phase":"observe","ordinal":77,"boot_id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","receipt_sha256":"[0-9a-f]{64}"/,
   );
   assert.equal(existsSync(recoveryApiRoot), false, "receipt recovery root must be removed after its bounded window");
+
+  // This is intentionally a real httpd boundary: a shell syntax check or a
+  // unit test of JSON formatting cannot prove that a failed measured child is
+  // observable through the same bounded recovery listener before it closes.
+  const failureRoot = path.join(inertRoot, "failure-window");
+  writeSealedStartup(failureRoot, "observe", 78);
+  writeFileSync(inertBootId, "cccccccc-cccc-cccc-cccc-cccccccccccc\n");
+  const failureStatusOutput = path.join(inertRoot, "failed-status.json");
+  const failureRunner = `
+"$1" >"$2" 2>"$3" &
+pid=$!
+i=0
+until curl -fsS "http://127.0.0.1:8091/status.json" >"$4"; do
+  [ "$i" -lt 100 ] || exit 3
+  sleep 0.02
+  i=$((i + 1))
+done
+wait "$pid"
+exit $?
+`;
+  const failure = run(
+    "sh",
+    [
+      "-c",
+      failureRunner,
+      "fixture",
+      inertRunScript,
+      path.join(inertRoot, "failure.stdout"),
+      path.join(inertRoot, "failure.stderr"),
+      failureStatusOutput,
+    ],
+    {
+      env: {
+        ...process.env,
+        BPIR_ORAM_BOOT_ID_FILE: inertBootId,
+        BPIR_PIR2_PROC_SWAPS: inertSwaps,
+        BPIR_PIR2_SNP_SEALED_ROOT: failureRoot,
+        BPIR_PIR2_SNP_SEALED_ATTEMPT_ROOT: path.join(failureRoot, "trusted-attempt"),
+        BPIR_TEST_CHILD_EXIT_ONE: "true",
+        BPIR_TEST_PIR2_SEALED_RECEIPT_RECOVERY_WINDOW_SECONDS: "1",
+      },
+    },
+  );
+  assert.notEqual(failure.status, 0, failure.stdout + failure.stderr);
+  assert.match(
+    readFileSync(failureStatusOutput, "utf8"),
+    /{"schema_version":1,"status":"failed","stage":"dispatcher","phase":"observe","ordinal":78,"detail_hex":"[0-9a-f]+"}/,
+  );
+  assert.match(readFileSync(path.join(inertRoot, "failure.stderr"), "utf8"), /fixture child exit one/);
+  assert.equal(existsSync(recoveryApiRoot), false, "failed-status recovery root must close after its bounded window");
 
   const forgedRoot = path.join(inertRoot, "forged-persistent");
   const forgedAttemptRoot = path.join(forgedRoot, "trusted-attempt");
@@ -618,6 +674,7 @@ exit 0
     .replace("TRUSTED_INPUT_ROOT=/run/bitcoinpir-oram-inputs", `TRUSTED_INPUT_ROOT=${mismatchRoot}/trusted-inputs`)
     .replace("TRUSTED_STATE_ROOT=/run/bitcoinpir-oram-state", `TRUSTED_STATE_ROOT=${mismatchRoot}/trusted-state`)
     .replaceAll("/run/bitcoinpir-oram-status-api", `${mismatchRoot}/status-api`)
+    .replaceAll("/run/bitcoinpir-pir2-sealed-preflight.stderr", `${mismatchRoot}/preflight.stderr`)
     .replaceAll("sleep 5", ":");
   writeFileSync(fixtureRunScript, transformed);
   chmodSync(fixtureRunScript, 0o755);
@@ -786,6 +843,7 @@ exit 1
     .replace("/usr/share/bitcoinpir/proofs/height-940611.leaf-proof.json", directBhtmProof)
     .replace("ORAMCTL=/usr/local/bin/oramctl", `ORAMCTL=${directOramctl}`)
     .replaceAll("/run/bitcoinpir-oram-status-api", directStatusApiRoot)
+    .replaceAll("/run/bitcoinpir-pir2-sealed-preflight.stderr", `${directRoot}/preflight.stderr`)
     .replace("start_direct_oram_status_api\nstart_total_watchdog", ":\nstart_total_watchdog")
     .replace(
       'stop_direct_oram_status_api || fatal "Direct ORAM status API did not release port 8091"\nremove_direct_oram_status_api_root || fatal "failed to remove Direct ORAM status API root"',


### PR DESCRIPTION
Adds the smallest sealed preflight failure recovery path.

- publishes a bounded failed status through the existing local recovery root before the success receipt listener exists
- captures and replays bounded child stderr as detail_hex
- keeps successful receipt behavior unchanged

Validation:
- sh -n scripts/dracut/97bpir-tier3-init/unified-server-run.sh
- node scripts/vpsbg-tier3-generation.test.mjs
- git diff --check