### PR TITLE
web: confirm before fetching a paid HarmonyPIR hint set; carry cashier costs with the grant

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-QTm40Ng03NnAH0tZ7DbhpbEtaT/YX1uZP+OE1OeaxSg=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-/Paty+iS6bicoLbE64G6aZ+fIna6CzE6h+WSpPokiYQ=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
     <title>Bitcoin PIR</title>
     <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>
@@ -1765,9 +1765,23 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             paStatus(`cashier ${cashierInfo.service}: ${cashierInfo.offers.length} offer(s), mint ${cashierInfo.mints[0]}`, 'success');
         }
 
+        // Price of one HarmonyPIR hint set in credits: remembered with the
+        // grant at purchase, otherwise asked from the cashier; null if unknown.
+        async function paHintSetCost() {
+            const stored = sessionGrantStore.load();
+            if (stored?.costs?.harmonyHintSet) return stored.costs.harmonyHintSet;
+            try {
+                cashierInfo = cashierInfo ?? await cashier.info();
+                return cashierInfo.costs?.harmonyHintSet ?? null;
+            } catch {
+                return null;
+            }
+        }
+
         async function paStoreGrant(offer, token, cashierUrl) {
             const issued = await cashier.redeem(offer, token);
-            sessionGrantStore.save({ version: 1, ...issued, cashierUrl });
+            const costs = cashierInfo?.costs;
+            sessionGrantStore.save({ version: 1, ...issued, cashierUrl, ...(costs ? { costs } : {}) });
             pendingPurchaseStore.clear();
             sessionGrantBalances.clear();
             renderPaidAccess();
@@ -4499,6 +4513,26 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             const offlineStatus = document.getElementById('hp-offlineStatus');
             const offlineFill = document.getElementById('hp-offlineFill');
             const offlineLabel = document.getElementById('hp-offlineLabel');
+            // Paid access: a hint set is charged to the session grant on the
+            // hint server, so every fetch (first load, DB switch, refresh
+            // after exhaustion) is an explicit, confirmed step.
+            const paidGrant = sessionGrantStore.load();
+            if (paidGrant) {
+                const cost = await paHintSetCost();
+                const hintBalance = sessionGrantBalances.get('HarmonyPIR hint');
+                const balanceText = hintBalance?.state === 'accepted'
+                    ? `${hintBalance.remaining} credits remaining on the hint server`
+                    : hintBalance?.state === 'not-enabled'
+                        ? 'the hint server does not meter grants'
+                        : 'hint-server balance unknown';
+                const question = `Fetch a HarmonyPIR hint set? This charges ${cost ?? "the server's hint-set price in"} credits to session grant ${paidGrant.grantIdHex.slice(0, 8)}… (${balanceText}). A set serves a limited number of queries; the count is shown once it is loaded.`;
+                if (!window.confirm(question)) {
+                    offlineStatus.textContent = 'Not loaded';
+                    offlineLabel.textContent = 'Hint set not fetched — declined.';
+                    log('HarmonyPIR: hint fetch declined (no credits spent)', 'warn');
+                    return false;
+                }
+            }
             offlineStatus.textContent = 'Downloading...';
             offlineFill.style.width = '0%';
             offlineLabel.textContent = 'Fetching hints from Hint Server...';
@@ -4511,6 +4545,10 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 offlineLabel.textContent = 'Hints loaded (~' + client.estimateHintSize() + ' MB, ' + remaining + ' queries available). Ready.';
                 if (client === hpClient) hpHintsLoaded = true;
                 log('HarmonyPIR: Hints downloaded successfully', 'success');
+                if (paidGrant) {
+                    // Re-present the grant so the balance line reflects the charge.
+                    try { await client.presentSessionGrant(0); } catch { /* balance refresh is best effort */ }
+                }
                 return true;
             } catch (error) {
                 offlineStatus.textContent = 'Failed';

--- a/web/src/__tests__/session-grant.test.ts
+++ b/web/src/__tests__/session-grant.test.ts
@@ -13,6 +13,7 @@ import {
   classifySessionGrantFailure,
   decodeSessionGrantFields,
   encodeSessionGrantPresentFrame,
+  parseCashierCosts,
   parseCashierInfo,
   parseIssuedGrant,
   parseSessionGrantResponsePayload,
@@ -309,5 +310,38 @@ describe('CashierClient fetch binding', () => {
     } finally {
       globalThis.fetch = original;
     }
+  });
+});
+
+describe('cashier costs', () => {
+  it('parses costs from /v1/info and tolerates their absence', () => {
+    const base = {
+      service: 'bitcoinpir-cashier', version: 1, cashier_pubkey_hex: 'ab'.repeat(32),
+      mints: ['https://mint.example'], offers: [{ credits: 1000, amount: 210, unit: 'sat' }], grant_ttl_secs: 86400,
+    };
+    expect(parseCashierInfo(base).costs).toBeUndefined();
+    expect(parseCashierInfo({ ...base, costs: { frame: 1, harmony_hint_set: 150 } }).costs)
+      .toEqual({ frame: 1, harmonyHintSet: 150 });
+    expect(parseCashierInfo({ ...base, costs: { frame: 0, harmony_hint_set: 150 } }).costs).toBeUndefined();
+    expect(parseCashierCosts({ frame: 1, harmonyHintSet: 150 })).toEqual({ frame: 1, harmonyHintSet: 150 });
+    expect(parseCashierCosts('nope')).toBeNull();
+  });
+
+  it('keeps costs on the stored grant and survives a reload', () => {
+    const storage = new Map<string, string>();
+    const store = new SessionGrantStore({
+      getItem: (k: string) => storage.get(k) ?? null,
+      setItem: (k: string, v: string) => { storage.set(k, v); },
+      removeItem: (k: string) => { storage.delete(k); },
+    });
+    const now = 1_800_000_000;
+    store.save({
+      version: 1, grantBase64: 'AAAA', grantIdHex: '00'.repeat(16), credits: 1000,
+      issuedAt: now, expiresAt: now + 3600, cashierUrl: 'https://cashier.example',
+      costs: { frame: 1, harmonyHintSet: 150 },
+    });
+    expect(store.load(now)?.costs).toEqual({ frame: 1, harmonyHintSet: 150 });
+    storage.set('bitcoinpir.session-grant.v1', JSON.stringify({ ...JSON.parse(storage.get('bitcoinpir.session-grant.v1')!), costs: 'bad' }));
+    expect(store.load(now)?.costs).toBeUndefined();
   });
 });

