### PR TITLE
web: call the cashier fetch implementation unbound (Illegal invocation)

### DIFF
--- a/web/src/__tests__/session-grant.test.ts
+++ b/web/src/__tests__/session-grant.test.ts
@@ -277,3 +277,37 @@ describe('PendingPurchaseStore', () => {
     expect(storage.size()).toBe(0);
   });
 });
+
+describe('CashierClient fetch binding', () => {
+  it('never invokes the fetch implementation as a method of the client', async () => {
+    let receiver: unknown = 'unset';
+    const fake = function (this: unknown): Promise<Response> {
+      receiver = this;
+      return Promise.resolve(
+        new Response(JSON.stringify({ service: 'bitcoinpir-cashier', version: 1, cashier_pubkey_hex: 'ab'.repeat(32), mints: ['https://mint.example'], offers: [{ credits: 1, amount: 1, unit: 'sat' }], grant_ttl_secs: 60 }), { status: 200, headers: { 'content-type': 'application/json' } }),
+      );
+    } as unknown as typeof fetch;
+    const client = new CashierClient('https://cashier.example', fake);
+    await client.info();
+    // A native `fetch` called with any receiver other than the global throws
+    // "Illegal invocation" in browsers; the client must call it unbound.
+    expect(receiver === client).toBe(false);
+    expect(receiver === undefined || receiver === globalThis).toBe(true);
+  });
+
+  it('uses a wrapper around the global fetch by default', async () => {
+    const original = globalThis.fetch;
+    let receiver: unknown = 'unset';
+    globalThis.fetch = function (this: unknown): Promise<Response> {
+      receiver = this;
+      return Promise.resolve(new Response('{}', { status: 500 }));
+    } as unknown as typeof fetch;
+    try {
+      const client = new CashierClient('https://cashier.example');
+      await expect(client.info()).rejects.toThrow(/cashier responded 500/);
+      expect(receiver === globalThis).toBe(true);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});

--- a/web/src/session-grant.ts
+++ b/web/src/session-grant.ts
@@ -328,9 +328,13 @@ export class CashierClient {
       throw new Error('cashier URL must be https:// (or a loopback http:// for development)');
     }
     this.baseUrl = baseUrl.replace(/\/+$/, '');
-    const impl = fetchImpl ?? (globalThis as { fetch?: typeof fetch }).fetch;
-    if (!impl) throw new Error('fetch is unavailable in this environment');
-    this.fetchImpl = impl;
+    // Never store the native `fetch` itself: calling it as a method of this
+    // object (`this.fetchImpl(...)`) makes the browser throw "Illegal
+    // invocation". The default is a wrapper that calls the global with the
+    // global receiver; an injected implementation is invoked unbound below.
+    const native = (globalThis as { fetch?: typeof fetch }).fetch;
+    if (!fetchImpl && !native) throw new Error('fetch is unavailable in this environment');
+    this.fetchImpl = fetchImpl ?? ((input, init) => native!.call(globalThis, input, init));
   }
 
   async info(): Promise<CashierInfo> {
@@ -354,8 +358,9 @@ export class CashierClient {
     const headers: Record<string, string> = { accept: 'application/json' };
     if (json !== undefined) headers['content-type'] = 'application/json';
     let response: Response;
+    const fetchImpl = this.fetchImpl; // unbound call: `this` must not be the client
     try {
-      response = await this.fetchImpl(this.baseUrl + path, {
+      response = await fetchImpl(this.baseUrl + path, {
         method,
         headers,
         body: json === undefined ? undefined : JSON.stringify(json),


### PR DESCRIPTION
Found while verifying the live cashier: clicking **Load cashier offers** on www.bitcoinpir.org failed with `cashier unreachable: Failed to execute 'fetch' on 'Window': Illegal invocation`.

`CashierClient` kept the native `fetch` in a field and called it as `this.fetchImpl(...)`, which invokes it with the client as receiver. The default implementation is now a wrapper that calls the global `fetch` with the global receiver, and an injected implementation is called unbound. Two regression tests assert the receiver is never the client.

Verification: `cd web && npm run build && npx vitest run` (30 files, 369 tests green). After merge: dispatch the Pages deploy and re-check the card in a browser (the cashier and mint endpoints themselves answer correctly to curl with the browser origin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)