### PR TITLE
fix: unbound status_args on bash 3.2 in production-status.sh

### DIFF
--- a/scripts/ops-operator-scripts.test.sh
+++ b/scripts/ops-operator-scripts.test.sh
@@ -64,6 +64,15 @@ status_preview=$("$script_dir/production-status.sh" --dry-run)
 grep -qx 'PASS production_status dry_run=true' <<<"$status_preview"
 grep -qx 'pir1_host=65.21.91.217' <<<"$status_preview"
 
+# Empty-array regressions: a bare quoted-at expansion crashes under `set -u`
+# on bash < 4.4 (macOS /bin/bash 3.2), so every status_args expansion must be
+# written with the "${status_args[@]+...}" guard idiom. The inner repetition
+# inside the idiom is fine; flag only expansions missing the @]+ guard.
+if grep '"${status_args\[@\]}"' "$script_dir/production-status.sh" | grep -qv '@\]+'; then
+  echo 'production-status.sh uses the unbound bare status_args expansion' >&2
+  exit 1
+fi
+
 check_preview=$("$script_dir/pir2-post-switch-check.sh" --dry-run)
 grep -qx "pin_source=$repo/web/src/attest-pin.ts" <<<"$check_preview"
 grep -qx 'PASS action=post_switch_check dry_run=true' <<<"$check_preview"

--- a/scripts/production-status.sh
+++ b/scripts/production-status.sh
@@ -81,7 +81,9 @@ echo 'PASS host=pir1'
 echo '[stage] pir2 VPSBG status'
 status_args=()
 [[ -z "$server_id" ]] || status_args+=(--server-id "$server_id")
-"$root/scripts/vpsbg-production-status.sh" "${status_args[@]}"
+# POSIX-safe empty-array expansion: a bare quoted-at expansion is an unbound
+# variable under `set -u` on bash < 4.4 (e.g. macOS /bin/bash 3.2).
+"$root/scripts/vpsbg-production-status.sh" "${status_args[@]+"${status_args[@]}"}"
 echo 'PASS host=pir2'
 echo 'PASS production_status'
 echo 'NEXT_STEP=use scripts/vpsbg-measured-boot.sh or scripts/vpsbg-data-disk.sh only after this run is authorized'


### PR DESCRIPTION
## Root cause

Diagnosed during the epoch-5 ceremony: `scripts/production-status.sh` without `--server-id` crashed at the pir2 stage with

```
status_args[@]: unbound variable
```

On bash < 4.4 (macOS ships /bin/bash 3.2.57) a bare `"${status_args[@]}"` expansion of an empty array is a nounset violation. Old bash is no longer on the production path but stays the default on operator laptops, so the read-only status wrapper should keep working there.

## Change

- `scripts/production-status.sh`: forward the possibly-empty array with the `"${status_args[@]+...}"` guard idiom (POSIX-correct on every bash).
- `scripts/ops-operator-scripts.test.sh`: offline static guard rejecting any unguarded `status_args` expansion in this wrapper, so a future "clean-up" cannot silently reintroduce the pattern. (The guard sentence documents the 3.2 failure mode.)

The same latent pattern in `vpsbg-measured-boot.sh status` is fixed in a separate PR to keep each change narrow.

## Checks (scripts change class)

- `bash scripts/ops-operator-scripts.test.sh`: PASS
- `bash scripts/vpsbg-production-status.test.sh`: PASS
- Live-path repro on /bin/bash 3.2 before the fix, idiom-equivalence check after: PASS