### PR TITLE
fix: stop passing deleted Payment V1 flags into pir2 UKI

### DIFF
--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -7,8 +7,8 @@
 # Base topology flags mirror deploy/systemd/pir-vpsbg.service. The measured
 # sealed profile is intentionally VPSBG-specific: observe/enroll/probe finish
 # inertly before database access, while Ready opens its measurement-bound
-# identity and BAT V2 clearing keys before Direct ORAM construction and again
-# in the final long-lived server process.
+# identity and presence-checked accounting files before Direct ORAM
+# construction and again in the final long-lived server process.
 #   --port 8091
 #   --role secondary   (DPF queries + HarmonyPIR query phase, no OnionPIR)
 #   --serve-queries    (pir2 is queries-only per the production topology
@@ -524,29 +524,6 @@ run_pir2_with_public_artifacts() {
     shift
     [ -f "$PIR2_ACTIVE_ARTIFACT_SET_PATH" ] && [ ! -L "$PIR2_ACTIVE_ARTIFACT_SET_PATH" ] \
         || fatal "trusted pir2 public artifact-set snapshot is unavailable"
-    while IFS= read -r artifact_line; do
-        artifact_kind=${artifact_line%%=*}
-        [ "$artifact_kind" != schema ] || continue
-        artifact_spec=${artifact_line#*=}
-        artifact_digest=${artifact_spec%%=*}
-        artifact_remainder=${artifact_spec#*=}
-        artifact_path=${artifact_remainder#*=}
-        case "$artifact_kind" in
-            current_policy)
-                set -- "$@" --service-storeless-bat-v2-policy-digest-hex "$artifact_digest"
-                ;;
-            retained_policy)
-                set -- "$@" --service-storeless-bat-v2-retained-policy "$artifact_digest=$artifact_path"
-                ;;
-            current_class|retained_class)
-                set -- "$@" --service-storeless-bat-v2-class "$artifact_digest=$artifact_path"
-                ;;
-            accounting_authorization|accounting_approval)
-                :
-                ;;
-            *) fatal "pir2 public artifact set changed after validation" ;;
-        esac
-    done <"$PIR2_ACTIVE_ARTIFACT_SET_PATH"
     if [ "$artifact_execution_mode" = exec ]; then
         exec "$@"
     fi
