### PR TITLE
fix(deploy): bound Tier3 UKI construction

### DIFF
--- a/.agents/skills/bitcoinpir-production-workflow/SKILL.md
+++ b/.agents/skills/bitcoinpir-production-workflow/SKILL.md
@@ -49,14 +49,19 @@ Success: `PASS issuer_state=init`. Next: build the UKI.
 
 ## 4. UKI
 
-Inputs: root build host, service policy, runtime binaries, and output path.
+Inputs: approved root build host plus explicit kernel, ORAM-enabled runtime,
+oramctl, proof, service policy, output, and archive paths. Read
+`docs/runbooks/uki-build.md`; Nix and attested-builder outputs are different
+reproducibility blocks and are not substitutes for this runtime UKI.
 
 ```bash
-sudo BPIR_TIER3_SERVICE_POLICY=/absolute/service-policy.bin OUT=/absolute/release.efi scripts/build_uki_tier3.sh --dry-run
-sudo BPIR_TIER3_SERVICE_POLICY=/absolute/service-policy.bin OUT=/absolute/release.efi scripts/build_uki_tier3.sh
+sudo env KERNEL=/boot/vmlinuz-EXACT-generic BINARY=/absolute/unified_server BPIR_UNIFIED_SERVER_BIN=/absolute/unified_server ORAMCTL=/absolute/oramctl BHTM_FROM_LEAF_PROOF=/absolute/height-940611.leaf-proof.json BPIR_TIER3_SERVICE_POLICY=/absolute/service-policy.bin OUT=/absolute/release.efi UKI_ARCHIVE_REMOTE=archive-host:/home/pir/uki-archive/tier3 UKI_ARCHIVE_REMOTE_REQUIRED=1 scripts/build_uki_tier3.sh --dry-run
+sudo env KERNEL=/boot/vmlinuz-EXACT-generic BINARY=/absolute/unified_server BPIR_UNIFIED_SERVER_BIN=/absolute/unified_server ORAMCTL=/absolute/oramctl BHTM_FROM_LEAF_PROOF=/absolute/height-940611.leaf-proof.json BPIR_TIER3_SERVICE_POLICY=/absolute/service-policy.bin OUT=/absolute/release.efi UKI_ARCHIVE_REMOTE=archive-host:/home/pir/uki-archive/tier3 UKI_ARCHIVE_REMOTE_REQUIRED=1 scripts/build_uki_tier3.sh
 ```
 
-Success: `wrote tier3 UKI: ...`, `tier3 uki sha256: ...`, and `PASS uki_build`.
+Success: a directly Zstandard-compressed initramfs, the required measured
+inventory, an EFI no larger than 256 MiB, `wrote tier3 UKI: ...`,
+`tier3 uki sha256: ...`, dual archive evidence, and `PASS uki_build`.
 Next: inspect or change VPSBG measured boot with `$vpsbg-measured-boot`.
 
 ## 5. VPSBG image

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -408,7 +408,10 @@ cargo test -p pir-sdk-wasm --lib
   - **pir1** (Hetzner: DPF-0 + OnionPIR + Harmony hint — no ORAM): `cargo build --locked --release -p runtime --bin unified_server` (default features).
   - **pir2** (VPSBG Tier 3: Direct/Circuit ORAM query path): `cargo build --locked --release -p runtime --features cuckoo-oram --bin unified_server`.
   - Do **not** use `build_unified_server.sh` or `nix build .#unified-server` for a production binary. The flake is a development/reproducibility harness only; the deployed pir1/pir2 binaries were never Nix-built (verified via embedded source paths and cargo feature fingerprints on the build host).
