### PR TITLE
Fix stale two-provider E2E independent-state path count

### DIFF
--- a/web/e2e/payment-two-provider.global-setup.ts
+++ b/web/e2e/payment-two-provider.global-setup.ts
@@ -543,8 +543,8 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
       databaseProof,
       providers: runtimeProviders,
     };
-    if (independentStatePaths.size !== 8) {
-      throw new Error('two issuers and two providers did not receive eight independent state paths');
+    if (independentStatePaths.size !== 4) {
+      throw new Error('two issuers and two providers did not receive four independent state paths');
     }
     assertIndependentRuntimeProviders(fixture.providers, backendMode);
     process.env.BITCOINPIR_PAYMENT_TWO_PROVIDER_FIXTURE = JSON.stringify(fixture);


### PR DESCRIPTION
## Summary
- The two-provider Playwright harness records four sqlite paths (one issuer store and one provider store per provider). The leftover `size !== 8` check always failed after an otherwise successful setup.
- That blocked the confirmed `deploy-web.yml` Pages publish of the image-291 pin roll.
- Isolation still fails closed on path aliasing and on `assertIndependentRuntimeProviders`.

## Test plan
- [x] Confirm the harness only calls `recordIndependentStatePath` twice per provider
- [ ] `deploy-web.yml` on `main` with `confirm_production_deploy=true`


Made with [Cursor](https://cursor.com)