### PR TITLE
fix: let vpsbg-measured-boot.sh status accept --token-file

### DIFF
--- a/scripts/ops-operator-scripts.test.sh
+++ b/scripts/ops-operator-scripts.test.sh
@@ -72,7 +72,16 @@ if grep '"${status_args\[@\]}"' "$script_dir/production-status.sh" | grep -qv '@
   echo 'production-status.sh uses the unbound bare status_args expansion' >&2
   exit 1
 fi
+if grep '"${status_args\[@\]}"' "$script_dir/vpsbg-measured-boot.sh" | grep -qv '@\]+'; then
+  echo 'vpsbg-measured-boot.sh uses the unbound bare status_args expansion' >&2
+  exit 1
+fi
 
+printf 'test-token\n' >"$tmp/vpsbg-token"
+status_token_preview=$("$script_dir/vpsbg-measured-boot.sh" status --token-file "$tmp/vpsbg-token" --dry-run)
+grep -qx 'PASS action=status dry_run=true' <<<"$status_token_preview"
+expect_fail 'status still rejects --image-id' \
+  "$script_dir/vpsbg-measured-boot.sh" status --image-id 291 --dry-run
 check_preview=$("$script_dir/pir2-post-switch-check.sh" --dry-run)
 grep -qx "pin_source=$repo/web/src/attest-pin.ts" <<<"$check_preview"
 grep -qx 'PASS action=post_switch_check dry_run=true' <<<"$check_preview"

--- a/scripts/vpsbg-measured-boot.sh
+++ b/scripts/vpsbg-measured-boot.sh
@@ -7,7 +7,7 @@ usage() {
 usage: scripts/vpsbg-measured-boot.sh <status|images|upload|switch|rollback> [options]
 
 Read-only:
-  status [--server-id ID] [--status-url URL]
+  status [--server-id ID] [--status-url URL] [--token-file PATH]
   images [--token-file PATH]
 
 Mutations (require --apply; --dry-run is the default-safe preview):
@@ -15,8 +15,9 @@ Mutations (require --apply; --dry-run is the default-safe preview):
   switch   --server-id ID --image-id ID [--token-file PATH] [--apply]
   rollback --server-id ID --image-id ID [--token-file PATH] [--apply]
 
-Status and images use VPSBG_API_TOKEN_FILE or
-<repo>/.secrets/vpsbg-api-token. Mutations also accept --token-file PATH.
+All actions use VPSBG_API_TOKEN_FILE or
+<repo>/.secrets/vpsbg-api-token and also accept --token-file PATH;
+the latter is forwarded to the status helper as VPSBG_API_TOKEN_FILE.
 There is no delete action. Output is [stage] progress plus PASS and
 NEXT_STEP. --dry-run neither reads the token nor contacts VPSBG.
 EOF
@@ -47,7 +48,7 @@ done
 
 case "$action" in
   status)
-    [[ -z "$image" && -z "$image_id" && -z "$token_file" ]] || { echo 'status accepts neither --uki, --image-id, nor --token-file' >&2; exit 2; }
+    [[ -z "$image" && -z "$image_id" ]] || { echo 'status accepts neither --uki nor --image-id' >&2; exit 2; }
     ;;
   images)
     [[ -z "$image" && -z "$image_id" && -z "$server_id" && "$status_url_set" == 0 ]] || {
@@ -72,7 +73,15 @@ if [[ "$action" == status ]]; then
     exit 0
   fi
   echo '[stage] read-only VPSBG production status'
-  "$root/scripts/vpsbg-production-status.sh" "${status_args[@]}"
+  # Forward an explicit --token-file to the helper as VPSBG_API_TOKEN_FILE
+  # (linked worktrees have no <repo>/.secrets). POSIX-safe empty-array
+  # expansion: a bare quoted-at expansion is an unbound variable under
+  # `set -u` on bash < 4.4 (e.g. macOS /bin/bash 3.2).
+  if [[ -n "$token_file" ]]; then
+    VPSBG_API_TOKEN_FILE=$token_file "$root/scripts/vpsbg-production-status.sh" "${status_args[@]+"${status_args[@]}"}"
+  else
+    "$root/scripts/vpsbg-production-status.sh" "${status_args[@]+"${status_args[@]}"}"
+  fi
   echo 'PASS action=status'
   echo 'NEXT_STEP=choose upload, switch, or rollback with explicit --apply when authorized'
   exit 0


### PR DESCRIPTION
## Root cause

Two diagnosed frictions from the epoch-5 ceremony, same wrapper:

1. `vpsbg-measured-boot.sh status` (no flags) crashed on macOS /bin/bash 3.2 with `status_args[@]: unbound variable` — same nounset/empty-array pattern fixed for production-status.sh in the sibling PR.
2. `status` rejected `--token-file`, even though every other action accepts it. Linked worktrees have no `<repo>/.secrets`, so the ceremony had to know the undocumented `VPSBG_API_TOKEN_FILE` escape hatch instead (recorded as a workaround in the epoch-5 HANDOFF).

## Change

- `scripts/vpsbg-measured-boot.sh`: guarded `"${status_args[@]+...}"` expansion; `status` now accepts `--token-file` and forwards it to `vpsbg-production-status.sh` as `VPSBG_API_TOKEN_FILE` (which the helper already honors); usage text updated to match. `--uki`/`--image-id` remain rejected for status.
- `scripts/ops-operator-scripts.test.sh`: offline static guard against the unguarded expansion in this wrapper, plus dry-run fixtures proving `status --token-file` is accepted and `status --image-id` still fails.

## Checks (scripts change class)

- `bash scripts/ops-operator-scripts.test.sh`: PASS
- `bash scripts/vpsbg-production-status.test.sh`: PASS
- /bin/bash 3.2 live-path repro: before = unbound variable; after = helper loads and validates the forwarded token file: PASS