-- **Build UKI** (with VPSBG kernel): `sudo env KERNEL=/boot/vmlinuz-7.0.0-15-generic BINARY=/absolute/path/to/unified_server BPIR_UNIFIED_SERVER_BIN=/absolute/path/to/unified_server ./scripts/build_uki_tier3.sh`
+- **Build UKI**: follow `docs/runbooks/uki-build.md` and set the exact kernel,
+  binary, oramctl, proof, policy, output and archive paths. The canonical script
+  pins Zstandard compression and excludes early microcode, GPU firmware and
+  unrelated globally installed BitcoinPIR dracut modules.
 - **Deploy UKI**: `scp pir-hetzner:/tmp/bpir-tier3.efi deploy/uki/bpir-tier3-vN.efi`, then portal → Upload → Save & Reboot
 - **Cross-build stack**: kernel 7.0.0-15, kmod 34.2, libkmod 2.5.1, dracut 110 (all backported from Ubuntu 25.04 plucky)
 - **Critical**: dracut 060 (Ubuntu 24.04) cannot build a working initramfs for kernel 7.0 — modprobe silently fails. dracut 110 required.
@@ -417,7 +420,8 @@ cargo test -p pir-sdk-wasm --lib
 Never use `echo "$var" | grep -q` under `set -o pipefail`. `grep -q` exits on first match → pipe closes → echo gets SIGPIPE (141) → pipefail propagates → false failure. Use `grep -q ... <<< "$var"` (here-string) instead. See `memory/pattern_shell_sigpipe.md`.
 
 ### UKI/initramfs internals
-- dracut-110 on Ubuntu 24.04 produces **zstd-compressed** initramfs (raw `.img` is Zstandard data)
+- `scripts/build_uki_tier3.sh` explicitly requests and validates a
+  **zstd-compressed** initramfs; never rely on the build host's dracut defaults.
 - Uses **real kmod** (`/usr/bin/kmod` +ZSTD), NOT busybox modprobe — `.ko.zst` support works
 - Kernel modules stored as `.ko.zst` in initramfs: `usr/lib/modules/$KVER/kernel/drivers/...`
 - Inspect with `lsinitrd` (handles all compression); `cpio -t <` does NOT work on zstd

--- a/docs/PHASE3_SLICE3_REPRO_PLAN.md
+++ b/docs/PHASE3_SLICE3_REPRO_PLAN.md
@@ -1,5 +1,13 @@
 # Phase 3 Slice 3 — UKI Reproducible-Build Plan (L4 polish)
 
