### PR TITLE
Accept wire-shape contract v3 in the formal lock

### DIFF
--- a/verification/locks/formal-proofs.json
+++ b/verification/locks/formal-proofs.json
@@ -11,7 +11,7 @@
   "implementationContract": {
     "schema": "BitcoinPIR/wire-shape-contract/v1",
     "path": "verification/contracts/wire-shape-v1.json",
-    "sha256": "648227ffba4946b5adc55291bdb77eb452d93a5c03c553a17dc6f5d053b97bf7"
+    "sha256": "5c5c488bb46fd03f4bba1328d2dbfcbf5defc294e1a34eb6948c338580ace745"
   },
   "trustedVerifier": {
     "schema": "BitcoinPIR/product-owned-easycrypt-verifier/v2",

--- a/verification/scripts/verify_formal_lock.py
+++ b/verification/scripts/verify_formal_lock.py
@@ -695,8 +695,8 @@ def main() -> None:
     contract, contract_raw = load_json(ROOT / contract_path, "wire contract")
     if contract.get("schema") != contract_lock["schema"]:
         fail("wire contract schema does not match the lock")
-    if int_field(contract, "contractVersion") != 2:
-        fail("wire contract must use contractVersion 2 for Payment V1 authorization")
+    if int_field(contract, "contractVersion") != 3:
+        fail("wire contract must use contractVersion 3 after Payment V1 removal")
     actual_contract_digest = sha256(contract_raw)
     if actual_contract_digest != expected_contract_digest:
         fail(


### PR DESCRIPTION
## Summary
- #272 published `wire-shape-v1.json` as **contractVersion 3** (no Payment V1 authorization round). The lock script still required v2 and pinned the old digest, so CI died before checking out proofs.
- Accept v3 and pin `implementationContract.sha256` to the current contract (`5c5c488bb4…`).
- This does **not** re-pin `protocol-proofs`. The locked commit still generates `ContractBinding.ec` with `RServiceAuthorization`. After this PR, CI should get past the version gate and fail on the generated-binding mismatch until the proof repo is regenerated.

## Test plan
- [x] `python3 verification/scripts/verify_formal_lock.py` (no `--proof-dir`) passes
- [x] `python3 verification/scripts/test_verify_formal_lock.py`
- [x] `cargo test --locked --offline -p pir-sdk --features serde --test wire_shape_contract` (4 passed)
- [ ] CI: lock validation without proof dir should pass; `--proof-dir` binding check remains red until protocol-proofs is rebuilt