@@ -946,12 +923,7 @@ run_pir2_sealed_ready_preflight() {
         --pir2-snp-sealed-current-boot-id-hex "$PIR2_BOOT_ID_HEX" \
         --pir2-snp-sealed-identity-cert "$PIR2_SEALED_IDENTITY_CERT_PATH" \
         --pir2-snp-sealed-accounting-authorization "$PIR2_SEALED_ACCOUNTING_AUTHORIZATION_PATH" \
-        --pir2-snp-sealed-issuer-approval "$PIR2_SEALED_ISSUER_APPROVAL_PATH" \
-        --service-storeless-bat-v2-accounting-authorization "$PIR2_SEALED_ACCOUNTING_AUTHORIZATION_PATH" \
-        --service-storeless-bat-v2-issuer-approval "$PIR2_SEALED_ISSUER_APPROVAL_PATH" \
-        --service-storeless-bat-v2-operator-key-hex "$PIR2_SEALED_OPERATOR_KEY_HEX" \
-        --service-storeless-bat-v2-issuer-settlement-key-hex "$PIR2_SEALED_ISSUER_SETTLEMENT_KEY_HEX" \
-        --service-storeless-bat-v2-minimum-authorization-epoch "$PIR2_SEALED_MINIMUM_AUTHORIZATION_EPOCH"
+        --pir2-snp-sealed-issuer-approval "$PIR2_SEALED_ISSUER_APPROVAL_PATH"
     sealed_status=$?
     [ "$sealed_status" -eq "$PIR2_SEALED_INERT_SUCCESS_EXIT_CODE" ] \
         || fatal "pir2 sealed Ready preflight failed with exit $sealed_status"
@@ -1470,11 +1442,9 @@ trap - EXIT
 trap - HUP INT TERM
 start_unified_server_runtime_log
 
-# VPSBG is query-only but now carries a Harmony V2 query scope (policy epoch 2).
-# Allow up to 2 concurrent online V2Full authorizations for Harmony query jobs.
-# Revalidate the mutable-mount public bytes after the bounded ORAM build. The
-# Rust loader then repeats canonical/signature/digest/member/role-key checks in
-# the final Ready process; the audit receipt is evidence, not runtime authority.
+# Revalidate the mutable-mount public bytes after the bounded ORAM build.
+# Ready presence checks remain on --pir2-snp-sealed-*; deleted Payment V1
+# --service-* flags must not be passed (unknown CLI flags are fatal).
 validate_pir2_public_artifact_set
 run_pir2_with_public_artifacts exec "$UNIFIED_SERVER" \
     --port 8091 \
@@ -1505,17 +1475,5 @@ run_pir2_with_public_artifacts exec "$UNIFIED_SERVER" \
     --pir2-snp-sealed-identity-cert "$PIR2_SEALED_IDENTITY_CERT_PATH" \
     --pir2-snp-sealed-accounting-authorization "$PIR2_SEALED_ACCOUNTING_AUTHORIZATION_PATH" \
     --pir2-snp-sealed-issuer-approval "$PIR2_SEALED_ISSUER_APPROVAL_PATH" \
-    --require-service-auth-v1 \
-    --service-policy "$SERVICE_POLICY_PATH" \
-    --service-provider-id-hex "$PIR2_SEALED_PROVIDER_ID_HEX" \
-    --service-policy-key-hex "$PIR2_SEALED_POLICY_KEY_HEX" \
-    --service-storeless-bat-v2-accounting-authorization "$PIR2_SEALED_ACCOUNTING_AUTHORIZATION_PATH" \
-    --service-storeless-bat-v2-issuer-approval "$PIR2_SEALED_ISSUER_APPROVAL_PATH" \
-    --service-storeless-bat-v2-operator-key-hex "$PIR2_SEALED_OPERATOR_KEY_HEX" \
-    --service-storeless-bat-v2-issuer-settlement-key-hex "$PIR2_SEALED_ISSUER_SETTLEMENT_KEY_HEX" \
-    --service-storeless-bat-v2-minimum-authorization-epoch "$PIR2_SEALED_MINIMUM_AUTHORIZATION_EPOCH" \
-    --service-max-concurrent-auth 4 \
-    --service-max-concurrent-online-v2full-auth 0 \
     --connection-idle-timeout-ms 300000 \
-    --service-pre-auth-timeout-ms 300000 \
     2>&1

--- a/scripts/payment-bat-v2-source-profile-gate.mjs
+++ b/scripts/payment-bat-v2-source-profile-gate.mjs
@@ -560,8 +560,8 @@ export function validatePir2RenderInputsV1(artifactSource, startupSource, runSou
     "bitcoinpir-pir2-sealed-startup-v2", "artifact_set_path", "artifact_set_sha256",
     "PIR2_SEALED_ARTIFACT_SET_SHA256", "validate_pir2_public_artifact_set",
     "PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH", "PIR2_ACTIVE_ARTIFACT_SET_PATH",
-    "artifact_set_sha256=", "--service-storeless-bat-v2-retained-policy",
-    "--service-storeless-bat-v2-class",
+    "artifact_set_sha256=", "--pir2-snp-sealed-accounting-authorization",
+    "--pir2-snp-sealed-issuer-approval",
   ]) {
     if (!runSource.includes(required)) fail(`pir2 measured run path is missing ${required}`);
   }