+> **Historical reproducibility record; not a production build runbook.** This
+> document contains several successive experiments, including a Nix UKI that
+> does not carry the current pir2 `cuckoo-oram`, `oramctl`, proof, policy, and
+> sealed-runtime contract. For the separated current source, binary, UKI,
+> measurement, Nix-harness, and attested-builder blocks, use
+> [`runbooks/uki-build.md`](runbooks/uki-build.md). Production operations start
+> at [`PRODUCTION_OPERATIONS.md`](PRODUCTION_OPERATIONS.md).
+
 **Status (2026-05-04)**: All five sub-tasks shipped. Sub-tasks 1+2+3b+4
 deployed to pir2 as Tier 3 v4 (MEASUREMENT `f6aa2915…` chip-verified).
 Sub-task 5 Phase 1 (Nix dev shell) + Phase 2 (`nix build .#unified-server`

--- a/docs/runbooks/uki-build.md
+++ b/docs/runbooks/uki-build.md
@@ -1,25 +1,94 @@
-# Build a Tier 3 UKI
+# Build and reproduce a Tier 3 UKI
 
-Use [`scripts/build_uki_tier3.sh`](../../scripts/build_uki_tier3.sh) to produce
-a UKI for a reviewed service-policy artifact.
+This is the current operator entry for the production `unified_server` runtime
+UKI. It keeps four different concerns separate so a historical experiment
+cannot silently become the release recipe.
 
-## Inputs
+## 1. Source and runtime binary
 
-- A Linux build host with the Tier 3 build dependencies.
-- The approved policy file path.
-- Optional output path and kernel selection.
-
-## Run
+Use a clean checkout at the exact reviewed release commit. Build the pir2
+runtime with its production feature profile, then strip only debug data:
 
 ```sh
-sudo BPIR_TIER3_SERVICE_POLICY=/absolute/path/service-policy.bin \
-  OUT=/absolute/path/bpir-tier3.efi \
-  scripts/build_uki_tier3.sh --dry-run
-sudo BPIR_TIER3_SERVICE_POLICY=/absolute/path/service-policy.bin \
-  OUT=/absolute/path/bpir-tier3.efi \
-  scripts/build_uki_tier3.sh
+cargo build --locked --release -p runtime \
+  --features cuckoo-oram --bin unified_server
+strip --strip-debug target/release/unified_server
 ```
 
-The build prints dependency checks, the selected kernel, and the output path.
-Successful completion prints `PASS uki_build` and `NEXT_STEP`. Record the UKI
-path and digest, then continue with the [VPSBG image runbook](vpsbg-image.md).
+Record the commit and binary SHA-256. `scripts/build_unified_server.sh` and
+`nix build .#unified-server` are reproducibility/development harnesses; neither
+is the production pir2 binary authority.
+
+## 2. UKI assembly inputs
+
+Run [`scripts/build_uki_tier3.sh`](../../scripts/build_uki_tier3.sh) as root on
+the approved Linux build host. Set every release input explicitly:
+
+- `KERNEL`: exact readable VPSBG-compatible kernel image;
+- `BINARY` and `BPIR_UNIFIED_SERVER_BIN`: the same stripped pir2 binary;
+- `ORAMCTL`: exact executable to embed;
+- `BHTM_FROM_LEAF_PROOF`: exact retained proof input;
+- `BPIR_TIER3_SERVICE_POLICY`: reviewed policy matching the source lock;
+- `OUT`: unique absolute candidate path;
+- archive locations, including a required off-host mirror when applicable.
+
+The script pins Zstandard compression, excludes early microcode, GPU firmware,
+and unrelated globally installed BitcoinPIR dracut modules, validates the
+measured inventory, and refuses to archive an EFI larger than 256 MiB. Compare
+the candidate's file class and size with the retained image-265 release record
+in [`../data-retention/production-release-image-265.env`](../data-retention/production-release-image-265.env).
+An unexplained change from that mature class is a failed build, not a release.
+
+```sh
+sudo env \
+  KERNEL=/boot/vmlinuz-EXACT-generic \
+  BINARY=/absolute/clean-checkout/target/release/unified_server \
+  BPIR_UNIFIED_SERVER_BIN=/absolute/clean-checkout/target/release/unified_server \
+  ORAMCTL=/absolute/oramctl \
+  BHTM_FROM_LEAF_PROOF=/absolute/height-940611.leaf-proof.json \
+  BPIR_TIER3_SERVICE_POLICY=/absolute/service-policy.bin \
+  OUT=/absolute/unique-release.efi \
+  UKI_ARCHIVE_REMOTE=archive-host:/home/pir/uki-archive/tier3 \
+  UKI_ARCHIVE_REMOTE_REQUIRED=1 \
+  scripts/build_uki_tier3.sh --dry-run
+
+# Repeat the exact command without --dry-run after reviewing its inputs.
+```
+
+Before the real build, report its expected duration, a 15-minute hard stop,
+and the progress signals: runtime binary, dracut initrd, inventory gates,
+`ukify`, SHA-256, and dual archive.
+
+## 3. Build-host choice
+
+Hetzner may build the candidate only when its exact kernel/modules and build
+dependencies satisfy the command above. The script must not inherit host
+compression or unrelated dracut modules.
+
+If those inputs are unavailable, the fallback is the established VPSBG
+maintenance shape: separately authorize changing measured boot to no attached
+UKI, reboot into the stock root filesystem, build there, archive off-host, and
+reattach the recorded rollback image if the maintenance build fails. Do not
+assume the VPSBG API's `null`/`None` behavior; confirm the operator action and
+rollback image before changing the server.
+
+## 4. Reproducibility and verification
+
+These are distinct claims:
+
+| Block | Current authority | What it proves |
+| --- | --- | --- |
+| Source | exact Git commit plus `Cargo.lock` | reviewed code and dependency selection |
+| pir2 binary | bare Cargo command above plus binary SHA-256 | exact ORAM-enabled runtime bytes used by the UKI |
+| UKI assembly | this runbook and `build_uki_tier3.sh` | exact kernel, initramfs inputs, compression, inventory, EFI and archive metadata |
+| Independent launch check | retained EFI + pinned OVMF + required VPSBG launch tuple | predicted SEV measurement can be compared with the chip readback |
+| Nix harness | `flake.nix` / historical reproducibility plan | development reproducibility only; not a production pir2 UKI |
+| Attested-builder UKI | `build_uki_attested_builder_tier3.sh` | one-shot database producer; never the runtime server UKI |
+
+Full cross-host byte reproduction requires the same declared kernel/modules
+and toolchain inputs. A matching binary hash or predicted measurement alone
+does not authorize upload, switch, reboot, sealed release, or activation.
+
+Successful completion prints `PASS uki_build` and `NEXT_STEP`. Record the EFI,
+SHA-256, metadata and both archive locations, then continue with the
+[VPSBG image runbook](vpsbg-image.md).

--- a/scripts/build_uki_tier3.sh
+++ b/scripts/build_uki_tier3.sh
@@ -12,8 +12,10 @@ Builds the Tier 3 UKI on the selected Linux build host.
 Required environment:
   BPIR_TIER3_SERVICE_POLICY  Reviewed signed service-policy file.
 
-Optional environment:
+Production release inputs (set explicitly in the operator command):
   KERNEL, BINARY, ORAMCTL, BHTM_FROM_LEAF_PROOF, OUT
+
+Archive environment:
   UKI_ARCHIVE_DIR, UKI_ARCHIVE_REMOTE, UKI_ARCHIVE_REMOTE_REQUIRED
 
 On success the script writes OUT (default /tmp/bpir-tier3.efi), prints its
@@ -27,8 +29,12 @@ case "${1:-}" in
     -h|--help) usage; exit 0 ;;
     --dry-run)
         echo '[stage] Tier 3 UKI build preview'
