### PR TITLE
feat(admin): pir2-sealed-receipt-verify accepts Enroll, Probe, and Ready receipts offline

### DIFF
--- a/apps/admin/src/main.rs
+++ b/apps/admin/src/main.rs
@@ -30,6 +30,7 @@ mod channel_test;
 mod db_proof;
 mod generate_identity;
 mod keygen;
+mod pir2_sealed_receipt_verify;
 mod pir2_sealed_release;
 mod show_vcek_url;
 mod sign_identity;
@@ -75,6 +76,10 @@ enum Command {
     /// Verify a fresh SNP observation and emit one canonical pir2 release.
     #[command(name = "pir2-sealed-release")]
     Pir2SealedRelease(Box<pir2_sealed_release::Pir2SealedReleaseArgs>),
+    /// Offline acceptance of one Enroll, Probe, or Ready phase receipt
+    /// against the operator-signed release (Flow G receipt gate).
+    #[command(name = "pir2-sealed-receipt-verify")]
+    Pir2SealedReceiptVerify(Box<pir2_sealed_receipt_verify::Pir2SealedReceiptVerifyArgs>),
 }
 
 #[tokio::main(flavor = "multi_thread")]
@@ -135,6 +140,13 @@ async fn main() {
                 1
             }
         },
+        Command::Pir2SealedReceiptVerify(args) => match pir2_sealed_receipt_verify::run(*args) {
+            Ok(()) => 0,
+            Err(e) => {
+                eprintln!("pir2-sealed-receipt-verify: {e}");
+                1
+            }
+        },
     };
     std::process::exit(exit_code);
 }
@@ -159,6 +171,7 @@ mod cli_tests {
             "upload",
             "db-proof",
             "pir2-sealed-release",
+            "pir2-sealed-receipt-verify",
         ] {
             assert!(help.contains(subcommand), "missing {subcommand} from help");
         }

