### PR TITLE
Pin protocol-proofs v3 after Payment V1 removal

### DIFF
--- a/verification/locks/formal-proofs.json
+++ b/verification/locks/formal-proofs.json
@@ -2,11 +2,11 @@
   "schema": "BitcoinPIR/formal-proof-lock/v1",
   "protocolProofs": {
     "repository": "Bitcoin-PIR/protocol-proofs",
-    "commit": "c519f1960aa9567ac324856f30c71071b04a4a17",
+    "commit": "549fb4db80164955c9f5809b8778c32009ebe333",
     "manifestPath": "proof-manifest.json",
-    "manifestSha256": "5763b9a4e5e40f7eed1f1f1eadeb44950c6b4172ea55c995ca24f062e0ee860d",
-    "verificationRecordPath": "verification/records/formal/c97d8fff7b072154e78fb0388a076cb849a2d99e9968be7a9cd0d838268b54d8.json",
-    "verificationRecordSha256": "c97d8fff7b072154e78fb0388a076cb849a2d99e9968be7a9cd0d838268b54d8"
+    "manifestSha256": "623f7a8f4b429e1659b3cc57addf30dd27a617b844300c4f3a5038a384e1bcab",
+    "verificationRecordPath": "verification/records/formal/b3905916389e1313502c6be0e82cae35c279e5b381adc176add4a6f2a56a5113.json",
+    "verificationRecordSha256": "b3905916389e1313502c6be0e82cae35c279e5b381adc176add4a6f2a56a5113"
   },
   "implementationContract": {
     "schema": "BitcoinPIR/wire-shape-contract/v1",

--- a/verification/records/formal/b3905916389e1313502c6be0e82cae35c279e5b381adc176add4a6f2a56a5113.json
+++ b/verification/records/formal/b3905916389e1313502c6be0e82cae35c279e5b381adc176add4a6f2a56a5113.json
@@ -1,0 +1,29 @@
+{
+  "command": "make check",
+  "commit": "549fb4db80164955c9f5809b8778c32009ebe333",
+  "exit_code": 0,
+  "generated_at": "2026-08-29T10:38:24.243343Z",
+  "manifest_sha256": "623f7a8f4b429e1659b3cc57addf30dd27a617b844300c4f3a5038a384e1bcab",
+  "proof_sources_sha256": "db50f0d945a2fa028243e49a64c48d25d43f608090c9c3db6fb3e22793598489",
+  "repository": "Bitcoin-PIR/protocol-proofs",
+  "result": "passed",
+  "result_derivation": "The record writer runs only after the manifest command exits with status 0; therefore exit_code 0 maps to result passed.",
+  "run_id": "33247722574",
+  "run_url": "https://github.com/Bitcoin-PIR/protocol-proofs/actions/runs/33247722574",
+  "schema_version": 1,
+  "toolchain": {
+    "base_image": "ghcr.io/easycrypt/ec-build-box@sha256:5a46a4d816e763ad5de9ee9502d52158c742b9b98cc1f60c443d135a270fdb6a",
+    "dockerfile": "toolchain/Dockerfile",
+    "easycrypt_commit": "dd9bd930d45e81980e546fc835ed2022418644be",
+    "easycrypt_repository": "https://github.com/EasyCrypt/easycrypt",
+    "ocaml_version": "4.14.1",
+    "platform": "linux/amd64",
+    "solvers": [
+      {
+        "name": "alt-ergo",
+        "version": "2.6.3"
+      }
+    ],
+    "why3_version": "1.8.2"
+  }
+}


### PR DESCRIPTION
## Summary
- `Bitcoin-PIR/protocol-proofs#2` landed at `549fb4db`. That revision drops `RServiceAuthorization` and regenerates `ContractBinding.ec` from wire-shape contract v3.
- Pin `verification/locks/formal-proofs.json` to that commit, manifest SHA-256 `623f7a8f4b…`, and CI verification record from run [33247722574](https://github.com/Bitcoin-PIR/protocol-proofs/actions/runs/33247722574).

## Test plan
- [x] `python3 verification/scripts/verify_formal_lock.py --proof-dir ~/bitcoin-pir/protocol-proofs`
- [x] `python3 verification/scripts/test_verify_formal_lock.py`
- [x] `cargo test --locked --offline -p pir-sdk --features serde --test wire_shape_contract` (4 passed)
- [ ] CI `formal-proof.yml` green on this PR