--- a/web/src/session-grant.ts
+++ b/web/src/session-grant.ts
@@ -34,6 +34,14 @@ export interface CashierOffer {
 }
 
 /** `GET /v1/info` — what the cashier sells and which mints it accepts. */
+/** Credits the PIR servers charge per metered unit (informational). */
+export interface CashierCosts {
+  /** One query-bearing request frame. */
+  frame: number;
+  /** One HarmonyPIR hint set (`--session-grant-hint-credits` on the servers). */
+  harmonyHintSet: number;
+}
+
 export interface CashierInfo {
   service: string;
   version: number;
@@ -41,6 +49,8 @@ export interface CashierInfo {
   mints: string[];
   offers: CashierOffer[];
   grantTtlSecs: number;
+  /** Absent when the cashier predates the `costs` field. */
+  costs?: CashierCosts;
 }
 
 /** Fields of a version-1 grant, decoded without signature verification. */
@@ -66,6 +76,8 @@ export interface IssuedGrant {
 export interface StoredSessionGrant extends IssuedGrant {
   version: 1;
   cashierUrl: string;
+  /** Prices the cashier advertised when the grant was bought. */
+  costs?: CashierCosts;
 }
 
 /** Outcome of presenting a grant on one connection. */
@@ -309,7 +321,20 @@ function readStoredGrant(value: unknown): StoredSessionGrant | null {
   ) {
     return null;
   }
-  return { version: 1, grantBase64, grantIdHex, credits, issuedAt, expiresAt, cashierUrl };
+  const costs = parseCashierCosts(value.costs);
+  return {
+    version: 1, grantBase64, grantIdHex, credits, issuedAt, expiresAt, cashierUrl,
+    ...(costs ? { costs } : {}),
+  };
+}
+
+/** `costs` from `GET /v1/info` or a stored grant; `null` when absent or malformed. */
+export function parseCashierCosts(value: unknown): CashierCosts | null {
+  if (!isRecord(value)) return null;
+  const frame = value.frame;
+  const hint = value.harmony_hint_set ?? value.harmonyHintSet;
+  if (!isPositiveInteger(frame) || !isPositiveInteger(hint)) return null;
+  return { frame, harmonyHintSet: hint };
 }
 
 // ─── Cashier HTTP client ────────────────────────────────────────────────────
@@ -419,6 +444,7 @@ export function parseCashierInfo(value: unknown): CashierInfo {
     throw new CashierError('cashier info lists no offers');
   }
   if (!isPositiveInteger(ttl)) throw new CashierError('cashier info has an invalid grant TTL');
+  const costs = parseCashierCosts(value.costs);
   return {
     service,
     version: CASHIER_API_VERSION,
@@ -426,6 +452,7 @@ export function parseCashierInfo(value: unknown): CashierInfo {
     mints: mints as string[],
     offers: offers.map(parseCashierOffer),
     grantTtlSecs: ttl,
+    ...(costs ? { costs } : {}),
   };
 }
 


### PR DESCRIPTION
Companion to #295 (servers price a HarmonyPIR hint set at `--session-grant-hint-credits`, default 150).

- When a session grant is stored, `hpFetchHints` asks for confirmation before every hint fetch (first load, DB switch, refresh after exhaustion) and names the price and the hint-server balance; declining spends nothing and reports `Hint set not fetched — declined`. Without a grant the free path is unchanged.
- After a paid fetch the grant is re-presented to the hint leg so the Paid access balance line reflects the charge.
- `parseCashierInfo` reads the cashier's optional `costs` (`frame`, `harmony_hint_set`); the price is stored with the grant at purchase (`StoredSessionGrant.costs`, tolerant of older records) and otherwise asked from the cashier when needed.
- Inline-script CSP hash repinned.

Tests: two new cases (costs parsing, stored-grant round trip and tolerance); `cd web && npm run build && npx vitest run` → 30 files, 371 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)