--- a/apps/admin/src/pir2_sealed_receipt_verify.rs
+++ b/apps/admin/src/pir2_sealed_receipt_verify.rs
@@ -1,0 +1,468 @@
+//! `bpir-admin pir2-sealed-receipt-verify` — offline, fail-closed acceptance
+//! of one persisted Enroll, Probe, or Ready receipt (or a post-release
+//! Observe receipt) against the operator-signed release the guest booted
+//! with. Pre-release Observe receipts are verified by `pir2-sealed-release`.
+//!
+//! This is the reviewed repository command the sealed-release runbook
+//! requires before any identity artifact is signed from a receipt. Checks,
+//! in order:
+//!
+//! 1. the release decodes and verifies under the source-pinned operator key;
+//! 2. the receipt file is canonical (magic, codec, lengths, claim contract,
+//!    `REPORT_DATA` carries the claims digest) and, when given, matches the
+//!    receipt hash declared by the phase status JSON;
+//! 3. the claims carry the expected phase, ordinal, verifier nonce, and boot
+//!    ID, bind this exact release, and repeat its identity generation; for
+//!    non-Observe phases the service identity key is a valid Ed25519 point;
+//! 4. the AMD ARK pin, ARK → ASK → VCEK chain, and SNP report signature;
+//! 5. the report's `REPORT_DATA`, Turin CPUID, measurement, full guest
+//!    policy, and TCB floor against the release.
+//!
+//! Nothing here reads a secret: the operator key is a public pin.
+
+use std::path::PathBuf;
+
+use clap::Args;
+use ed25519_dalek::VerifyingKey;
+use pir_runtime_core::snp_sealed_secrets::{
+    Pir2SealedReceiptClaimsV1, Pir2SealedReceiptFileV1, Pir2SealedReceiptPhaseV1,
+    VerifiedPir2SealedReleaseV1, MAX_SEALED_RECEIPT_FILE_LEN_V1,
+};
+use sha2::{Digest as _, Sha256};
+
+use crate::pir2_sealed_release::{
+    parse_fixed_hex, read_public_bounded, validate_report_cpu, validate_signed_report_against_pins,
+    verify_offline_report, MAX_RELEASE_LEN,
+};
+
+/// Inputs for one offline phase-receipt acceptance.
+#[derive(Args, Debug)]
+pub struct Pir2SealedReceiptVerifyArgs {
+    /// Persisted phase receipt (recovery API download or Flow F copy).
+    #[arg(long)]
+    pub receipt: PathBuf,
+    /// Operator-signed release the guest booted with.
+    #[arg(long)]
+    pub release: PathBuf,
+    /// Source-pinned operator Ed25519 public key (64 hex) the release must
+    /// verify under.
+    #[arg(long)]
+    pub operator_pubkey_hex: String,
+    /// Expected phase: observe, enroll, probe, or ready.
+    #[arg(long)]
+    pub expected_phase: String,
+    /// Ordinal written into this boot's startup.env.
+    #[arg(long)]
+    pub expected_ordinal: u64,
+    /// Verifier nonce written into this boot's startup.env (64 hex).
+    #[arg(long)]
+    pub expected_verifier_nonce_hex: String,
+    /// Boot ID declared by the phase status JSON or marker (32 hex).
+    #[arg(long)]
+    pub expected_boot_id_hex: String,
+    /// Receipt SHA-256 declared by the phase status JSON (64 hex). Strongly
+    /// recommended: it rejects a cached receipt from an earlier phase.
+    #[arg(long)]
+    pub expected_receipt_sha256_hex: Option<String>,
+    /// AMD ARK PEM for the report's CPU generation.
+    #[arg(long)]
+    pub ark: PathBuf,
+    /// AMD ASK PEM for the report's CPU generation.
+    #[arg(long)]
+    pub ask: PathBuf,
+    /// Chip-specific AMD VCEK PEM.
+    #[arg(long)]
+    pub vcek: PathBuf,
+    /// SHA-256 of the DER-encoded ARK certificate.
+    #[arg(long)]
+    pub expected_ark_sha256_hex: String,
+}
+
+pub fn run(args: Pir2SealedReceiptVerifyArgs) -> Result<(), String> {
+    let expected_phase = Pir2SealedReceiptPhaseV1::parse_name(&args.expected_phase)
+        .ok_or_else(|| "expected phase must be observe, enroll, probe, or ready".to_owned())?;
+    if args.expected_ordinal == 0 {
+        return Err("expected ordinal must be non-zero".to_owned());
+    }
+    let expected_nonce =
+        parse_fixed_hex::<32>(&args.expected_verifier_nonce_hex, "expected verifier nonce")?;
+    let expected_boot_id = parse_fixed_hex::<16>(&args.expected_boot_id_hex, "expected boot ID")?;
+    let operator_pubkey = parse_fixed_hex::<32>(&args.operator_pubkey_hex, "operator public key")?;
+    let operator = VerifyingKey::from_bytes(&operator_pubkey)
+        .map_err(|_| "operator public key is not a valid Ed25519 point".to_owned())?;
+    let expected_ark_sha256 =
+        parse_fixed_hex::<32>(&args.expected_ark_sha256_hex, "expected ARK SHA-256")?;
+    let expected_receipt_sha256 = args
+        .expected_receipt_sha256_hex
+        .as_deref()
+        .map(|value| parse_fixed_hex::<32>(value, "expected receipt SHA-256"))
+        .transpose()?;
+
+    let release_bytes =
+        read_public_bounded(&args.release, MAX_RELEASE_LEN, "operator-signed release")?;
+    let release = VerifiedPir2SealedReleaseV1::decode_and_verify(&release_bytes, &operator)
+        .map_err(|error| format!("verify operator-signed release: {error}"))?;
+
+    let receipt_bytes = read_public_bounded(
+        &args.receipt,
+        MAX_SEALED_RECEIPT_FILE_LEN_V1,
+        "phase receipt",
+    )?;
+    if let Some(expected) = expected_receipt_sha256 {
+        let actual: [u8; 32] = Sha256::digest(&receipt_bytes).into();
+        if actual != expected {
+            return Err(
+                "receipt SHA-256 differs from the phase status declaration; treat the \
+                 download as rejecting evidence and recover the receipt through Flow F"
+                    .to_owned(),
+            );
+        }
+    }
+    let receipt = Pir2SealedReceiptFileV1::decode(&receipt_bytes)
+        .map_err(|error| format!("decode phase receipt: {error}"))?;
+    check_claims(
+        &receipt.claims,
+        &release,
+        expected_phase,
+        args.expected_ordinal,
+        expected_nonce,
+        expected_boot_id,
+    )?;
+
+    // The AMD trust decision comes only after every cheap binding passed.
+    let expected_report_data = receipt
+        .claims
+        .report_data()
+        .map_err(|error| format!("derive receipt REPORT_DATA: {error}"))?;
+    let report = verify_offline_report(
+        &receipt.raw_report,
+        &args.ark,
+        &args.ask,
+        &args.vcek,
+        expected_ark_sha256,
+        expected_report_data,
+    )?;
+    validate_report_cpu(&report)?;
+    let pinned = release.release();
+    validate_signed_report_against_pins(
+        &report,
+        expected_report_data,
+        pinned.expected_measurement,
+        pinned.expected_guest_policy,
+        pinned.minimum_tcb,
+    )?;
+
+    let claims = &receipt.claims;
+    println!(
+        "PASS pir2_sealed_receipt_verify phase={} ordinal={} identity_generation={} \
+         stable_server_id={} boot_id_hex={} current_channel_pubkey_hex={} \
+         service_identity_pubkey_hex={} service_identity_fingerprint_hex={} measurement_hex={}",
+        claims.phase.name(),
+        claims.ordinal,
+        claims.identity_generation,
+        pinned.stable_server_id,
+        hex::encode(claims.boot_id),
+        hex::encode(claims.current_channel_pubkey),
+        hex::encode(claims.public_keys.service_identity),
+        hex::encode(claims.public_fingerprints.service_identity),
+        hex::encode(pinned.expected_measurement),
+    );
+    println!("NEXT_STEP={}", next_step(expected_phase));
+    Ok(())
+}
+
+/// Bind the decoded claims to the operator's expectations and to the
+/// verified release. Runs before any AMD certificate is read.
+pub(crate) fn check_claims(
+    claims: &Pir2SealedReceiptClaimsV1,
+    release: &VerifiedPir2SealedReleaseV1,
+    expected_phase: Pir2SealedReceiptPhaseV1,
+    expected_ordinal: u64,
+    expected_nonce: [u8; 32],
+    expected_boot_id: [u8; 16],
+) -> Result<(), String> {
+    if claims.phase != expected_phase {
+        return Err(format!(
+            "receipt phase is {}, expected {}",
+            claims.phase.name(),
+            expected_phase.name()
+        ));
+    }
+    if claims.ordinal != expected_ordinal {
+        return Err(format!(
+            "receipt ordinal is {}, expected {expected_ordinal}",
+            claims.ordinal
+        ));
+    }
+    if claims.verifier_nonce != expected_nonce {
+        return Err("receipt verifier nonce differs from the startup nonce".to_owned());
+    }
+    if claims.boot_id != expected_boot_id {
+        return Err("receipt boot ID differs from the phase status boot ID".to_owned());
+    }
+    if claims.release_artifact_digest != release.artifact_digest() {
+        return Err("receipt binds a different release".to_owned());
+    }
+    if claims.identity_generation != release.release().identity_generation {
+        return Err(format!(
+            "receipt identity generation is {}, release has {}",
+            claims.identity_generation,
+            release.release().identity_generation
+        ));
+    }
+    if claims.phase != Pir2SealedReceiptPhaseV1::Observe {
+        VerifyingKey::from_bytes(&claims.public_keys.service_identity)
+            .map_err(|_| "receipt service identity key is not a valid Ed25519 point".to_owned())?;
+    }
+    Ok(())
+}
+
+fn next_step(phase: Pir2SealedReceiptPhaseV1) -> &'static str {
+    match phase {
+        Pir2SealedReceiptPhaseV1::Observe => {
+            "a post-release Observe is accepted; the pre-release Observe used by \
+             pir2-sealed-release is a different receipt"
+        }
+        Pir2SealedReceiptPhaseV1::Enroll => {
+            "sign the runtime identity certificate for service_identity_pubkey_hex with \
+             `bpir-admin sign-identity --server-id <stable_server_id>`, place it with Flow F, \
+             then run Probe with a fresh ordinal and nonce"
+        }
+        Pir2SealedReceiptPhaseV1::Probe => {
+            "run a second independent Probe, or Ready once two Probe receipts are accepted"
+        }
+        Pir2SealedReceiptPhaseV1::Ready => "run scripts/pir2-post-switch-check.sh (Flow E step 6)",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use pir_attest_verify::SNP_REPORT_LEN;
+    use pir_runtime_core::snp_sealed_secrets::{
+        encode_signed_pir2_sealed_release_v1, FreshSnpReportV1, Pir2SealedReceiptV1,
+        Pir2SealedReleaseClaimsV1, Pir2SealedSigningMaterialV1, SnpDerivedKeyMaterialV1,
+        SnpDerivedKeyProvider, SnpDerivedKeyProviderErrorV1, SnpDerivedKeyRequestV1,
+        SnpTcbVersionV1,
+    };
+    use std::fs;
+    use std::path::Path;
+
+    struct ReportProviderV1;
+
+    impl SnpDerivedKeyProvider for ReportProviderV1 {
+        fn fresh_report(
+            &self,
+            report_data: [u8; 64],
+        ) -> Result<FreshSnpReportV1, SnpDerivedKeyProviderErrorV1> {
+            let mut raw_report = vec![0xA5; SNP_REPORT_LEN];
+            raw_report[0x50..0x90].copy_from_slice(&report_data);
+            let tcb = SnpTcbVersionV1 {
+                fmc: Some(1),
+                bootloader: 1,
+                tee: 1,
+                snp: 1,
+                microcode: 1,
+            };
+            Ok(FreshSnpReportV1 {
+                report_version: 3,
+                vmpl: 0,
+                guest_policy: 1 << 17,
+                measurement: [0x33; 48],
+                report_data,
+                reported_tcb: tcb,
+                committed_tcb: tcb,
+                raw_report,
+            })
+        }
+
+        fn derive_key(
+            &self,
+            _request: &SnpDerivedKeyRequestV1,
+        ) -> Result<SnpDerivedKeyMaterialV1, SnpDerivedKeyProviderErrorV1> {
+            Err(SnpDerivedKeyProviderErrorV1::RequestDrift)
+        }
+    }
+
+    fn release_claims() -> Pir2SealedReleaseClaimsV1 {
+        Pir2SealedReleaseClaimsV1 {
+            provider_id: [0x11; 32],
+            stable_server_id: "pir2-test".to_owned(),
+            uki_sha256: [0x22; 32],
+            expected_measurement: [0x33; 48],
+            expected_guest_policy: 1 << 17,
+            minimum_tcb: SnpTcbVersionV1 {
+                fmc: Some(1),
+                bootloader: 1,
+                tee: 1,
+                snp: 1,
+                microcode: 1,
+            },
+            derived_key_request: SnpDerivedKeyRequestV1::production().canonical_evidence(),
+            identity_generation: 5,
+        }
+    }
+
+    const NONCE: [u8; 32] = [0x81; 32];
+    const BOOT_ID: [u8; 16] = [0x83; 16];
+
+    fn fixture(dir: &Path) -> (Pir2SealedReceiptVerifyArgs, VerifiedPir2SealedReleaseV1) {
+        let operator = SigningKey::from_bytes(&[0x61; 32]);
+        let release_bytes =
+            encode_signed_pir2_sealed_release_v1(&release_claims(), &operator).unwrap();
+        let release = VerifiedPir2SealedReleaseV1::decode_and_verify(
+            &release_bytes,
+            &operator.verifying_key(),
+        )
+        .unwrap();
+        let material = Pir2SealedSigningMaterialV1::from_seed(&[0x71; 32]);
+        let claims = Pir2SealedReceiptClaimsV1::for_release(
+            &release,
+            Pir2SealedReceiptPhaseV1::Enroll,
+            45,
+            NONCE,
+            [0x82; 32],
+            BOOT_ID,
+            Some(&material),
+        )
+        .unwrap();
+        let receipt = Pir2SealedReceiptV1::request(&release, claims, &ReportProviderV1).unwrap();
+        let receipt_bytes = receipt.encode().unwrap();
+        let release_path = dir.join("release.bin");
+        let receipt_path = dir.join("enroll.receipt.bin");
+        fs::write(&release_path, &release_bytes).unwrap();
+        fs::write(&receipt_path, &receipt_bytes).unwrap();
+        let args = Pir2SealedReceiptVerifyArgs {
+            receipt: receipt_path,
+            release: release_path,
+            operator_pubkey_hex: hex::encode(operator.verifying_key().to_bytes()),
+            expected_phase: "enroll".to_owned(),
+            expected_ordinal: 45,
+            expected_verifier_nonce_hex: hex::encode(NONCE),
+            expected_boot_id_hex: hex::encode(BOOT_ID),
+            expected_receipt_sha256_hex: Some(hex::encode(Sha256::digest(&receipt_bytes))),
+            ark: dir.join("missing.ark"),
+            ask: dir.join("missing.ask"),
+            vcek: dir.join("missing.vcek"),
+            expected_ark_sha256_hex: hex::encode([3_u8; 32]),
+        };
+        (args, release)
+    }
+
+    #[test]
+    fn accepted_bindings_fail_closed_at_the_amd_chain() {
+        let dir = tempfile::tempdir().unwrap();
+        let (args, _) = fixture(dir.path());
+        let error = run(args).unwrap_err();
+        assert!(error.contains("AMD ARK"), "{error}");
+    }
+
+    #[test]
+    fn expectation_mismatches_are_rejected_before_any_certificate_read() {
+        let dir = tempfile::tempdir().unwrap();
+        type Mutation = fn(&mut Pir2SealedReceiptVerifyArgs);
+        let cases: [(&str, Mutation); 6] = [
+            ("phase", |a| a.expected_phase = "probe".to_owned()),
+            ("ordinal", |a| a.expected_ordinal = 46),
+            ("nonce", |a| {
+                a.expected_verifier_nonce_hex = hex::encode([0x91_u8; 32])
+            }),
+            ("boot ID", |a| {
+                a.expected_boot_id_hex = hex::encode([0x93_u8; 16])
+            }),
+            ("receipt SHA-256", |a| {
+                a.expected_receipt_sha256_hex = Some(hex::encode([0_u8; 32]))
+            }),
+            ("operator key", |a| {
+                a.operator_pubkey_hex = hex::encode(
+                    SigningKey::from_bytes(&[0x62; 32])
+                        .verifying_key()
+                        .to_bytes(),
+                )
+            }),
+        ];
+        for (label, mutate) in cases {
+            let (mut args, _) = fixture(dir.path());
+            mutate(&mut args);
+            let error = run(args).unwrap_err();
+            assert!(
+                !error.contains("AMD"),
+                "{label}: reached the AMD chain: {error}"
+            );
+            assert!(
+                error.contains(label) || error.contains("release"),
+                "{label}: unexpected error {error}"
+            );
+            fs::remove_file(dir.path().join("release.bin")).unwrap();
+            fs::remove_file(dir.path().join("enroll.receipt.bin")).unwrap();
+        }
+    }
+
+    #[test]
+    fn claims_must_bind_the_release_and_its_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_, release) = fixture(dir.path());
+        let material = Pir2SealedSigningMaterialV1::from_seed(&[0x71; 32]);
+        let claims = Pir2SealedReceiptClaimsV1::for_release(
+            &release,
+            Pir2SealedReceiptPhaseV1::Probe,
+            46,
+            NONCE,
+            [0x82; 32],
+            BOOT_ID,
+            Some(&material),
+        )
+        .unwrap();
+        assert!(check_claims(
+            &claims,
+            &release,
+            Pir2SealedReceiptPhaseV1::Probe,
+            46,
+            NONCE,
+            BOOT_ID
+        )
+        .is_ok());
+
+        let mut other_release = claims.clone();
+        other_release.release_artifact_digest[0] ^= 1;
+        let error = check_claims(
+            &other_release,
+            &release,
+            Pir2SealedReceiptPhaseV1::Probe,
+            46,
+            NONCE,
+            BOOT_ID,
+        )
+        .unwrap_err();
+        assert!(error.contains("different release"), "{error}");
+
+        let mut other_generation = claims.clone();
+        other_generation.identity_generation = 4;
+        let error = check_claims(
+            &other_generation,
+            &release,
+            Pir2SealedReceiptPhaseV1::Probe,
+            46,
+            NONCE,
+            BOOT_ID,
+        )
+        .unwrap_err();
+        assert!(error.contains("generation"), "{error}");
+
+        // y = 2 has no square root on the curve, so this is not a point.
+        let mut bad_key = claims;
+        bad_key.public_keys.service_identity = [0; 32];
+        bad_key.public_keys.service_identity[0] = 2;
+        let error = check_claims(
+            &bad_key,
+            &release,
+            Pir2SealedReceiptPhaseV1::Probe,
+            46,
+            NONCE,
+            BOOT_ID,
+        )
+        .unwrap_err();
+        assert!(error.contains("Ed25519"), "{error}");
+    }
+}

