### PR TITLE
Pin the epoch-5 VPSBG runtime

### DIFF
--- a/scripts/build_uki_tier3.sh
+++ b/scripts/build_uki_tier3.sh
@@ -56,10 +56,10 @@ fi
 
 # ─── Defaults (override via env) ───────────────────────────────────────────
 CUSTOM_INITRD=/tmp/bpir-tier3-initrd.img
-# The next reviewed image accepts service-policy epoch 4 with this exact
+# The next reviewed image accepts service-policy epoch 5 with this exact
 # digest. A policy rotation is a production behavior change and must update
 # this reviewed lock in source before a new UKI can be emitted.
-TIER3_SERVICE_POLICY_SHA256=f5e172db281cac90fba804adb98aad6f14b9cf69ec807ac9ad14219bbfbfeeb5
+TIER3_SERVICE_POLICY_SHA256=324b07017cfa1f8ce3f8efc57433a5593bb72fc3ab24b3e23ef851164c50778d
 TIER3_INITRD_COMPRESSION=zstd
 TIER3_INITRD_MAGIC=28b52ffd
 TIER3_MAX_UKI_BYTES=$((256 * 1024 * 1024))

--- a/scripts/tier3-uki-policy-contract.test.mjs
+++ b/scripts/tier3-uki-policy-contract.test.mjs
@@ -17,7 +17,7 @@ const runPath = resolve(
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh",
 );
 const reviewedPolicySha256 =
-  "f5e172db281cac90fba804adb98aad6f14b9cf69ec807ac9ad14219bbfbfeeb5";
+  "324b07017cfa1f8ce3f8efc57433a5593bb72fc3ab24b3e23ef851164c50778d";
 
 function validateBuildContract(source) {
   assert.match(

--- a/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
+++ b/web/src/__tests__/functional-beta-trusted-bootstrap.test.ts
@@ -24,10 +24,10 @@ describe('bundled functional-beta trusted bootstrap', () => {
       '30e02d80704f77099ae342a428ab22e1176baf61b4a0593b1783289e5cb5b63c',
     );
     expect(parsed.providers[1].serverPin.measurementHex).toBe(
-      'bede0c87aaaf7abe84a8f8b46201106989eab74c01ec882f0e812dc72d0504aa922a9f5834c971d7f075db36166b88f4',
+      'd5c34d4dd9601234474c387b32f6623f0b7fb60b1f0ea916e2f1bc98b140f0872a9236d75f4c2dbf8f949db79172e8ab',
     );
     expect(parsed.providers[1].serverPin.binarySha256Hex).toBe(
-      '61c4acae35a769b47b09b5a8bffd40cc6d4687ee02eb5a0f3421632e71098d1e',
+      '790f6d5b5434bb42ded3dd550fc3631d429c594d5fd89d1026aaad07be343f0e',
     );
     expect(parsed.providers[0].supportedWorkloads).toEqual([
       'dpf-query', 'harmony-hint', 'onion-session',

--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -126,19 +126,19 @@ export interface ServerAttestPin {
 }
 
 /**
- * weikeng2.bitcoinpir.org — VPSBG Tier 3 SNP-sealed UKI, pinned 2026-08-22
- * after the epoch-3 sealed ceremony (Observe/Enroll/Ready on image 291).
- * Image 291 serves DPF, Harmony-query and TEE ORAM under the relaxed
+ * weikeng2.bitcoinpir.org — VPSBG Tier 3 SNP-sealed UKI, pinned 2026-08-26
+ * after the epoch-5 sealed ceremony (Observe/Enroll/Probe/Ready on image 295).
+ * Image 295 serves DPF, Harmony-query and TEE ORAM under the epoch-5
  * BAT V2 class that covers offers 402 and 502.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // Captured from live image 291 after validating the AMD chain, REPORT_DATA,
+  // Captured from live image 295 after validating the AMD chain, REPORT_DATA,
   // exact unified_server binary and both attested database manifest roots.
   measurementHex:
-    'bede0c87aaaf7abe84a8f8b46201106989eab74c01ec882f0e812dc72d0504aa922a9f5834c971d7f075db36166b88f4',
+    'd5c34d4dd9601234474c387b32f6623f0b7fb60b1f0ea916e2f1bc98b140f0872a9236d75f4c2dbf8f949db79172e8ab',
   binarySha256Hex:
-    '61c4acae35a769b47b09b5a8bffd40cc6d4687ee02eb5a0f3421632e71098d1e',
-  description: 'weikeng2.bitcoinpir.org (VPSBG image 291, SEV-SNP, sealed Tier 3 DPF + Harmony + Direct ORAM, epoch 3)',
+    '790f6d5b5434bb42ded3dd550fc3631d429c594d5fd89d1026aaad07be343f0e',
+  description: 'weikeng2.bitcoinpir.org (VPSBG image 295, SEV-SNP, sealed Tier 3 DPF + Harmony + Direct ORAM, epoch 5)',
 };
 
 /**

--- a/web/src/functional-beta-trusted-bootstrap.json
+++ b/web/src/functional-beta-trusted-bootstrap.json
@@ -68,8 +68,8 @@
       "operatorSigningKeyHex": "30e02d80704f77099ae342a428ab22e1176baf61b4a0593b1783289e5cb5b63c",
       "stableServerId": "pir2-vpsbg-dpf-v1",
       "serverPin": {
-        "binarySha256Hex": "61c4acae35a769b47b09b5a8bffd40cc6d4687ee02eb5a0f3421632e71098d1e",
-        "measurementHex": "bede0c87aaaf7abe84a8f8b46201106989eab74c01ec882f0e812dc72d0504aa922a9f5834c971d7f075db36166b88f4"
+        "binarySha256Hex": "790f6d5b5434bb42ded3dd550fc3631d429c594d5fd89d1026aaad07be343f0e",
+        "measurementHex": "d5c34d4dd9601234474c387b32f6623f0b7fb60b1f0ea916e2f1bc98b140f0872a9236d75f4c2dbf8f949db79172e8ab"
       },
       "hardwareAttestation": "required",
       "expectedArkFingerprintHex": "1f084161a44bb6d93778a904877d4819cafa5d05ef4193b2ded9dd9c73dd3f6a",


### PR DESCRIPTION
## Summary

- bind the Tier 3 UKI build contract to the signed epoch-5 service policy
- publish the strictly verified image 295 SNP measurement and runtime binary pin
- keep the functional-beta trusted bootstrap and its contract test in sync

## Production evidence

- ordinal 37 Ready preflight and runtime receipts passed strict offline verification
- ordinal 37 and fresh ordinal 38 both passed AMD chain, SNP report-data, launch measurement, binary, database-root, encrypted handshake, ping/pong, and get_info verification
- clearing authorization epoch 2 remains reserved and inactive

## Validation

- wasm-pack build crates/sdk/wasm --target web --out-dir pkg -- --locked --offline
- cd web && npm run build && npm test && npm run build-web
- node scripts/github-workflow-supply-chain-gate.mjs
- node --test scripts/tier3-uki-policy-contract.test.mjs
- bash scripts/vpsbg-production-status.test.sh
- bash scripts/ops-operator-scripts.test.sh