-        echo 'required_input=BPIR_TIER3_SERVICE_POLICY'
-        echo 'output=OUT (default /tmp/bpir-tier3.efi)'
+        for input_name in KERNEL BINARY ORAMCTL BHTM_FROM_LEAF_PROOF BPIR_TIER3_SERVICE_POLICY OUT; do
+            input_value=${!input_name:-MISSING}
+            echo "$input_name=$input_value"
+        done
+        echo 'initrd_compression=zstd'
+        echo 'max_uki_bytes=268435456'
         echo 'PASS uki_build dry_run=true'
         echo 'NEXT_STEP=run without --dry-run as root on the approved UKI build host'
         exit 0
@@ -36,19 +42,32 @@ case "${1:-}" in
     *) usage >&2; exit 2 ;;
 esac
 
+for input_name in KERNEL BINARY ORAMCTL BHTM_FROM_LEAF_PROOF BPIR_TIER3_SERVICE_POLICY OUT; do
+    if [ -z "${!input_name:-}" ]; then
+        echo "error: $input_name must be set explicitly for a production Tier 3 UKI" >&2
+        exit 1
+    fi
+done
+
 if [ "$EUID" != "0" ]; then
     echo "error: build_uki_tier3.sh must run as root on the UKI build host" >&2
     exit 1
 fi
 
 # ─── Defaults (override via env) ───────────────────────────────────────────
-KERNEL=${KERNEL:-}
-OUT=${OUT:-/tmp/bpir-tier3.efi}
 CUSTOM_INITRD=/tmp/bpir-tier3-initrd.img
 # The currently deployed image accepts service-policy epoch 8 with this exact
 # digest. A policy rotation is a production behavior change and must update
 # this reviewed lock in source before a new UKI can be emitted.
 TIER3_SERVICE_POLICY_SHA256=5e57ed6b5313ebf89f8f00b24d9ad78452be24e9e59bc88c96d56203f4a26092
+TIER3_INITRD_COMPRESSION=zstd
+TIER3_INITRD_MAGIC=28b52ffd
+TIER3_MAX_UKI_BYTES=$((256 * 1024 * 1024))
+# Only the three modules in --add below belong to the production runtime UKI.
+# Omit dracut modules that may be installed globally by maintenance, builder,
+# or retired release work. The generic drm module pulls host GPU firmware into
+# a non-hostonly image even though the serial-console SEV guest does not use it.
+TIER3_OMIT_DRACUT_MODULES="drm bpir-verify bpir-attested-builder bpir-builder-tier3-init bpir-pir2-sealed-provisioner bhtm-proof-init"
 
 # Resolve dracut module dir relative to this script.
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
@@ -57,12 +76,16 @@ ARCHIVE_SCRIPT="$SCRIPT_DIR/archive_uki_artifact.sh"
 
 # ─── Sanity checks ─────────────────────────────────────────────────────────
 
