### PR TITLE
Script production flows A–I and record attested-builder coverage

### DIFF
--- a/.agents/skills/bitcoinpir-production-workflow/SKILL.md
+++ b/.agents/skills/bitcoinpir-production-workflow/SKILL.md
@@ -5,111 +5,36 @@ description: Run BitcoinPIR's production workflow through its repository command
 
 # BitcoinPIR production workflow
 
-Run each step in order. The wrapper steps print `PASS` and `NEXT_STEP=...`.
-Begin a wrapper that supports `--dry-run` with that option, then use the live
-form shown by its runbook for the selected operation.
+Do not run this skill as one end-to-end payment-to-UKI chain. Open
+[`docs/PRODUCTION_OPERATIONS.md`](../../../docs/PRODUCTION_OPERATIONS.md),
+pick **one** flow A–I, and run only that flow's numbered steps.
 
-## 1. Current status
+Wrapper commands print `PASS` and `NEXT_STEP`. Begin any mutation that
+supports `--dry-run` with that option. `--apply` is per step: never
+combine `upload` with `switch`, or `put` with `close`.
 
-Input: VPSBG server ID (when the deployment includes VPSBG).
+## Classify, then estimate
 
-```bash
-scripts/vpsbg-measured-boot.sh status --server-id ID
-```
+| Ask | Flow |
+| --- | --- |
+| Is pir up / what image is attached | A |
+| PR, tests, CI | B |
+| Publish www.bitcoinpir.org | C |
+| Restart or rebuild Hetzner | D |
+| New **runtime** pir2 UKI / switch / rollback | E |
+| Edit `/home/pir/data/` or place `startup.env` | F |
+| Sealed Observe / Enroll / Probe / Ready | G |
+| New DB / DPF / Harmony / Onion / ORAM proofs / pins | H (producer scope: attested-builder README; UKI: ATTESTED_BUILDER_TIER3_UKI.md) |
+| Payment artifacts or source-readiness | I |
 
-Success: `PASS action=status`. Record the returned status fields; a concrete
-image ID is available only when the status output reports one. Next: build
-payment artifacts.
+Before a long step, state the duration, hard stop, and progress signal
+from the workload table on that page.
 
-## 2. Payment artifacts
+## Commands the flows already own
 
-Inputs: the selected BAT V2 builder and its `bpir-admin payment-artifact`
-arguments. Obtain the exact arguments first.
+Status, images, UKI, measured-boot, data-disk, post-switch check, sealed
+phase/release, payment wrappers, and Pages dispatch are listed in
+Production operations. Copy commands from the matching flow; do not
+invent issuer deploy, keygen, funds, or image delete.
 
-```bash
-scripts/payment-v1-artifacts.sh bat-v2-class --help
-scripts/payment-v1-artifacts.sh bat-v2-class [original CLI arguments] --dry-run
-scripts/payment-v1-artifacts.sh bat-v2-class [original CLI arguments]
-```
-
-Success: `PASS artifact=bat-v2-class`. Next: initialize issuer state or the
-sealed release, as reported by `NEXT_STEP`.
-
-## 3. Issuer state
-
-Inputs: issuer store path, issuer ID, and network.
-
-```bash
-scripts/payment-v1-issuer-state.sh init --store /secure/issuer.sqlite3 --issuer-id-hex HEX --network bitcoin --dry-run
-scripts/payment-v1-issuer-state.sh init --store /secure/issuer.sqlite3 --issuer-id-hex HEX --network bitcoin
-```
-
-Success: `PASS issuer_state=init`. Next: build the UKI.
-
-## 4. UKI
-
-Inputs: approved root build host plus explicit kernel, ORAM-enabled runtime,
-oramctl, proof, service policy, output, and archive paths. Read
-`docs/runbooks/uki-build.md`; Nix and attested-builder outputs are different
-reproducibility blocks and are not substitutes for this runtime UKI.
-
-```bash
-sudo env KERNEL=/boot/vmlinuz-EXACT-generic BINARY=/absolute/unified_server BPIR_UNIFIED_SERVER_BIN=/absolute/unified_server ORAMCTL=/absolute/oramctl BHTM_FROM_LEAF_PROOF=/absolute/height-940611.leaf-proof.json BPIR_TIER3_SERVICE_POLICY=/absolute/service-policy.bin OUT=/absolute/release.efi UKI_ARCHIVE_REMOTE=archive-host:/home/pir/uki-archive/tier3 UKI_ARCHIVE_REMOTE_REQUIRED=1 scripts/build_uki_tier3.sh --dry-run
-sudo env KERNEL=/boot/vmlinuz-EXACT-generic BINARY=/absolute/unified_server BPIR_UNIFIED_SERVER_BIN=/absolute/unified_server ORAMCTL=/absolute/oramctl BHTM_FROM_LEAF_PROOF=/absolute/height-940611.leaf-proof.json BPIR_TIER3_SERVICE_POLICY=/absolute/service-policy.bin OUT=/absolute/release.efi UKI_ARCHIVE_REMOTE=archive-host:/home/pir/uki-archive/tier3 UKI_ARCHIVE_REMOTE_REQUIRED=1 scripts/build_uki_tier3.sh
-```
-
-Success: a directly Zstandard-compressed initramfs, the required measured
-inventory, an EFI no larger than 256 MiB, `wrote tier3 UKI: ...`,
-`tier3 uki sha256: ...`, dual archive evidence, and `PASS uki_build`.
-Next: inspect or change VPSBG measured boot with `$vpsbg-measured-boot`.
-
-## 5. VPSBG image
-
-Inputs: server ID, built UKI, and the prior image ID for rollback.
-
-```bash
-scripts/vpsbg-measured-boot.sh status --server-id ID
-scripts/vpsbg-measured-boot.sh upload --uki /absolute/release.efi --dry-run
-scripts/vpsbg-measured-boot.sh upload --uki /absolute/release.efi --apply
-scripts/vpsbg-measured-boot.sh switch --server-id ID --image-id IMAGE_ID --apply
-```
-
-Success: `PASS action=switch server_id=ID image_id=IMAGE_ID`. Next: run sealed phases.
-
-## 6. Sealed release phases
-
-Inputs for each phase: an unused startup-file path, ordinal, verifier nonce,
-current policy digest, BAT V2 class digest, public artifact-set SHA-256, and
-minimum authorization epoch. Use the exact measured UKI/OVMF values and
-Observe receipt for the release.
-
-```bash
-scripts/pir2-sealed-ceremony.sh phase --phase observe --out /absolute/observe.startup.env --ordinal ORDINAL --verifier-nonce-hex HEX64 --policy-digest-hex HEX64 --class-digest-hex HEX64 --artifact-set-sha256 HEX64 --minimum-authorization-epoch EPOCH --dry-run
-scripts/pir2-sealed-ceremony.sh phase --phase observe --out /absolute/observe.startup.env --ordinal ORDINAL --verifier-nonce-hex HEX64 --policy-digest-hex HEX64 --class-digest-hex HEX64 --artifact-set-sha256 HEX64 --minimum-authorization-epoch EPOCH
-scripts/pir2-sealed-ceremony.sh release --help
-scripts/pir2-sealed-ceremony.sh release [release options] --dry-run
-scripts/pir2-sealed-ceremony.sh release [release options]
-```
-
-After the Observe config passes, use that exact file as
-`/home/pir/data/pir2-sealed/startup.env` and boot the measured UKI. After the
-Observe receipt and release pass, repeat the `phase` command with fresh inputs
-and output files for `enroll`, `probe`, and `ready`, booting each in that order.
-Success: release prints `PASS sealed_release`; every phase file prints
-`PASS sealed_phase_config=<phase>` and `NEXT_STEP`.
-
-## 7. Private start and production source readiness
-
-Private inputs: absolute publisher plan and apply-approval paths, plus the
-approved plan, source, launcher, launcher-manifest, and approval SHA-256
-values. `production` has no command arguments.
-
-```bash
-scripts/payment-v1-activate.sh private --plan /absolute/publisher-plan --approved-plan-sha256 HEX64 --approved-source-sha256 HEX64 --approved-launcher-sha256 HEX64 --approved-manifest-sha256 HEX64 --approval /absolute/apply-approval.json --approved-approval-sha256 HEX64 --dry-run
-scripts/payment-v1-activate.sh private --plan /absolute/publisher-plan --approved-plan-sha256 HEX64 --approved-source-sha256 HEX64 --approved-launcher-sha256 HEX64 --approved-manifest-sha256 HEX64 --approval /absolute/apply-approval.json --approved-approval-sha256 HEX64 --apply
-scripts/payment-v1-activate.sh production --dry-run
-scripts/payment-v1-activate.sh production
-```
-
-Private success is `PASS private_start`; production source success is
-`PASS production_source_readiness`. Follow the printed `NEXT_STEP`.
+Human-only work stays human-only even if this skill is invoked.

--- a/.agents/skills/vpsbg-measured-boot/SKILL.md
+++ b/.agents/skills/vpsbg-measured-boot/SKILL.md
@@ -6,14 +6,20 @@ compatibility: Requires scripts/vpsbg-measured-boot.sh, jq, curl, a VPSBG API to
 
 # VPSBG measured boot
 
-Run all VPSBG operations through `scripts/vpsbg-measured-boot.sh`. It is the
-only API entry point.
+This is Flow E in
+[`docs/PRODUCTION_OPERATIONS.md`](../../../docs/PRODUCTION_OPERATIONS.md).
+Data-disk edits are Flow F (`scripts/vpsbg-data-disk.sh`). Do not SSH
+for measured-boot attach/detach.
+
+Run measured-boot operations through `scripts/vpsbg-measured-boot.sh`.
+It is the only API entry for status, images, upload, switch, and
+rollback.
 
 ## Inputs
 
 - `--server-id ID` for status, switch, or rollback.
-- `VPSBG_API_TOKEN_FILE` for status, or `--token-file PATH` for a mutation,
-  when the default token location is not appropriate.
+- `VPSBG_API_TOKEN_FILE` or `--token-file PATH` when
+  `<repo>/.secrets/vpsbg-api-token` is not the credential to use.
 - `--uki PATH` for `upload`.
 - `--image-id ID` for `switch` or `rollback`.
 
@@ -23,11 +29,12 @@ Start with the read-only view:
 
 ```bash
 scripts/vpsbg-measured-boot.sh status --server-id ID
+scripts/vpsbg-measured-boot.sh images
 ```
 
-Success prints `PASS action=status` and status fields. Record a concrete image
-ID when one is attached; `image_id=unavailable` is a valid observation, not an
-image selection.
+Success prints `PASS action=status` or `PASS action=images` and status
+fields. Record a concrete image ID when one is attached;
+`image_id=unavailable` is a valid observation, not an image selection.
 
 For an authorized mutation, confirm that this exact upload, switch, or rollback
 is authorized, then run one command:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,10 @@ Documentation index: [`docs/README.md`](docs/README.md).
 
 - Every production operation starts at
   [`docs/PRODUCTION_OPERATIONS.md`](docs/PRODUCTION_OPERATIONS.md).
-  Upload, switch, reboot, rollback, deployment, and funds all require
-  explicit authorization per run.
+  Pick one numbered flow (A–I). Upload, switch, reboot, rollback,
+  Pages deploy, and funds all require explicit authorization per step.
 - VPSBG measured-boot operations use `scripts/vpsbg-measured-boot.sh` (API),
-  not SSH.
+  not SSH. VPSBG data-disk edits use `scripts/vpsbg-data-disk.sh`.
 - Read [`docs/DATABASE_ARTIFACT_RETENTION.md`](docs/DATABASE_ARTIFACT_RETENTION.md)
   before touching database or ORAM artifacts.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ for agents are in [`AGENTS.md`](AGENTS.md); read that first.
 | Which tests to run | [`docs/TESTING.md`](docs/TESTING.md) |
 | Any production operation | [`docs/PRODUCTION_OPERATIONS.md`](docs/PRODUCTION_OPERATIONS.md) |
 | Client trust pins (binary hashes, SEV measurement, DB proofs) | [`web/src/attest-pin.ts`](web/src/attest-pin.ts) — never copy values into prose |
-| Live production state | Query it (`scripts/vpsbg-production-status.sh`); never infer from documents |
+| Live production state | Query it (`scripts/production-status.sh`); never infer from documents |
 | Privacy invariants and proofs | [`docs/VERIFICATION_OVERVIEW.md`](docs/VERIFICATION_OVERVIEW.md) + [`verification/locks/`](verification/locks/) |
 
 ## Privacy invariants (NEVER weaken; details in VERIFICATION_OVERVIEW.md)

--- a/crates/sdk/client/src/onion.rs
+++ b/crates/sdk/client/src/onion.rs
@@ -544,9 +544,9 @@ impl OnionClient {
         verify_database_proof(&db, &bundle, policy)
     }
 
-    /// Fetch and verify the staged v2 proof without falling back to v1.
-    /// Production callers can opt in after v2 evidence and sidecars are
-    /// deployed; the existing v1 method remains available during migration.
+    /// Fetch and verify the v2 proof without falling back to v1.
+    /// Production OnionPIR and Direct ORAM use this path. The v1
+    /// method remains the DPF/Harmony compatibility surface.
     pub async fn verify_database_proof_v2(
         &mut self,
         db_id: u8,

--- a/crates/sdk/client/tests/integration_test.rs
+++ b/crates/sdk/client/tests/integration_test.rs
@@ -151,9 +151,9 @@ const PRODUCTION_DATABASE_PINS: [ProductionDatabasePin; 2] = [
     },
 ];
 
