### PR TITLE
Fix Harmony production entitlement preflight

### DIFF
--- a/apps/server/tests/payment_v1_process_e2e.rs
+++ b/apps/server/tests/payment_v1_process_e2e.rs
@@ -696,6 +696,55 @@ async fn two_independent_providers_enforce_secure_paid_capabilities_over_real_so
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn harmony_work_limit_rejection_returns_an_encrypted_error_response() {
+    let root = tempfile::tempdir().expect("test root");
+    chmod(root.path(), 0o700);
+    let (db_path, manifest_root) = write_tiny_manifest_database(root.path());
+    let first_index_frame_work = u64::try_from(INDEX_PARAMS.k).unwrap();
+    let provider = build_provider_with_harmony_work_limit(
+        root.path(),
+        0,
+        manifest_root,
+        unix_now(),
+        None,
+        first_index_frame_work - 1,
+    );
+    let port = unused_loopback_port();
+    let server = ServerProcess::spawn(root.path(), &db_path, &provider, port, 0);
+    let requests = valid_tiny_harmony_query_requests();
+    let receipt = provider.receipt(provider.harmony_scope_id, HARMONY_OFFER_ID, 0xa0);
+    let (mut secure, accepted) =
+        open_verified_session(port, &provider, manifest_root, &requests[0]).await;
+    let proof = dangerous_unpaired_build_authorization_proof_v1(
+        &accepted,
+        &provider.harmony_scope_id,
+        HARMONY_OFFER_ID,
+        &receipt.encode().unwrap(),
+    )
+    .unwrap();
+    dangerous_unpaired_authorize_service_operation_v1(
+        &mut secure,
+        &accepted,
+        provider.harmony_scope_id,
+        HARMONY_OFFER_ID,
+        OperationStartV1::HarmonyQuery { db_id: 0 },
+        proof,
+    )
+    .await
+    .expect("undersized scope must still authorize before the backend frame is counted");
+
+    let response = secure
+        .roundtrip(&requests[0])
+        .await
+        .expect("resource-limit rejection must remain an encrypted response");
+    expect_error_response(&response, "service entitlement limit exceeded");
+    secure.close().await.unwrap();
+
+    let (stdout, stderr) = server.stop();
+    assert_loopback_listener(0, port, &stdout, &stderr);
+}
+
 #[cfg(feature = "standard-cashu-process-e2e")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn all_non_receipt_methods_commit_before_real_harmony_query_and_replay_after_restart() {
@@ -1462,6 +1511,17 @@ fn build_provider(
     now: u64,
     matrix_mint: Option<&TestCashuMint>,
 ) -> ProviderFixture {
+    build_provider_with_harmony_work_limit(root, index, manifest_root, now, matrix_mint, 320)
+}
+
+fn build_provider_with_harmony_work_limit(
+    root: &Path,
+    index: u8,
+    manifest_root: [u8; 32],
+    now: u64,
+    matrix_mint: Option<&TestCashuMint>,
+    harmony_max_work_units: u64,
+) -> ProviderFixture {
     let provider_root = root.join(format!("provider-{index}"));
     let store_dir = provider_root.join("store-domain");
     fs::create_dir_all(&store_dir).unwrap();
@@ -1621,7 +1681,7 @@ fn build_provider(
                     max_wall_time_ms: 10_000,
                     max_concurrent_sockets: 1,
                     max_hint_groups: 0,
-                    max_work_units: 320,
+                    max_work_units: harmony_max_work_units,
                 },
                 offers: harmony_offers,
             },
@@ -1774,4 +1834,3 @@ fn unix_now() -> u64 {
         .expect("system clock before epoch")
         .as_secs()
 }
-