-for tool in ukify dracut sha256sum; do
+for tool in ukify dracut sha256sum zstd od stat; do
     command -v "$tool" >/dev/null 2>&1 || {
         echo "error: $tool not installed (apt install systemd-ukify dracut)" >&2
         exit 1
     }
 done
+
+DRACUT_VERSION=$(dracut --version 2>&1 | head -1)
+UKIFY_VERSION=$(ukify --version 2>&1 | head -1)
+ZSTD_VERSION=$(zstd --version 2>&1 | head -1)
 
 # The Tier 3 init process uses runit. Check its executables before invoking
 # dracut so a missing package has a direct error.
@@ -83,19 +106,12 @@ done
 }
 
 # The unified_server and oramctl binaries must be built and present.
-BINARY=${BINARY:-/home/pir/BitcoinPIR/target/release/unified_server}
 [ -x "$BINARY" ] || {
     echo "error: $BINARY not executable" >&2
     echo "       run: cargo build --release -p runtime --features cuckoo-oram --bin unified_server" >&2
     exit 1
 }
-if [ -n "${ORAMCTL:-}" ]; then
-    ORAMCTL_BIN="$ORAMCTL"
-elif [ -x /home/pir/BitcoinPIR/vendor/bitcoinpir-oram/target/release/oramctl ]; then
-    ORAMCTL_BIN=/home/pir/BitcoinPIR/vendor/bitcoinpir-oram/target/release/oramctl
-else
-    ORAMCTL_BIN=/home/pir/bitcoin-pir/oram/target/release/oramctl
-fi
+ORAMCTL_BIN="$ORAMCTL"
 [ -x "$ORAMCTL_BIN" ] || {
     echo "error: $ORAMCTL_BIN not executable" >&2
     echo "       run: cd /home/pir/bitcoin-pir/oram && cargo build --release --bin oramctl" >&2
@@ -104,7 +120,6 @@ fi
 }
 export BPIR_ORAMCTL_BIN="$ORAMCTL_BIN"
 
