### PR TITLE
pir2 UKI: pin the cashier session-grant key and the hint-set price

### DIFF
--- a/docs/SESSION_GRANTS.md
+++ b/docs/SESSION_GRANTS.md
@@ -66,6 +66,11 @@ cashier.key` produces one and prints the public key hex.
 | `--require-session-grant` | Reject query-bearing frames until a valid grant is presented. Needs at least one pinned key. |
 | `--session-grant-hint-credits N` | Credits one HarmonyPIR hint set costs (default 150). The cashier advertises the same number in `GET /v1/info` `costs`. |
 
+On pir1 the flags live in the systemd unit. On pir2 they live in the measured
+UKI (`scripts/dracut/97bpir-tier3-init/unified-server-run.sh` pins the cashier
+public key and the hint-set price next to `--admin-pubkey-hex`), so changing
+the key or the price is a new image and a sealed ceremony.
+
 With no pinned key the server refuses `REQ_SESSION_GRANT_PRESENT` with an
 error and serves free queries as before. Production activation is an
 operator decision routed through

--- a/docs/runbooks/cashier-and-mint.md
+++ b/docs/runbooks/cashier-and-mint.md
@@ -47,9 +47,11 @@ secret; `keygen` and `pubkey` print only the public key.
   `--session-grant-hint-credits 150` for the HarmonyPIR hint price). The
   free path stays open until `--require-session-grant` is added, which is
   an operator decision.
-- pir2: the flags live in `unified-server-run.sh` inside the measured UKI,
-  so pinning requires a new image (Flow E/G). Until then pir2 answers
-  "session grants not enabled" and the client treats it as the free path.
+- pir2: the flags live in `unified-server-run.sh` inside the measured UKI
+  (`PIR2_SESSION_GRANT_PUBKEY_HEX`, `PIR2_SESSION_GRANT_HINT_CREDITS`), so a
+  key or price change is a new image (Flow E/G). An image built before the
+  pin answers "session grants not enabled" and the client treats it as the
+  free path.
 
 ## Read — health
 
@@ -120,7 +122,8 @@ to the crate.
    (Human), then `bpir-cashier pubkey` into a new `grant.pub`.
 2. Pin the new public key on every server **before** switching the
    cashier (`--session-grant-pubkey` is repeatable, so both keys can be
-   accepted during the overlap; pir2 needs a new image).
+   accepted during the overlap; pir2 needs a new image with the new
+   `PIR2_SESSION_GRANT_PUBKEY_HEX`).
 3. Move the new key into place, restart the cashier; unexpired grants
    under the old key stay valid on servers that still pin it.
 

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -54,8 +54,9 @@ PIR2_SEALED_IDENTITY_CERT_PATH="$PIR2_SEALED_ROOT/identity.cert"
 # pins for session grants, and the price of one HarmonyPIR hint set. Both
 # are part of the measured image, like --admin-pubkey-hex below; changing
 # either is a new UKI. The flag takes a file, so the key is materialized
-# under /run right before the final exec. --require-session-grant is an
-# operator decision and is deliberately not set here.
+# under /run right before the final exec. Requiring a grant for every query
+# (closing the free path) is an operator decision and is deliberately not
+# enabled here.
 PIR2_SESSION_GRANT_PUBKEY_HEX=59392a0738106c4954c317f9bfae2e4918fe809fa0c49fdf23493ce709b9c6e0
 PIR2_SESSION_GRANT_PUBKEY_FILE=/run/bitcoinpir-session-grant.pub
 PIR2_SESSION_GRANT_HINT_CREDITS=150

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -50,6 +50,15 @@ PIR2_SEALED_RECEIPT_DIR="$PIR2_SEALED_ROOT/receipts"
 PIR2_SEALED_MARKER_DIR="$PIR2_SEALED_ROOT/markers"
 PIR2_SEALED_ATTEMPT_DIR=${BPIR_PIR2_SNP_SEALED_ATTEMPT_ROOT:-/run/bitcoinpir-pir2-sealed}
 PIR2_SEALED_IDENTITY_CERT_PATH="$PIR2_SEALED_ROOT/identity.cert"
+# Paid queries (docs/SESSION_GRANTS.md): the cashier public key this image
+# pins for session grants, and the price of one HarmonyPIR hint set. Both
+# are part of the measured image, like --admin-pubkey-hex below; changing
+# either is a new UKI. The flag takes a file, so the key is materialized
+# under /run right before the final exec. --require-session-grant is an
+# operator decision and is deliberately not set here.
+PIR2_SESSION_GRANT_PUBKEY_HEX=59392a0738106c4954c317f9bfae2e4918fe809fa0c49fdf23493ce709b9c6e0
+PIR2_SESSION_GRANT_PUBKEY_FILE=/run/bitcoinpir-session-grant.pub
+PIR2_SESSION_GRANT_HINT_CREDITS=150
 PIR2_SEALED_INERT_SUCCESS_EXIT_CODE=42
 # Inert Observe/Enroll/Probe runs leave no listener behind.  VPSBG currently
 # has no console or file-extraction API, so expose only the canonical receipt
@@ -1223,6 +1232,8 @@ remove_direct_oram_status_api_root || fatal "failed to remove Direct ORAM status
 trap - EXIT
 trap - HUP INT TERM
 start_unified_server_runtime_log
+(umask 022; printf '%s\n' "$PIR2_SESSION_GRANT_PUBKEY_HEX" > "$PIR2_SESSION_GRANT_PUBKEY_FILE") \
+    || fatal "failed to materialize the session grant public key"
 
 # Ready reopens the sealed identity in the final exec. Deleted Payment V1
 # service flags must not be passed (unknown CLI flags are fatal).
@@ -1253,5 +1264,7 @@ exec "$UNIFIED_SERVER" \
     --pir2-snp-sealed-verifier-nonce-hex "$PIR2_SEALED_VERIFIER_NONCE_HEX" \
     --pir2-snp-sealed-current-boot-id-hex "$PIR2_BOOT_ID_HEX" \
     --pir2-snp-sealed-identity-cert "$PIR2_SEALED_IDENTITY_CERT_PATH" \
+    --session-grant-pubkey "$PIR2_SESSION_GRANT_PUBKEY_FILE" \
+    --session-grant-hint-credits "$PIR2_SESSION_GRANT_HINT_CREDITS" \
     --connection-idle-timeout-ms 300000 \
     2>&1

--- a/scripts/tier3-uki-policy-contract.test.mjs
+++ b/scripts/tier3-uki-policy-contract.test.mjs
@@ -140,5 +140,6 @@ test("runtime UKI pins the cashier key and the hint-set price, never --require-s
   assert.match(source, /^PIR2_SESSION_GRANT_HINT_CREDITS=[1-9][0-9]*$/m);
   assert.match(source, /--session-grant-pubkey "\$PIR2_SESSION_GRANT_PUBKEY_FILE"/);
   assert.match(source, /--session-grant-hint-credits "\$PIR2_SESSION_GRANT_HINT_CREDITS"/);
-  assert.doesNotMatch(source, /--require-session-grant/);
+  // A flag line, not a mention: the free path is closed by an operator, not by the image.
+  assert.doesNotMatch(source, /^\s*--require-session-grant\b/m);
 });

--- a/scripts/tier3-uki-policy-contract.test.mjs
+++ b/scripts/tier3-uki-policy-contract.test.mjs
@@ -133,3 +133,12 @@ test("dracut module rejects a policy re-introduction", () => {
     ),
   );
 });
+
+test("runtime UKI pins the cashier key and the hint-set price, never --require-session-grant", () => {
+  const source = readFileSync(runPath, "utf8");
+  assert.match(source, /^PIR2_SESSION_GRANT_PUBKEY_HEX=[0-9a-f]{64}$/m);
+  assert.match(source, /^PIR2_SESSION_GRANT_HINT_CREDITS=[1-9][0-9]*$/m);
+  assert.match(source, /--session-grant-pubkey "\$PIR2_SESSION_GRANT_PUBKEY_FILE"/);
+  assert.match(source, /--session-grant-hint-credits "\$PIR2_SESSION_GRANT_HINT_CREDITS"/);
+  assert.doesNotMatch(source, /--require-session-grant/);
+});


### PR DESCRIPTION
Flow B change for the next pir2 measured image.

- `unified-server-run.sh`: constants `PIR2_SESSION_GRANT_PUBKEY_HEX` (the cashier public key pir1 already pins), `PIR2_SESSION_GRANT_PUBKEY_FILE` (materialized under `/run` right before the final exec, because the flag takes a file), `PIR2_SESSION_GRANT_HINT_CREDITS=150`; the final Ready server gets `--session-grant-pubkey` and `--session-grant-hint-credits`. Preflight/inert phases are untouched. `--require-session-grant` is deliberately absent (free path stays an operator decision).
- Contract test: the run script pins a 64-hex key and a positive hint price, passes both flags, and never requires grants.
- Docs: where each host's flags live (pir1 unit vs pir2 measured image); rotation note.

Once merged, the image is built from the merge commit (Flow E on the VPSBG stock root) and rolled through Observe/Enroll/Probe/Ready with a new identity generation; `PIR2_TIER3_PIN` follows in the pin PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)