### PR TITLE
Add Harmony query scope back to pir2 service policy (epoch 2)

### DIFF
--- a/scripts/build_uki_tier3.sh
+++ b/scripts/build_uki_tier3.sh
@@ -56,10 +56,10 @@ fi
 
 # ─── Defaults (override via env) ───────────────────────────────────────────
 CUSTOM_INITRD=/tmp/bpir-tier3-initrd.img
-# The currently deployed image accepts service-policy epoch 8 with this exact
+# The currently deployed image accepts service-policy epoch 2 with this exact
 # digest. A policy rotation is a production behavior change and must update
 # this reviewed lock in source before a new UKI can be emitted.
-TIER3_SERVICE_POLICY_SHA256=5e57ed6b5313ebf89f8f00b24d9ad78452be24e9e59bc88c96d56203f4a26092
+TIER3_SERVICE_POLICY_SHA256=e32ed6e9bd4ae3ee32e174898c8da1072c26d4c74915ef905573739dc59cecc3
 TIER3_INITRD_COMPRESSION=zstd
 TIER3_INITRD_MAGIC=28b52ffd
 TIER3_MAX_UKI_BYTES=$((256 * 1024 * 1024))

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -1470,8 +1470,8 @@ trap - EXIT
 trap - HUP INT TERM
 start_unified_server_runtime_log
 
-# VPSBG is query-only and has no Harmony V2 hint pool, so the measured
-# invocation keeps online V2Full authorization disabled (limit 0).
+# VPSBG is query-only but now carries a Harmony V2 query scope (policy epoch 2).
+# Allow up to 2 concurrent online V2Full authorizations for Harmony query jobs.
 # Revalidate the mutable-mount public bytes after the bounded ORAM build. The
 # Rust loader then repeats canonical/signature/digest/member/role-key checks in
 # the final Ready process; the audit receipt is evidence, not runtime authority.
@@ -1515,7 +1515,7 @@ run_pir2_with_public_artifacts exec "$UNIFIED_SERVER" \
     --service-storeless-bat-v2-issuer-settlement-key-hex "$PIR2_SEALED_ISSUER_SETTLEMENT_KEY_HEX" \
     --service-storeless-bat-v2-minimum-authorization-epoch "$PIR2_SEALED_MINIMUM_AUTHORIZATION_EPOCH" \
     --service-max-concurrent-auth 4 \
-    --service-max-concurrent-online-v2full-auth 0 \
+    --service-max-concurrent-online-v2full-auth 2 \
     --connection-idle-timeout-ms 300000 \
     --service-pre-auth-timeout-ms 300000 \
     2>&1

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -27,7 +27,7 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "9376bdfeb2d469c3bcec055d361bfff84c018740f769131f7849c9c16f417700",
+    "13880c1e13fc1f6169dca9f69ccecd19edb3481e4adbb07be1c65ba1a2f973cd",
   "scripts/dracut/97bpir-tier3-init/unified-server-finish.sh":
     "361d6a52a2e61482d8e766823a17c3b12187f96805c7e1f9d0f785e27ae64ef9",
   "scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh":

--- a/scripts/tier3-uki-policy-contract.test.mjs
+++ b/scripts/tier3-uki-policy-contract.test.mjs
@@ -17,7 +17,7 @@ const runPath = resolve(
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh",
 );
 const reviewedPolicySha256 =
-  "5e57ed6b5313ebf89f8f00b24d9ad78452be24e9e59bc88c96d56203f4a26092";
+  "e32ed6e9bd4ae3ee32e174898c8da1072c26d4c74915ef905573739dc59cecc3";
 
 function validateBuildContract(source) {
   assert.match(


### PR DESCRIPTION
## Summary

- Re-signs the pir2 Tier 3 service policy at epoch 2, restoring the HarmonyPIR V2 query scope (`backend=harmony-pir-v2`, `workload=harmony-query-job-v1`) alongside the existing DPF scope
- The genesis policy (epoch 1) deliberately omitted Harmony to minimize the initial release surface; this rotation adds it back with a Free-PoW offer (offer_id 501)
- Enables `--service-max-concurrent-online-v2full-auth 2` (was 0) in `unified-server-run.sh` so the runtime admits Harmony V2Full authorizations
- Updates `TIER3_SERVICE_POLICY_SHA256` in `build_uki_tier3.sh` and `tier3-uki-policy-contract.test.mjs` to the new epoch-2 policy file hash

## Production steps (separate authorized operations)

This PR is the code-side preparation. The following production steps are separate and require explicit authorization:

1. UKI build with the new policy (root on approved Linux build host)
2. VPSBG image upload + switch (triggers pir2 reboot)
3. Sealed ceremony: Observe → Enroll → Probe → Ready (fresh ordinals/nonces)
4. Client trust pin rotation (`web/src/attest-pin.ts`)

## Test plan

- [x] `tier3-uki-policy-contract.test.mjs` — 6/6 pass
- [x] `payment-v1-deployment-template-gate` — PASS
- [x] `payment-bat-v2-source-profile-gate` — PASS
- [x] Policy signed and verified with `bpir-admin service-policy sign/verify` — epoch 2, 2 scopes (DPF + Harmony), 3 offers total
- [ ] Full CI on this PR

Made with [Cursor](https://cursor.com)