-BHTM_FROM_LEAF_PROOF=${BHTM_FROM_LEAF_PROOF:-/home/pir/BitcoinPIR/web/public/proofs/trust-chain/delta_940611_948454/bhtm/height-940611.leaf-proof.json}
 [ -r "$BHTM_FROM_LEAF_PROOF" ] || {
     echo "error: BHTM from-leaf proof not readable: $BHTM_FROM_LEAF_PROOF" >&2
     exit 1
@@ -134,18 +149,9 @@ if [ "$SERVICE_POLICY_HASH" != "$TIER3_SERVICE_POLICY_SHA256" ]; then
 fi
 
 # ─── Kernel auto-detection ──────────────────────────────────────────────────
-# Prefer explicit KERNEL=/boot/vmlinuz-<ver> in the environment.
-# Otherwise, auto-detect the latest installed kernel (highest sort order under
-# /boot/vmlinuz-*). This adapts to unattended-upgrades replacing the kernel
-# and apt autoremove cleaning stale modules without manual pin maintenance.
-if [ -z "$KERNEL" ]; then
-    KERNEL=$(ls -1 /boot/vmlinuz-*-generic 2>/dev/null | sort -V | tail -1)
-    if [ -z "$KERNEL" ]; then
-        echo "error: no kernel found under /boot/vmlinuz-*-generic — set KERNEL= explicitly" >&2
-        exit 1
-    fi
-    echo "auto-detected kernel: $KERNEL"
-fi
+# Production builds never auto-select the newest installed kernel: package
+# upgrades would otherwise change the measured artifact without changing the
+# operator command or source commit.
 [ -r "$KERNEL" ] || { echo "error: $KERNEL not readable" >&2; exit 1; }
 
 # Derive kernel version from KERNEL filename.
@@ -243,6 +249,9 @@ echo "oramctl sha256:           $ORAMCTL_HASH"
 echo "BHTM proof sha256:        $BHTM_PROOF_HASH"
 echo "service policy:          $BPIR_TIER3_SERVICE_POLICY"
 echo "service policy sha256:   $SERVICE_POLICY_HASH"
+echo "dracut:                  $DRACUT_VERSION"
+echo "ukify:                   $UKIFY_VERSION"
+echo "initrd compression:      $TIER3_INITRD_COMPRESSION ($ZSTD_VERSION)"
 
 # ─── Generate initramfs ────────────────────────────────────────────────────
 # --add network            : pulls in dracut's network plumbing (mostly
@@ -256,6 +265,10 @@ echo "service policy sha256:   $SERVICE_POLICY_HASH"
 # --reproducible           : strip mtimes / stamps from the cpio so a
 #                            re-run of this script with the same inputs
 #                            produces byte-identical output.
+# --compress zstd          : do not inherit a build-host compression default.
+# --no-early-microcode     : CPU microcode is a host/firmware responsibility;
+#                            the measured guest does not consume a 20+ MB blob.
+# --omit drm ...           : exclude GPU firmware and stale global BPIR modules.
 # SOURCE_DATE_EPOCH=0      : force every fallback timestamp to 1970-01-01.
 echo "generating tier3 initrd…"
 # --no-strip: dracut's default is to `strip` binaries on copy to save
@@ -273,11 +286,23 @@ echo "generating tier3 initrd…"
 # (modprobe pulls it transitively, but listing it makes intent explicit).
 DRIVER_LIST="virtio_net virtio_pci virtio_blk $SEV_DRIVER_LIST"
 SOURCE_DATE_EPOCH=0 dracut --force --no-hostonly --reproducible --nostrip \
+    --compress "$TIER3_INITRD_COMPRESSION" \
+    --no-early-microcode \
+    --omit "$TIER3_OMIT_DRACUT_MODULES" \
     --add "network bpir-cloudflared bpir-unified-server bpir-tier3-init" \
     --add-drivers " $DRIVER_LIST " \
     --kver "$KVER" \
     "$CUSTOM_INITRD"
-echo "initrd:                   $CUSTOM_INITRD ($(du -h "$CUSTOM_INITRD" | cut -f1))"
+INITRD_BYTES=$(stat -c '%s' "$CUSTOM_INITRD")
+INITRD_MAGIC=$(od -An -tx1 -N4 "$CUSTOM_INITRD" | tr -d '[:space:]')
+if [ "$INITRD_MAGIC" != "$TIER3_INITRD_MAGIC" ]; then
+    echo "ERROR: Tier 3 initramfs is not a directly zstd-compressed archive" >&2
+    echo "  expected magic: $TIER3_INITRD_MAGIC" >&2
+    echo "  actual magic:   $INITRD_MAGIC" >&2
+    echo "  refusing UKI assembly; inspect dracut compression/module selection" >&2
+    exit 1
+fi
+echo "initrd:                   $CUSTOM_INITRD ($(du -h "$CUSTOM_INITRD" | cut -f1), $INITRD_BYTES bytes, zstd)"
 
 # Post-build validation: verify SEV-SNP kernel modules actually landed in the
 # initramfs. Dracut silently skips modules it cannot find; the pre-build check
@@ -291,6 +316,22 @@ if [ -z "$INITRD_LISTING" ]; then
     echo "ERROR: lsinitrd failed — cannot inspect initramfs" >&2
     exit 1
 fi
+FORBIDDEN_TIER3_ITEMS=(
+    'usr/lib/firmware/nvidia/'
+    'kernel/x86/microcode/'
+    'usr/lib/dracut/modules.d/[0-9]+bpir-verify/'
+    'usr/lib/dracut/modules.d/[0-9]+bpir-attested-builder/'
+    'usr/lib/dracut/modules.d/[0-9]+bpir-builder-tier3-init/'
+    'usr/lib/dracut/modules.d/[0-9]+bpir-pir2-sealed-provisioner/'
+    'usr/lib/dracut/modules.d/[0-9]+bhtm-proof-init/'
+)
+for unexpected in "${FORBIDDEN_TIER3_ITEMS[@]}"; do
+    if grep -Eq -- "$unexpected" <<< "$INITRD_LISTING"; then
+        echo "ERROR: forbidden build-host payload leaked into Tier 3 initramfs: $unexpected" >&2
+        exit 1
+    fi
+done
+echo "GPU firmware, early microcode, and unrelated global BPIR modules absent"
 MISSING_MODS=""
 for mod in $REQUIRED_SEV_MODS; do
     # Use here-string instead of pipe to avoid SIGPIPE under set -o pipefail:
@@ -382,9 +423,17 @@ ukify build \
 
 # ─── Report ────────────────────────────────────────────────────────────────
 SIZE=$(du -h "$OUT" | cut -f1)
+UKI_BYTES=$(stat -c '%s' "$OUT")
+if [ "$UKI_BYTES" -gt "$TIER3_MAX_UKI_BYTES" ]; then
+    echo "ERROR: Tier 3 UKI exceeds the sealed-release input limit" >&2
+    echo "  limit: $TIER3_MAX_UKI_BYTES bytes" >&2
+    echo "  actual: $UKI_BYTES bytes" >&2
+    echo "  refusing archive; inspect the initramfs inventory" >&2
+    exit 1
+fi
 UKI_SHA=$(sha256sum "$OUT" | awk '{print $1}')
 echo
-echo "wrote tier3 UKI:          $OUT (${SIZE})"
+echo "wrote tier3 UKI:          $OUT (${SIZE}, $UKI_BYTES bytes)"
 echo "tier3 uki sha256:         $UKI_SHA"
 "$ARCHIVE_SCRIPT" tier3 "$OUT" \
     "kernel=$KERNEL" \
@@ -393,6 +442,11 @@ echo "tier3 uki sha256:         $UKI_SHA"
     "binary_sha256=$BIN_HASH" \
     "oramctl_sha256=$ORAMCTL_HASH" \
     "bhtm_from_leaf_sha256=$BHTM_PROOF_HASH" \
-    "service_policy_sha256=$SERVICE_POLICY_HASH"
+    "service_policy_sha256=$SERVICE_POLICY_HASH" \
+    "initrd_compression=$TIER3_INITRD_COMPRESSION" \
+    "initrd_size_bytes=$INITRD_BYTES" \
+    "dracut_version=$DRACUT_VERSION" \
+    "ukify_version=$UKIFY_VERSION" \
+    "zstd_version=$ZSTD_VERSION"
 echo 'PASS uki_build'
 echo 'NEXT_STEP=use scripts/vpsbg-measured-boot.sh to preview or apply the measured-boot image transition'

--- a/scripts/tier3-uki-policy-contract.test.mjs
+++ b/scripts/tier3-uki-policy-contract.test.mjs
@@ -20,6 +20,14 @@ const reviewedPolicySha256 =
   "5e57ed6b5313ebf89f8f00b24d9ad78452be24e9e59bc88c96d56203f4a26092";
 
 function validateBuildContract(source) {
+  assert.match(
+    source,
+    /for input_name in KERNEL BINARY ORAMCTL BHTM_FROM_LEAF_PROOF BPIR_TIER3_SERVICE_POLICY OUT/,
+  );
+  assert.match(
+    source,
+    /error: \$input_name must be set explicitly for a production Tier 3 UKI/,
+  );
   const policyRequirement = source.indexOf(
     '[ -n "${BPIR_TIER3_SERVICE_POLICY:-}" ] || {',
   );
@@ -46,6 +54,26 @@ function validateBuildContract(source) {
     /\[ "\$EMBEDDED_SERVICE_POLICY_HASH" != "\$SERVICE_POLICY_HASH" \]/,
   );
   assert.match(source, /"service_policy_sha256=\$SERVICE_POLICY_HASH"/);
+  assert.match(source, /TIER3_INITRD_COMPRESSION=zstd/);
+  assert.match(source, /TIER3_INITRD_MAGIC=28b52ffd/);
+  assert.match(source, /TIER3_MAX_UKI_BYTES=\$\(\(256 \* 1024 \* 1024\)\)/);
+  assert.match(source, /--compress "\$TIER3_INITRD_COMPRESSION"/);
+  assert.match(source, /--no-early-microcode/);
+  assert.match(source, /TIER3_OMIT_DRACUT_MODULES="[^"]*drm[^"]*"/);
+  assert.match(source, /TIER3_OMIT_DRACUT_MODULES="[^"]*bpir-verify[^"]*"/);
+  assert.match(source, /usr\/lib\/firmware\/nvidia\//);
+  assert.match(source, /kernel\/x86\/microcode\//);
+  assert.match(source, /forbidden build-host payload leaked into Tier 3 initramfs/);
+  assert.match(source, /\[ "\$INITRD_MAGIC" != "\$TIER3_INITRD_MAGIC" \]/);
+  assert.match(source, /\[ "\$UKI_BYTES" -gt "\$TIER3_MAX_UKI_BYTES" \]/);
+  assert.ok(
+    source.indexOf('[ "$UKI_BYTES" -gt "$TIER3_MAX_UKI_BYTES" ]') <
+      source.indexOf('"$ARCHIVE_SCRIPT" tier3 "$OUT"'),
+    "oversized UKIs must be rejected before archival",
+  );
+  assert.match(source, /"initrd_compression=\$TIER3_INITRD_COMPRESSION"/);
+  assert.match(source, /"dracut_version=\$DRACUT_VERSION"/);
+  assert.match(source, /"ukify_version=\$UKIFY_VERSION"/);
   assert.doesNotMatch(source, /BPIR_TIER3_IDENTITY_KEY/);
   assert.match(
     source,
@@ -98,6 +126,26 @@ test("production Tier3 build rejects policy lock or embedded-byte regressions", 
       source.replace(
         '[ "$EMBEDDED_SERVICE_POLICY_HASH" != "$SERVICE_POLICY_HASH" ]',
         '[ "$EMBEDDED_SERVICE_POLICY_HASH" = "$SERVICE_POLICY_HASH" ]',
+      ),
+    ),
+  );
+});
+
+test("production Tier3 build pins compression and rejects oversized output", () => {
+  const source = readFileSync(buildPath, "utf8");
+  assert.throws(() =>
+    validateBuildContract(
+      source.replace(
+        '--compress "$TIER3_INITRD_COMPRESSION"',
+        '--no-compress',
+      ),
+    ),
+  );
+  assert.throws(() =>
+    validateBuildContract(
+      source.replace(
+        '[ "$UKI_BYTES" -gt "$TIER3_MAX_UKI_BYTES" ]',
+        '[ "$UKI_BYTES" -lt "$TIER3_MAX_UKI_BYTES" ]',
       ),
     ),
   );


### PR DESCRIPTION
## Summary

Recover the established Tier3 UKI construction path and make host-dependent initrd growth fail closed before archival.

The rejected oversized candidate was dominated by build-host payload leakage: firmware, early microcode, unrelated modules, and global BitcoinPIR dracut modules. The production runtime binaries themselves were not the source of the roughly 192 MB increase.

## Changes

- require explicit kernel, unified_server, oramctl, proof, service-policy, and output inputs
- force Zstd initrd compression and reject an unexpected compression signature
- disable early microcode and omit DRM plus unrelated global BitcoinPIR dracut modules
- inspect the generated initrd and reject NVIDIA firmware, early microcode, or unrelated BitcoinPIR modules
- reject UKIs larger than 256 MiB before archival
- record dracut, ukify, and zstd versions plus initrd size in build metadata
- separate the current production build, the Nix reproducibility harness, and the attested-builder path in the runbook
- mark the older Slice 3 reproducibility plan as historical rather than the production entry point

## Verification

- PASS: bash syntax check for scripts/build_uki_tier3.sh
- PASS: Tier3 UKI policy contract tests, 6 of 6
- PASS: whitespace and patch consistency check
- NOT RUN: generic GitHub workflow supply-chain gate; this fresh worktree does not have the web locked YAML parser installed and reports: locked YAML parser unavailable; run npm ci in web first. This is unrelated to the UKI patch.

## Non-goals

- no UKI was built, uploaded, attached, or started
- no VPSBG server or image state was changed
- no issuer state was initialized or activated
- no payment or funds operation was performed
- the Nix harness was not promoted to the production binary authority
- no production artifact register was rewritten
