### PR TITLE
session-grant: price HarmonyPIR hint sets by compute (--session-grant-hint-credits, default 150)

### DIFF
--- a/apps/server/src/bin/unified_server/cli.rs
+++ b/apps/server/src/bin/unified_server/cli.rs
@@ -94,6 +94,9 @@ pub(crate) struct CliArgs {
     /// Reject query-bearing opcodes until a valid session grant is presented
     /// (`--require-session-grant`). Needs at least one pinned key.
     pub(crate) require_session_grant: bool,
+    /// Credits one HarmonyPIR hint set costs
+    /// (`--session-grant-hint-credits N`, default 150; query frames cost 1).
+    pub(crate) session_grant_hint_credits: u32,
     /// Measurement-bound pir2 identity dispatcher. This group is
     /// evaluated before any database, ORAM image, or listener is opened.
     pub(crate) pir2_sealed: Pir2SealedCliV1,
@@ -321,6 +324,7 @@ pub(crate) fn parse_args_from(args: Vec<String>) -> CliArgs {
     let mut harmony_pool_dbs: Vec<(u8, PathBuf)> = Vec::new();
     let mut session_grant_pubkeys: Vec<PathBuf> = Vec::new();
     let mut require_session_grant = false;
+    let mut session_grant_hint_credits: u32 = crate::session_grant::DEFAULT_HINT_SET_CREDITS;
     let mut pir2_sealed = Pir2SealedCliV1::default();
     let mut max_connections: usize = 128;
     let mut websocket_handshake_timeout_ms: u64 = 10_000;
@@ -466,6 +470,16 @@ pub(crate) fn parse_args_from(args: Vec<String>) -> CliArgs {
             }
             "--require-session-grant" => {
                 require_session_grant = true;
+            }
+            "--session-grant-hint-credits" => {
+                let Some(v) = args.get(i + 1) else {
+                    fatal_cli("--session-grant-hint-credits requires a positive integer");
+                };
+                session_grant_hint_credits = match v.parse::<u32>() {
+                    Ok(n) if n >= 1 => n,
+                    _ => fatal_cli("--session-grant-hint-credits must be an integer >= 1"),
+                };
+                i += 1;
             }
             "--max-connections" => {
                 max_connections = args
@@ -760,6 +774,7 @@ pub(crate) fn parse_args_from(args: Vec<String>) -> CliArgs {
         harmony_pool_bindings,
         session_grant_pubkeys,
         require_session_grant,
+        session_grant_hint_credits,
         pir2_sealed,
         max_connections,
         websocket_handshake_timeout_ms,

--- a/apps/server/src/bin/unified_server/serve.rs
+++ b/apps/server/src/bin/unified_server/serve.rs
@@ -369,15 +369,18 @@ pub(crate) async fn serve_connections(
                     continue;
                 }
 
-                // Session-grant gate: query-bearing variants spend one credit
-                // of the presented grant, or are refused when grants are
-                // required and none was presented. Runs after the mode gates
-                // so a frame this host does not serve never costs a credit.
+                // Session-grant gate: metered variants spend their credit cost
+                // (one per query-bearing frame, the hint-set price for a
+                // HarmonyPIR hint request) from the presented grant, or are
+                // refused when grants are required and none was presented.
+                // Runs after the mode gates so a frame this host does not
+                // serve never costs a credit.
                 if let Some(gate) = server.session_grants.as_ref() {
-                    if is_query_bearing_variant(variant) {
+                    let cost = gate.credit_cost(variant);
+                    if cost > 0 {
                         let refusal = match session_grant {
                             Some(grant_id) => current_unix_seconds_v1()
-                                .and_then(|now| gate.consume(&grant_id, now))
+                                .and_then(|now| gate.consume_n(&grant_id, cost, now))
                                 .err(),
                             None if gate.require() => Some(
                                 "session grant required — send REQ_SESSION_GRANT_PRESENT first"

--- a/apps/server/src/bin/unified_server/session_grant.rs
+++ b/apps/server/src/bin/unified_server/session_grant.rs
@@ -24,7 +24,8 @@ use runtime::onionpir::{
 };
 use runtime::protocol::{
     REQ_BUCKET_MERKLE_SIB_BATCH, REQ_BUCKET_MERKLE_TREE_TOPS, REQ_CHUNK_BATCH,
-    REQ_HARMONY_BATCH_QUERY, REQ_HARMONY_QUERY, REQ_INDEX_BATCH, REQ_ORAM_LOOKUP,
+    REQ_HARMONY_BATCH_QUERY, REQ_HARMONY_HINTS, REQ_HARMONY_HINTS_V2, REQ_HARMONY_QUERY,
+    REQ_INDEX_BATCH, REQ_ORAM_LOOKUP,
 };
 
 use crate::{read_regular_file_bounded_v1, CliArgs};
@@ -36,6 +37,25 @@ const MAX_PUBLIC_KEY_FILE_BYTES: usize = 128;
 /// when one is required. Everything else (info, ping, attest, handshake,
 /// announce, catalog, DB proofs, HarmonyPIR hints, admin, and the grant
 /// presentation itself) stays free.
+/// Credits one HarmonyPIR hint set costs unless `--session-grant-hint-credits`
+/// says otherwise. Measured on pir1 (i7-8700): regenerating one pool entry
+/// takes about 136 CPU-seconds, a metered DPF frame about 0.9, so 150 keeps
+/// hint sets priced by compute with some margin (docs/SESSION_GRANTS.md).
+pub(crate) const DEFAULT_HINT_SET_CREDITS: u32 = 150;
+
+/// Credits a request frame costs: one per query-bearing frame, the hint-set
+/// price for the two HarmonyPIR hint requests that take a pool entry
+/// (`REQ_HARMONY_HINTS`, `REQ_HARMONY_HINTS_V2`), nothing for everything
+/// else. `REQ_HARMONY_HINTS_V2_HALF` streams the second half of an entry the
+/// `_V2` request already paid for, so it is free.
+pub(crate) fn credit_cost(variant: u8, hint_set_credits: u32) -> u32 {
+    match variant {
+        REQ_HARMONY_HINTS | REQ_HARMONY_HINTS_V2 => hint_set_credits,
+        _ if is_query_bearing_variant(variant) => 1,
+        _ => 0,
+    }
+}
+
 pub(crate) fn is_query_bearing_variant(variant: u8) -> bool {
     matches!(
         variant,
@@ -62,6 +82,7 @@ pub(crate) struct SessionGrantGateV1 {
     issuers: TrustedIssuers,
     ledger: Mutex<GrantLedger>,
     require: bool,
+    hint_set_credits: u32,
 }
 
 impl SessionGrantGateV1 {
@@ -88,6 +109,7 @@ impl SessionGrantGateV1 {
             issuers,
             ledger: Mutex::new(GrantLedger::new()),
             require: args.require_session_grant,
+            hint_set_credits: args.session_grant_hint_credits,
         }))
     }
 
@@ -95,15 +117,21 @@ impl SessionGrantGateV1 {
         self.require
     }
 
+    /// Credits `variant` costs on this host (see [`credit_cost`]).
+    pub(crate) fn credit_cost(&self, variant: u8) -> u32 {
+        credit_cost(variant, self.hint_set_credits)
+    }
+
     pub(crate) fn startup_log_line(&self) -> String {
         format!(
-            "Session grants: {} ({} cashier key(s) pinned)",
+            "Session grants: {} ({} cashier key(s) pinned; query frame = 1 credit, hint set = {} credits)",
             if self.require {
                 "required for queries"
             } else {
                 "accepted, not required"
             },
-            self.issuers.len()
+            self.issuers.len(),
+            self.hint_set_credits
         )
     }
 
@@ -124,13 +152,26 @@ impl SessionGrantGateV1 {
         Ok((verified.grant_id, remaining))
     }
 
-    /// Spend one credit of an attached grant; returns the remaining credits.
-    pub(crate) fn consume(&self, grant_id: &GrantId, now: u64) -> Result<u32, String> {
+    /// Spend `credits` credits of an attached grant at once; returns the
+    /// remaining credits. A grant that cannot cover the amount is left
+    /// untouched and the error names both numbers.
+    pub(crate) fn consume_n(
+        &self,
+        grant_id: &GrantId,
+        credits: u32,
+        now: u64,
+    ) -> Result<u32, String> {
         self.ledger
             .lock()
             .unwrap()
-            .consume(grant_id, now)
+            .consume_n(grant_id, credits, now)
             .map_err(|error| format!("session grant: {error}"))
+    }
+
+    /// Spend one credit of an attached grant; returns the remaining credits.
+    #[cfg(test)]
+    pub(crate) fn consume(&self, grant_id: &GrantId, now: u64) -> Result<u32, String> {
+        self.consume_n(grant_id, 1, now)
     }
 }
 

--- a/apps/server/src/bin/unified_server/tests.rs
+++ b/apps/server/src/bin/unified_server/tests.rs
@@ -1797,7 +1797,9 @@ mod session_grant_gate {
     //! shared credit ledger behind `REQ_SESSION_GRANT_PRESENT`.
 
     use crate::parse_args_from;
-    use crate::session_grant::{is_query_bearing_variant, SessionGrantGateV1};
+    use crate::session_grant::{
+        credit_cost, is_query_bearing_variant, SessionGrantGateV1, DEFAULT_HINT_SET_CREDITS,
+    };
     use pir_session_grant::{GrantSigner, SESSION_GRANT_LEN};
     use runtime::onionpir::*;
     use runtime::protocol::*;
@@ -1819,6 +1821,106 @@ mod session_grant_gate {
         let path = dir.join(name);
         std::fs::write(&path, contents).expect("write public key file");
         path.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn hint_set_price_is_a_cli_option_with_the_measured_default() {
+        assert_eq!(DEFAULT_HINT_SET_CREDITS, 150);
+        assert_eq!(
+            args(&[]).session_grant_hint_credits,
+            DEFAULT_HINT_SET_CREDITS
+        );
+        assert_eq!(
+            args(&["--session-grant-hint-credits", "200"]).session_grant_hint_credits,
+            200
+        );
+    }
+
+    #[test]
+    fn credit_cost_prices_hint_sets_and_query_frames_only() {
+        use runtime::protocol::{
+            REQ_ANNOUNCE, REQ_ATTEST, REQ_CHUNK_BATCH, REQ_HARMONY_GET_INFO, REQ_HARMONY_HINTS,
+            REQ_HARMONY_HINTS_V2, REQ_HARMONY_HINTS_V2_HALF, REQ_HARMONY_QUERY, REQ_INDEX_BATCH,
+            REQ_ORAM_LOOKUP, REQ_SESSION_GRANT_PRESENT,
+        };
+        assert_eq!(credit_cost(REQ_HARMONY_HINTS_V2, 150), 150);
+        assert_eq!(credit_cost(REQ_HARMONY_HINTS, 150), 150);
+        assert_eq!(
+            credit_cost(REQ_HARMONY_HINTS_V2_HALF, 150),
+            0,
+            "continuation of a paid entry"
+        );
+        for query in [
+            REQ_INDEX_BATCH,
+            REQ_CHUNK_BATCH,
+            REQ_HARMONY_QUERY,
+            REQ_ORAM_LOOKUP,
+        ] {
+            assert!(is_query_bearing_variant(query));
+            assert_eq!(credit_cost(query, 150), 1);
+        }
+        for free in [
+            REQ_HARMONY_GET_INFO,
+            REQ_ATTEST,
+            REQ_ANNOUNCE,
+            REQ_SESSION_GRANT_PRESENT,
+        ] {
+            assert_eq!(credit_cost(free, 150), 0);
+        }
+        assert!(
+            !is_query_bearing_variant(REQ_HARMONY_HINTS_V2),
+            "hint requests stay hint-gated"
+        );
+    }
+
+    #[test]
+    fn hint_set_charge_is_all_or_nothing_and_names_the_shortfall() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let signer = signer();
+        let file = pubkey_file(
+            dir.path(),
+            "cashier.pub",
+            hex::encode(signer.public_key()).as_bytes(),
+        );
+        let gate = SessionGrantGateV1::from_cli(&args(&[
+            "--session-grant-pubkey",
+            &file,
+            "--session-grant-hint-credits",
+            "150",
+        ]))
+        .expect("gate")
+        .expect("present");
+        let bytes = signer
+            .issue([8u8; 16], NOW - 1, NOW + 600, 174)
+            .expect("grant")
+            .encode();
+        let (id, remaining) = gate.present(&bytes, NOW).expect("accepted");
+        assert_eq!(remaining, 174);
+        assert_eq!(
+            gate.consume_n(
+                &id,
+                gate.credit_cost(runtime::protocol::REQ_HARMONY_HINTS_V2),
+                NOW
+            ),
+            Ok(24)
+        );
+        let refused = gate
+            .consume_n(
+                &id,
+                gate.credit_cost(runtime::protocol::REQ_HARMONY_HINTS_V2),
+                NOW,
+            )
+            .unwrap_err();
+        assert!(
+            refused.contains("24 credits left") && refused.contains("needs 150"),
+            "{refused}"
+        );
+        assert_eq!(
+            gate.consume(&id, NOW),
+            Ok(23),
+            "the refused hint charge took nothing"
+        );
+        assert!(gate.startup_log_line().contains("hint set = 150 credits"));
     }
 
     #[test]
@@ -1875,7 +1977,7 @@ mod session_grant_gate {
         assert!(!gate.require());
         assert_eq!(
             gate.startup_log_line(),
-            "Session grants: accepted, not required (2 cashier key(s) pinned)"
+            "Session grants: accepted, not required (2 cashier key(s) pinned; query frame = 1 credit, hint set = 150 credits)"
         );
 
         let bad_path = pubkey_file(dir.path(), "bad.txt", b"not a key");
@@ -1921,7 +2023,7 @@ mod session_grant_gate {
         assert!(gate.require());
         assert_eq!(
             gate.startup_log_line(),
-            "Session grants: required for queries (1 cashier key(s) pinned)"
+            "Session grants: required for queries (1 cashier key(s) pinned; query frame = 1 credit, hint set = 150 credits)"
         );
         let grant = signer
             .issue([9u8; 16], NOW - 1, NOW + 600, 2)

--- a/crates/trust/session-grant/src/lib.rs
+++ b/crates/trust/session-grant/src/lib.rs
@@ -97,6 +97,9 @@ pub enum GrantError {
     LifetimeTooLong,
     /// Every credit of the grant has been spent.
     Exhausted,
+    /// The request costs more credits than the grant has left; nothing was
+    /// charged.
+    Insufficient { needed: u32, remaining: u32 },
     /// The grant id is unknown to this ledger (never presented, or evicted).
     NotAdmitted,
     /// The grant id was already admitted with different credits or expiry.
@@ -131,6 +134,10 @@ impl core::fmt::Display for GrantError {
                 "session grant lifetime exceeds {MAX_LIFETIME_SECS} seconds"
             ),
             Self::Exhausted => f.write_str("session grant credits are exhausted"),
+            Self::Insufficient { needed, remaining } => write!(
+                f,
+                "session grant has {remaining} credits left, this request needs {needed}"
+            ),
             Self::NotAdmitted => f.write_str("session grant has not been presented on this server"),
             Self::Conflict => {
                 f.write_str("session grant id was already admitted with different terms")
@@ -464,6 +471,20 @@ impl GrantLedger {
     /// Spend one credit of an admitted grant. Returns the remaining
     /// credits. An expired entry is evicted on contact.
     pub fn consume(&mut self, grant_id: &GrantId, now: u64) -> Result<u32, GrantError> {
+        self.consume_n(grant_id, 1, now)
+    }
+
+    /// Spend `credits` credits of an admitted grant at once (a hint set, for
+    /// example) and return the remaining balance. A grant that cannot cover
+    /// the whole amount is left untouched: [`GrantError::Exhausted`] when it
+    /// has nothing left, [`GrantError::Insufficient`] when it has some.
+    /// `credits == 0` charges nothing and reports the balance.
+    pub fn consume_n(
+        &mut self,
+        grant_id: &GrantId,
+        credits: u32,
+        now: u64,
+    ) -> Result<u32, GrantError> {
         let expired = matches!(self.entries.get(grant_id), Some(entry) if now >= entry.expires_at);
         if expired {
             self.entries.remove(grant_id);
@@ -473,10 +494,17 @@ impl GrantLedger {
             .entries
             .get_mut(grant_id)
             .ok_or(GrantError::NotAdmitted)?;
-        if entry.used >= entry.credits {
+        let remaining = entry.credits - entry.used;
+        if remaining == 0 && credits > 0 {
             return Err(GrantError::Exhausted);
         }
-        entry.used += 1;
+        if credits > remaining {
+            return Err(GrantError::Insufficient {
+                needed: credits,
+                remaining,
+            });
+        }
+        entry.used += credits;
         Ok(entry.credits - entry.used)
     }
 
@@ -769,5 +797,40 @@ mod tests {
         assert_eq!(two.len(), 2);
         assert!(!two.is_empty());
         assert!(two.contains(&key));
+    }
+    #[test]
+    fn consume_n_charges_whole_amounts_or_nothing() {
+        let signer = signer();
+        let trusted = TrustedIssuers::new(&[signer.public_key()]).expect("trusted");
+        let grant = signer.issue(ID, NOW - 10, NOW + 3600, 200).expect("valid");
+        let verified = grant.verify(&trusted, NOW).expect("verifies");
+        let mut ledger = GrantLedger::new();
+        assert_eq!(ledger.admit(&verified, NOW), Ok(200));
+        assert_eq!(ledger.consume_n(&ID, 0, NOW), Ok(200));
+        assert_eq!(ledger.consume_n(&ID, 150, NOW), Ok(50));
+        assert_eq!(
+            ledger.consume_n(&ID, 150, NOW),
+            Err(GrantError::Insufficient {
+                needed: 150,
+                remaining: 50
+            })
+        );
+        assert_eq!(
+            ledger.remaining(&ID),
+            Some(50),
+            "a refused charge leaves the balance untouched"
+        );
+        assert_eq!(ledger.consume(&ID, NOW), Ok(49));
+        assert_eq!(ledger.consume_n(&ID, 49, NOW), Ok(0));
+        assert_eq!(ledger.consume_n(&ID, 1, NOW), Err(GrantError::Exhausted));
+        assert_eq!(ledger.consume_n(&ID, 150, NOW), Err(GrantError::Exhausted));
+        assert_eq!(
+            GrantError::Insufficient {
+                needed: 150,
+                remaining: 24
+            }
+            .to_string(),
+            "session grant has 24 credits left, this request needs 150"
+        );
     }
 }

--- a/docs/CASHIER_API.md
+++ b/docs/CASHIER_API.md
@@ -24,7 +24,8 @@ cookies and no referrer.
   "offers": [
     { "credits": 1000, "amount": 210, "unit": "sat" }
   ],
-  "grant_ttl_secs": 86400
+  "grant_ttl_secs": 86400,
+  "costs": { "frame": 1, "harmony_hint_set": 150 }
 }
 ```
 
@@ -35,6 +36,10 @@ cookies and no referrer.
   `credits`; there is no fractional pricing.
 - `grant_ttl_secs`: lifetime the cashier stamps on issued grants (bounded by
   the server-side maximum of 30 days).
+- `costs` (optional, informational): what the servers charge, in credits,
+  for one query-bearing frame and for one HarmonyPIR hint set. The servers
+  enforce their own flags (`--session-grant-hint-credits`); the cashier
+  publishes the same numbers so the client can show prices before spending.
 
 ## `POST /v1/grants`
 

--- a/docs/SESSION_GRANTS.md
+++ b/docs/SESSION_GRANTS.md
@@ -34,9 +34,18 @@ cashier.key` produces one and prints the public key hex.
 
 - One credit per **query-bearing request frame**: INDEX / CHUNK / bucket
   Merkle batches, HarmonyPIR query and batch query, ORAM lookup, OnionPIR
-  key registration and queries. Info, ping, attest, handshake, announce,
-  catalog, DB proofs, HarmonyPIR hints, admin opcodes, and the presentation
-  itself are free.
+  key registration and queries.
+- One **hint set** (`REQ_HARMONY_HINTS` or `REQ_HARMONY_HINTS_V2`, the
+  requests that take an entry from the hint pool) costs
+  `--session-grant-hint-credits` credits, default 150. Priced by compute:
+  regenerating a pool entry measured 136 CPU-seconds on pir1 against about
+  0.9 for a metered DPF frame, and a set serves roughly 26 queries, so the
+  amortised cost per HarmonyPIR query is close to a DPF query's. The
+  `_V2_HALF` continuation of an already-paid entry is free. A grant that
+  cannot cover the whole set is refused with the shortfall named and
+  nothing charged.
+- Info, ping, attest, handshake, announce, catalog, DB proofs, admin
+  opcodes, and the presentation itself are free.
 - The credit is spent after the mode gates and before dispatch, so a frame
   this host does not serve costs nothing and a malformed query still costs
   one.
@@ -55,6 +64,7 @@ cashier.key` produces one and prints the public key hex.
 | --- | --- |
 | `--session-grant-pubkey FILE` (repeatable) | Pin a cashier public key: 32 raw bytes or 64 hex characters. Enables verification and metering. |
 | `--require-session-grant` | Reject query-bearing frames until a valid grant is presented. Needs at least one pinned key. |
+| `--session-grant-hint-credits N` | Credits one HarmonyPIR hint set costs (default 150). The cashier advertises the same number in `GET /v1/info` `costs`. |
 
 With no pinned key the server refuses `REQ_SESSION_GRANT_PRESENT` with an
 error and serves free queries as before. Production activation is an

--- a/docs/runbooks/cashier-and-mint.md
+++ b/docs/runbooks/cashier-and-mint.md
@@ -43,9 +43,10 @@ secret; `keygen` and `pubkey` print only the public key.
 ## Server pins
 
 - pir1: `pir-primary.service` passes
-  `--session-grant-pubkey /etc/bitcoinpir/cashier/grant.pub`. The free
-  path stays open until `--require-session-grant` is added, which is an
-  operator decision.
+  `--session-grant-pubkey /etc/bitcoinpir/cashier/grant.pub` (and
+  `--session-grant-hint-credits 150` for the HarmonyPIR hint price). The
+  free path stays open until `--require-session-grant` is added, which is
+  an operator decision.
 - pir2: the flags live in `unified-server-run.sh` inside the measured UKI,
   so pinning requires a new image (Flow E/G). Until then pir2 answers
   "session grants not enabled" and the client treats it as the free path.


### PR DESCRIPTION
## Why

Metering charged one credit per query-bearing frame and left HarmonyPIR hint requests free. A hint request takes an entry from the precomputed pool (`--pool-size 8`), and regenerating one entry costs real compute. Measured on pir1 (i7-8700, `/proc` CPU time of `unified_server`):

| Operation | CPU time | Wall |
| --- | --- | --- |
| Regenerate one hint-pool entry | 135.9 s | 12.1 s |
| Serve one hint set | 0.05 s | — |
| DPF query, 1 address (server0) | 8.3 s | 4.3 s |
| DPF query, 2 addresses (server0, 16 metered frames) | 14 s | 5.1 s |

One hint set serves about 26 queries, so 150 credits per set keeps HarmonyPIR priced by compute (≈5.8 credits per amortised query, next to ≈5.6 CPU-s per DPF address per server) and stops free pool drains.

## What

- `pir-session-grant`: `GrantLedger::consume_n` charges a whole amount or nothing; `GrantError::Insufficient { needed, remaining }` names the shortfall.
- `unified_server`: `credit_cost()` prices `REQ_HARMONY_HINTS` / `REQ_HARMONY_HINTS_V2` at `--session-grant-hint-credits` (default 150; the `_V2_HALF` continuation of an already-paid entry is free) and query-bearing frames at 1; the serve loop consumes by cost; `is_query_bearing_variant` is unchanged so the `--serve-queries` gate is untouched; the startup line states both prices.
- Docs: metering rule and flag table in `SESSION_GRANTS.md`, optional informational `costs` field in the cashier `/v1/info` contract, runbook pin line.

## Tests

- crate: `consume_n` all-or-nothing, `consume == consume_n(1)`, zero is a no-op, error text.
- server: CLI default/override, `credit_cost` mapping (hint requests priced, `_V2_HALF` free, query frames 1, info/attest/announce/present free, hint requests not query-bearing), all-or-nothing hint charge through the gate with the shortfall message, startup line.
- `cargo test -p pir-session-grant` (15), `cargo test -p runtime --bin unified_server session_grant` (9), `cargo clippy --no-deps -p runtime --bin unified_server -- -D warnings` clean.

Follow-ups (separate PRs): cashier publishes `costs`; web HarmonyPIR gets an explicit "Fetch hints (150 credits)" stage and a confirmation before re-fetching on exhaustion; pir1 unit adds the flag; pir2 gets the flag with its next measured image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