--- a/apps/admin/src/pir2_sealed_release.rs
+++ b/apps/admin/src/pir2_sealed_release.rs
@@ -23,7 +23,7 @@ use sha2::{Digest as _, Sha256};
 const MAX_UKI_LEN: usize = 256 * 1024 * 1024;
 const MAX_OVMF_LEN: usize = 64 * 1024 * 1024;
 const MAX_CERT_LEN: usize = 128 * 1024;
-const MAX_RELEASE_LEN: usize = 4096;
+pub(crate) const MAX_RELEASE_LEN: usize = 4096;
 
 const REQUIRED_VCPUS: u32 = 4;
 const REQUIRED_VCPU_SIGNATURE: u32 = 0x00B1_0F10;
@@ -187,7 +187,7 @@ pub fn run(args: Pir2SealedReleaseArgs) -> Result<(), String> {
         snp: args.minimum_tcb_snp,
         microcode: args.minimum_tcb_microcode,
     };
-    validate_verified_observation(
+    validate_signed_report_against_pins(
         &report,
         expected_report_data,
         measurement,
@@ -216,7 +216,7 @@ pub fn run(args: Pir2SealedReleaseArgs) -> Result<(), String> {
     Ok(())
 }
 
-fn verify_offline_report(
+pub(crate) fn verify_offline_report(
     report_bytes: &[u8],
     ark_path: &Path,
     ask_path: &Path,
@@ -261,7 +261,7 @@ fn validate_launch_tuple(
     Ok(())
 }
 
-fn validate_report_cpu(report: &SnpReport) -> Result<(), String> {
+pub(crate) fn validate_report_cpu(report: &SnpReport) -> Result<(), String> {
     if report.cpuid_fam_id != Some(REQUIRED_CPU_FAMILY)
         || report.cpuid_mod_id != Some(REQUIRED_CPU_MODEL)
         || report.cpuid_step != Some(REQUIRED_CPU_STEPPING)
@@ -319,7 +319,9 @@ fn compute_exact_launch_measurement(
         .map_err(|_| "exact launch measurement has the wrong length".to_owned())
 }
 
-fn validate_verified_observation(
+/// Shared by the release command (Observe) and the phase-receipt verifier:
+/// REPORT_DATA, measurement, full guest policy, and TCB floor.
+pub(crate) fn validate_signed_report_against_pins(
     report: &SnpReport,
     expected_report_data: [u8; 64],
     measurement: [u8; 48],
@@ -397,7 +399,7 @@ fn parse_hex_u64(value: &str, label: &str) -> Result<u64, String> {
     u64::from_str_radix(value, 16).map_err(|_| format!("{label} is not valid hexadecimal"))
 }
 
-fn parse_fixed_hex<const N: usize>(value: &str, label: &str) -> Result<[u8; N], String> {
+pub(crate) fn parse_fixed_hex<const N: usize>(value: &str, label: &str) -> Result<[u8; N], String> {
     let value = value.strip_prefix("0x").unwrap_or(value);
     if value.len() != N * 2 {
         return Err(format!("{label} must contain exactly {} hex digits", N * 2));
@@ -436,7 +438,7 @@ fn public_file_snapshot_v1(stat: &rustix::fs::Stat) -> PublicFileSnapshotV1 {
 }
 
 #[cfg(unix)]
-fn read_public_bounded(path: &Path, max: usize, label: &str) -> Result<Vec<u8>, String> {
+pub(crate) fn read_public_bounded(path: &Path, max: usize, label: &str) -> Result<Vec<u8>, String> {
     use rustix::fs::{self as rustix_fs, FileType, Mode, OFlags};
 
     let fd = rustix_fs::open(
@@ -470,7 +472,7 @@ fn read_public_bounded(path: &Path, max: usize, label: &str) -> Result<Vec<u8>, 
 }
 
 #[cfg(not(unix))]
-fn read_public_bounded(path: &Path, max: usize, label: &str) -> Result<Vec<u8>, String> {
+pub(crate) fn read_public_bounded(path: &Path, max: usize, label: &str) -> Result<Vec<u8>, String> {
     let _ = (path, max);
     Err(format!(
         "reading {label} requires a local Unix/POSIX filesystem"
@@ -753,7 +755,7 @@ mod tests {
         let report = verified_report();
         let claims = release_claims();
 
-        assert!(validate_verified_observation(
+        assert!(validate_signed_report_against_pins(
             &report,
             [0x45; 64],
             claims.expected_measurement,
@@ -763,7 +765,7 @@ mod tests {
         .is_err());
         let mut wrong_measurement = claims.expected_measurement;
         wrong_measurement[0] ^= 1;
-        assert!(validate_verified_observation(
+        assert!(validate_signed_report_against_pins(
             &report,
             report.report_data,
             wrong_measurement,
@@ -771,7 +773,7 @@ mod tests {
             claims.minimum_tcb,
         )
         .is_err());
-        assert!(validate_verified_observation(
+        assert!(validate_signed_report_against_pins(
             &report,
             report.report_data,
             claims.expected_measurement,
@@ -782,7 +784,7 @@ mod tests {
         let mut missing_reserved_one = report;
         missing_reserved_one.policy =
             sev::firmware::guest::GuestPolicy::from_bytes(&0_u64.to_le_bytes()).unwrap();
-        assert!(validate_verified_observation(
+        assert!(validate_signed_report_against_pins(
             &missing_reserved_one,
             missing_reserved_one.report_data,
             claims.expected_measurement,

--- a/crates/protocol/runtime/src/snp_sealed_secrets.rs
+++ b/crates/protocol/runtime/src/snp_sealed_secrets.rs
@@ -728,7 +728,10 @@ pub struct Pir2SealedSigningMaterialV1 {
 }
 
 impl Pir2SealedSigningMaterialV1 {
-    fn from_seed(service_identity_seed: &[u8; 32]) -> Self {
+    /// Derive the signing material for one service identity seed. The
+    /// measured runtime calls this after unsealing; offline tooling uses it
+    /// only in tests, never with a production seed.
+    pub fn from_seed(service_identity_seed: &[u8; 32]) -> Self {
         let service_identity = SigningKey::from_bytes(service_identity_seed);
         let fingerprints = fingerprints_for_key_v1(&service_identity);
         Self {
@@ -994,6 +997,42 @@ pub enum Pir2SealedReceiptPhaseV1 {
     Ready = 4,
 }
 
+impl Pir2SealedReceiptPhaseV1 {
+    /// Wire byte to phase; unknown bytes are rejected rather than mapped.
+    pub fn from_wire(byte: u8) -> Result<Self, SnpSealedSecretsErrorV1> {
+        match byte {
+            1 => Ok(Self::Observe),
+            2 => Ok(Self::Enroll),
+            3 => Ok(Self::Probe),
+            4 => Ok(Self::Ready),
+            _ => Err(SnpSealedSecretsErrorV1::InvalidReceipt(
+                "unknown receipt phase",
+            )),
+        }
+    }
+
+    /// Lowercase name shared with `startup.env` and operator tooling.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Observe => "observe",
+            Self::Enroll => "enroll",
+            Self::Probe => "probe",
+            Self::Ready => "ready",
+        }
+    }
+
+    /// Inverse of [`Self::name`].
+    pub fn parse_name(name: &str) -> Option<Self> {
+        match name {
+            "observe" => Some(Self::Observe),
+            "enroll" => Some(Self::Enroll),
+            "probe" => Some(Self::Probe),
+            "ready" => Some(Self::Ready),
+            _ => None,
+        }
+    }
+}
+
 /// Canonical non-secret receipt claims. The verifier nonce, channel key and
 /// boot ID jointly prevent a successful receipt from an earlier boot from
 /// authorizing this process.
@@ -1079,6 +1118,55 @@ impl Pir2SealedReceiptClaimsV1 {
             ));
         }
         Ok(())
+    }
+
+    /// Strict inverse of `encode_claims`: fixed layout, validated contract,
+    /// and byte-for-byte canonical re-encoding.
+    fn decode_claims(bytes: &[u8]) -> Result<Self, SnpSealedSecretsErrorV1> {
+        let truncated = |_| SnpSealedSecretsErrorV1::InvalidReceipt("receipt claims are truncated");
+        let mut decoder = DecoderV1::new(bytes);
+        let phase =
+            Pir2SealedReceiptPhaseV1::from_wire(decoder.u8("receipt phase").map_err(truncated)?)?;
+        let ordinal = decoder.u64("receipt ordinal").map_err(truncated)?;
+        let verifier_nonce = decoder.array("verifier nonce").map_err(truncated)?;
+        let current_channel_pubkey = decoder
+            .array("current channel public key")
+            .map_err(truncated)?;
+        let boot_id = decoder.array("boot ID").map_err(truncated)?;
+        let release_artifact_digest = decoder
+            .array("release artifact digest")
+            .map_err(truncated)?;
+        let service_identity_key = decoder
+            .array("service identity public key")
+            .map_err(truncated)?;
+        let service_identity_fingerprint = decoder
+            .array("service identity fingerprint")
+            .map_err(truncated)?;
+        let identity_generation = decoder.u64("identity generation").map_err(truncated)?;
+        decoder.finish().map_err(|_| {
+            SnpSealedSecretsErrorV1::InvalidReceipt("receipt claims have trailing bytes")
+        })?;
+        let claims = Self {
+            phase,
+            ordinal,
+            verifier_nonce,
+            current_channel_pubkey,
+            boot_id,
+            release_artifact_digest,
+            public_keys: Pir2SealedPublicKeysV1 {
+                service_identity: service_identity_key,
+            },
+            public_fingerprints: Pir2SealedPublicFingerprintsV1 {
+                service_identity: service_identity_fingerprint,
+            },
+            identity_generation,
+        };
+        if claims.encode_claims()? != bytes {
+            return Err(SnpSealedSecretsErrorV1::InvalidReceipt(
+                "receipt claims are not canonical",
+            ));
+        }
+        Ok(claims)
     }
 
     fn encode_claims(&self) -> Result<Vec<u8>, SnpSealedSecretsErrorV1> {
@@ -1188,6 +1276,85 @@ impl Pir2SealedReceiptV1 {
         out.extend_from_slice(&report_len.to_le_bytes());
         out.extend_from_slice(&self.fresh_report.raw_report);
         Ok(out)
+    }
+}
+
+/// Encoded length of [`Pir2SealedReceiptClaimsV1`].
+const SEALED_RECEIPT_CLAIMS_LEN_V1: usize = 1 + 8 + 32 + 32 + 16 + 32 + 32 + 32 + 8;
+/// Bound for a persisted receipt file: header, claims, and the largest fresh
+/// report the runtime accepts.
+pub const MAX_SEALED_RECEIPT_FILE_LEN_V1: usize = SEALED_RECEIPT_MAGIC_V1.len()
+    + 2
+    + 4
+    + SEALED_RECEIPT_CLAIMS_LEN_V1
+    + 4
+    + MAX_FRESH_SNP_REPORT_LEN_V1;
+
+/// A persisted phase receipt as an offline verifier reads it back: the
+/// canonical claims plus the exact raw SNP report bytes. Decoding checks the
+/// magic, codec, lengths, claim contract, canonical re-encoding, and that the
+/// raw report's `REPORT_DATA` carries the claims digest. It verifies neither
+/// the AMD chain nor the report signature; the operator command does.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Pir2SealedReceiptFileV1 {
+    pub claims: Pir2SealedReceiptClaimsV1,
+    pub raw_report: Vec<u8>,
+}
+
+impl Pir2SealedReceiptFileV1 {
+    pub fn decode(exact_bytes: &[u8]) -> Result<Self, SnpSealedSecretsErrorV1> {
+        use SnpSealedSecretsErrorV1::InvalidReceipt;
+        if exact_bytes.len() > MAX_SEALED_RECEIPT_FILE_LEN_V1 {
+            return Err(InvalidReceipt("receipt exceeds its source bound"));
+        }
+        let mut decoder = DecoderV1::new(exact_bytes);
+        decoder
+            .exact(SEALED_RECEIPT_MAGIC_V1, "receipt magic")
+            .map_err(|_| InvalidReceipt("invalid receipt magic"))?;
+        if decoder
+            .u16("receipt codec")
+            .map_err(|_| InvalidReceipt("truncated receipt codec"))?
+            != SEALED_CODEC_VERSION
+        {
+            return Err(InvalidReceipt("unsupported sealed receipt codec"));
+        }
+        let claims_len = decoder
+            .u32("receipt claims length")
+            .map_err(|_| InvalidReceipt("truncated receipt claims length"))?;
+        if usize::try_from(claims_len).ok() != Some(SEALED_RECEIPT_CLAIMS_LEN_V1) {
+            return Err(InvalidReceipt("receipt claims length is not canonical"));
+        }
+        let claims_bytes = decoder
+            .bytes(SEALED_RECEIPT_CLAIMS_LEN_V1, "receipt claims")
+            .map_err(|_| InvalidReceipt("truncated receipt claims"))?;
+        let report_len = usize::try_from(
+            decoder
+                .u32("fresh report length")
+                .map_err(|_| InvalidReceipt("truncated fresh report length"))?,
+        )
+        .map_err(|_| InvalidReceipt("fresh report length overflow"))?;
+        if report_len == 0 || report_len > MAX_FRESH_SNP_REPORT_LEN_V1 {
+            return Err(InvalidReceipt(
+                "fresh SNP report bytes are absent or oversized",
+            ));
+        }
+        let raw_report = decoder
+            .bytes(report_len, "fresh report")
+            .map_err(|_| InvalidReceipt("truncated fresh SNP report"))?
+            .to_vec();
+        decoder
+            .finish()
+            .map_err(|_| InvalidReceipt("receipt has trailing bytes"))?;
+        let claims = Pir2SealedReceiptClaimsV1::decode_claims(claims_bytes)?;
+        let embedded = pir_core::attest::extract_report_data(&raw_report).ok_or(InvalidReceipt(
+            "fresh SNP report is too short for REPORT_DATA",
+        ))?;
+        if embedded != claims.report_data()? {
+            return Err(InvalidReceipt(
+                "fresh SNP REPORT_DATA does not bind the receipt digest",
+            ));
+        }
+        Ok(Self { claims, raw_report })
     }
 }
 
@@ -2284,7 +2451,9 @@ mod tests {
         old_codec[8..10].copy_from_slice(&1_u16.to_le_bytes());
         assert!(matches!(
             VerifiedPir2SealedReleaseV1::decode_and_verify(&old_codec, &operator.verifying_key()),
-            Err(SnpSealedSecretsErrorV1::InvalidRelease("unsupported sealed release codec"))
+            Err(SnpSealedSecretsErrorV1::InvalidRelease(
+                "unsupported sealed release codec"
+            ))
         ));
     }
 
@@ -2369,6 +2538,64 @@ mod tests {
         let mut old_channel = claims;
         old_channel.current_channel_pubkey[0] ^= 1;
         assert!(receipt.verify_binding(&old_channel).is_err());
+    }
+
+    #[test]
+    fn persisted_receipt_decodes_canonically_and_rejects_tampering() {
+        let (verified, _) = verified_release();
+        let material = Pir2SealedSigningMaterialV1::from_seed(&[0x71; 32]);
+        let claims = Pir2SealedReceiptClaimsV1::for_release(
+            &verified,
+            Pir2SealedReceiptPhaseV1::Enroll,
+            45,
+            [0x81; 32],
+            [0x82; 32],
+            [0x83; 16],
+            Some(&material),
+        )
+        .unwrap();
+        let provider = MockProviderV1::good(verified.release(), [0x42; 32]);
+        let receipt = Pir2SealedReceiptV1::request(&verified, claims.clone(), &provider).unwrap();
+        let encoded = receipt.encode().unwrap();
+        assert!(encoded.len() <= MAX_SEALED_RECEIPT_FILE_LEN_V1);
+
+        let decoded = Pir2SealedReceiptFileV1::decode(&encoded).unwrap();
+        assert_eq!(decoded.claims, claims);
+        assert_eq!(decoded.raw_report, receipt.fresh_report.raw_report);
+        assert_eq!(decoded.claims.phase.name(), "enroll");
+        assert_eq!(
+            Pir2SealedReceiptPhaseV1::parse_name("ready"),
+            Some(Pir2SealedReceiptPhaseV1::Ready)
+        );
+        assert_eq!(Pir2SealedReceiptPhaseV1::parse_name("Ready"), None);
+        assert!(Pir2SealedReceiptPhaseV1::from_wire(5).is_err());
+
+        // Header, claims, and REPORT_DATA bytes are all bound by decode alone;
+        // the report signature is the offline AMD-chain verifier's job.
+        let claims_start = SEALED_RECEIPT_MAGIC_V1.len() + 2 + 4;
+        let report_start = claims_start + SEALED_RECEIPT_CLAIMS_LEN_V1 + 4;
+        for index in [
+            0,
+            SEALED_RECEIPT_MAGIC_V1.len(),
+            claims_start - 1,
+            claims_start,
+            claims_start + 9,
+            claims_start + SEALED_RECEIPT_CLAIMS_LEN_V1 - 1,
+            report_start + 0x50,
+        ] {
+            let mut tampered = encoded.clone();
+            tampered[index] ^= 1;
+            assert!(
+                Pir2SealedReceiptFileV1::decode(&tampered).is_err(),
+                "byte {index} was not bound"
+            );
+        }
+        let mut truncated = encoded.clone();
+        truncated.pop();
+        assert!(Pir2SealedReceiptFileV1::decode(&truncated).is_err());
+        let mut extended = encoded.clone();
+        extended.push(0);
+        assert!(Pir2SealedReceiptFileV1::decode(&extended).is_err());
     }
 
     #[test]

--- a/docs/PRODUCTION_OPERATIONS.md
+++ b/docs/PRODUCTION_OPERATIONS.md
@@ -376,6 +376,7 @@ do not leave a mixed fleet.
 | Check pir2 after a switch | [VPSBG image](runbooks/vpsbg-image.md) | `scripts/pir2-post-switch-check.sh` | `PASS action=post_switch_check` |
 | Publish the web client | this page, Flow C | `deploy-web.yml` dispatch | deploy job green |
 | Run the pir2 sealed release | [Sealed release](runbooks/pir2-sealed-release.md) | `scripts/pir2-sealed-ceremony.sh` | `PASS sealed_release` or `PASS sealed_phase_config=...` |
+| Accept an Enroll, Probe, or Ready receipt | [Sealed release](runbooks/pir2-sealed-release.md) | `scripts/pir2-sealed-ceremony.sh receipt` | `PASS pir2_sealed_receipt_verify` |
 
 Paid access (cashier-signed session grants, outside the measured image) is
 described in [`SESSION_GRANTS.md`](SESSION_GRANTS.md); the retired Payment V1

--- a/docs/runbooks/pir2-sealed-release.md
+++ b/docs/runbooks/pir2-sealed-release.md
@@ -64,13 +64,27 @@ together:
 - for non-Observe phases, a valid Ed25519 service identity public key, its
   fingerprint, and the identity generation.
 
-The repository currently has a dedicated verifier for the fixed Observe
-receipt as part of `bpir-admin pir2-sealed-release`, but no generic offline
-decoder/verifier command for Enroll, Probe, or Ready receipts. Do not treat a
-successful hex/field parser, the status JSON, or a file hash as a substitute.
-Until a reviewed repository command exists, stop after downloading the receipt
-and use a reviewed offline verifier that performs the checks above before
-constructing identity or accounting artifacts.
+The pre-release Observe receipt is verified inside `bpir-admin
+pir2-sealed-release`. Every later receipt is accepted with the reviewed
+repository command, which runs exactly the checks above and prints the
+enrolled service identity public key:
+
+```sh
+scripts/pir2-sealed-ceremony.sh receipt \
+  --receipt /absolute/enroll.receipt.bin --release /absolute/release.bin \
+  --operator-pubkey-hex HEX64 \
+  --expected-phase enroll --expected-ordinal ORDINAL \
+  --expected-verifier-nonce-hex HEX64 --expected-boot-id-hex HEX32 \
+  --expected-receipt-sha256-hex HEX64 \
+  --ark ark.pem --ask ask.pem --vcek vcek.pem --expected-ark-sha256-hex HEX64
+```
+
+Take the ordinal and nonce from the phase's own `startup.env`, the boot ID
+and receipt hash from its status JSON or persisted marker, and the operator
+key from the source pin. A successful run prints `PASS
+pir2_sealed_receipt_verify` and `NEXT_STEP`; anything else is rejecting
+evidence. Do not treat a hex/field parser, the status JSON, or a file hash
+as a substitute for this command.
 
 Ready writes two receipts for the same boot: `ready-preflight-BOOT.bin` before
 ORAM access and `ready-runtime-BOOT.bin` when the final server opens the sealed

--- a/scripts/pir2-sealed-ceremony.sh
+++ b/scripts/pir2-sealed-ceremony.sh
@@ -3,18 +3,21 @@
 set -euo pipefail
 usage() { cat <<'EOF'
 usage: scripts/pir2-sealed-ceremony.sh release [bpir-admin pir2-sealed-release options] [--dry-run]
+       scripts/pir2-sealed-ceremony.sh receipt [bpir-admin pir2-sealed-receipt-verify options] [--dry-run]
        scripts/pir2-sealed-ceremony.sh phase \
          --phase observe|enroll|probe|ready --out PATH --ordinal NON_ZERO \
          --verifier-nonce-hex HEX64 [--dry-run]
 
 `release` forwards its options exactly to `bpir-admin pir2-sealed-release`.
+`receipt` forwards its options exactly to `bpir-admin pir2-sealed-receipt-verify`,
+the offline acceptance of an Enroll, Probe, or Ready receipt.
 `phase` writes the public, canonical-v3 startup.env consumed by the measured
 UKI. --dry-run never reads a signing key, release input, or host state.
 EOF
 }
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 action=${1:-}; [[ "$action" != --help && "$action" != -h ]] || { usage; exit 0; }
-[[ "$action" =~ ^(release|phase)$ ]] || { usage >&2; exit 2; }; shift || true
+[[ "$action" =~ ^(release|phase|receipt)$ ]] || { usage >&2; exit 2; }; shift || true
 if [[ "$action" == phase ]]; then
   dry_run=0
   phase= out= ordinal= verifier_nonce_hex=
@@ -82,11 +85,27 @@ while (($#)); do
     *) args+=("$1"); shift ;;
   esac
 done
+if [[ "$action" == receipt ]]; then
+  subcommand=pir2-sealed-receipt-verify
+else
+  subcommand=pir2-sealed-release
+fi
 if ((${#args[@]})) && [[ "${args[0]}" == --help || "${args[0]}" == -h ]]; then
-  (cd "$root" && exec cargo run --locked --offline -p bpir-admin -- pir2-sealed-release --help)
+  (cd "$root" && exec cargo run --locked --offline -p bpir-admin -- "$subcommand" --help)
   exit $?
 fi
-cmd=(cargo run --locked --offline -p bpir-admin -- pir2-sealed-release "${args[@]}")
+cmd=(cargo run --locked --offline -p bpir-admin -- "$subcommand" "${args[@]}")
+if [[ "$action" == receipt ]]; then
+  if ((dry_run)); then
+    echo '[stage] sealed receipt acceptance command preview'; printf 'COMMAND='; printf '%q ' "${cmd[@]}"; echo
+    echo 'PASS sealed_receipt_verify dry_run=true'
+    echo 'NEXT_STEP=run without --dry-run once the receipt, its status hash, and boot ID are downloaded'
+    exit 0
+  fi
+  echo '[stage] accept sealed phase receipt against the operator-signed release'
+  (cd "$root" && "${cmd[@]}")
+  exit 0
+fi
 if ((dry_run)); then
   echo '[stage] sealed release command preview'; printf 'COMMAND='; printf '%q ' "${cmd[@]}"; echo
   echo 'PASS sealed_release dry_run=true'


### PR DESCRIPTION
Flow B change required by the authorized R5 production campaign (Flow E + G): the sealed-release runbook says Enroll, Probe, and Ready receipts must be accepted by an offline verifier before any identity artifact is signed from them, and that "until a reviewed repository command exists" operators must stop. The verifier used for epoch 5 was a throwaway package whose source and binary no longer exist. This PR adds the repository command.

## `bpir-admin pir2-sealed-receipt-verify`

Offline and fail-closed; reads no secret (the operator key is the public source pin). Checks, in order:

1. the release decodes and verifies under `--operator-pubkey-hex`;
2. the receipt file is canonical (magic, codec, lengths, claim contract, `REPORT_DATA` carries the claims digest) and, with `--expected-receipt-sha256-hex`, equals the hash the phase status JSON declared — the Cloudflare cached-receipt failure from the epoch-5 incident is rejected here;
3. the claims carry `--expected-phase / --expected-ordinal / --expected-verifier-nonce-hex / --expected-boot-id-hex`, bind this exact release (`release_artifact_digest`) and repeat its identity generation; for non-Observe phases the service identity key is a valid Ed25519 point;
4. AMD ARK pin, ARK → ASK → VCEK chain, SNP report signature;
5. `REPORT_DATA`, Turin CPUID, measurement, full guest policy, and TCB floor against the release.

Steps 4–5 are the existing `pir2-sealed-release` functions (`verify_offline_report`, `validate_report_cpu`, `validate_signed_report_against_pins` — renamed from `validate_verified_observation`, now shared), not new code. Output: `PASS pir2_sealed_receipt_verify phase=… ordinal=… identity_generation=… stable_server_id=… boot_id_hex=… current_channel_pubkey_hex=… service_identity_pubkey_hex=… service_identity_fingerprint_hex=… measurement_hex=…` plus a phase-specific `NEXT_STEP` (Enroll → `sign-identity` for the printed key).

`scripts/pir2-sealed-ceremony.sh receipt …` forwards to it like `release` does.

## Runtime crate

`Pir2SealedReceiptFileV1::decode` — strict inverse of the receipt encoder the guest already uses (magic, codec 2, exact claims length, canonical claims re-encoding, report length bound, `REPORT_DATA` binding); `Pir2SealedReceiptPhaseV1::{from_wire, name, parse_name}`; `Pir2SealedSigningMaterialV1::from_seed` made public for offline test fixtures. No wire format changes.

## Docs

`docs/runbooks/pir2-sealed-release.md` receipt-acceptance section now names the command; `docs/PRODUCTION_OPERATIONS.md` command index row.

## Verification

- `cargo test --locked --offline -p pir-runtime-core snp_sealed` — 14 passed (new: `persisted_receipt_decodes_canonically_and_rejects_tampering`, header/claims/REPORT_DATA byte flips, truncation, extension)
- `cargo test --locked --offline -p bpir-admin pir2_sealed` — 10 passed (3 new: accepted bindings fail closed at the AMD chain; phase / ordinal / nonce / boot ID / receipt hash / operator key mismatches are rejected before any certificate is read; claims must bind the release, its generation, and a valid identity point); `cli_tests` — 1 passed
- `cargo clippy --locked --offline --all-targets --no-deps -p bpir-admin -- -D warnings` — clean; `cargo clippy -p pir-runtime-core` fails only on the four pre-existing lints in `admin.rs` / `eval.rs` (untouched)
- `rustfmt --check` clean; `bash -n scripts/pir2-sealed-ceremony.sh` and `receipt … --dry-run` preview OK
- Not exercised here: a real Turin receipt against the AMD chain — that is the production Enroll step this command exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