--- a/scripts/payment-v1-deployment-template-gate.mjs
+++ b/scripts/payment-v1-deployment-template-gate.mjs
@@ -27,7 +27,7 @@ export const ACTIVE_BASELINES = Object.freeze({
   "deploy/systemd/cloudflared.service":
     "2a405d952610f5132453c80198ab2486b3884ee83b8c4674d04425cc3c81715c",
   "scripts/dracut/97bpir-tier3-init/unified-server-run.sh":
-    "62bfe52b1e8875b7baf2579b528cfa01ce494705656fa9de6717fe4b55dcf596",
+    "3ae30fc6e07ff2c5c355de6607df8e595342e38b936269e21dd02cc6a185074b",
   "scripts/dracut/97bpir-tier3-init/unified-server-finish.sh":
     "361d6a52a2e61482d8e766823a17c3b12187f96805c7e1f9d0f785e27ae64ef9",
   "scripts/dracut/97bpir-tier3-init/direct-oram-supervisor.sh":
@@ -2290,17 +2290,10 @@ export function validateVpsbgPremiumFreePowMeasuredFinalExec(text) {
     const finalLine = finalLines[0];
     for (const required of [
       "--pir2-snp-sealed-require-ready",
-      "--require-service-auth-v1",
-      "--service-policy \"$SERVICE_POLICY_PATH\"",
-      "--service-provider-id-hex \"$PIR2_SEALED_PROVIDER_ID_HEX\"",
-      "--service-policy-key-hex \"$PIR2_SEALED_POLICY_KEY_HEX\"",
-      "--service-storeless-bat-v2-accounting-authorization",
-      "--service-storeless-bat-v2-issuer-approval",
-      "--service-storeless-bat-v2-operator-key-hex",
-      "--service-storeless-bat-v2-issuer-settlement-key-hex",
-      "--service-storeless-bat-v2-minimum-authorization-epoch",
+      "--pir2-snp-sealed-identity-cert",
+      "--pir2-snp-sealed-accounting-authorization",
+      "--pir2-snp-sealed-issuer-approval",
       "--connection-idle-timeout-ms 300000",
-      "--service-pre-auth-timeout-ms 300000",
     ]) requireText(finalLine, required, label);
     for (const [name, value] of [
       ["PIR2_SEALED_OPERATOR_KEY_HEX", /^PIR2_SEALED_OPERATOR_KEY_HEX=([0-9a-f]{64})$/mu.exec(text)?.[1]],
@@ -2319,7 +2312,6 @@ export function validateVpsbgPremiumFreePowMeasuredFinalExec(text) {
     ]) rejectPattern(text, pattern, label, description);
     for (const [needle, description] of [
       ["--connection-idle-timeout-ms 300000", "connection idle timeout"],
-      ["--service-pre-auth-timeout-ms 300000", "service pre-auth timeout"],
     ]) {
       if (finalLine.split(needle).length !== 2) {
         fail(`${label} must contain ${description} exactly once in the final invocation`);
@@ -2329,8 +2321,8 @@ export function validateVpsbgPremiumFreePowMeasuredFinalExec(text) {
       "bitcoinpir-pir2-sealed-startup-v2",
       "PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH",
       "artifact_set_sha256=",
-      "--service-storeless-bat-v2-retained-policy",
-      "--service-storeless-bat-v2-class",
+      "--pir2-snp-sealed-accounting-authorization",
+      "--pir2-snp-sealed-issuer-approval",
     ]) requireText(text, required, label);
     return;
   }
@@ -3083,8 +3075,14 @@ function validateActiveBaselines(root) {
         "PIR2_SEALED_TRUSTED_ARTIFACT_SET_PATH",
         "artifact_set_sha256=",
         "run_pir2_with_public_artifacts exec",
-        "--service-storeless-bat-v2-retained-policy",
+        "--pir2-snp-sealed-accounting-authorization",
       ]) requireText(text, required, relativePath);
+      rejectPattern(
+        text,
+        /--service-storeless-bat-v2-|--require-service-auth-v1|--service-policy |--service-provider-id-hex|--service-policy-key-hex|--service-max-concurrent|--service-pre-auth-timeout-ms/u,
+        relativePath,
+        "deleted Payment V1 flag",
+      );
       rejectPattern(
         text,
         /--service-storeless-bat-v2-pir1-clearing-key|--service-shared-(?:clearing|idempotency)/u,

--- a/scripts/tier3-uki-policy-contract.test.mjs
+++ b/scripts/tier3-uki-policy-contract.test.mjs
@@ -104,6 +104,8 @@ function validateMeasuredRunContract(source) {
   assert.doesNotMatch(source, /--service-shared-clearing-key/);
   assert.doesNotMatch(source, /--service-shared-idempotency-key/);
   assert.doesNotMatch(source, /--service-storeless-bat-v2-pir1-clearing-key/);
+  assert.doesNotMatch(source, /--service-storeless-bat-v2-/);
+  assert.doesNotMatch(source, /--require-service-auth-v1/);
   assert.match(source, /--pir2-snp-sealed-envelope/);
   assert.match(source, /--pir2-snp-sealed-identity-cert/);
   assert.match(source, /--pir2-snp-sealed-accounting-authorization/);

--- a/scripts/vpsbg-tier3-generation.test.mjs
+++ b/scripts/vpsbg-tier3-generation.test.mjs
@@ -187,12 +187,12 @@ try {
   assert.match(
     tier3RunText,
     /validate_pir2_public_artifact_set[\s\S]*run_pir2_with_public_artifacts exec[\s\S]*--pir2-snp-sealed-require-ready/,
-    "final serving must use sealed Ready plus the validated public BAT V2 artifact set",
+    "final serving must use sealed Ready plus the validated public artifact set",
   );
-  assert.match(
+  assert.doesNotMatch(
     tier3RunText,
-    /run_pir2_with_public_artifacts\(\)[\s\S]*--service-storeless-bat-v2-policy-digest-hex[\s\S]*--service-storeless-bat-v2-retained-policy[\s\S]*--service-storeless-bat-v2-class/,
-    "the bounded artifact runner must project current, retained, and class flags",
+    /--service-storeless-bat-v2-|--require-service-auth-v1|--service-policy |--service-provider-id-hex|--service-policy-key-hex|--service-max-concurrent|--service-pre-auth-timeout-ms/,
+    "measured argv must not pass deleted Payment V1 flags",
   );
   assert.doesNotMatch(
     tier3ModuleSetupText,
@@ -924,12 +924,12 @@ exit 1
   assert.match(finalArgs, /--direct-oram-db\n0=.*db0-mainnet-948454/);
   assert.match(finalArgs, /--direct-oram-db\n1=.*db1-delta-940611-948454/);
   assert.match(finalArgs, /--pir2-snp-sealed-require-ready/);
-  assert.match(finalArgs, /--service-storeless-bat-v2-policy-digest-hex/);
-  assert.equal(
-    (finalArgs.match(/--service-storeless-bat-v2-retained-policy/g) ?? []).length,
-    0,
+  assert.match(finalArgs, /--pir2-snp-sealed-accounting-authorization/);
+  assert.match(finalArgs, /--pir2-snp-sealed-issuer-approval/);
+  assert.doesNotMatch(
+    finalArgs,
+    /--service-storeless-bat-v2-|--require-service-auth-v1|--service-policy |--service-provider-id-hex|--service-policy-key-hex|--service-max-concurrent|--service-pre-auth-timeout-ms/,
   );
-  assert.equal((finalArgs.match(/--service-storeless-bat-v2-class/g) ?? []).length, 1);
   assert.doesNotMatch(finalArgs, /(?:--identity-key-path|--service-shared-clearing-key|--service-storeless-bat-v2-pir1-clearing-key)/);
   assert.deepEqual(
     readFileSync(directEvents, "utf8").trim().split("\n").map((event) =>


### PR DESCRIPTION
## Summary
The first R5.1 runtime UKI failed Ready dispatcher because `unified-server-run.sh` still passed deleted Payment V1 `--service-*` flags. Unknown CLI flags are fatal in the post-S4 binary.

This drops those flags from the measured run path and keeps `--pir2-snp-sealed-*` presence checks. Gate tests are updated to match.

## Test plan
- `node --test scripts/tier3-uki-policy-contract.test.mjs`
- `node --test scripts/vpsbg-tier3-generation.test.mjs`
- `node scripts/payment-v1-deployment-template-gate.mjs`
- `node scripts/payment-bat-v2-source-profile-gate.mjs`

Do not rebuild or switch a UKI from this branch until it is merged.