### PR TITLE
docs: record epoch-5 ceremony operational lessons

### DIFF
--- a/docs/KEY_MANAGEMENT.md
+++ b/docs/KEY_MANAGEMENT.md
@@ -29,6 +29,16 @@ Subdirectory holding AMD certs (ARK/ASK/VCEK PEMs), per-epoch
 `public-artifact-set.env`, BAT V2 class/authorization/approval
 binaries, and per-ordinal `startup.env` files.
 
+The owner identity-authority activation certificate and the sealed runtime
+certificate are different wire artifacts. `GenerationBoundIdentityCertV2`
+belongs to the owner authority store and is not accepted at the runtime
+`identity.cert` path. The current sealed runtime requires a legacy
+`IdentityCert` V1 signed for the same enrolled identity public key. Its
+`server_id` must be copied from the signature-verified sealed `release.bin`
+`stable_server_id`; do not infer that value from the authority-store record.
+Keep both certificates because the V2 artifact proves the reserved generation
+activation while the V1 artifact is the runtime compatibility certificate.
+
 ## `.secrets/` — API tokens
 
 | File | Purpose |
@@ -44,7 +54,7 @@ to `~/.config/bitcoinpir`. Override with `VPSBG_API_TOKEN_FILE` or
 This is Flow F in [Production operations](PRODUCTION_OPERATIONS.md).
 Use [`scripts/vpsbg-data-disk.sh`](../scripts/vpsbg-data-disk.sh). It
 detaches measured boot with `{"kernel_image_id":null}`, stop/starts the
-guest, and SSHes with `.keys/vpsbg-ssh.key` plus
+stock guest, and SSHes with `.keys/vpsbg-ssh.key` plus
 [`deploy/vpsbg_known_hosts`](../deploy/vpsbg_known_hosts). `open` and
 `close` each require an explicit `--image-id` and `--apply`; `put` does
 not call `close`.
@@ -56,6 +66,17 @@ scripts/vpsbg-data-disk.sh put --local /absolute/file \
   --remote /home/pir/data/relative/path --apply
 scripts/vpsbg-data-disk.sh close --server-id 25285 --image-id CURRENT --apply
 ```
+
+`close` reattaches the selected measured-boot image but does not call the
+VPSBG `/start` endpoint. `PASS action=close` therefore proves attachment, not
+that the guest is running. Read back control-plane status; starting a stopped
+guest is a separate explicitly authorized production action.
+
+VPSBG may complete the detach while the immediately following stop request
+returns HTTP 423. After that response, read status before retrying anything. If
+status already reports `boot_mode=stock`, rerun `open` so it waits for stock
+SSH without detaching again. If status still reports measured boot, stop and
+investigate instead of repeating the mutation.
 
 A sealed `startup.env` must be placed at
 `/home/pir/data/pir2-sealed/startup.env`. Never build a dedicated

--- a/docs/PRODUCTION_OPERATIONS.md
+++ b/docs/PRODUCTION_OPERATIONS.md
@@ -61,7 +61,7 @@ stop and report.
 | Native full-build V2 snapshot/delta | hours; no wall-clock is written here | no progress for 3 min → stop | `build-summary.txt`, then `latest/` only after the V2 gate |
 | Direct ORAM release reconstruct | target 10 min | 15 min (3 min without a stage) | ORAM debug runbook stages |
 | VPSBG `images` / `upload` | seconds / a few min | 10 min upload | `PASS action=images\|upload` |
-| VPSBG `switch` / `close` reboot | 2–10 min | 15 min | `boot_mode=measured`, `running=true` |
+| VPSBG `switch` / `close` attachment | seconds; starting is separate | 15 min | `boot_mode=measured`, expected image id; read `running` separately |
 | Data-disk `open` | 2–10 min | 15 min | `boot_mode=stock`, `ssh_ready=true` |
 | `pir2-post-switch-check.sh` | 5–20 min | 15 min wait + attest | `PASS action=post_switch_check` |
 
@@ -215,7 +215,9 @@ Never build a provisioner UKI. Detach body is
    `/home/pir/data/pir2-sealed/startup.env`.
 4. Auth — `close --server-id 25285 --image-id CURRENT --apply`. Same
    image id as step 1 unless the user named a different one.
-5. Read — Flow E step 6 if the guest should be serving again.
+5. Read — confirm the expected image is attached. `close` does not start a
+   stopped guest; starting it requires its own explicit authorization. Run
+   Flow E step 6 only when the guest should be serving again.
 
 ## G. pir2 sealed ceremony — Local then Auth
 

--- a/docs/runbooks/issuer-state.md
+++ b/docs/runbooks/issuer-state.md
@@ -10,6 +10,14 @@ after Payment V1 artifacts are ready and an issuer environment has been selected
 
 - `--store PATH`, `--issuer-id-hex HEX`, and `--network NETWORK`.
 
+The current no-funds BAT V2 owner environment keeps its schema-v9 issuer
+store on the Hetzner host at
+`/var/lib/bitcoinpir-mainnet-bat-v2-issuer/issuer.sqlite3`. Run owner CLI
+commands as the dedicated `bitcoinpir-mainnet-issuer` user; the private-file
+checks intentionally reject opening this service-owned store as `root`. The
+presence of this store does not mean an issuer service is installed, active,
+funded, or publicly enabled.
+
 ## Run
 
 ```sh
@@ -21,3 +29,33 @@ scripts/payment-v1-issuer-state.sh check --store /absolute/path/store \
 
 The command forwards the issuer-state CLI output and prints the selected
 operation. Success prints `PASS issuer_state=init|check` and `NEXT_STEP`.