--- a/crates/sdk/client/src/lib.rs
+++ b/crates/sdk/client/src/lib.rs
@@ -107,9 +107,9 @@ pub use harmony::{HarmonyClient, HintProgress, PRP_FASTPRP, PRP_HMR12};
 pub use onion::OnionClient;
 pub use oram::{OramClient, OramLookupItem, OramLookupResult, OramLookupSlot};
 pub use query_plan::{
-    plan_dpf_service_query_v1, plan_harmony_service_hint_v1, plan_harmony_service_query_v1,
-    ProductBackendV1, ProductQueryLowerBoundsV1, ProductQueryOmissionsV1, ProductQueryShapeV1,
-    ProductWorkloadV1,
+    assert_product_query_shape_fits_scope_v1, plan_dpf_service_query_v1,
+    plan_harmony_service_hint_v1, plan_harmony_service_query_v1, ProductBackendV1,
+    ProductQueryLowerBoundsV1, ProductQueryOmissionsV1, ProductQueryShapeV1, ProductWorkloadV1,
 };
 pub use service::{
     accept_bat_v2_authorization_response_v2, accept_pow_challenge_response_v1,

--- a/crates/sdk/client/src/query_plan.rs
+++ b/crates/sdk/client/src/query_plan.rs
@@ -9,6 +9,7 @@
 use crate::dpf::plan_index_pbc_rounds_for_hashes;
 use pir_core::params::{CHUNK_CUCKOO_NUM_HASHES, INDEX_CUCKOO_NUM_HASHES, NUM_HASHES};
 use pir_sdk::{DatabaseInfo, PirError, PirResult, ScriptHash};
+use pir_service_protocol::{BackendId, ServiceScopePolicyV1, WorkloadId};
 
 /// Product-facing backend identifier. String labels match the signed service
 /// scope and `web/src/service-entitlement.ts::ProductQueryShapeV1`.
@@ -103,6 +104,75 @@ pub struct ProductQueryShapeV1 {
     pub exact_index_frames: Option<u64>,
     /// Counters deliberately omitted instead of estimated.
     pub omitted: ProductQueryOmissionsV1,
+}
+
+/// Fail locally when a signed service scope cannot admit the planner-proven
+/// lower bounds for a query. This deliberately checks only counters present in
+/// [`ProductQueryLowerBoundsV1`]; omitted, data-dependent transcript costs
+/// remain the operator's responsibility when sizing the signed scope.
+pub fn assert_product_query_shape_fits_scope_v1(
+    shape: &ProductQueryShapeV1,
+    scope: &ServiceScopePolicyV1,
+    label: &str,
+) -> PirResult<()> {
+    let (backend, workload) = match (shape.backend, shape.workload) {
+        (ProductBackendV1::DpfPir, ProductWorkloadV1::DpfQuery) => {
+            (BackendId::DpfPirV1, WorkloadId::DpfEvaluateJobV1)
+        }
+        (ProductBackendV1::HarmonyPir, ProductWorkloadV1::HarmonyQuery) => {
+            (BackendId::HarmonyPirV2, WorkloadId::HarmonyQueryJobV1)
+        }
+        (ProductBackendV1::HarmonyPir, ProductWorkloadV1::HarmonyHint) => {
+            (BackendId::HarmonyPirV2, WorkloadId::HarmonyHintBundleV1)
+        }
+        _ => {
+            return Err(PirError::InvalidState(format!(
+                "{label} has an unknown backend/workload"
+            )))
+        }
+    };
+    if scope.scope.backend != backend || scope.scope.workload != workload {
+        return Err(PirError::InvalidState(format!(
+            "{label} does not match the planned backend/workload"
+        )));
+    }
+
+    let limits = &scope.limits;
+    let required = &shape.lower_bounds;
+    let comparisons = [
+        (
+            "logical inputs",
+            Some(required.logical_inputs),
+            u64::from(limits.max_logical_inputs),
+        ),
+        (
+            "frames",
+            Some(required.frames),
+            u64::from(limits.max_frames),
+        ),
+        (
+            "concurrent sockets",
+            required.concurrent_sockets.map(u64::from),
+            u64::from(limits.max_concurrent_sockets),
+        ),
+        (
+            "hint groups",
+            required.hint_groups,
+            u64::from(limits.max_hint_groups),
+        ),
+        ("work units", required.work_units, limits.max_work_units),
+    ];
+    for (field, required, maximum) in comparisons {
+        let Some(required) = required else {
+            continue;
+        };
+        if required > maximum {
+            return Err(PirError::InvalidState(format!(
+                "{label} {field} limit is insufficient (requires {required}, signed maximum {maximum})"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Plan a DPF query for one provider without opening a socket.
@@ -322,6 +392,7 @@ fn checked_product(values: &[u64], label: &str) -> PirResult<u64> {
 mod tests {
     use super::*;
     use pir_sdk::DatabaseKind;
+    use pir_service_protocol::{DatasetBindingV1, EntitlementLimitsV1, ServiceScopeV1};
 
     fn db(index_k: u8, chunk_k: u8) -> DatabaseInfo {
         DatabaseInfo {
@@ -419,5 +490,45 @@ mod tests {
         assert!(plan_harmony_service_query_v1(&[], &valid).is_err());
         assert!(plan_dpf_service_query_v1(&[[0; 20]], &db(2, 3)).is_err());
         assert!(plan_harmony_service_hint_v1(&db(3, 2)).is_err());
+    }
+
+    #[test]
+    fn signed_scope_preflight_reports_the_exact_insufficient_counter() {
+        let plan = plan_harmony_service_query_v1(&[[0; 20], [1; 20]], &db(75, 80)).unwrap();
+        let required_work = plan.lower_bounds.work_units.unwrap();
+        let scope = ServiceScopePolicyV1 {
+            scope: ServiceScopeV1 {
+                provider_id: [7; 32],
+                backend: BackendId::HarmonyPirV2,
+                workload: WorkloadId::HarmonyQueryJobV1,
+                protocol_version: 2,
+                dataset: DatasetBindingV1::ManifestRoot { root: [8; 32] },
+                operation_profile: 1,
+                entitlement_profile: 1,
+            },
+            limits: EntitlementLimitsV1 {
+                max_logical_inputs: u16::MAX,
+                max_frames: u32::MAX,
+                max_request_bytes: u64::MAX,
+                max_response_bytes: u64::MAX,
+                max_wall_time_ms: u32::MAX,
+                max_concurrent_sockets: u8::MAX,
+                max_hint_groups: u16::MAX,
+                max_work_units: required_work - 1,
+            },
+            offers: Vec::new(),
+        };
+
+        let error =
+            assert_product_query_shape_fits_scope_v1(&plan, &scope, "selected Harmony query scope")
+                .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "invalid state: selected Harmony query scope work units limit is insufficient \
+                 (requires {required_work}, signed maximum {})",
+                required_work - 1,
+            )
+        );
     }
 }

--- a/crates/sdk/client/tests/common/mod.rs
+++ b/crates/sdk/client/tests/common/mod.rs
@@ -29,9 +29,9 @@
 use ed25519_dalek::VerifyingKey;
 use pir_sdk::{PirError, PirResult};
 use pir_sdk_client::{
-    dangerous_unpaired_build_authorization_proof_v1, AcceptedServicePolicyV1,
-    DatabaseProofPolicy, DpfClient, HarmonyClient, OnionClient, PirClient, RootPolicy,
-    ServicePolicyCheckpointV1,
+    assert_product_query_shape_fits_scope_v1, dangerous_unpaired_build_authorization_proof_v1,
+    AcceptedServicePolicyV1, DatabaseProofPolicy, DpfClient, HarmonyClient, OnionClient, PirClient,
+    ProductQueryShapeV1, RootPolicy, ServicePolicyCheckpointV1,
 };
 use pir_service_protocol::{
     pow_solution_meets_difficulty_v1, AuthScheme, BackendId, FreeModeV1, FreePowProofV1,
@@ -423,16 +423,23 @@ async fn admit_harmony_hint_authorize(
     Ok(())
 }
 
-/// Authorize the Harmony query leg's free offer. Call this only after all
-/// hint-megabyte work is done: the live `harmony-query-job-v1` scope grants
-/// `max_wall_time_ms = 120_000` measured from the AUTH grant, and a fresh
-/// ~21 s main-bundle download plus per-level sibling streams must not eat
-/// into the query phase's window.
-async fn admit_harmony_query_authorize(
+struct PreparedHarmonyQueryAuthorization {
+    accepted: AcceptedServicePolicyV1,
+    scope_id: [u8; 32],
+    offer_id: u32,
+    free_mode: FreeModeV1,
+}
+
+/// Fetch and verify the Harmony query policy, then fail before query-leg PoW,
+/// hint authorization/download, or query AUTH if its signed counters cannot
+/// admit the planner-proven query lower bounds. Fetching the policy does not
+/// start the grant window.
+async fn prepare_harmony_query_authorization(
     client: &mut HarmonyClient,
     db_id: u8,
     pins: &LiveProviderPins,
-) -> PirResult<()> {
+    query_shape: &ProductQueryShapeV1,
+) -> PirResult<PreparedHarmonyQueryAuthorization> {
     let accepted = client
         .fetch_service_policy_v1(
             1,
@@ -448,6 +455,36 @@ async fn admit_harmony_query_authorize(
         BackendId::HarmonyPirV2,
         WorkloadId::HarmonyQueryJobV1,
     )?;
+    let scope = accepted
+        .policy()
+        .scopes
+        .iter()
+        .find(|entry| entry.scope.scope_id() == scope_id)
+        .ok_or_else(|| {
+            PirError::InvalidState("selected Harmony query scope is not in policy".into())
+        })?;
+    assert_product_query_shape_fits_scope_v1(query_shape, scope, "selected Harmony query scope")?;
+    Ok(PreparedHarmonyQueryAuthorization {
+        accepted,
+        scope_id,
+        offer_id,
+        free_mode,
+    })
+}
+
+/// Authorize the prepared Harmony query leg only after all hint-megabyte work
+/// is done, so the signed grant window is reserved for the query transcript.
+async fn admit_harmony_query_authorize(
+    client: &mut HarmonyClient,
+    db_id: u8,
+    prepared: PreparedHarmonyQueryAuthorization,
+) -> PirResult<()> {
+    let PreparedHarmonyQueryAuthorization {
+        accepted,
+        scope_id,
+        offer_id,
+        free_mode,
+    } = prepared;
     let proof_bytes = free_proof_bytes(
         free_mode,
         client.request_query_pow_challenge_v1(db_id, &accepted, scope_id, offer_id, now_unix()),
@@ -472,31 +509,32 @@ impl pir_sdk_client::HintProgress for NoopHintProgress {
 }
 
 /// Complete the live admission sequence for a HarmonyPIR query, ordered to
-/// respect the production grant windows (the same staging the browser
-/// product uses):
+/// fail before paid/expensive work and respect the signed grant windows:
 ///
 /// 1. install the verified database proof,
 /// 2. snapshot the catalog (once the hint-leg grant is flushed, the hint
 ///    connection accepts exactly the V2Full main-dispatch frame; any other
 ///    frame — even an otherwise-ungated one like REQ_GET_DB_CATALOG —
 ///    terminalizes it),
-/// 3. open both legs' secure channels and authorize the hint leg
-///    (`harmony-hint-bundle-v1`, V2Full transport),
-/// 4. preflight the proof-verified tree tops over the query leg,
-/// 5. download the complete main + Merkle-sibling hint bundle under the
-///    V2Full grant — all hint-leg traffic, bounded by the hint scope's
-///    300 s window,
-/// 6. ONLY THEN authorize the query leg (`harmony-query-job-v1`), whose
-///    grant allows 120 s total for the INDEX → CHUNK → Merkle query phase.
+/// 3. open the query leg's secure channel and preflight the proof-verified
+///    tree tops,
+/// 4. fetch the query policy and reject undersized signed limits locally,
+/// 5. open and authorize the hint leg (`harmony-hint-bundle-v1`, V2Full
+///    transport),
+/// 6. download the complete main + Merkle-sibling hint bundle under the
+///    V2Full grant — all hint-leg traffic is bounded by the signed hint scope,
+/// 7. ONLY THEN authorize the query leg (`harmony-query-job-v1`), reserving
+///    its signed grant window for the INDEX → CHUNK → Merkle query phase.
 ///
-/// Authorizing the query leg up-front instead spends a double-digit share
-/// of its 120 s window on the ~21 s main-bundle download + sibling streams
-/// before the first INDEX frame leaves, so the admission sequence keeps
-/// hint-leg megabytes outside the query grant's budget.
+/// Authorizing the query leg up-front instead spends part of its signed window
+/// on the main-bundle download + sibling streams before the first INDEX frame
+/// leaves, so the admission sequence keeps hint-leg megabytes outside the
+/// query grant's budget.
 pub async fn admit_harmony_live(
     client: &mut HarmonyClient,
     db_id: u8,
     proof_policy: &DatabaseProofPolicy,
+    script_hashes: &[pir_sdk::ScriptHash],
 ) -> PirResult<()> {
     client.set_root_policy(RootPolicy::RequireVerified);
     let roots = client.verify_database_proof(db_id, proof_policy).await?;
@@ -514,6 +552,12 @@ pub async fn admit_harmony_live(
         .find(|db| db.db_id == db_id)
         .cloned()
         .ok_or(PirError::DatabaseNotFound(db_id))?;
+    let query_shape = client.plan_service_query(script_hashes, db_id)?;
+
+    admit_harmony_leg_channel(client, 1).await?;
+    client.preflight_verified_database(db_id).await?;
+    let prepared =
+        prepare_harmony_query_authorization(client, db_id, &vpsbg_pins(), &query_shape).await?;
 
     admit_harmony_leg_channel(client, 0).await?;
     admit_harmony_hint_authorize(client, db_id, &hetzner_pins()).await?;
@@ -521,13 +565,11 @@ pub async fn admit_harmony_live(
     // hint connection may only carry the V2Full main dispatch followed by
     // the canonical sibling sequence. Query-leg work below uses the other
     // connection and is unaffected.
-    admit_harmony_leg_channel(client, 1).await?;
-    client.preflight_verified_database(db_id).await?;
     client
         .fetch_complete_hints_with_progress(&db_info, &NoopHintProgress)
         .await?;
 
-    admit_harmony_query_authorize(client, db_id, &vpsbg_pins()).await?;
+    admit_harmony_query_authorize(client, db_id, prepared).await?;
     Ok(())
 }
 

--- a/crates/sdk/client/tests/integration_test.rs
+++ b/crates/sdk/client/tests/integration_test.rs
@@ -827,9 +827,14 @@ async fn test_harmony_strict_production_canary() {
     // the exact browser ordering only after the public db0/db1 preflights, then
     // exercise the supported db0 query path.
     let pin = PRODUCTION_DATABASE_PINS[0];
-    common::admit_harmony_live(&mut client, pin.db_id, &production_proof_policy(pin))
-        .await
-        .expect("strict HarmonyPIR live admission failed");
+    common::admit_harmony_live(
+        &mut client,
+        pin.db_id,
+        &production_proof_policy(pin),
+        &probes,
+    )
+    .await
+    .expect("strict HarmonyPIR live admission failed");
 
     let fresh_sync = client
         .sync(&probes, None)

--- a/crates/sdk/client/tests/leakage_integration_test.rs
+++ b/crates/sdk/client/tests/leakage_integration_test.rs
@@ -354,8 +354,13 @@ async fn harmony_query_profile(shs: &[ScriptHash]) -> QueryProfile {
         let (k_index, k_chunk, db_id) =
             (main.index_k as usize, main.chunk_k as usize, main.db_id);
         // The public deployment enforces Payment-V1 admission.
-        common::admit_harmony_live(&mut client, db_id, &common::production_db0_proof_policy())
-            .await?;
+        common::admit_harmony_live(
+            &mut client,
+            db_id,
+            &common::production_db0_proof_policy(),
+            shs,
+        )
+        .await?;
         client.query_batch(shs, db_id).await?;
         client.disconnect().await.ok();
         Ok(QueryProfile { profile: recorder.take_profile("harmony"), k_index, k_chunk })
@@ -800,7 +805,13 @@ async fn harmony_cold_batch_query(
 ) -> Result<std::time::Duration, PirError> {
     let mut client = HarmonyClient::new(&harmony_hint_url(), &harmony_query_url());
     client.connect().await?;
-    common::admit_harmony_live(&mut client, db_id, &common::production_db0_proof_policy()).await?;
+    common::admit_harmony_live(
+        &mut client,
+        db_id,
+        &common::production_db0_proof_policy(),
+        shs,
+    )
+    .await?;
     let started = std::time::Instant::now();
     client.query_batch(shs, db_id).await?;
     let elapsed = started.elapsed();
@@ -1739,8 +1750,13 @@ async fn harmony_data_correctness_diagnostic() {
             db.height, db.index_bins, db.chunk_bins,
         );
         // The public deployment enforces Payment-V1 admission.
-        common::admit_harmony_live(&mut client, db_id, &common::production_db0_proof_policy())
-            .await?;
+        common::admit_harmony_live(
+            &mut client,
+            db_id,
+            &common::production_db0_proof_policy(),
+            &[sh_a, sh_b],
+        )
+        .await?;
         let results = client.query_batch(&[sh_a, sh_b], db_id).await?;
         client.disconnect().await.ok();
         Ok(results)

--- a/scripts/build_uki_tier3.sh
+++ b/scripts/build_uki_tier3.sh
@@ -56,10 +56,10 @@ fi
 
 # ─── Defaults (override via env) ───────────────────────────────────────────
 CUSTOM_INITRD=/tmp/bpir-tier3-initrd.img
-# The currently deployed image accepts service-policy epoch 3 with this exact
+# The next reviewed image accepts service-policy epoch 4 with this exact
 # digest. A policy rotation is a production behavior change and must update
 # this reviewed lock in source before a new UKI can be emitted.
-TIER3_SERVICE_POLICY_SHA256=4de63f8a9a1ca21c60fcdb89581603faa3cafa10081c463bdfa2681288ad4f82
+TIER3_SERVICE_POLICY_SHA256=f5e172db281cac90fba804adb98aad6f14b9cf69ec807ac9ad14219bbfbfeeb5
 TIER3_INITRD_COMPRESSION=zstd
 TIER3_INITRD_MAGIC=28b52ffd
 TIER3_MAX_UKI_BYTES=$((256 * 1024 * 1024))

--- a/scripts/tier3-uki-policy-contract.test.mjs
+++ b/scripts/tier3-uki-policy-contract.test.mjs
@@ -17,7 +17,7 @@ const runPath = resolve(
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh",
 );
 const reviewedPolicySha256 =
-  "4de63f8a9a1ca21c60fcdb89581603faa3cafa10081c463bdfa2681288ad4f82";
+  "f5e172db281cac90fba804adb98aad6f14b9cf69ec807ac9ad14219bbfbfeeb5";
 
 function validateBuildContract(source) {
   assert.match(


### PR DESCRIPTION
## Summary

- fail locally when a signed DPF/Harmony scope cannot admit planner-proven query lower bounds
- move the strict Harmony production canary preflight before hint authorization/download and query proof-of-work
- preserve encrypted resource-limit errors instead of surfacing a hard reset
- lock the reviewed epoch 4 policy candidate into the Tier 3 UKI build contract

## Root cause

The signed production Harmony query scope allowed 10,000 work units, while the current main-database two-probe query needs at least 393,200 before Merkle follow-ups. This is deterministic policy under-capacity, not runner flakiness. The re-rated epoch 4 candidate allows 1,000,000 work units; other resource limits and the DPF scope are unchanged.

## Validation

- `cargo test -p pir-sdk-client`
- `cargo test --locked --offline -p pir-sdk-client signed_scope_preflight_reports_the_exact_insufficient_counter`
- `cargo test --locked --offline -p runtime --test payment_v1_process_e2e harmony_work_limit_rejection_returns_an_encrypted_error_response -- --exact`
- `node --test scripts/tier3-uki-policy-contract.test.mjs`
- `node scripts/github-workflow-supply-chain-gate.mjs`
- `bash scripts/vpsbg-production-status.test.sh`
- `bash scripts/ops-operator-scripts.test.sh`
- signed epoch 4 candidate self-verification

## Production boundary

This PR does not build, upload, switch, or reboot a production UKI. A policy epoch rotation also requires rebuilt BAT V2 class/accounting authorization/approval/final artifact-set inputs in the sealed-release flow.