-/// V2 is activated only for strict OnionPIR. DPF/Harmony keep the v1 opcode
-/// during the compatibility window, so their production pins above remain
-/// intentionally unchanged.
+/// V2 is required for strict OnionPIR. DPF/Harmony keep the v1 opcode
+/// as their compatibility surface, so their production pins above remain
+/// a separate table.
 fn production_onion_v2_pin(mut pin: ProductionDatabasePin) -> ProductionDatabasePin {
     pin.params_hash_hex = match pin.db_id {
         0 => "a600f33fa0e644aab533a050eabf9c03882aa00f1b293ddf9d7f4bf7c8142563",

--- a/docs/ATTESTED_BUILDER_TIER3_UKI.md
+++ b/docs/ATTESTED_BUILDER_TIER3_UKI.md
@@ -1,12 +1,26 @@
 # Attested Builder Tier 3 UKI
 
-This runbook is for the temporary VPSBG SEV-SNP builder image. It is separate
-from the production pir2 Tier 3 UKI. The builder UKI has no sshd, no
-cloudflared, and no runit service tree. It boots, mounts `/home/pir/data`, runs
-one selected attested-builder workflow, writes SEV-SNP evidence, then powers
-off. The image is pinned to reviewed `Bitcoin-PIR/attested-builder` commit
-`8d9d21a6be560236cb666269cf1f93a3de53bb1f`, which provides native
-predecessor-free full-build V2 pipelines for both snapshots and deltas.
+This is the **producer** UKI used by Flow H in
+[Production operations](PRODUCTION_OPERATIONS.md). It is not the
+serving pir2 UKI (Flow E, `scripts/build_uki_tier3.sh`). Placing
+`config.env` and collecting outputs is Flow F
+(`scripts/vpsbg-data-disk.sh`), not the VPSBG portal.
+
+What the producer covers (DPF/Harmony INDEX+CHUNK, Onion v2, Direct
+ORAM inputs, MuHash, BuildEvidence v2, SEV-SNP) and what it does not
+(Harmony hints, BHTM, k-of-n builder quorum, Nitro) is the attested-builder
+README, not this UKI runbook.
+
+This runbook is for the one-shot VPSBG SEV-SNP builder image. The
+builder UKI has no sshd, no cloudflared, and no runit service tree. It
+boots, mounts `/home/pir/data`, runs one selected attested-builder
+workflow, writes SEV-SNP evidence, then powers off. The reviewed
+producer commit is the value bound by
+`PRODUCTION_ORAM_DB_PROOF_V2_PINS` in
+[`web/src/attest-pin.ts`](../web/src/attest-pin.ts) and by
+`scripts/build_uki_attested_builder_tier3.sh`; do not copy it into
+other prose. That producer provides native predecessor-free full-build
+V2 pipelines for both snapshots and deltas.
 `MODE=native-full-build-v2-snapshot` and
 `MODE=native-full-build-v2-delta` stage the complete server-loadable database,
 typed Direct ORAM inputs/manifest, BuildEvidence V2 and SNP report as one
@@ -15,7 +29,7 @@ eligibility claim unless it observes V2, `evidence_mode=full_build`, and no
 predecessor hashes. `MODE=reattest-existing-v2` remains a proof migration tool
 only and is ineligible for production TEE-ORAM.
 
-## Build the UKI on VPSBG Slice 2
+## Build the producer UKI
 
 The standalone `attested-builder` checkout is expected at:
 
@@ -23,10 +37,10 @@ The standalone `attested-builder` checkout is expected at:
 /home/pir/bitcoin-pir/attested-builder
 ```
 
-Build:
+Build on an approved Linux host that already has that checkout
+(stock-rootfs SSH is Flow F if that host is the VPSBG guest):
 
 ```bash
-ssh vpsbg-pir
 cd /home/pir/BitcoinPIR
 sudo ./scripts/build_uki_attested_builder_tier3.sh
 ```
@@ -110,7 +124,7 @@ production TEE-ORAM must reject them.
 
 Use the snapshot mode for a new full database:
 
-Prepare these while the server is still in Slice 2:
+Prepare these on the stock rootfs (Flow F) before attaching the builder UKI:
 
 ```bash
 sudo mkdir -p /home/pir/data/attested-builder/inputs
@@ -216,19 +230,18 @@ Building/uploading the UKI, switching measured boot and rebooting are separate
 production operations and require explicit authorization; the source runbook
 or a prepared config does not grant it.
 
-Upload `/tmp/bpir-attested-builder-tier3.efi` in the VPSBG Measured Boot UI and
-reboot. The image powers off after success or failure.
+Upload and switch with Flow E commands
+(`scripts/vpsbg-measured-boot.sh upload` then `switch`) as their own
+authorization. The builder image powers off after success or failure.
 
 After it powers off:
 
-1. Switch Measured Boot back to `None`.
-2. Boot the normal Slice 2 rootfs.
-3. Collect outputs from the configured `OUT_DIR`. A successful native V2 run
-   updates the convenience link only after its evidence gate passes:
-
-```bash
-/home/pir/data/attested-builder-runs/latest/
-```
+1. Flow F `open` (detach `{"kernel_image_id":null}`, stock rootfs, SSH).
+2. Collect outputs from the configured `OUT_DIR`. A successful native V2
+   run updates `/home/pir/data/attested-builder-runs/latest/` only after
+   its evidence gate passes.
+3. Flow F `close` with the recorded **runtime** image id when the guest
+   should serve again. Do not leave the builder UKI attached.
 
 Important files:
 
@@ -261,7 +274,7 @@ The runner also writes coarse status/log files under:
 
 ## Verify After Boot
 
-On Slice 2 or another host with the same attested-builder binary:
+On the stock rootfs or another host with the same attested-builder binary:
 
 ```bash
 pir-attested-builder verify-build-evidence \

--- a/docs/DATABASE_ARTIFACT_RETENTION.md
+++ b/docs/DATABASE_ARTIFACT_RETENTION.md
@@ -1,5 +1,9 @@
 # Database artifact retention and debug handoff
 
+This is the current-lineage map used by Flow H in
+[Production operations](PRODUCTION_OPERATIONS.md). It is not an
+activation instruction.
+
 This is the canonical map for the production database lineage at heights
 `940611 -> 948454`. It exists to prevent another incident from turning into a
 full rebuild merely because an intermediate file cannot be found.

--- a/docs/DATABASE_ROOT_ROTATION_RUNBOOK.md
+++ b/docs/DATABASE_ROOT_ROTATION_RUNBOOK.md
@@ -1,10 +1,17 @@
 # Database and root rotation runbook
 
+This is Flow H in [Production operations](PRODUCTION_OPERATIONS.md).
+VPSBG maintenance boots are Flow F. Frontend pin publication is Flow C.
+The producer UKI is [Attested-builder Tier 3 UKI](ATTESTED_BUILDER_TIER3_UKI.md),
+never the runtime UKI in Flow E.
+
 Use this runbook whenever production moves to a new full snapshot, adds or
 replaces a delta, or rebuilds an existing height with different database
 roots. It covers the proof, server catalog, production pins, and strict v2
-OnionPIR proof pins as one release unit. DPF/HarmonyPIR retain their v1 proof
-compatibility surface; strict OnionPIR does not use a v1 layout-pin fallback.
+OnionPIR / ORAM proof pins as one release unit. DPF/HarmonyPIR retain their
+v1 proof compatibility surface; strict OnionPIR does not use a v1
+layout-pin fallback. Pin-family names and verifier scope are in
+Production operations H.0.
 
 The safety rule is simple: a client may be temporarily unavailable during a
 rotation, but it must never fall back to an unverified root. A proof/pin or
@@ -28,9 +35,15 @@ measurement/report identity after the measured run. The native snapshot or
 delta run must emit the complete server-loadable generation and its evidence
 as one output; a collection assembled afterward is not a production candidate.
 This single-output rule covers the native V2 `server-db`, Direct inputs and V2
-evidence. The explicitly retained V1 proof sidecars used only for
-DPF/Harmony compatibility remain separate `proof_dir` inputs; they cannot fill
-a missing native V2 production stage.
+evidence. That V2 evidence already binds `bucket_super_root` (DPF/Harmony)
+together with the Onion layout and Direct ORAM inputs. The explicitly
+retained V1 proof sidecars used only for the live DPF/Harmony *opcode*
+remain separate `proof_dir` inputs; they cannot fill a missing native V2
+production stage. The production UKI does not emit a second
+`BUILD_EVIDENCE_VERSION=1` directory. A new height therefore needs a
+Human decision on the DPF/Harmony pin/transport before activation; do
+not invent a v1 UKI mode or splice a host-side v1 pass onto the measured
+V2 tree.
 
 This repository's `scripts/build_full.sh`, related `build_*` wrappers and
 `tools/db-builder` remain useful for development and regression work, but they
@@ -41,8 +54,11 @@ authorize a build, VPSBG boot, database mutation or deployment.
 ## Invariants
 
 - Every database selected by the sync plan has one independently verified
-  `DatabaseProofBundle` and one matching entry in
-  `PRODUCTION_DB_PROOF_PINS`.
+  `DatabaseProofBundle` and matching entries in the pin tables that
+  backend uses: `PRODUCTION_DB_PROOF_PINS` (DPF/Harmony v1),
+  `PRODUCTION_ONION_DB_PROOF_V2_PINS` (pir1 Onion), and
+  `PRODUCTION_ORAM_DB_PROOF_V2_PINS` plus
+  `verification/locks/generated-proofs.json` (pir2 Direct ORAM).
 - Every sync plan selectable from a supported starting height is contiguous in
   both height and block hash. Overlapping alternatives in the active catalog do
   not have to form one full-snapshot-to-delta chain: production may serve a
@@ -147,11 +163,16 @@ In the same change set, update `web/src/attest-pin.ts`:
    packed-entry counts, table sizes, slot sizes, arity, and Merkle geometry
    against the independently accepted v2 proof. Do not recreate the removed
    `PRODUCTION_ONION_QUERY_LAYOUT_PINS` table or a v1 layout fallback.
-3. Update the duplicate `PRODUCTION_DATABASE_PINS` in
+3. For Direct ORAM, update `PRODUCTION_ORAM_DB_PROOF_V2_PINS` and the
+   matching lock in `verification/locks/generated-proofs.json`. That
+   table shares layout and Merkle roots with the Onion v2 pins and
+   independently binds the native full-build producer. Do not collapse
+   Onion and ORAM builder identities into one table.
+4. Update the duplicate `PRODUCTION_DATABASE_PINS` in
    `crates/sdk/client/tests/integration_test.rs`. The scheduled native canary must
    fail on an unreviewed rotation; keep these values synchronized with the
    independently reviewed web pins.
-4. Update proof artifacts under `web/public/proofs/` and any public block links
+5. Update proof artifacts under `web/public/proofs/` and any public block links
    or reproducibility manifests for the new endpoints.
 
 Run the Rust/WASM/web tests that cover proof parsing, full-field pin matching,
@@ -192,13 +213,15 @@ V2 output used by Onion/ORAM and Direct ORAM reconstruction. Review it and use
 the maintenance-window activation step below; never collapse or manually edit
 these generated path/proof pairings.
 
-Hetzner can be staged over its normal SSH/operator path. VPSBG Tier 3 has no
-SSH, so a complete proof/root rotation must use a planned portal maintenance
-boot: select `UKI: None`, reboot into the maintenance system, stage the
-immutable directories over SSH, verify them, and write the proposed config to
-a separate file without replacing the active `databases.toml`. Then reselect
-the known-good Tier 3 UKI and reboot with the old active config until the
-activation window.
+Hetzner can be staged over its normal SSH/operator path. VPSBG measured
+boot has no SSH, so a complete proof/root rotation uses Flow F in
+[Production operations](PRODUCTION_OPERATIONS.md)
+(`scripts/vpsbg-data-disk.sh open`), stages the immutable directories
+over stock-rootfs SSH, verifies them, and writes the proposed config to
+a separate file without replacing the active `databases.toml`. Then
+`close` with the known-good runtime image id and reboot with the old
+active config until the activation window. Do not use the VPSBG portal
+as the primary path, and do not build a provisioner UKI.
 
 The authenticated `bpir-admin upload --no-activate` path may stage an ordinary
 database directory while Tier 3 is running, but it is not a substitute for the
@@ -228,12 +251,14 @@ before following the activation steps below.
 There is no single atomic switch across both hosts and GitHub Pages. Use a
 short maintenance window and accept temporary fail-closed queries:
 
-1. Stop or drain the Hetzner services through their normal supervisor. In the
-   VPSBG portal, select `UKI: None` and reboot into the SSH-capable maintenance
-   system; this stops the Tier 3 query path without launching an ad hoc server.
+1. Stop or drain the Hetzner services through their normal supervisor. On
+   VPSBG, use Flow F in [Production operations](PRODUCTION_OPERATIONS.md)
+   (`scripts/vpsbg-data-disk.sh open`) so the guest reaches stock rootfs
+   and SSH. Do not use the portal as the primary path, and do not build a
+   provisioner UKI.
 2. Atomically replace each host's active `databases.toml` with the prepared
-   version. Restart the normal Hetzner services. On VPSBG, reselect the same
-   known-good Tier 3 UKI and reboot; an unchanged data/proof schema needs this
+   version. Restart the normal Hetzner services. On VPSBG, `close` with the
+   same known-good Tier 3 image id; an unchanged data/proof schema needs this
    config reload but does not require rebuilding the UKI. Do not run a second
    server that bypasses either deployed supervisor/boot path.
 3. Until both hosts agree, treat the fleet as unavailable. DPF and the
@@ -247,11 +272,18 @@ short maintenance window and accept temporary fail-closed queries:
      --server wss://weikeng2.bitcoinpir.org --db-id <db-id> <expected-args>
    ```
 
+   `verify-live` fetches the v1 database-proof opcode only. It covers
+   DPF/Harmony compatibility. It does not certify Onion v2 or ORAM v2.
+   Those stay on the local `db-proof verify` / `verify-proof-directory`
+   path and the browser/WASM check after Flow C.
+
 5. Confirm runtime pin and operator identity on Hetzner, and runtime pin,
    operator identity, SEV-SNP measurement, AMD certificate chain, and secure
    channel on VPSBG.
-6. Merge/deploy the already-reviewed frontend proof pins. Wait for the exact
-   commit's Pages workflow to complete successfully.
+6. Merge the already-reviewed frontend proof pins (Flow B), then publish
+   them with Flow C in [Production operations](PRODUCTION_OPERATIONS.md).
+   Wait for that exact commit's `deploy-web.yml` run to complete
+   successfully. A push to `main` does not publish.
 
 Activating the servers before the new web pins makes old clients reject the
 new proof; deploying the pins first makes new clients reject old servers.
@@ -304,14 +336,15 @@ record. Routine rotations belong in a dated operations record
 
 Rollback the generation as a unit:
 
-1. Stop the Hetzner services and use the VPSBG portal to select `UKI: None` and
-   reboot into the SSH-capable maintenance system.
+1. Stop the Hetzner services and open a VPSBG stock-rootfs window with
+   Flow F (`scripts/vpsbg-data-disk.sh open`).
 2. Restore the prior `databases.toml`, database directories, and proof
    directories on both hosts. Restart the normal Hetzner services, then
-   reselect the prior known-good Tier 3 UKI in the VPSBG portal and reboot.
+   `close` with the prior known-good Tier 3 image id.
 3. Run `verify-live` for every restored database ID on both hosts and confirm
    both catalogs agree.
-4. Redeploy the prior known-good frontend proof pins and wait for Pages.
+4. Redeploy the prior known-good frontend proof pins with Flow C and wait
+   for Pages.
 5. Repeat the strict browser acceptance checks above.
 
 If only one host fails after activation, do not leave a mixed fleet serving.

--- a/docs/KEY_MANAGEMENT.md
+++ b/docs/KEY_MANAGEMENT.md
@@ -35,19 +35,30 @@ binaries, and per-ordinal `startup.env` files.
 | --- | --- |
 | `vpsbg-api-token` | VPSBG control-plane API bearer token |
 
+VPSBG scripts default to these repository paths. They do not fall back
+to `~/.config/bitcoinpir`. Override with `VPSBG_API_TOKEN_FILE` or
+`--token-file` only when the repository file is the wrong credential.
+
 ## VPSBG file modification procedure
 
-To modify files on the VPSBG data disk (`/home/pir/data/`):
+This is Flow F in [Production operations](PRODUCTION_OPERATIONS.md).
+Use [`scripts/vpsbg-data-disk.sh`](../scripts/vpsbg-data-disk.sh). It
+detaches measured boot with `{"kernel_image_id":null}`, stop/starts the
+guest, and SSHes with `.keys/vpsbg-ssh.key` plus
+[`deploy/vpsbg_known_hosts`](../deploy/vpsbg_known_hosts). `open` and
+`close` each require an explicit `--image-id` and `--apply`; `put` does
+not call `close`.
 
-1. **Disable measured boot** via the VPSBG API:
-   `POST /v1/servers/25285/measured-boot` with `image_id: null`.
-2. **Stop then start** the server:
-   `POST /v1/servers/25285/stop` → wait → `POST /v1/servers/25285/start`.
-3. **SSH in** using `ssh -i .keys/vpsbg-ssh.key root@87.120.8.198`.
-4. Modify files directly on the data disk.
-5. **Re-enable measured boot** by switching to the desired UKI image:
-   `scripts/vpsbg-measured-boot.sh switch --server-id 25285 --image-id <ID> --apply`.
+```sh
+scripts/vpsbg-data-disk.sh open --server-id 25285 --image-id CURRENT --dry-run
+scripts/vpsbg-data-disk.sh open --server-id 25285 --image-id CURRENT --apply
+scripts/vpsbg-data-disk.sh put --local /absolute/file \
+  --remote /home/pir/data/relative/path --apply
+scripts/vpsbg-data-disk.sh close --server-id 25285 --image-id CURRENT --apply
+```
 
-Never build a dedicated "provisioner UKI" to write files to the data
-disk. The provisioner approach (scripts/dracut/97bpir-pir2-sealed-provisioner/)
-was an error and has been removed.
+A sealed `startup.env` must be placed at
+`/home/pir/data/pir2-sealed/startup.env`. Never build a dedicated
+"provisioner UKI" to write files to the data disk. The provisioner
+approach (`scripts/dracut/97bpir-pir2-sealed-provisioner/`) was an
+error; the leftover builder is unused by the production UKI.

--- a/docs/PRODUCTION_OPERATIONS.md
+++ b/docs/PRODUCTION_OPERATIONS.md
@@ -1,26 +1,387 @@
 # Production operations
 
-Start here for an authorized production change. Query live state first
-(`scripts/vpsbg-production-status.sh` for pir2; each operation script below
-has a status/help subcommand) — never infer it from documents.
-For the ordered end-to-end path, use the
-[BitcoinPIR production workflow skill](../.agents/skills/bitcoinpir-production-workflow/SKILL.md).
+Start here for any authorized production change. Query live state first —
+never infer it from documents. Pick **one** flow below. Run its numbered
+steps in order. Stop at every authorization gate. Do not invent a
+composite path, and do not roll into the next flow without a new ask.
+
+Live status:
+
+```sh
+scripts/production-status.sh
+```
+
+That prints pir1 SSH health and the pir2 VPSBG snapshot. For pir2 only,
+use `scripts/vpsbg-production-status.sh` or
+`scripts/vpsbg-measured-boot.sh status`. Each mutation script also has
+`--help` and, where it can change a host, `--dry-run`.
+
+Identity values (hashes, measurements, image IDs) stay in
+[`web/src/attest-pin.ts`](../web/src/attest-pin.ts) or in live command
+output. Do not copy them into prose.
+
+## How an agent should use this page
+
+1. Classify the ask against the flow table. If it matches none, stop and
+   ask; do not improvise.
+2. State the flow id, the remaining steps, the expected duration, and
+   the hard stop **before** a long build, upload, or reboot.
+3. Run only scripted commands shown here. Human-only steps need an
+   explicit user decision and must not be bundled with a later step.
+4. When a step prints `PASS` and `NEXT_STEP`, stop if the next step is
+   a mutation or a different flow.
+
+### Step types
+
+| Type | Meaning | Agent may run? |
+| --- | --- | --- |
+| Read | No host, image, pin, or fund change | Yes, without extra authorization |
+| Local | Laptop or CI check; no production mutation | Yes for the matching change class in [Testing](TESTING.md) |
+| Auth | Changes a remote host, image, service, Pages site, or identity | Only after explicit authorization **for that step** |
+| Human | Key, funds, image delete, pin edit, or issuer deploy | Do not start; ask and wait |
+
+`--apply` is per command. `upload` does not switch. `put` does not
+close. `close` and `switch` require the caller-supplied `--image-id`.
+
+### Workload estimates
+
+Use these before starting. Missing progress before the hard stop means
+stop and report.
+
+| Work | Expected | Hard stop | Progress signal |
+| --- | --- | --- | --- |
+| `production-status.sh` | ~30 s | 20 s per SSH/API call | `PASS production_status` |
+| Local web check (`tsc` + vitest + `build-web`) | 2–10 min | 15 min | npm scripts exit 0 |
+| PR `web-build.yml` | 10–25 min | 30 min job | wasm-pack, tsc, vitest, `build-web` |
+| PR `ci-summary.yml` | waits for siblings | 75 min | one green/red advisory status |
+| Pages `deploy-web.yml` | 20–60 min | 75 min build | Playwright e2e, then deploy job |
+| pir1 `cargo build --release -p runtime` | 2–5 min | 15 min | compiler output, then systemd active |
+| Tier 3 **runtime** UKI (`build_uki_tier3.sh`) | 5–15 min | 15 min | dracut, inventory, `ukify`, `PASS uki_build` |
+| Attested-builder **producer** UKI | 5–15 min | 15 min | archive `.efi` + `.meta` |
+| Native full-build V2 snapshot/delta | hours; no wall-clock is written here | no progress for 3 min → stop | `build-summary.txt`, then `latest/` only after the V2 gate |
+| Direct ORAM release reconstruct | target 10 min | 15 min (3 min without a stage) | ORAM debug runbook stages |
+| VPSBG `images` / `upload` | seconds / a few min | 10 min upload | `PASS action=images\|upload` |
+| VPSBG `switch` / `close` reboot | 2–10 min | 15 min | `boot_mode=measured`, `running=true` |
+| Data-disk `open` | 2–10 min | 15 min | `boot_mode=stock`, `ssh_ready=true` |
+| `pir2-post-switch-check.sh` | 5–20 min | 15 min wait + attest | `PASS action=post_switch_check` |
+
+## Flow catalog
+
+| Id | When to use | First command |
+| --- | --- | --- |
+| A | Diagnose live hosts | `scripts/production-status.sh` |
+| B | Source / PR; no production mutation | [Testing](TESTING.md) |
+| C | Publish the browser client to GitHub Pages | Flow C below |
+| D | Change the pir1 Hetzner binary or unit | Flow D below |
+| E | Build, upload, switch, or roll back the **runtime** pir2 UKI | [UKI build](runbooks/uki-build.md) then [VPSBG image](runbooks/vpsbg-image.md) |
+| F | Edit `/home/pir/data/` on VPSBG, including `startup.env` | [Key management](KEY_MANAGEMENT.md) |
+| G | pir2 sealed Observe / Enroll / Probe / Ready | [Sealed release](runbooks/pir2-sealed-release.md) |
+| H | Produce or rotate DPF / Harmony / Onion v2 / ORAM proofs | [Database root rotation](DATABASE_ROOT_ROTATION_RUNBOOK.md) |
+| I | Payment artifacts or source-readiness only | [Payment artifacts](runbooks/payment-artifacts.md) |
+
+Payment issuer deploy, mainnet Lightning, key generation, funds, and
+image deletion are **not** flows. Signet / functional-beta is archive
+only (`docs/archive/payment/`).
+
+## A. Diagnose — Read
+
+1. Read — `scripts/production-status.sh` (`--dry-run` lists paths only).
+2. Read — if only pir2 matters:
+   `scripts/vpsbg-measured-boot.sh status --server-id ID`.
+3. Read — before a UKI upload:
+   `scripts/vpsbg-measured-boot.sh images`.
+4. Stop. `image_id=unavailable` is a valid observation, not a selection.
+
+Success: `PASS production_status` and/or `PASS action=status|images`.
+
+## B. Source change and CI — Local
+
+Green CI is not a deploy. Merges are manual; there is no required
+aggregate check on `main`.
+
+1. Local — pick the narrowest row in [Testing](TESTING.md).
+2. Local — open a `codex/` branch; do not mix a production mutation with
+   a docs or CI cleanup in the same commit.
+3. Local — open a PR against `main`. Path-filtered workflows run on
+   that PR. Two run on every PR: `formal-proof.yml` and advisory
+   `ci-summary.yml` (waits for sibling runs on the head SHA).
+4. Human — inspect the CI summary, then merge only if the user asked.
+
+Usual PR workflows, when their paths match:
+
+| Workflow | What it proves | Not a deploy of |
+| --- | --- | --- |
+| `web-build.yml` | wasm-pack, `tsc`, vitest, `build-web` | GitHub Pages |
+| `pir-sdk-integration.yml` | deterministic SDK jobs | live servers (live jobs are schedule/dispatch) |
+| `payment-platform.yml` | Payment source/process lanes | issuer or Lightning |
+| `build-determinism.yml` | pir-core reproducibility | databases |
+| `workflow-supply-chain.yml` | workflow/UKI contract scripts | a UKI |
+| `generated-proof-lock.yml` | lock files | live proofs |
+| `formal-proof.yml` | locked EasyCrypt / contract | production hosts |
+
+Do not add workflows or required checks from this page.
+
+## C. Web / GitHub Pages — Local then Auth
+
+The site is `https://www.bitcoinpir.org/`. A push to `main` does **not**
+publish. `.github/workflows/deploy-web.yml` deploys only on
+`workflow_dispatch` from `main` with `confirm_production_deploy=true`.
+The build job has contents-read only; Pages write/OIDC is confined to
+the deploy job. `scripts/payment-v1-pages-deploy-gate.mjs` enforces that
+shape.
+
+1. Local — land the web or pin change through Flow B. Pin edits must
+   keep `web/src/attest-pin.ts`, `verification/locks/`, and the
+   duplicate pins in `crates/sdk/client/tests/integration_test.rs`
+   consistent ([rotation runbook](DATABASE_ROOT_ROTATION_RUNBOOK.md) §3).
+2. Local — wait for `web-build.yml` on that `main` commit.
+3. Auth — dispatch `deploy-web.yml` on `main` with
+   `confirm_production_deploy=true`. Expected 20–60 min, hard stop
+   75 min. Progress: wasm-pack, tsc, vitest, three Playwright payment
+   e2e jobs, `npm run build-web`, then the deploy job.
+4. Read — optional live browser check, only if the user asks:
+   dispatch `web-strict-production-canary.yml` (45 min timeout) or the
+   [production-test skill](../.claude/skills/production-test/SKILL.md).
+
+Success: the dispatch run's deploy job is green and the live site
+serves that commit. Updating pins is a separate Human step if the
+check fails.
+
+## D. pir1 Hetzner binary — Auth
+
+pir1 is `root@65.21.91.217`, public `wss://weikeng1.bitcoinpir.org`.
+It serves DPF-0, OnionPIR, and Harmony hints. There is no Hetzner
+script; pin SSH against [`deploy/known_hosts`](../deploy/known_hosts).
+The [hetzner skill](../.claude/skills/hetzner-pir/SKILL.md) still
+contains a stale single-host caveat — ignore that; pir2 is VPSBG.
+
+1. Local — Flow B for the runtime change. Production binary is
+   `cargo build --locked --release -p runtime --bin unified_server`
+   plus `strip --strip-debug`. Nix is not the authority.
+2. Auth — on the host, fast-forward the reviewed commit, build the
+   same command, restart `pir-primary`. Restart `cloudflared` only if
+   the tunnel itself is broken. Build 2–5 min, hard stop 15 min.
+3. Read — `scripts/production-status.sh` and confirm `:8091` /
+   `pir-primary` are active. Do not treat `pir-secondary` as the
+   public peer. This step is systemd/SSH health only; it does not
+   compare the live binary to `PIR1_PIN`. That pin is checked by the
+   browser client after Flow C.
+
+Database swaps on pir1 stay inside Flow H. Do not restart during a
+partial database write.
+
+## E. pir2 **runtime** UKI and measured boot — Local then Auth
+
+This flow builds and switches the **serving** UKI
+(`scripts/build_uki_tier3.sh`). The attested-builder **producer** UKI
+(`scripts/build_uki_attested_builder_tier3.sh`) is Flow H. They share
+the VPSBG measured-boot slot and must not be substituted.
+
+Details: [UKI build](runbooks/uki-build.md),
+[VPSBG image](runbooks/vpsbg-image.md). Token default is
+`.secrets/vpsbg-api-token`.
+
+1. Read — Flow A. Record the live `image_id` as the rollback target.
+2. Read — `scripts/vpsbg-measured-boot.sh images`. If count is 5/5,
+   stop; deleting an image is Human.
+3. Local — on the approved Linux build host, set every UKI input
+   explicitly and run `scripts/build_uki_tier3.sh --dry-run`, then the
+   live build. Nix and the attested-builder UKI are not this runtime
+   UKI.
+4. Auth — `scripts/vpsbg-measured-boot.sh upload --uki FILE --apply`.
+   Record the returned image id. Do not switch in the same command.
+5. Auth — `switch --server-id ID --image-id NEW --apply` only after
+   a separate authorization. This reboots immediately.
+6. Read — `scripts/pir2-post-switch-check.sh`. It reads pins from
+   `web/src/attest-pin.ts` and must not edit that file. Mismatch is a
+   hard stop.
+7. Auth — rollback is `scripts/vpsbg-measured-boot.sh rollback` with
+   the **previous** image id, then step 6 again.
+
+A data/proof-only rotation does not need a new UKI (Flow H).
+
+## F. VPSBG data-disk window — Auth
+
+Use [`scripts/vpsbg-data-disk.sh`](../scripts/vpsbg-data-disk.sh).
+Never build a provisioner UKI. Detach body is
+`{"kernel_image_id":null}`. SSH only when `boot_mode=stock`.
+
+1. Read — Flow A. The `--image-id` passed to `open` and `close` is
+   the UKI to reattach, usually the current live image.
+2. Auth — `open --server-id 25285 --image-id CURRENT --apply`.
+   Hard stop 15 min: `boot_mode=stock` and SSH.
+3. Auth — `put` (writes), or Read `get` / `ssh`. Remote paths must
+   stay under `/home/pir/data/`. A ceremony `startup.env` must land at
+   `/home/pir/data/pir2-sealed/startup.env`.
+4. Auth — `close --server-id 25285 --image-id CURRENT --apply`. Same
+   image id as step 1 unless the user named a different one.
+5. Read — Flow E step 6 if the guest should be serving again.
+
+## G. pir2 sealed ceremony — Local then Auth
+
+Details: [Sealed release](runbooks/pir2-sealed-release.md).
+
+1. Local — `scripts/pir2-sealed-ceremony.sh phase --phase observe ...`
+   (`--dry-run` first). Inputs (ordinal, nonce, digests, epoch) are
+   supplied by the operator; do not invent them.
+2. Auth — Flow F to place that exact file at
+   `/home/pir/data/pir2-sealed/startup.env`, then boot the measured UKI.
+3. Local — after the Observe receipt exists,
+   `scripts/pir2-sealed-ceremony.sh release` (`--dry-run` first).
+4. Repeat steps 1–2 for `enroll`, `probe`, and `ready` with fresh
+   output files, in that order.
+5. Read — Flow E step 6 when Ready is serving.
+
+Success: `PASS sealed_phase_config=<phase>` or `PASS sealed_release`.
+
+## H. Database, proofs, and pins — Auth
+
+Follow [Database root rotation](DATABASE_ROOT_ROTATION_RUNBOOK.md) and
+read [Database artifact retention](DATABASE_ARTIFACT_RETENTION.md)
+before touching artifacts. Producer UKI details:
+[Attested-builder Tier 3 UKI](ATTESTED_BUILDER_TIER3_UKI.md).
+
+One generation is **one** `server-db` tree plus its evidence. DPF and
+Harmony share INDEX/CHUNK + `bucket_super_root` with that V2 evidence.
+Live DPF/Harmony clients still fetch the **v1** opcode from `proof_dir`
+(retained mixed-provenance sidecars on the current lineage). OnionPIR
+(pir1) and Direct ORAM (pir2) consume the same tree's Onion half plus
+**v2** `proof_v2_dir`. The producer UKI does not emit a parallel v1
+sidecar. Do not pair a serving tree from one run with a proof directory
+from another.
+
+Production databases come from the locked external
+`Bitcoin-PIR/attested-builder` native full-build V2 pipeline at an
+exact reviewed commit. That repo's README is the producer scope:
+one run emits DPF/Harmony, Onion v2, and Direct ORAM inputs together.
+`scripts/build_full.sh` and `tools/db-builder` are development-only.
+`MODE=reattest-existing-v2` is a proof-migration tool and is
+ineligible for production TEE-ORAM.
+
+The live `940611 -> 948454` lineage is an accepted mixed-provenance
+exception. Do not rebuild or relabel it. The two Core snapshots are
+irreplaceable; a later snapshot plus a delta cannot reconstruct the
+earlier MuHash.
+
+VPSBG file placement is Flow F, not the portal and not a provisioner
+UKI. Pin publication is Flow C. A new runtime binary/UKI, if the
+schema requires one, is Flow D or E as a **separate** gate.
+
+### H.0 Classify the proof family — Read
+
+Identity values stay in [`web/src/attest-pin.ts`](../web/src/attest-pin.ts)
+or `verification/locks/`. Do not copy them into prose. EasyCrypt /
+wire-shape locks in [Verification overview](VERIFICATION_OVERVIEW.md)
+are Flow B, not this flow.
+
+| Family | Serves | Pin / lock | Verifier an agent may run |
+| --- | --- | --- | --- |
+| DB proof v1 | DPF + Harmony live opcode | `PRODUCTION_DB_PROOF_PINS` | `verify-live` (v1 opcode only). Roots are already in the V2 evidence; the UKI does not emit a second v1 sidecar |
+| Onion v2 | pir1 OnionPIR | `PRODUCTION_ONION_DB_PROOF_V2_PINS` | local `db-proof verify` / `verify-proof-directory`; **not** `verify-live` |
+| ORAM v2 | pir2 Direct ORAM | `PRODUCTION_ORAM_DB_PROOF_V2_PINS` + `verification/locks/generated-proofs.json` | same local v2 verifiers; **not** `verify-live` |
+| Builder SNP | attested-builder run | ORAM source manifests under `web/public/proofs/oram-source/` | `pir-attested-builder verify-build-evidence` |
+| Runtime SNP | serving pir2 UKI | `PIR2_TIER3_PIN` | Flow E step 6; `bpir-admin attest` |
+| pir1 binary | serving pir1 | `PIR1_PIN` | browser after Flow C; Flow D step 3 is host health only |
+| BHTM / trust-chain | height + block hash + MuHash | `web/public/proofs/trust-chain/` | browser tests; UKI consumes `BHTM_FROM_LEAF_PROOF` |
+| Formal / EasyCrypt | protocol source | `verification/locks/formal-proofs.json` | Flow B only |
+
+`server-info.super_root` is diagnostic. Never copy it into a pin.
+`--expect-*` values come from the independently accepted proof record,
+never from a live server or from the proof printing itself.
+
+### Numbered rotation steps
+
+1. Human — freeze the generation (rotation §1): producer review,
+   exact builder commit, reserved SNP fields, height/hash, Core
+   MuHash, magic, params hash, db ids, directory names. Independent
+   block-hash check. Do not start a build.
+2. Auth — if a new producer UKI is required, build
+   `scripts/build_uki_attested_builder_tier3.sh` (not
+   `build_uki_tier3.sh`). Place `config.env` with Flow F. Switch that
+   builder image with Flow E-style `upload` / `switch` as its own
+   authorization. The guest powers off when the run ends.
+3. Auth — Flow F `open` to collect the complete output
+   (`server-db/`, `oram-direct-inputs/`, V2 evidence, manifests,
+   `build-summary.txt`). `latest/` exists only after the V2
+   `full_build` gate. Then `close` to the recorded **runtime** image.
+4. Local — `bpir-admin db-proof verify` with explicit `--expect-*`.
+   For typed Onion/ORAM layout also run `verify-proof-directory`.
+   Direct ORAM reconstruct: 3 min without a stage → stop; 15 min hard
+   stop. Missing progress is a failed build, not a reason to delete
+   Core snapshots.
+5. Human — edit pins in the same change set (rotation §3):
+   `PRODUCTION_DB_PROOF_PINS`, `PRODUCTION_ONION_DB_PROOF_V2_PINS`,
+   `PRODUCTION_ORAM_DB_PROOF_V2_PINS`,
+   `verification/locks/generated-proofs.json` (ORAM table),
+   `crates/sdk/client/tests/integration_test.rs`, and
+   `web/public/proofs/`. Do not recreate
+   `PRODUCTION_ONION_QUERY_LAYOUT_PINS`.
+6. Local — Flow B tests for that pin/lock change.
+7. Auth — stage both hosts without activating. VPSBG:
+   Flow F + `scripts/stage_vpsbg_tier3_generation.sh` (candidate
+   catalog only). Keep `path` = V2 `server-db`, `proof_dir` = locked
+   V1 sidecars, `proof_v2_dir` = complete V2 output. Do not use
+   `bpir-admin upload --no-activate` for attested evidence (it
+   rewrites `MANIFEST.toml`).
+8. Auth — activate in a fail-closed window (rotation §5): Flow F
+   `open`, atomic `databases.toml` replace, Hetzner restart, `close`
+   with the known-good **runtime** image id.
+9. Read — `db-proof verify-live` on both hosts covers **v1 /
+   DPF+Harmony only**. Onion/ORAM v2 live check is the browser/WASM
+   path after Flow C, or `pir2-post-switch-check.sh` for the runtime
+   SNP + ORAM smoke. Do not invent a unified “verify all proofs”
+   command.
+10. Auth — publish pins with Flow C. Write the release record with
+    `scripts/generate-release-record.sh` (unique `--out`; never
+    `--force` over an earlier record).
+
+Rollback is rotation §7: restore both hosts to the last generation
+proven on both, then Flow C for the prior pins. If one host fails,
+do not leave a mixed fleet.
+
+## I. Payment source-ready — Local, not a production enablement
+
+| Step | Type | Command | Success |
+| --- | --- | --- | --- |
+| 1 | Local | `scripts/payment-v1-artifacts.sh KIND --dry-run` then without | `PASS artifact=...` |
+| 2 | Local | `scripts/payment-v1-issuer-state.sh init\|check` | `PASS issuer_state=...` |
+| 3 | Auth | `scripts/payment-v1-activate.sh private ... --apply` | `PASS private_start` |
+| 4 | Local | `scripts/payment-v1-activate.sh production` | `PASS production_source_readiness` |
+
+Step 4 is an offline source check. It does not install, start, fund, or
+enable a production issuer. Mainnet Lightning is not decided.
+
+## Human-only — do not start from this page
+
+- Key generation (`bpir-admin service-keygen`) and writing `.keys/`.
+- Funds, channels, or issuer deploy.
+- VPSBG image delete.
+- Editing `web/src/attest-pin.ts` or `verification/locks/` (the user
+  supplies the pin change).
+- Filling `--expect-*` from a live server or `server-info.super_root`.
+- Rebuilding or deleting retained Core snapshots / ORAM inputs.
+- Substituting `build_uki_attested_builder_tier3.sh` for the runtime
+  UKI, or the reverse.
+
+## Command index
 
 | Operation | Runbook | Command | Successful handoff |
 | --- | --- | --- | --- |
-| Build a UKI | [UKI build](runbooks/uki-build.md) | `scripts/build_uki_tier3.sh` | `PASS uki_build` |
-| Upload, switch, or roll back a VPSBG image | [VPSBG image](runbooks/vpsbg-image.md) | `scripts/vpsbg-measured-boot.sh` | `PASS action=...` |
+| Read pir1 and pir2 status | this page, Flow A | `scripts/production-status.sh` | `PASS production_status` |
+| Build the **runtime** UKI | [UKI build](runbooks/uki-build.md) | `scripts/build_uki_tier3.sh` | `PASS uki_build` |
+| Build the **producer** UKI | [Attested-builder UKI](ATTESTED_BUILDER_TIER3_UKI.md) | `scripts/build_uki_attested_builder_tier3.sh` | archived `.efi` + `.meta` |
+| Verify a local DB proof | [Database root rotation](DATABASE_ROOT_ROTATION_RUNBOOK.md) | `bpir-admin db-proof verify` | verifier exit 0 |
+| Stage a VPSBG generation | [Database root rotation](DATABASE_ROOT_ROTATION_RUNBOOK.md) | `scripts/stage_vpsbg_tier3_generation.sh` | candidate catalog only |
+| List, upload, switch, or roll back a VPSBG image | [VPSBG image](runbooks/vpsbg-image.md) | `scripts/vpsbg-measured-boot.sh` | `PASS action=...` |
+| Open or close a VPSBG data-disk window | [Key management](KEY_MANAGEMENT.md) | `scripts/vpsbg-data-disk.sh` | `PASS action=open\|put\|get\|ssh\|close` |
+| Check pir2 after a switch | [VPSBG image](runbooks/vpsbg-image.md) | `scripts/pir2-post-switch-check.sh` | `PASS action=post_switch_check` |
+| Publish the web client | this page, Flow C | `deploy-web.yml` dispatch | deploy job green |
 | Prepare Payment V1 artifacts | [Payment artifacts](runbooks/payment-artifacts.md) | `scripts/payment-v1-artifacts.sh` | `PASS artifact=...` |
 | Initialize issuer state | [Issuer state](runbooks/issuer-state.md) | `scripts/payment-v1-issuer-state.sh` | `PASS issuer_state=...` |
 | Run the pir2 sealed release | [Sealed release](runbooks/pir2-sealed-release.md) | `scripts/pir2-sealed-ceremony.sh` | `PASS sealed_release` or `PASS sealed_phase_config=...` |
 | Start the private publisher network | [Private start](runbooks/payment-private-start.md) | `scripts/payment-v1-activate.sh private` | `PASS private_start` |
 | Prepare final production enablement | [Production enablement](runbooks/production-enable.md) | `scripts/payment-v1-activate.sh production` | `PASS production_source_readiness` |
 
-Before a command changes a remote host, image, service, identity, or funds,
-confirm the authorization for this run. Each script prints its next required
-input and a `NEXT_STEP` line.
-
-For the retained database inputs and artifact locations, see
-[Database artifact retention](DATABASE_ARTIFACT_RETENTION.md). Technical
-payment references remain in [`docs/payment/`](payment/); prior plans and
-evidence are in [`docs/archive/payment/`](archive/payment/README.md).
+Technical payment references remain in [`docs/payment/`](payment/);
+prior plans and evidence are in
+[`docs/archive/payment/`](archive/payment/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,15 +2,17 @@
 
 Start production work at [Production operations](PRODUCTION_OPERATIONS.md).
 Live production state is queried, never inferred from documents:
-`scripts/vpsbg-production-status.sh` for pir2, and each operation script's
-status subcommand for the rest.
+`scripts/production-status.sh` for pir1+pir2,
+`scripts/vpsbg-production-status.sh` for pir2 only, and each operation
+script's status subcommand for the rest.
 
 ## Runbooks
 
 | Work | Entry |
 | --- | --- |
-| UKI, VPSBG images, Payment artifacts, issuer state, sealed release, private start, and production source readiness | [Production operations](PRODUCTION_OPERATIONS.md) |
-| Database and root rotation | [Database root rotation](DATABASE_ROOT_ROTATION_RUNBOOK.md) |
+| Diagnose, CI/PR, Pages, pir1, pir2 runtime UKI, data-disk, sealed release, DB/proofs, payment source-ready | [Production operations](PRODUCTION_OPERATIONS.md) (flows A–I) |
+| Database and root rotation (DPF / Harmony / Onion v2 / ORAM proofs) | [Database root rotation](DATABASE_ROOT_ROTATION_RUNBOOK.md) |
+| Producer (attested-builder) UKI | [Attested-builder Tier 3 UKI](ATTESTED_BUILDER_TIER3_UKI.md); producer *scope* is that repo's README |
 | Database source and artifact retention | [Database artifact retention](DATABASE_ARTIFACT_RETENTION.md) |
 | Direct ORAM diagnosis | [Direct ORAM debug](ORAM_DIRECT_TEE_DEBUG_RUNBOOK.md) |
 | Development and PR checks | [Testing](TESTING.md) |

--- a/docs/REPOSITORY_BOUNDARIES.md
+++ b/docs/REPOSITORY_BOUNDARIES.md
@@ -14,7 +14,7 @@ of truth is versioned, pinned, tested, and consumed without copying source.
 |---|---|---|
 | `Bitcoin-PIR/Bitcoin-PIR` | Wire protocol, database catalog, production clients and server, strict trust policy, deployment integration | Consumer-side proof verifiers, trusted-root installation, attestation and operator-pin policy, Merkle preflight, production Web app |
 | `Bitcoin-PIR/harmonypir` | Generic HarmonyPIR protocol and reusable client state machine | Bitcoin database orchestration and BitcoinPIR wire framing do not move upstream |
-| `Bitcoin-PIR/attested-builder` | Reproducible database/root-bundle producer | The production client verifier remains here until a stable, versioned verifier API exists |
+| `Bitcoin-PIR/attested-builder` | Native full-build V2 database + BuildEvidence producer (see that repo's README) | Client verifiers, pin tables, and live `verify-live` stay here |
 | `Bitcoin-PIR/bhtm` | BHTM proof producer | Production pinning and proof consumption |
 | `Bitcoin-PIR/oram` | ORAM implementation and proof producer | Production ORAM policy and live deployment binding |
 | [`Bitcoin-PIR/protocol-proofs`](https://github.com/Bitcoin-PIR/protocol-proofs) | Formal protocol and wire-shape specifications | A lock to an exact proof commit and the generated contract binding it compiles |
@@ -183,10 +183,11 @@ count. The current milestone consists of:
 
 After that milestone merges, use this order:
 
-1. Import the production DB, BHTM, and ORAM bundles from `web/public/proofs/`
-   into `proof-registry`. Add `verification/locks/generated-proofs.json`, rerun
-   the current consumer verifier in this repository, and generate browser
-   assets from the lock before deleting the original files.
+1. **Partial:** `verification/locks/generated-proofs.json` exists and is
+   the ORAM lock in Flow H.0. Bundles still live in-tree under
+   `web/public/proofs/`. Deleting those files after generating browser
+   assets from the lock is remaining cleanup, not a missing proof
+   family.
 2. Reconcile the two `rootbundle` implementations. **Complete:**
    `attested-builder` now has CI, shared golden vectors, compatibility tests,
    and protected `rootbundle-v*` releases; this repository pins the exact

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,5 +1,9 @@
 # Testing entry points
 
+This is Flow B in [Production operations](PRODUCTION_OPERATIONS.md).
+Green CI is not a deploy. Publishing the browser client is Flow C
+(manual `deploy-web.yml` on `main`).
+
 Pick your checks by *change class*, not by a single default command. The
 matrix below maps what you touched to the minimum local checks and to the CI
 that will actually run on your PR (most workflows are path-filtered; two run
@@ -19,11 +23,11 @@ and passing it says nothing about non-Payment changes.
 | `crates/sdk/wasm` or the WASM↔TS boundary | `wasm-pack build crates/sdk/wasm --target web --out-dir pkg -- --locked --offline`, then `cd web && npm run build && npm test` | `web-build.yml` | — |
 | `crates/sdk/server` | `cargo test --locked --offline -p pir-sdk-server`; `cargo build -p pir-sdk-server` | **None** — no workflow watches this path | Crate has ~0 lib tests; CI stays green if you break it |
 | `apps/server` / `crates/protocol/runtime` | `cargo test --locked --offline -p runtime --lib hint_pool`; `cargo test --locked --offline -p runtime --bin unified_server`; for admission/process behavior run `scripts/payment-v1-local-check.sh --pr` or the matching `scripts/payment-v1-ci-lane.sh --lane runtime-*` | `payment-platform.yml` (via `apps/server/**`); `pir-sdk-integration.yml` only if you touched `hint_pool.rs`, `unified_server.rs`, or the crate manifest | A deployed binary/UKI is a separate authorized release, never implied by green CI |
-| `web/` (TypeScript, pins, tests) | `cd web && npm run build && npm test && npm run build-web` | `web-build.yml`; `deploy-web.yml` adds Playwright gates only at the manual release dispatch | Pin edits: keep `web/src/attest-pin.ts`, the `verification/locks` files, and the duplicate pins in `crates/sdk/client/tests/integration_test.rs` consistent (rotation runbook §3) |
+| `web/` (TypeScript, pins, tests) | `cd web && npm run build && npm test && npm run build-web` | `web-build.yml`; `deploy-web.yml` adds Playwright gates only at the manual release dispatch | Pin edits: keep `PRODUCTION_DB_PROOF_PINS`, `PRODUCTION_ONION_DB_PROOF_V2_PINS`, `PRODUCTION_ORAM_DB_PROOF_V2_PINS`, `verification/locks/generated-proofs.json`, and the duplicate pins in `crates/sdk/client/tests/integration_test.rs` consistent (rotation runbook §3 / Flow H.0) |
 | Payment V1 (crates/payment, issuer apps, deploy templates) | Profiles below (`--quick` / `--pr`; `--deploy-template-audit` only for template work) | `payment-platform.yml`, sometimes `directory-relay-artifact.yml` | Source-ready ≠ deployed; production routing is in [Production operations](PRODUCTION_OPERATIONS.md) |
 | `verification/locks`, contracts, verifier scripts | `cargo test --locked --offline -p pir-sdk --features serde --test wire_shape_contract`; `python3 -m unittest verification/scripts/test_verify_formal_lock.py`; `cd web && npm test` (lock↔pin tests) | `formal-proof.yml` (every PR, unfiltered); `generated-proof-lock.yml` (lock paths) | Protocol framing / round-shape / padding changes must update the contract and proof lock (`REPOSITORY_BOUNDARIES.md`) |
 | `tools/db-builder`, `scripts/build_*.sh` | `cargo build -p build`; there is no test suite | **None** | Production databases come from the locked attested-builder, not these scripts; see `DATABASE_ARTIFACT_RETENTION.md` before any rebuild |
-| UKI scripts, `.github/workflows/**` | `node scripts/github-workflow-supply-chain-gate.mjs`; `node --test scripts/tier3-uki-policy-contract.test.mjs` | `workflow-supply-chain.yml` | UKI builds themselves are operator actions on the build host, not CI |
+| UKI scripts, VPSBG operator scripts, `.github/workflows/**` | `node scripts/github-workflow-supply-chain-gate.mjs`; `node --test scripts/tier3-uki-policy-contract.test.mjs`; `bash scripts/vpsbg-production-status.test.sh`; `bash scripts/ops-operator-scripts.test.sh` | `workflow-supply-chain.yml` | UKI builds and live VPSBG mutations are operator actions, not CI |
 | Documentation only | none | none (all workflows are path-filtered) | CI does not check documentation truth; identity values (hashes, image IDs) must be pointers to `web/src/attest-pin.ts` / `docs/data-retention/`, not copies |
 
 Merges are manual: there is no aggregate **required** check on `main`. The

--- a/docs/runbooks/issuer-state.md
+++ b/docs/runbooks/issuer-state.md
@@ -1,5 +1,8 @@
 # Initialize issuer state
 
+This is Flow I step 2 in
+[Production operations](../PRODUCTION_OPERATIONS.md).
+
 Use [`scripts/payment-v1-issuer-state.sh`](../../scripts/payment-v1-issuer-state.sh)
 after Payment V1 artifacts are ready and an issuer environment has been selected.
 

--- a/docs/runbooks/payment-artifacts.md
+++ b/docs/runbooks/payment-artifacts.md
@@ -1,5 +1,9 @@
 # Generate Payment V1 artifacts
 
+This is Flow I step 1 in
+[Production operations](../PRODUCTION_OPERATIONS.md). It is not a
+production issuer deploy.
+
 Use [`scripts/payment-v1-artifacts.sh`](../../scripts/payment-v1-artifacts.sh)
 to build and self-verify one selected Payment V1 or BAT V2 artifact.
 

--- a/docs/runbooks/payment-private-start.md
+++ b/docs/runbooks/payment-private-start.md
@@ -1,5 +1,8 @@
 # Start the private publisher network
 
+This is Flow I step 3 in
+[Production operations](../PRODUCTION_OPERATIONS.md).
+
 Use [`scripts/payment-v1-activate.sh`](../../scripts/payment-v1-activate.sh)
 with the `private` subcommand.
 

--- a/docs/runbooks/pir2-sealed-release.md
+++ b/docs/runbooks/pir2-sealed-release.md
@@ -1,5 +1,8 @@
 # Run the pir2 sealed release
 
+This is Flow G in [Production operations](../PRODUCTION_OPERATIONS.md).
+Placing `startup.env` is Flow F, not a provisioner UKI.
+
 Use [`scripts/pir2-sealed-ceremony.sh`](../../scripts/pir2-sealed-ceremony.sh)
 to advance the prepared pir2 release through Observe, sealed release, Enroll,
 Probe, and Ready.
@@ -28,9 +31,17 @@ scripts/pir2-sealed-ceremony.sh phase \
 scripts/pir2-sealed-ceremony.sh release [existing release arguments]
 ```
 
-After `PASS sealed_phase_config=observe`, use that exact file as
-`/home/pir/data/pir2-sealed/startup.env` for the measured Observe boot. Run the
-release after the Observe receipt is available. Generate new startup files for
-`enroll`, `probe`, and `ready`, and boot each in that order. A completed release
-prints `PASS sealed_release`; every phase file prints
-`PASS sealed_phase_config=<phase>` and `NEXT_STEP`.
+After `PASS sealed_phase_config=observe`, place that exact file with
+[`scripts/vpsbg-data-disk.sh`](../../scripts/vpsbg-data-disk.sh):
+
+```sh
+scripts/vpsbg-data-disk.sh open --server-id 25285 --image-id CURRENT --apply
+scripts/vpsbg-data-disk.sh put --local /absolute/observe.startup.env \
+  --remote /home/pir/data/pir2-sealed/startup.env --apply
+scripts/vpsbg-data-disk.sh close --server-id 25285 --image-id CURRENT --apply
+```
+
+Do not build a provisioner UKI. Run the release after the Observe receipt is
+available. Generate new startup files for `enroll`, `probe`, and `ready`, and
+boot each in that order. A completed release prints `PASS sealed_release`;
+every phase file prints `PASS sealed_phase_config=<phase>` and `NEXT_STEP`.

--- a/docs/runbooks/production-enable.md
+++ b/docs/runbooks/production-enable.md
@@ -1,5 +1,9 @@
 # Prepare final production enablement
 
+This is Flow I step 4 in
+[Production operations](../PRODUCTION_OPERATIONS.md). It is an offline
+source-readiness check, not a live issuer enablement.
+
 Use [`scripts/payment-v1-activate.sh`](../../scripts/payment-v1-activate.sh)
 with the `production` subcommand. The current repository entry performs the
 source-readiness handoff before a rendered installation and activation

--- a/docs/runbooks/uki-build.md
+++ b/docs/runbooks/uki-build.md
@@ -1,8 +1,12 @@
 # Build and reproduce a Tier 3 UKI
 
-This is the current operator entry for the production `unified_server` runtime
-UKI. It keeps four different concerns separate so a historical experiment
-cannot silently become the release recipe.
+This is Flow E step 3 in
+[Production operations](../PRODUCTION_OPERATIONS.md). It is the current
+operator entry for the production `unified_server` **runtime** UKI. The
+attested-builder producer UKI is Flow H
+([Attested-builder Tier 3 UKI](../ATTESTED_BUILDER_TIER3_UKI.md)); do
+not substitute it here. It keeps four different concerns separate so a
+historical experiment cannot silently become the release recipe.
 
 ## 1. Source and runtime binary
 
@@ -65,12 +69,11 @@ Hetzner may build the candidate only when its exact kernel/modules and build
 dependencies satisfy the command above. The script must not inherit host
 compression or unrelated dracut modules.
 
-If those inputs are unavailable, the fallback is the established VPSBG
-maintenance shape: separately authorize changing measured boot to no attached
-UKI, reboot into the stock root filesystem, build there, archive off-host, and
-reattach the recorded rollback image if the maintenance build fails. Do not
-assume the VPSBG API's `null`/`None` behavior; confirm the operator action and
-rollback image before changing the server.
+If those inputs are unavailable, the fallback is Flow F in
+[Production operations](../PRODUCTION_OPERATIONS.md):
+`scripts/vpsbg-data-disk.sh open`, build on the stock root filesystem,
+archive off-host, then `close` with the recorded rollback image if the
+maintenance build fails. The detach body is `{"kernel_image_id":null}`.
 
 ## 4. Reproducibility and verification
 

--- a/docs/runbooks/vpsbg-image.md
+++ b/docs/runbooks/vpsbg-image.md
@@ -1,25 +1,37 @@
 # Manage a VPSBG image
 
-Use [`scripts/vpsbg-measured-boot.sh`](../../scripts/vpsbg-measured-boot.sh)
-for image inspection, upload, switch, and rollback. Switching or rolling back
-an image applies it with an immediate reboot.
+This is Flow E in [Production operations](../PRODUCTION_OPERATIONS.md)
+(steps 1–2, 4–7). Use
+[`scripts/vpsbg-measured-boot.sh`](../../scripts/vpsbg-measured-boot.sh)
+for image inspection, listing, upload, switch, and rollback. Switching or
+rolling back an image applies it with an immediate reboot. The default API
+token path is `.secrets/vpsbg-api-token`. There is no delete action.
+
+After an authorized switch, use
+[`scripts/pir2-post-switch-check.sh`](../../scripts/pir2-post-switch-check.sh)
+to wait for `boot_mode=measured` and verify the live host against
+[`web/src/attest-pin.ts`](../../web/src/attest-pin.ts). A mismatch is a
+hard stop; the check does not edit the pin file.
 
 ## Inputs
 
 - VPSBG API configuration accepted by the command.
 - For upload, the completed UKI path.
-- For switch or rollback, the image ID printed by `status` or `upload`.
+- For switch or rollback, the image ID printed by `status`, `images`, or `upload`.
 
 ## Run
 
 ```sh
 scripts/vpsbg-measured-boot.sh --help
 scripts/vpsbg-measured-boot.sh status --server-id SERVER_ID
+scripts/vpsbg-measured-boot.sh images
 scripts/vpsbg-measured-boot.sh upload --uki /absolute/path/bpir-tier3.efi --dry-run
 scripts/vpsbg-measured-boot.sh switch --server-id SERVER_ID --image-id IMAGE_ID --dry-run
 scripts/vpsbg-measured-boot.sh rollback --server-id SERVER_ID --image-id IMAGE_ID --dry-run
+scripts/pir2-post-switch-check.sh --dry-run
 ```
 
 Mutation commands default to a dry-run preview. After confirming this run's
 authorization, repeat the required mutation with `--apply`. Each successful
-operation prints `PASS action=status|upload|switch|rollback` and `NEXT_STEP`.
+operation prints `PASS action=status|images|upload|switch|rollback` or
+`PASS action=post_switch_check` and `NEXT_STEP`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,7 +5,8 @@ Helper scripts for running and testing the PIR system.
 > **Scope note (2026-08).** The database build and refresh sections below
 > describe the local development pipeline. They are **not** the production
 > database release path: production rotations use the locked
-> `Bitcoin-PIR/attested-builder` producer and
+> `Bitcoin-PIR/attested-builder` producer (that repo's README is the
+> coverage map) and
 > [`docs/DATABASE_ROOT_ROTATION_RUNBOOK.md`](../docs/DATABASE_ROOT_ROTATION_RUNBOOK.md),
 > and every retention/cleanup decision is governed by
 > [`docs/DATABASE_ARTIFACT_RETENTION.md`](../docs/DATABASE_ARTIFACT_RETENTION.md).
@@ -13,14 +14,20 @@ Helper scripts for running and testing the PIR system.
 
 ## Production status
 
-For production diagnosis, run this read-only command first:
+For production diagnosis (Flow A in
+[`docs/PRODUCTION_OPERATIONS.md`](../docs/PRODUCTION_OPERATIONS.md)),
+run this read-only command first:
 
 ```bash
-./scripts/vpsbg-production-status.sh
+./scripts/production-status.sh
 ```
 
-It only GETs the VPSBG control plane and public `/status.json`; it never uses SSH.
-It reports control-plane state, boot mode, and attached image. The ORAM endpoint exists only during build/switch; after `unified_server` owns 8091, its fields are expected to be `unavailable`.
+That prints pir1 SSH health and then the pir2 VPSBG snapshot. For pir2
+only, `./scripts/vpsbg-production-status.sh` GETs the VPSBG control plane
+and public `/status.json` and never uses SSH. Both default to
+`.secrets/vpsbg-api-token`. The ORAM endpoint exists only during
+build/switch; after `unified_server` owns 8091, its fields are expected
+to be `unavailable`.
 Do not infer profile, attestation, generation, database identity, or other unavailable fields. `--root` reads an offline evidence directory only. See [`docs/PRODUCTION_OPERATIONS.md`](../docs/PRODUCTION_OPERATIONS.md) for release and canary routing.
 
 Before a database or Direct ORAM rebuild, read

--- a/scripts/build_uki_attested_builder_tier3.sh
+++ b/scripts/build_uki_attested_builder_tier3.sh
@@ -267,7 +267,8 @@ echo "builder Tier 3 UKI sha256:  $UKI_SHA"
     "builder_binary_sha256=$ATTESTED_BUILDER_BIN_SHA256"
 echo
 cat <<EOF
-Before booting this UKI, provision runtime inputs on VPSBG Slice 2:
+Before booting this UKI, provision runtime inputs on the stock rootfs
+(Flow F, scripts/vpsbg-data-disk.sh):
 
 For database-proof v2 re-attestation of the retained production layouts:
 
@@ -321,9 +322,10 @@ The wrapper rejects every other full-build mode. The native pipeline must emit
 the server DB, proof sidecars, Direct ORAM inputs, final BuildEvidence v2, and
 SNP quote before this runner marks its output eligible for staging.
 
-Upload $OUT in VPSBG Measured Boot as a temporary UKI and reboot.
-The UKI will power off after completion. Then switch Measured Boot back to
-"None", boot Slice 2, and collect:
+Upload and switch with scripts/vpsbg-measured-boot.sh (Flow E-style
+authorization, separate from this build). The UKI powers off after
+completion. Then Flow F open, collect, and close to the recorded
+runtime image:
 
   /home/pir/data/attested-builder-runs/latest/build-summary.txt
   /home/pir/data/attested-builder-runs/latest/build-evidence.bin

--- a/scripts/ops-operator-scripts.test.sh
+++ b/scripts/ops-operator-scripts.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$script_dir/.." && pwd)"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/bpir-ops-scripts.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+expect_pass() {
+  local label=$1
+  shift
+  local out
+  out=$("$@")
+  grep -q 'PASS ' <<<"$out" || {
+    echo "$label did not print PASS" >&2
+    printf '%s\n' "$out" >&2
+    exit 1
+  }
+}
+
+expect_fail() {
+  local label=$1
+  shift
+  if "$@" >/dev/null 2>"$tmp/err"; then
+    echo "$label unexpectedly succeeded" >&2
+    exit 1
+  fi
+}
+
+images_preview=$("$script_dir/vpsbg-measured-boot.sh" images --dry-run)
+grep -qx 'PASS action=images dry_run=true' <<<"$images_preview"
+grep -q '\.secrets/vpsbg-api-token' <<<"$images_preview"
+
+open_preview=$("$script_dir/vpsbg-data-disk.sh" open --image-id 291 --dry-run)
+grep -qx 'server_id=25285' <<<"$open_preview"
+grep -qx 'detach_body={"kernel_image_id":null}' <<<"$open_preview"
+grep -qx 'PASS action=open dry_run=true' <<<"$open_preview"
+
+close_preview=$("$script_dir/vpsbg-data-disk.sh" close --server-id 25285 --image-id 291 --dry-run)
+grep -qx 'PASS action=close dry_run=true' <<<"$close_preview"
+
+printf '%s\n' \
+  'schema=bitcoinpir-pir2-sealed-startup-v2' \
+  'profile=pir2-snp-sealed-v1' \
+  'phase=observe' >"$tmp/observe.startup.env"
+put_preview=$("$script_dir/vpsbg-data-disk.sh" put \
+  --local "$tmp/observe.startup.env" \
+  --remote /home/pir/data/pir2-sealed/startup.env --dry-run)
+grep -qx 'PASS action=put dry_run=true' <<<"$put_preview"
+
+expect_fail 'put outside /home/pir/data' \
+  "$script_dir/vpsbg-data-disk.sh" put --local "$tmp/observe.startup.env" --remote /tmp/startup.env --dry-run
+expect_fail 'put startup.env at wrong sealed path' \
+  "$script_dir/vpsbg-data-disk.sh" put --local "$tmp/observe.startup.env" --remote /home/pir/data/startup.env --dry-run
+expect_fail 'put provisioner path' \
+  "$script_dir/vpsbg-data-disk.sh" put --local "$tmp/observe.startup.env" --remote /home/pir/data/provisioner.env --dry-run
+printf 'not-a-ceremony\n' >"$tmp/bad.startup.env"
+expect_fail 'put non-ceremony startup.env' \
+  "$script_dir/vpsbg-data-disk.sh" put --local "$tmp/bad.startup.env" --remote /home/pir/data/pir2-sealed/startup.env --dry-run
+expect_fail 'open without image id' \
+  "$script_dir/vpsbg-data-disk.sh" open --dry-run
+
+status_preview=$("$script_dir/production-status.sh" --dry-run)
+grep -qx 'PASS production_status dry_run=true' <<<"$status_preview"
+grep -qx 'pir1_host=65.21.91.217' <<<"$status_preview"
+
+check_preview=$("$script_dir/pir2-post-switch-check.sh" --dry-run)
+grep -qx "pin_source=$repo/web/src/attest-pin.ts" <<<"$check_preview"
+grep -qx 'PASS action=post_switch_check dry_run=true' <<<"$check_preview"
+
+printf 'export const PIR2_TIER3_PIN: ServerAttestPin = {\n};\n' >"$tmp/empty-pin.ts"
+expect_fail 'post-switch-check missing pin fields' \
+  "$script_dir/pir2-post-switch-check.sh" --pin-file "$tmp/empty-pin.ts" --dry-run
+
+echo 'ops operator scripts offline fixture: PASS'

--- a/scripts/pir2-post-switch-check.sh
+++ b/scripts/pir2-post-switch-check.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Wait for pir2 measured boot, then verify against web/src/attest-pin.ts.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: scripts/pir2-post-switch-check.sh [--server-id ID] [--status-url URL]
+       [--pin-file PATH] [--dry-run]
+
+Reads PIR2 measurement and binary pins from web/src/attest-pin.ts (or
+--pin-file), waits until VPSBG reports boot_mode=measured and
+running=true, then runs scripts/verify_oram_tier3_deploy.sh. A pin
+mismatch is a hard stop; this command never edits attest-pin.ts.
+EOF
+}
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+readonly DEFAULT_PIN_FILE="$root/web/src/attest-pin.ts"
+readonly HARD_STOP_SECONDS=900
+
+server_id= status_url= pin_file=$DEFAULT_PIN_FILE dry_run=0
+while (($#)); do
+  case "$1" in
+    --server-id) server_id=${2:?missing server ID}; shift 2 ;;
+    --status-url) status_url=${2:?missing status URL}; shift 2 ;;
+    --pin-file) pin_file=${2:?missing pin file}; shift 2 ;;
+    --dry-run) dry_run=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+[[ -z "$server_id" || "$server_id" =~ ^[0-9]+$ ]] || { echo 'server ID must be numeric' >&2; exit 2; }
+[[ -r "$pin_file" && -s "$pin_file" ]] || { echo "pin file is missing or empty: $pin_file" >&2; exit 2; }
+
+parsed=$(python3 - "$pin_file" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+block = re.search(
+    r"export const PIR2_TIER3_PIN\s*:\s*ServerAttestPin\s*=\s*\{(.*?)\n\};",
+    text,
+    re.S,
+)
+if not block:
+    sys.stderr.write("PIR2_TIER3_PIN is missing from the pin file\n")
+    sys.exit(2)
+
+def field(name: str) -> str:
+    match = re.search(
+        rf"{name}\s*:\s*['\"]([0-9a-fA-F]+)['\"]",
+        block.group(1),
+    )
+    return match.group(1).lower() if match else ""
+
+measurement = field("measurementHex")
+binary = field("binarySha256Hex")
+if len(measurement) != 96:
+    sys.stderr.write("PIR2_TIER3_PIN.measurementHex is missing or not 96 hex characters\n")
+    sys.exit(2)
+if len(binary) != 64:
+    sys.stderr.write("PIR2_TIER3_PIN.binarySha256Hex is missing or not 64 hex characters\n")
+    sys.exit(2)
+print(measurement)
+print(binary)
+PY
+)
+measurement=${parsed%%$'\n'*}
+binary=${parsed#*$'\n'}
+
+echo "pin_source=$pin_file"
+echo 'pin_fields=measurementHex,binarySha256Hex'
+echo "hard_stop_seconds=$HARD_STOP_SECONDS"
+
+if ((dry_run)); then
+  echo '[stage] post-switch check preview'
+  echo 'PASS action=post_switch_check dry_run=true'
+  echo 'NEXT_STEP=run without --dry-run after the guest reports running'
+  exit 0
+fi
+
+status_args=()
+[[ -z "$server_id" ]] || status_args+=(--server-id "$server_id")
+[[ -z "$status_url" ]] || status_args+=(--status-url "$status_url")
+
+status_field() {
+  local key=$1
+  awk -F= -v key="$key" '$1 == key { print $2; found=1 } END { if (!found) print "unavailable" }'
+}
+
+echo '[stage] wait for measured boot'
+started=$(date -u +%s)
+while :; do
+  now=$(date -u +%s)
+  if (( now - started >= HARD_STOP_SECONDS )); then
+    echo "hard stop: pir2 did not reach boot_mode=measured and running=true in ${HARD_STOP_SECONDS}s" >&2
+    exit 1
+  fi
+  snapshot=$("$root/scripts/vpsbg-production-status.sh" "${status_args[@]}")
+  boot_mode=$(status_field boot_mode <<<"$snapshot")
+  running=$(status_field control_plane_running <<<"$snapshot")
+  image_id=$(status_field image_id <<<"$snapshot")
+  printf 'boot_mode=%s control_plane_running=%s image_id=%s elapsed_seconds=%s\n' \
+    "$boot_mode" "$running" "$image_id" "$((now - started))"
+  if [[ "$boot_mode" == measured && "$running" == true ]]; then
+    break
+  fi
+  sleep 10
+done
+
+echo "image_id=$image_id"
+echo '[stage] verify live attest against pin file'
+EXPECT_MEASUREMENT=$measurement EXPECT_BINARY=$binary \
+  "$root/scripts/verify_oram_tier3_deploy.sh"
+echo 'PASS action=post_switch_check'
+echo 'NEXT_STEP=leave attest-pin.ts unchanged unless a separate pin-update is authorized'

--- a/scripts/pir2-sealed-ceremony.sh
+++ b/scripts/pir2-sealed-ceremony.sh
@@ -88,7 +88,7 @@ if [[ "$action" == phase ]]; then
   trap - EXIT HUP INT TERM
   echo "startup_env=$out"
   echo "PASS sealed_phase_config=$phase"
-  echo 'NEXT_STEP=place/use this exact startup.env and boot the measured UKI'
+  echo 'NEXT_STEP=place this exact startup.env with scripts/vpsbg-data-disk.sh put, then boot the measured UKI'
   exit 0
 fi
 dry_run=0; args=()

--- a/scripts/production-status.sh
+++ b/scripts/production-status.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Read-only pir1 SSH health plus pir2 VPSBG control-plane status.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: scripts/production-status.sh [--server-id ID] [--dry-run]
+
+Prints pir1 systemd/port/disk health over SSH, then the existing pir2
+VPSBG status snapshot. This command never restarts a service and does
+not inspect Signet or functional-beta units.
+EOF
+}
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+readonly HETZNER_HOST=65.21.91.217
+readonly HETZNER_KNOWN_HOSTS="$root/deploy/known_hosts"
+readonly DEFAULT_TOKEN_FILE="$root/.secrets/vpsbg-api-token"
+
+server_id= dry_run=0
+while (($#)); do
+  case "$1" in
+    --server-id) server_id=${2:?missing server ID}; shift 2 ;;
+    --dry-run) dry_run=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+[[ -z "$server_id" || "$server_id" =~ ^[0-9]+$ ]] || { echo 'server ID must be numeric' >&2; exit 2; }
+
+[[ -r "$HETZNER_KNOWN_HOSTS" && -s "$HETZNER_KNOWN_HOSTS" ]] || {
+  echo "Hetzner known_hosts is missing or empty: $HETZNER_KNOWN_HOSTS" >&2
+  exit 2
+}
+token_file=${VPSBG_API_TOKEN_FILE:-$DEFAULT_TOKEN_FILE}
+
+if ((dry_run)); then
+  echo '[stage] production status preview'
+  echo "pir1_host=$HETZNER_HOST"
+  echo "pir1_known_hosts=$HETZNER_KNOWN_HOSTS"
+  echo "pir2_token_file=$token_file"
+  [[ -n "$server_id" ]] && echo "server_id=$server_id"
+  echo 'PASS production_status dry_run=true'
+  echo 'NEXT_STEP=run without --dry-run for the live pir1 SSH and pir2 API snapshot'
+  exit 0
+fi
+
+[[ -r "$token_file" && -s "$token_file" ]] || {
+  echo "VPSBG API token file is missing or empty: $token_file" >&2
+  exit 2
+}
+
+echo '[stage] pir1 Hetzner health'
+echo "pir1_host=$HETZNER_HOST"
+pir1_out=$(
+  ssh -o BatchMode=yes -o ConnectTimeout=20 \
+    -o UserKnownHostsFile="$HETZNER_KNOWN_HOSTS" \
+    -o StrictHostKeyChecking=yes \
+    "root@$HETZNER_HOST" 'bash -s' <<'REMOTE'
+set -euo pipefail
+primary=$(systemctl is-active pir-primary 2>/dev/null || true)
+cloudflared=$(systemctl is-active cloudflared 2>/dev/null || true)
+if ss -tln 2>/dev/null | grep -Eq ':8091\b'; then
+  port=listening
+else
+  port=missing
+fi
+disk=$(df -P /home/pir | awk 'NR==2 { print $5 }')
+printf 'pir1_primary=%s\n' "${primary:-unavailable}"
+printf 'pir1_cloudflared=%s\n' "${cloudflared:-unavailable}"
+printf 'pir1_port_8091=%s\n' "$port"
+printf 'pir1_disk_used=%s\n' "${disk:-unavailable}"
+REMOTE
+) || {
+  echo 'pir1 SSH health check failed or exceeded 20s' >&2
+  exit 1
+}
+printf '%s\n' "$pir1_out"
+echo 'PASS host=pir1'
+
+echo '[stage] pir2 VPSBG status'
+status_args=()
+[[ -z "$server_id" ]] || status_args+=(--server-id "$server_id")
+"$root/scripts/vpsbg-production-status.sh" "${status_args[@]}"
+echo 'PASS host=pir2'
+echo 'PASS production_status'
+echo 'NEXT_STEP=use scripts/vpsbg-measured-boot.sh or scripts/vpsbg-data-disk.sh only after this run is authorized'

--- a/scripts/smoke_db_proof_attestation.sh
+++ b/scripts/smoke_db_proof_attestation.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# Smoke-test the attested-builder database proof binding.
+# Smoke-test the retained mixed-provenance v1 database-proof opcode.
+#
+# This is not the production pin catalog and not a v2/Onion/ORAM check.
+# Flow H.0: verify-live is v1-only. Onion/ORAM stay on local
+# db-proof verify / the browser after Flow C.
 #
 # This script is intentionally read-only. It verifies the local mirrored proof
 # directory, then verifies live PIR servers if requested. It does not SSH,

--- a/scripts/vpsbg-data-disk.sh
+++ b/scripts/vpsbg-data-disk.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# Open a VPSBG stock-rootfs window, copy files on /home/pir/data/, then reattach a UKI.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: scripts/vpsbg-data-disk.sh <open|put|get|ssh|close> [options]
+
+  open  --image-id ID [--server-id ID] [--token-file PATH] (--dry-run | --apply)
+  close --image-id ID [--server-id ID] [--token-file PATH] (--dry-run | --apply)
+  put   --local FILE --remote /home/pir/data/... [--server-id ID] (--dry-run | --apply)
+  get   --remote /home/pir/data/... --local FILE [--server-id ID]
+  ssh   [--server-id ID] [--] [REMOTE_COMMAND...]
+
+open detaches measured boot (kernel_image_id=null), stop/starts the guest,
+and waits until boot_mode=stock and SSH works. close switches back to the
+caller-supplied image ID; it never remembers the previous image. put/get/ssh
+refuse to run unless the guest is already stock. There is no provisioner UKI
+path. Mutations default to a dry-run preview unless --apply is set.
+EOF
+}
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+readonly API_BASE='https://api.vpsbg.eu/v1'
+readonly DEFAULT_SERVER_ID=25285
+readonly VPSBG_HOST=87.120.8.198
+readonly HARD_STOP_SECONDS=900
+readonly DEFAULT_TOKEN_FILE="$root/.secrets/vpsbg-api-token"
+readonly DEFAULT_SSH_KEY="$root/.keys/vpsbg-ssh.key"
+readonly DEFAULT_KNOWN_HOSTS="$root/deploy/vpsbg_known_hosts"
+
+action=${1:-}
+[[ "$action" != --help && "$action" != -h ]] || { usage; exit 0; }
+[[ "$action" =~ ^(open|put|get|ssh|close)$ ]] || { usage >&2; exit 2; }
+shift || true
+
+server_id=$DEFAULT_SERVER_ID
+image_id= local_path= remote_path= token_file= ssh_key= known_hosts=
+apply=0 dry_run=0
+ssh_cmd=()
+while (($#)); do
+  case "$1" in
+    --server-id) server_id=${2:?missing server ID}; shift 2 ;;
+    --image-id) image_id=${2:?missing image ID}; shift 2 ;;
+    --local) local_path=${2:?missing local path}; shift 2 ;;
+    --remote) remote_path=${2:?missing remote path}; shift 2 ;;
+    --token-file) token_file=${2:?missing token file}; shift 2 ;;
+    --ssh-key) ssh_key=${2:?missing SSH key}; shift 2 ;;
+    --known-hosts) known_hosts=${2:?missing known_hosts}; shift 2 ;;
+    --apply) apply=1; shift ;;
+    --dry-run) dry_run=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; ssh_cmd+=("$@"); break ;;
+    *)
+      if [[ "$action" == ssh ]]; then
+        ssh_cmd+=("$1"); shift
+      else
+        echo "unknown option: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+[[ "$server_id" =~ ^[0-9]+$ ]] || { echo 'server ID must be numeric' >&2; exit 2; }
+[[ -z "$image_id" || "$image_id" =~ ^[0-9]+$ ]] || { echo 'image ID must be numeric' >&2; exit 2; }
+printf 'server_id=%s\n' "$server_id"
+
+reject_provisioner() {
+  local value
+  for value in "$@"; do
+    [[ "$value" != *provisioner* ]] || {
+      echo 'provisioner UKI path is forbidden; use stock-rootfs SSH' >&2
+      exit 2
+    }
+  done
+}
+
+require_data_path() {
+  local path=$1
+  [[ "$path" == /home/pir/data/* ]] || {
+    echo "remote path must be under /home/pir/data/: $path" >&2
+    exit 2
+  }
+  [[ "$path" != *..* ]] || { echo "remote path must not contain ..: $path" >&2; exit 2; }
+  if [[ "$(basename "$path")" == startup.env ]]; then
+    [[ "$path" == /home/pir/data/pir2-sealed/startup.env ]] || {
+      echo 'startup.env must be placed at /home/pir/data/pir2-sealed/startup.env' >&2
+      exit 2
+    }
+  fi
+}
+
+require_startup_env_schema() {
+  local path=$1
+  [[ -f "$path" && -s "$path" ]] || { echo "local startup.env is missing or empty: $path" >&2; exit 2; }
+  grep -qx 'schema=bitcoinpir-pir2-sealed-startup-v2' "$path" \
+    || { echo 'startup.env is not a ceremony v2 file' >&2; exit 2; }
+  grep -qx 'profile=pir2-snp-sealed-v1' "$path" \
+    || { echo 'startup.env is not a pir2 sealed profile file' >&2; exit 2; }
+  grep -Eq '^phase=(observe|enroll|probe|ready)$' "$path" \
+    || { echo 'startup.env phase is not observe, enroll, probe, or ready' >&2; exit 2; }
+}
+
+status_field() {
+  local key=$1
+  awk -F= -v key="$key" '$1 == key { print $2; found=1 } END { if (!found) print "unavailable" }'
+}
+
+read_status() {
+  "$root/scripts/vpsbg-production-status.sh" --server-id "$server_id"
+}
+
+ssh_opts() {
+  ssh_key=${ssh_key:-${VPSBG_SSH_KEY:-$DEFAULT_SSH_KEY}}
+  known_hosts=${known_hosts:-${VPSBG_KNOWN_HOSTS:-$DEFAULT_KNOWN_HOSTS}}
+  [[ -r "$ssh_key" && -s "$ssh_key" ]] || { echo "VPSBG SSH key is missing or empty: $ssh_key" >&2; exit 2; }
+  [[ -r "$known_hosts" && -s "$known_hosts" ]] || { echo "VPSBG known_hosts is missing or empty: $known_hosts" >&2; exit 2; }
+}
+
+ssh_base() {
+  ssh_opts
+  SSH_BASE=(
+    ssh
+    -i "$ssh_key"
+    -o IdentitiesOnly=yes
+    -o UserKnownHostsFile="$known_hosts"
+    -o StrictHostKeyChecking=yes
+    -o ConnectTimeout=20
+  )
+}
+
+scp_base() {
+  ssh_opts
+  SCP_BASE=(
+    scp
+    -i "$ssh_key"
+    -o IdentitiesOnly=yes
+    -o UserKnownHostsFile="$known_hosts"
+    -o StrictHostKeyChecking=yes
+    -o ConnectTimeout=20
+  )
+}
+
+require_stock() {
+  local snapshot boot_mode
+  snapshot=$(read_status)
+  printf '%s\n' "$snapshot"
+  boot_mode=$(status_field boot_mode <<<"$snapshot")
+  [[ "$boot_mode" == stock ]] || {
+    echo "refusing SSH/copy while boot_mode=$boot_mode; run open first" >&2
+    exit 2
+  }
+}
+
+api_token() {
+  token_file=${token_file:-${VPSBG_API_TOKEN_FILE:-$DEFAULT_TOKEN_FILE}}
+  [[ -s "$token_file" ]] || { echo "VPSBG API token file is missing or empty: $token_file" >&2; exit 2; }
+  tr -d '\r\n' <"$token_file"
+}
+
+api_post() {
+  local path=$1 body=$2
+  local token
+  token=$(api_token)
+  curl --fail --silent --show-error --max-time 30 --retry 0 \
+    -H 'Accept: application/json' \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    -d "$body" \
+    "$API_BASE$path"
+  unset token
+}
+
+wait_for_stock_ssh() {
+  local started now snapshot boot_mode running ssh_ready
+  started=$(date -u +%s)
+  ssh_base
+  echo "[stage] wait for stock rootfs and SSH (hard_stop_seconds=$HARD_STOP_SECONDS)"
+  while :; do
+    now=$(date -u +%s)
+    if (( now - started >= HARD_STOP_SECONDS )); then
+      echo "hard stop: guest did not reach boot_mode=stock with SSH in ${HARD_STOP_SECONDS}s" >&2
+      exit 1
+    fi
+    snapshot=$(read_status) || true
+    boot_mode=$(status_field boot_mode <<<"$snapshot")
+    running=$(status_field control_plane_running <<<"$snapshot")
+    ssh_ready=false
+    if [[ "$boot_mode" == stock ]]; then
+      if "${SSH_BASE[@]}" -o BatchMode=yes "root@$VPSBG_HOST" true >/dev/null 2>&1; then
+        ssh_ready=true
+      fi
+    fi
+    printf 'boot_mode=%s control_plane_running=%s ssh_ready=%s elapsed_seconds=%s\n' \
+      "$boot_mode" "$running" "$ssh_ready" "$((now - started))"
+    if [[ "$boot_mode" == stock && "$ssh_ready" == true ]]; then
+      return 0
+    fi
+    sleep 10
+  done
+}
+
+reject_provisioner "$local_path" "$remote_path" "${ssh_cmd[@]+"${ssh_cmd[@]}"}"
+
+case "$action" in
+  open)
+    [[ -n "$image_id" ]] || { echo 'open requires --image-id ID as the recorded close target' >&2; exit 2; }
+    (( dry_run + apply <= 1 )) || { echo 'open accepts only one of --dry-run or --apply' >&2; exit 2; }
+    echo 'expected_duration=up to 15 minutes'
+    echo "hard_stop_seconds=$HARD_STOP_SECONDS"
+    echo 'progress=detach,stop,start,boot_mode=stock,ssh_ready'
+    echo "recorded_close_image_id=$image_id"
+    echo 'detach_body={"kernel_image_id":null}'
+    if ((dry_run || !apply)); then
+      echo '[stage] open preview'
+      echo 'PASS action=open dry_run=true'
+      echo 'NEXT_STEP=review recorded_close_image_id, then rerun with --apply'
+      exit 0
+    fi
+    command -v curl >/dev/null 2>&1 || { echo 'curl is required for open --apply' >&2; exit 2; }
+    command -v jq >/dev/null 2>&1 || { echo 'jq is required for open --apply' >&2; exit 2; }
+    echo '[stage] read live VPSBG status before detach'
+    snapshot=$(read_status)
+    printf '%s\n' "$snapshot"
+    live_image_id=$(status_field image_id <<<"$snapshot")
+    live_boot_mode=$(status_field boot_mode <<<"$snapshot")
+    printf 'live_image_id=%s\n' "$live_image_id"
+    printf 'live_boot_mode=%s\n' "$live_boot_mode"
+    if [[ "$live_boot_mode" == measured && "$live_image_id" != "$image_id" ]]; then
+      echo "recorded close image $image_id does not match live image $live_image_id" >&2
+      exit 2
+    fi
+    if [[ "$live_boot_mode" != stock ]]; then
+      echo '[stage] detach measured boot'
+      api_post "/servers/$server_id/measured-boot" '{"kernel_image_id":null}' >/dev/null
+      echo '[stage] stop guest'
+      api_post "/servers/$server_id/stop" '{}' >/dev/null
+      echo '[stage] start guest'
+      api_post "/servers/$server_id/start" '{}' >/dev/null
+    else
+      echo '[stage] already stock; skip detach'
+    fi
+    wait_for_stock_ssh
+    echo 'PASS action=open'
+    echo "NEXT_STEP=copy files with put/get/ssh, then close --image-id $image_id --apply"
+    ;;
+  close)
+    [[ -n "$image_id" ]] || { echo 'close requires --image-id ID' >&2; exit 2; }
+    (( dry_run + apply <= 1 )) || { echo 'close accepts only one of --dry-run or --apply' >&2; exit 2; }
+    if ((dry_run || !apply)); then
+      echo '[stage] close preview'
+      echo "image_id=$image_id"
+      echo 'PASS action=close dry_run=true'
+      echo 'NEXT_STEP=rerun with --apply to switch this exact image'
+      exit 0
+    fi
+    echo '[stage] switch measured-boot image'
+    "$root/scripts/vpsbg-measured-boot.sh" switch --server-id "$server_id" --image-id "$image_id" --apply
+    echo 'PASS action=close'
+    echo 'NEXT_STEP=run scripts/pir2-post-switch-check.sh after the guest reports running'
+    ;;
+  put)
+    [[ -n "$local_path" && -n "$remote_path" ]] || { echo 'put requires --local FILE and --remote PATH' >&2; exit 2; }
+    require_data_path "$remote_path"
+    [[ "$local_path" == /* ]] || { echo 'local path must be absolute' >&2; exit 2; }
+    if [[ "$(basename "$remote_path")" == startup.env ]]; then
+      require_startup_env_schema "$local_path"
+    fi
+    (( dry_run + apply <= 1 )) || { echo 'put accepts only one of --dry-run or --apply' >&2; exit 2; }
+    if ((dry_run || !apply)); then
+      echo '[stage] put preview'
+      echo "local_path=$local_path"
+      echo "remote_path=$remote_path"
+      echo 'PASS action=put dry_run=true'
+      echo 'NEXT_STEP=confirm stock boot, then rerun with --apply'
+      exit 0
+    fi
+    [[ -f "$local_path" && -s "$local_path" ]] || { echo "local file is missing or empty: $local_path" >&2; exit 2; }
+    require_stock
+    scp_base
+    echo '[stage] copy local file to VPSBG data disk'
+    "${SCP_BASE[@]}" "$local_path" "root@$VPSBG_HOST:$remote_path"
+    echo "copied=$remote_path"
+    echo 'PASS action=put'
+    echo 'NEXT_STEP=close with the recorded image ID when the data-disk edit is done'
+    ;;
+  get)
+    (( ! apply && ! dry_run )) || { echo 'get is read-only and accepts neither --apply nor --dry-run' >&2; exit 2; }
+    [[ -n "$local_path" && -n "$remote_path" ]] || { echo 'get requires --remote PATH and --local FILE' >&2; exit 2; }
+    require_data_path "$remote_path"
+    [[ "$local_path" == /* ]] || { echo 'local path must be absolute' >&2; exit 2; }
+    require_stock
+    scp_base
+    echo '[stage] copy VPSBG data-disk file to local path'
+    "${SCP_BASE[@]}" "root@$VPSBG_HOST:$remote_path" "$local_path"
+    echo "copied=$local_path"
+    echo 'PASS action=get'
+    echo 'NEXT_STEP=inspect the local copy; close is a separate authorized step'
+    ;;
+  ssh)
+    (( ! apply && ! dry_run )) || { echo 'ssh accepts neither --apply nor --dry-run' >&2; exit 2; }
+    require_stock
+    ssh_base
+    echo '[stage] SSH to stock VPSBG rootfs'
+    if ((${#ssh_cmd[@]})); then
+      "${SSH_BASE[@]}" -o BatchMode=yes "root@$VPSBG_HOST" "${ssh_cmd[@]}"
+    else
+      "${SSH_BASE[@]}" "root@$VPSBG_HOST"
+    fi
+    echo 'PASS action=ssh'
+    echo 'NEXT_STEP=close with the recorded image ID when the data-disk edit is done'
+    ;;
+esac

--- a/scripts/vpsbg-measured-boot.sh
+++ b/scripts/vpsbg-measured-boot.sh
@@ -4,18 +4,20 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-usage: scripts/vpsbg-measured-boot.sh <status|upload|switch|rollback> [options]
+usage: scripts/vpsbg-measured-boot.sh <status|images|upload|switch|rollback> [options]
 
-Read-only status:
+Read-only:
   status [--server-id ID] [--status-url URL]
+  images [--token-file PATH]
 
 Mutations (require --apply; --dry-run is the default-safe preview):
   upload   --uki FILE [--token-file PATH] [--apply]
   switch   --server-id ID --image-id ID [--token-file PATH] [--apply]
   rollback --server-id ID --image-id ID [--token-file PATH] [--apply]
 
-Status uses VPSBG_API_TOKEN_FILE or the standard local token path. Mutations
-also accept --token-file PATH. Output is [stage] progress plus PASS and
+Status and images use VPSBG_API_TOKEN_FILE or
+<repo>/.secrets/vpsbg-api-token. Mutations also accept --token-file PATH.
+There is no delete action. Output is [stage] progress plus PASS and
 NEXT_STEP. --dry-run neither reads the token nor contacts VPSBG.
 EOF
 }
@@ -39,13 +41,19 @@ while (($#)); do
     *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
-[[ "$action" =~ ^(status|upload|switch|rollback)$ ]] || { usage >&2; exit 2; }
+[[ "$action" =~ ^(status|images|upload|switch|rollback)$ ]] || { usage >&2; exit 2; }
 [[ -z "$server_id" || "$server_id" =~ ^[0-9]+$ ]] || { echo 'server ID must be numeric' >&2; exit 2; }
 [[ -z "$image_id" || "$image_id" =~ ^[0-9]+$ ]] || { echo 'image ID must be numeric' >&2; exit 2; }
 
 case "$action" in
   status)
     [[ -z "$image" && -z "$image_id" && -z "$token_file" ]] || { echo 'status accepts neither --uki, --image-id, nor --token-file' >&2; exit 2; }
+    ;;
+  images)
+    [[ -z "$image" && -z "$image_id" && -z "$server_id" && "$status_url_set" == 0 ]] || {
+      echo 'images accepts neither --uki, --image-id, --server-id, nor --status-url' >&2
+      exit 2
+    }
     ;;
   upload)
     [[ -z "$server_id" && -z "$image_id" && "$status_url_set" == 0 ]] || { echo 'upload accepts neither --server-id, --image-id, nor --status-url' >&2; exit 2; }
@@ -70,6 +78,65 @@ if [[ "$action" == status ]]; then
   exit 0
 fi
 
+default_token_file="$root/.secrets/vpsbg-api-token"
+
+if [[ "$action" == images ]]; then
+  (( ! apply )) || { echo 'images does not accept --apply' >&2; exit 2; }
+  if ((dry_run)); then
+    echo '[stage] images preview'
+    echo "token_file=${token_file:-${VPSBG_API_TOKEN_FILE:-$default_token_file}}"
+    echo 'PASS action=images dry_run=true'
+    echo 'NEXT_STEP=run without --dry-run to list uploaded VPSBG measured-boot images'
+    exit 0
+  fi
+  command -v curl >/dev/null 2>&1 || { echo 'curl is required for a live VPSBG image list' >&2; exit 2; }
+  command -v jq >/dev/null 2>&1 || { echo 'jq is required for a live VPSBG image list' >&2; exit 2; }
+  token_file=${token_file:-${VPSBG_API_TOKEN_FILE:-$default_token_file}}
+  [[ -s "$token_file" ]] || { echo "VPSBG API token file is missing or empty: $token_file" >&2; exit 2; }
+  token=$(tr -d '\r\n' <"$token_file")
+  trap 'unset token' EXIT
+  echo '[stage] read-only VPSBG measured-boot images'
+  response=$(curl --fail --silent --show-error --max-time 20 --retry 0 \
+    -H 'Accept: application/json' -H "Authorization: Bearer $token" \
+    https://api.vpsbg.eu/v1/measured-boot-images)
+  unset token
+  trap - EXIT
+  images_json=$(jq -ec '
+    if type == "object" and (.data | type) == "array" then .data
+    elif type == "array" then .
+    else error("expected {data:[...]} or an image array")
+    end
+  ' <<<"$response") || { echo 'VPSBG image list response is not an image array' >&2; exit 1; }
+  jq -e '
+    type == "array" and all(
+      type == "object" and
+      (.id | type == "number" and floor == . and . >= 0) and
+      (.name | type == "string")
+    )
+  ' <<<"$images_json" >/dev/null \
+    || { echo 'VPSBG image list entries are missing numeric id or name' >&2; exit 1; }
+  image_count=$(jq -er 'length' <<<"$images_json")
+  jq -r '
+    .[] |
+    "image_id=" + (.id | tostring) +
+    " image_name=" + .name +
+    " image_size=" + (
+      .size as $size |
+      if ($size | type) == "number" and ($size | floor) == $size and $size >= 0
+      then ($size | tostring) else "unavailable" end
+    ) +
+    " image_in_use=" + (
+      .in_use as $used |
+      if ($used | type) == "boolean" then ($used | tostring) else "unavailable" end
+    )
+  ' <<<"$images_json"
+  printf 'image_count=%s\n' "$image_count"
+  printf 'image_quota=5\n'
+  echo "PASS action=images count=$image_count/5"
+  echo 'NEXT_STEP=record unused image IDs before upload; deleting an image needs separate authorization'
+  exit 0
+fi
+
 if [[ "$action" == upload ]]; then
   [[ -n "$image" ]] || { echo 'upload requires --uki FILE' >&2; exit 2; }
 elif [[ -z "$server_id" || -z "$image_id" ]]; then
@@ -88,8 +155,8 @@ fi
 
 command -v curl >/dev/null 2>&1 || { echo 'curl is required for a live VPSBG mutation' >&2; exit 2; }
 command -v jq >/dev/null 2>&1 || { echo 'jq is required for a live VPSBG mutation' >&2; exit 2; }
-token_file=${token_file:-${VPSBG_API_TOKEN_FILE:-"${XDG_CONFIG_HOME:-${HOME:?HOME is required}/.config}/bitcoinpir/secrets/vpsbg-api-token"}}
-[[ -s "$token_file" ]] || { echo 'VPSBG API token file is missing or empty' >&2; exit 2; }
+token_file=${token_file:-${VPSBG_API_TOKEN_FILE:-$default_token_file}}
+[[ -s "$token_file" ]] || { echo "VPSBG API token file is missing or empty: $token_file" >&2; exit 2; }
 token=$(tr -d '\r\n' <"$token_file")
 trap 'unset token' EXIT
 api_base=https://api.vpsbg.eu/v1

--- a/scripts/vpsbg-production-status.sh
+++ b/scripts/vpsbg-production-status.sh
@@ -2,9 +2,11 @@
 # Read-only VPSBG control-plane and Direct ORAM progress snapshot.
 set -euo pipefail
 
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 readonly API_BASE='https://api.vpsbg.eu/v1'
 readonly DEFAULT_STATUS_URL='https://weikeng2.bitcoinpir.org/status.json'
-readonly DEFAULT_TOKEN_FILE="${XDG_CONFIG_HOME:-${HOME:?HOME is required}/.config}/bitcoinpir/secrets/vpsbg-api-token"
+readonly DEFAULT_TOKEN_FILE="$REPO_ROOT/.secrets/vpsbg-api-token"
 
 usage() {
   cat <<'USAGE'
@@ -59,7 +61,10 @@ if [[ -n "$root" ]]; then
   fi
 else
   token_file="${VPSBG_API_TOKEN_FILE:-$DEFAULT_TOKEN_FILE}"
-  [[ -r "$token_file" && -s "$token_file" ]] || { echo 'VPSBG API token file is missing or empty' >&2; exit 2; }
+  [[ -r "$token_file" && -s "$token_file" ]] || {
+    echo "VPSBG API token file is missing or empty: $token_file" >&2
+    exit 2
+  }
   token=$(tr -d '\r\n' <"$token_file")
   [[ -n "$token" ]] || { echo 'VPSBG API token is empty' >&2; exit 2; }
   curl --fail --silent --show-error --max-time 20 --retry 0 -H 'Accept: application/json' -H "Authorization: Bearer $token" "$API_BASE/servers" | jq -e . >"$servers_file"

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -114,9 +114,9 @@ function bytesToHex(bytes: Uint8Array): string {
  *   against MEASUREMENT (transitively, for Tier 3) and against
  *   the cmdline pin (for Slice 2 with bpir-verify hook).
  *
- * Operator publishes both in `docs/history/PHASE3_ROADMAP.md::Attested
- * values published`. Update here whenever you re-bake + republish
- * the UKI on pir2 (every binary change).
+ * This file is the pin catalog. `docs/history/PHASE3_ROADMAP.md` is
+ * frozen rationale, not an identity source. Update these fields when
+ * a reviewed pir2 UKI republish is accepted (every binary change).
  */
 export interface ServerAttestPin {
   measurementHex?: string;


### PR DESCRIPTION
## Summary
- Add operator scripts for combined status, VPSBG data-disk, and post-switch check, and route production work through numbered flows A–I.
- Record that one native V2 attested-builder run covers DPF, Harmony, Onion, and Direct ORAM; leftover PLAN.md / handoff language is not a missing backend.
- Keep `verify-live` as the v1 opcode only, and stop treating Flow D step 3 as a `PIR1_PIN` check.

## Test plan
- [ ] `bash scripts/ops-operator-scripts.test.sh`
- [ ] Confirm `scripts/production-status.sh --help` and `scripts/vpsbg-data-disk.sh --help` print without mutating hosts
- [ ] Inspect PR CI summary: web-build, pir-sdk-integration, and formal-proof should run; no production host mutation


Made with [Cursor](https://cursor.com)