+
+## Activate a reserved BAT V2 clearing epoch
+
+Activation is a separate owner-authorized production mutation. First use the
+owner CLI's `read-bat-v2-clearing-epoch` command as the dedicated issuer user
+and require the exact issuer, network, provider, and reserved authorization
+epoch to report `reservation_state=inactive`. Do not derive the epoch from an
+old artifact or increment a remembered value.
+
+Then activate the exact signed authorization and approval against their pinned
+public verification keys:
+
+```sh
+payment-issuer activate-bat-v2-accounting-authorization \
+  --store /absolute/path/store \
+  --issuer-id-hex ISSUER_ID_HEX \
+  --network bitcoin \
+  --authorization /absolute/path/accounting-authorization.bin \
+  --approval /absolute/path/issuer-approval.bin \
+  --operator-verifying-key /absolute/path/operator-verifying-key.bin \
+  --issuer-settlement-verifying-key \
+    /absolute/path/issuer-settlement-verifying-key.bin
+```
+
+Immediately run `read-bat-v2-clearing-epoch` again and require
+`reservation_state=active`, the exact authorization epoch, clearing verifying
+key, authorization digest, and activation commit sequence returned by the
+activation. Run both commands as the store's dedicated owner, never as `root`.
+Activation alone does not install or start an issuer service, move funds,
+publish an artifact, or update the production pin.

--- a/docs/runbooks/pir2-sealed-release.md
+++ b/docs/runbooks/pir2-sealed-release.md
@@ -45,3 +45,47 @@ Do not build a provisioner UKI. Run the release after the Observe receipt is
 available. Generate new startup files for `enroll`, `probe`, and `ready`, and
 boot each in that order. A completed release prints `PASS sealed_release`;
 every phase file prints `PASS sealed_phase_config=<phase>` and `NEXT_STEP`.
+
+## Receipt acceptance
+
+A phase status marker proves only that the guest persisted a receipt. Before a
+later authority signs or activates anything derived from an Enroll, Probe, or
+Ready receipt, an offline verifier must accept all of the following together:
+
+- the AMD ARK pin, ARK-to-ASK-to-VCEK chain, and SNP report signature;
+- the receipt digest duplicated in the signed SNP `REPORT_DATA`;
+- the exact signed release digest, measurement, guest policy, and TCB floor;
+- the expected phase, ordinal, fresh verifier nonce, and current boot ID; and
+- for non-Observe phases, distinct valid Ed25519 public keys, their
+  role-separated fingerprints, identity generation, and clearing epoch.
+
+The repository currently has a dedicated verifier for the fixed Observe
+receipt as part of `bpir-admin pir2-sealed-release`, but no generic offline
+decoder/verifier command for Enroll, Probe, or Ready receipts. Do not treat a
+successful hex/field parser, the status JSON, or a file hash as a substitute.
+Until a reviewed repository command exists, stop after downloading the receipt
+and use a reviewed offline verifier that performs the checks above before
+constructing identity or accounting artifacts.
+
+Ready writes two receipts for the same boot: `ready-preflight-BOOT.bin` before
+ORAM access and `ready-runtime-BOOT.bin` when the final server opens the sealed
+keys. Unlike Observe, Enroll, and Probe, a successful Ready boot does not expose
+either receipt through the finite recovery HTTP root. Retrieve them only in a
+separately authorized Flow F maintenance window, using the exact boot ID from
+the persisted ORAM published marker; a later boot must use a new ordinal and
+fresh nonce.
+
+After the ORAM progress API releases port 8091, the final server still loads the
+large database mappings before it listens. During that interval the public
+origin can return HTTP 502 even though the control plane is healthy. Once the
+server is listening it is WebSocket-only, so an ordinary HTTPS request to
+`/status.json` is not a Ready health check. Use the repository attestation and
+encrypted-channel checks instead.
+
+The current sealed production artifact set has signed BAT V2 production
+offers, not an exact manifest-bound Free-PoW offer. Therefore the Free-PoW query in
+`verify_oram_tier3_deploy.sh` is not a pre-activation Ready canary: it must stop
+locally with no query when that offer is absent. Do not bypass the policy or
+substitute a paid authorization before the separately authorized issuer
+activation. Attestation, channel verification, and strict Ready receipt
+acceptance remain valid Flow G evidence.


### PR DESCRIPTION
## What

Four documentation edits carried over from the epoch-4/epoch-5 production ceremony (authored during the incident, reviewed here before commit):

- **docs/runbooks/issuer-state.md**: locate the live schema-v9 BAT V2 issuer store (host path + dedicated user) and document the owner-authorized clearing-epoch activation command with mandatory readbacks.
- **docs/runbooks/pir2-sealed-release.md**: full offline receipt-acceptance criteria before signing derived artifacts; Ready's two-receipt layout and Flow F-only retrieval; 502-during-ORAM-load is not a failure signal; Free-PoW canary contract under the current artifact set.
- **docs/KEY_MANAGEMENT.md**: authority V2 identity cert vs runtime V1 cert (`stable_server_id` must come from the verified release); `close` attaches but does not start the guest; HTTP 423 detach/stop race handling.
- **docs/PRODUCTION_OPERATIONS.md**: `close` = attachment, starting is a separately authorized action.

One editorial change on top of the carried-over text: the sealed-release runbook said "current epoch-4 artifact set" — made epoch-neutral since epoch 5 is now live.

Docs-only; per docs/TESTING.md no checks apply (workflows are path-filtered).