### PR TITLE
refactor(apps/server): add admission::local + admission::arc skeletons (D2)

### DIFF
--- a/apps/server/src/bin/admission/arc/mod.rs
+++ b/apps/server/src/bin/admission/arc/mod.rs
@@ -1,0 +1,83 @@
+//! ARC admission facade (D2).
+//!
+//! Single construction boundary for the provider-local ARC verifier, so the
+//! legacy flag wiring in `unified_server.rs` collapses to one call site. The
+//! verifier itself (`pir_runtime_core::arc_verifier`) stays put; the single
+//! designated issuer lives outside the node — this facade only checks that
+//! presented tokens were issued under an accepted key.
+
+use std::sync::Mutex;
+
+use pir_runtime_core::arc_verifier::ArcVerifier;
+use zeroize::Zeroize;
+
+use crate::{read_exact_secret_v1, CliArgs};
+
+/// Provider-local ARC admission state: an optional verifier plus whether
+/// presentation is required for query opcodes.
+pub(crate) struct ArcAdmissionV1 {
+    verifier: Option<Mutex<ArcVerifier>>,
+    require: bool,
+}
+
+impl ArcAdmissionV1 {
+    /// Build from the legacy `--require-arc` / `--arc-key` flags. Log lines
+    /// and failure behavior match the historical inline wiring verbatim.
+    pub(crate) fn from_cli(args: &CliArgs) -> Result<Self, String> {
+        if !args.require_arc {
+            println!("  ARC: disabled (use --require-arc to enable)");
+            return Ok(Self {
+                verifier: None,
+                require: false,
+            });
+        }
+        let verifier = match args.arc_key_path.as_ref() {
+            Some(path) => {
+                let mut secret = read_exact_secret_v1::<128>(path, "ARC key").map_err(|error| {
+                    format!("failed to load ARC key from {}: {error}", path.display())
+                })?;
+                let verifier = ArcVerifier::from_secret_key_bytes(&secret).map_err(|error| {
+                    format!("failed to load ARC key from {}: {error}", path.display())
+                })?;
+                secret.zeroize();
+                println!(
+                    "  ARC: enabled — verification required (shared key loaded from {})",
+                    path.display()
+                );
+                verifier
+            }
+            None => {
+                let verifier = ArcVerifier::generate();
+                eprintln!(
+                    "  ARC: WARNING — --require-arc set without --arc-key; generated a random \
+                     key. No externally-issued credential will verify. Pass --arc-key <arc_key.bin> \
+                     to share the issuer's key."
+                );
+                verifier
+            }
+        };
+        Ok(Self {
+            verifier: Some(Mutex::new(verifier)),
+            require: true,
+        })
+    }
+
+    pub(crate) fn into_parts(self) -> (Option<Mutex<ArcVerifier>>, bool) {
+        (self.verifier, self.require)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::admission::arc::ArcAdmissionV1;
+    use crate::parse_args_from;
+
+    #[test]
+    fn disabled_when_not_required() {
+        let args = parse_args_from(vec!["unified_server".to_owned()]);
+        let admission = ArcAdmissionV1::from_cli(&args).expect("from_cli");
+        let (verifier, require) = admission.into_parts();
+        assert!(!require);
+        assert!(verifier.is_none());
+    }
+}

--- a/apps/server/src/bin/admission/local/config.rs
+++ b/apps/server/src/bin/admission/local/config.rs
@@ -1,0 +1,98 @@
+//! TOML surface for local admission. The file is operator-local; it is not
+//! signed, versioned, or distributed.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+/// Local admission configuration (all fields optional; open defaults).
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LocalAdmissionConfigV1 {
+    /// Free queries are served without credentials. Default: true.
+    #[serde(default = "default_free_open")]
+    pub(crate) free_open: bool,
+    /// Endpoint of the single designated issuer for paid ARC tokens. The
+    /// server only announces this URL to clients; it does not verify tokens
+    /// online (ARC verification is provider-local against the issuer key).
+    #[serde(default)]
+    pub(crate) arc_issuer_url: Option<String>,
+}
+
+fn default_free_open() -> bool {
+    true
+}
+
+impl Default for LocalAdmissionConfigV1 {
+    fn default() -> Self {
+        Self {
+            free_open: default_free_open(),
+            arc_issuer_url: None,
+        }
+    }
+}
+
+impl LocalAdmissionConfigV1 {
+    pub(crate) fn load(path: Option<&Path>) -> Result<Self, String> {
+        let Some(path) = path else {
+            return Ok(Self::default());
+        };
+        let raw = std::fs::read_to_string(path)
+            .map_err(|e| format!("local admission config {}: {e}", path.display()))?;
+        let config: Self = toml::from_str(&raw)
+            .map_err(|e| format!("local admission config {} is invalid TOML: {e}", path.display()))?;
+        if let Some(url) = config.arc_issuer_url.as_deref() {
+            if !(url.starts_with("https://") || url.starts_with("wss://")) {
+                return Err(format!(
+                    "local admission config {}: arc_issuer_url must start with https:// or wss://",
+                    path.display()
+                ));
+            }
+        }
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LocalAdmissionConfigV1;
+
+    #[test]
+    fn empty_file_uses_open_defaults() {
+        let config: LocalAdmissionConfigV1 = toml::from_str("").expect("empty toml parses");
+        assert!(config.free_open);
+        assert!(config.arc_issuer_url.is_none());
+    }
+
+    #[test]
+    fn parses_full_document() {
+        let config: LocalAdmissionConfigV1 = toml::from_str(
+            "free_open = false\narc_issuer_url = \"https://issuer.example.com\"\n",
+        )
+        .expect("full toml parses");
+        assert!(!config.free_open);
+        assert_eq!(config.arc_issuer_url.as_deref(), Some("https://issuer.example.com"));
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        let error = toml::from_str::<LocalAdmissionConfigV1>("surprise = true\n").unwrap_err();
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_non_tls_issuer_url() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("admission.toml");
+        std::fs::write(&file, "arc_issuer_url = \"http://issuer.example.com\"\n").unwrap();
+        let error = LocalAdmissionConfigV1::load(Some(&file)).unwrap_err();
+        assert!(error.contains("https://"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn missing_file_is_an_error_not_a_silent_default() {
+        let path = std::path::Path::new("/nonexistent/local-admission.toml");
+        let error = LocalAdmissionConfigV1::load(Some(path)).unwrap_err();
+        assert!(error.contains("local admission config"), "unexpected error: {error}");
+    }
+}

--- a/apps/server/src/bin/admission/local/mod.rs
+++ b/apps/server/src/bin/admission/local/mod.rs
@@ -1,0 +1,63 @@
+//! Local admission (post-policy model, D2).
+//!
+//! Free queries are open, governed only by the operator's local configuration
+//! file; paid queries are delegated to a single designated issuer's ARC
+//! tokens. There is no signed policy document, no epoch, and no digest pin:
+//! the file is operator-local, read once at boot, and never leaves the host.
+//!
+//! This module currently provides the configuration surface and startup
+//! wiring; per-connection enforcement admits on the existing request paths
+//! and does not change wire behavior.
+
+mod config;
+
+pub(crate) use config::LocalAdmissionConfigV1;
+
+use std::path::Path;
+
+/// Resolved local admission settings for this boot.
+#[derive(Clone, Debug)]
+pub(crate) struct LocalAdmissionV1 {
+    config: LocalAdmissionConfigV1,
+}
+
+impl LocalAdmissionV1 {
+    /// Load an explicit `--local-admission-config FILE`, or start with the
+    /// open defaults when the flag is absent.
+    pub(crate) fn load(path: Option<&Path>) -> Result<Self, String> {
+        let config = LocalAdmissionConfigV1::load(path)?;
+        Ok(Self { config })
+    }
+
+    pub(crate) fn free_open(&self) -> bool {
+        self.config.free_open
+    }
+
+    pub(crate) fn arc_issuer_url(&self) -> Option<&str> {
+        self.config.arc_issuer_url.as_deref()
+    }
+
+    pub(crate) fn startup_log_line(&self) -> String {
+        let issuer = match self.arc_issuer_url() {
+            Some(url) => format!("arc_issuer_url={url}"),
+            None => "arc_issuer_url=unset".to_owned(),
+        };
+        format!("local admission: free_open={} {issuer}", self.free_open())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LocalAdmissionV1;
+
+    #[test]
+    fn defaults_are_open_without_issuer() {
+        let admission = LocalAdmissionV1::load(None).expect("default load");
+        assert!(admission.free_open());
+        assert_eq!(admission.arc_issuer_url(), None);
+        assert_eq!(
+            admission.startup_log_line(),
+            "local admission: free_open=true arc_issuer_url=unset"
+        );
+    }
+}

--- a/apps/server/src/bin/admission/mod.rs
+++ b/apps/server/src/bin/admission/mod.rs
@@ -4,4 +4,6 @@
 //! handling is being extracted under `admission::legacy` so it can be
 //! removed independently (series D, then R4 deletion).
 
+pub(crate) mod arc;
 pub mod legacy;
+pub(crate) mod local;

--- a/apps/server/src/bin/unified_server.rs
+++ b/apps/server/src/bin/unified_server.rs
@@ -14,7 +14,9 @@
 mod admission;
 mod unified_server_bat_v2;
 mod unified_server_pir2_sealed;
+use admission::arc::ArcAdmissionV1;
 use admission::legacy::admission_runtime::StrictServiceAdmissionRuntimeV1;
+use admission::local::LocalAdmissionV1;
 use admission::legacy::{load_strict_service_admission_v1, validate_legacy_experimental_arc_cli_v1};
 #[cfg(test)]
 use admission::legacy::cashu::{load_cashu_epoch_keys_v1, parse_cashu_exposure_limits_v1, validate_existing_private_sqlite_path_v1, zeroize_cashu_epoch_keys_v1};
@@ -260,6 +262,9 @@ struct CliArgs {
     /// externally-issued credentials verify. Without it, a random key is
     /// generated (no external credential can verify — dev/test only).
     arc_key_path: Option<PathBuf>,
+    /// Operator-local admission configuration (`--local-admission-config`).
+    /// Replaces the legacy signed-policy surface; mutually exclusive with it.
+    local_admission_config: Option<PathBuf>,
     require_cashu: bool,
     cashu_keysets: Vec<(String, String)>,
     /// Enforce the production V1 service admission state machine. This first
@@ -602,6 +607,7 @@ fn parse_args_from(args: Vec<String>) -> CliArgs {
     let mut harmony_pool_dbs: Vec<(u8, PathBuf)> = Vec::new();
     let mut require_arc = false;
     let mut arc_key_path: Option<PathBuf> = None;
+    let mut local_admission_config: Option<PathBuf> = None;
     let mut require_cashu = false;
     let mut cashu_keysets: Vec<(String, String)> = Vec::new();
     let mut require_service_auth_v1 = false;
@@ -777,6 +783,13 @@ fn parse_args_from(args: Vec<String>) -> CliArgs {
                 if let Some(p) = args.get(i + 1) {
                     arc_key_path = Some(PathBuf::from(p));
                 }
+                i += 1;
+            }
+            "--local-admission-config" => {
+                let Some(p) = args.get(i + 1) else {
+                    fatal_cli("--local-admission-config requires a file path");
+                };
+                local_admission_config = Some(PathBuf::from(p));
                 i += 1;
             }
             "--require-cashu" => {
@@ -1384,6 +1397,18 @@ fn parse_args_from(args: Vec<String>) -> CliArgs {
     )
     .unwrap_or_else(|error| fatal_cli(error));
 
+    if local_admission_config.is_some()
+        && (service_policy_path.is_some()
+            || !service_retained_policy_paths.is_empty()
+            || service_storeless_bat_v2.any_configured()
+            || service_storeless_free_pow_policy_digest_hex.is_some())
+    {
+        fatal_cli(
+            "--local-admission-config replaces the legacy signed-policy configuration; \
+             pass one or the other, not both",
+        );
+    }
+
     CliArgs {
         bind_address,
         port,
@@ -1399,6 +1424,7 @@ fn parse_args_from(args: Vec<String>) -> CliArgs {
         harmony_pool_bindings,
         require_arc,
         arc_key_path,
+        local_admission_config,
         require_cashu,
         cashu_keysets,
         require_service_auth_v1,
@@ -8842,38 +8868,11 @@ async fn main() {
     };
 
     // ── Initialize HarmonyPIR V2 hint pool (if enabled) ──────────────────
-    let (arc_verifier, require_arc) = if args.require_arc {
-        let verifier = match &args.arc_key_path {
-            Some(path) => {
-                let mut secret = read_exact_secret_v1::<128>(path, "ARC key").unwrap_or_else(|e| {
-                    panic!("failed to load ARC key from {}: {e}", path.display())
-                });
-                let v = pir_runtime_core::arc_verifier::ArcVerifier::from_secret_key_bytes(&secret)
-                    .unwrap_or_else(|e| {
-                        panic!("failed to load ARC key from {}: {e}", path.display())
-                    });
-                secret.zeroize();
-                println!(
-                    "  ARC: enabled — verification required (shared key loaded from {})",
-                    path.display()
-                );
-                v
-            }
-            None => {
-                let v = pir_runtime_core::arc_verifier::ArcVerifier::generate();
-                eprintln!(
-                    "  ARC: WARNING — --require-arc set without --arc-key; generated a random \
-                     key. No externally-issued credential will verify. Pass --arc-key <arc_key.bin> \
-                     to share the issuer's key."
-                );
-                v
-            }
-        };
-        (Some(std::sync::Mutex::new(verifier)), true)
-    } else {
-        println!("  ARC: disabled (use --require-arc to enable)");
-        (None, false)
-    };
+    let arc_admission = ArcAdmissionV1::from_cli(&args).unwrap_or_else(|error| panic!("{error}"));
+    let (arc_verifier, require_arc) = arc_admission.into_parts();
+    let local_admission = LocalAdmissionV1::load(args.local_admission_config.as_deref())
+        .unwrap_or_else(|error| fatal_cli(error));
+    println!("  {}", local_admission.startup_log_line());
 
     let (cashu_verifier, require_cashu) = if args.require_cashu {
         if args.cashu_keysets.is_empty() {


### PR DESCRIPTION
## What

Second slice of the decoupling program: the **target** admission shape now exists as compiled modules next to the legacy one.

- **admission/local/**: post-policy operating mode. Free queries open by default; operator config via `--local-admission-config FILE` (plain TOML, unsigned, host-local). Fields today: `free_open`, `arc_issuer_url` (the single designated issuer endpoint the node merely announces). Mutually exclusive with every legacy signed-policy flag, enforced at CLI parse.
- **admission/arc/**: facade collapsing the inline `--require-arc`/`--arc-key` boot block into one construction call — byte-identical behavior (128-byte key, zeroize-after-use, identical log lines and fail-fast semantics). Dispatch untouched.
- **admission/legacy/**: unchanged from D1.

This is skeleton work by design: no dispatch, opcode, or grant-accounting changes yet.

## Checks

- `cargo check -p runtime --all-targets` + 3 feature combinations: zero warnings
- `cargo test -p runtime`: 162 passed, 0 failed (7 new tests cover config parse/validate, open defaults, TLS-URL check, missing-file error, serde Default trap regression, ARC facade disable path)