### PR TITLE
docs: link the cashier contract to Bitcoin-PIR/cashier

### DIFF
--- a/docs/CASHIER_API.md
+++ b/docs/CASHIER_API.md
@@ -1,9 +1,9 @@
 # Cashier HTTP contract (v1)
 
 The cashier sells [session grants](SESSION_GRANTS.md) for Cashu ecash. It is
-operator-run, lives in its own repository under the Bitcoin-PIR
-organisation, and is the only component that holds the grant signing key or
-talks to a mint. The PIR servers pin its **public** key; the browser pins
+operator-run, lives in its own repository
+([Bitcoin-PIR/cashier](https://github.com/Bitcoin-PIR/cashier)), and is the
+only component that holds the grant signing key or talks to a mint. The PIR servers pin its **public** key; the browser pins
 its **URL** (`PRODUCTION_CASHIER_URL` in `web/src/constants.ts`). This page
 is the contract both sides code against; the implementation is free to add
 fields, never to change the meaning of the ones below.

--- a/docs/SESSION_GRANTS.md
+++ b/docs/SESSION_GRANTS.md
@@ -10,7 +10,7 @@ retired and never reassigned.
 
 | Role | Where | Holds |
 | --- | --- | --- |
-| Cashier | separate repository under the Bitcoin-PIR organisation; operator-run, outside the PIR hosts | payment integration (Cashu ecash, Lightning, …) and the grant signing key |
+| Cashier | [Bitcoin-PIR/cashier](https://github.com/Bitcoin-PIR/cashier); operator-run, outside the PIR hosts | payment integration (Cashu ecash, Lightning, …) and the grant signing key |
 | PIR server (`unified_server`) | pir1 / pir2 | the cashier's **public** key(s) and an in-memory credit ledger |
 | Client | browser / SDK | buys a grant from the cashier and presents it once per connection |
 


### PR DESCRIPTION
The cashier implementation now lives at https://github.com/Bitcoin-PIR/cashier (bpir-cashier v0.1.0: cdk wallet swap, deterministic grant ids, JSON-lines idempotency store, contract error codes). This links the two docs that described it as "its own repository".

🤖 Generated with [Claude Code](https://claude.com/claude-code)