### PR TITLE
uki: pin the baked cloudflared to the official 2026.8.3 static release

### DIFF
--- a/docs/runbooks/uki-build.md
+++ b/docs/runbooks/uki-build.md
@@ -33,7 +33,14 @@ the approved Linux build host. Set every release input explicitly:
 - `ORAMCTL`: exact executable to embed;
 - `BHTM_FROM_LEAF_PROOF`: exact retained proof input;
 - `OUT`: unique absolute candidate path;
-- archive locations, including a required off-host mirror when applicable.
+- archive locations, including a required off-host mirror when applicable;
+- `/usr/local/bin/cloudflared` on the build host: the official static
+  `cloudflared-linux-amd64` release that the script pins by version and
+  SHA-256 (`TIER3_CLOUDFLARED_VERSION`, `TIER3_CLOUDFLARED_SHA256`). It is
+  baked into the initramfs and therefore into MEASUREMENT, so the pin moves
+  only together with a new image; place the pinned asset on the build host
+  before building, and after the build extract `/usr/bin/cloudflared` from
+  the candidate UKI's initrd to confirm it is the pinned bytes.
 
 The script pins Zstandard compression, excludes early microcode, GPU firmware,
 and unrelated globally installed BitcoinPIR dracut modules, validates the

--- a/flake.nix
+++ b/flake.nix
@@ -152,8 +152,8 @@
         # Pinned by content hash, so `fetchurl` stays a hermetic
         # fixed-output derivation (this part needs no `--impure`).
         cloudflaredStatic = pkgs.fetchurl {
-          url = "https://github.com/cloudflare/cloudflared/releases/download/2026.3.0/cloudflared-linux-amd64";
-          hash = "sha256-Sp5Q5tbXmOkPzQGTMVGpC/ft2ZoKVcKK0Y8uFiY6XDA=";
+          url = "https://github.com/cloudflare/cloudflared/releases/download/2026.8.3/cloudflared-linux-amd64";
+          hash = "sha256-8pMk/pNNHhAGF0hMeN7vgDxNws01HWRbveQulrT8zF4=";
         };
 
         # Boot scripts — copied verbatim from scripts/dracut/97bpir-tier3-init/.

--- a/scripts/build_uki_tier3.sh
+++ b/scripts/build_uki_tier3.sh
@@ -21,6 +21,13 @@ NEXT_STEP. --dry-run lists inputs without inspecting the host or reading files.
 EOF
 }
 
+# The baked tunnel client is part of MEASUREMENT: pin the exact official
+# static release (cloudflared-linux-amd64) so unnoticed build-host drift can
+# never change the image. Refresh both values together, only with a new image
+# (docs/runbooks/uki-build.md section 2).
+TIER3_CLOUDFLARED_VERSION=2026.8.3
+TIER3_CLOUDFLARED_SHA256=f29324fe934d1e100617484c78deef803c4dc2cd351d645bbde42e96b4fccc5e
+
 case "${1:-}" in
     '') ;;
     -h|--help) usage; exit 0 ;;
@@ -30,6 +37,7 @@ case "${1:-}" in
             input_value=${!input_name:-MISSING}
             echo "$input_name=$input_value"
         done
+        echo "cloudflared_pin=$TIER3_CLOUDFLARED_VERSION"
         echo 'initrd_compression=zstd'
         echo 'max_uki_bytes=268435456'
         echo 'PASS uki_build dry_run=true'
@@ -97,6 +105,23 @@ done
     echo "error: /usr/local/bin/cloudflared not executable" >&2
     exit 1
 }
+cloudflared_version=$(/usr/local/bin/cloudflared --version 2>/dev/null \
+    | awk '/^cloudflared version /{ print $3; exit }')
+[ "$cloudflared_version" = "$TIER3_CLOUDFLARED_VERSION" ] || {
+    echo "error: /usr/local/bin/cloudflared reports '${cloudflared_version:-unknown}', expected $TIER3_CLOUDFLARED_VERSION" >&2
+    echo "  Install the official static cloudflared-linux-amd64 release $TIER3_CLOUDFLARED_VERSION on this build host first." >&2
+    exit 1
+}
+if command -v sha256sum >/dev/null 2>&1; then
+    cloudflared_sha256=$(sha256sum /usr/local/bin/cloudflared | awk '{print $1}')
+else
+    cloudflared_sha256=$(shasum -a 256 /usr/local/bin/cloudflared | awk '{print $1}')
+fi
+[ "$cloudflared_sha256" = "$TIER3_CLOUDFLARED_SHA256" ] || {
+    echo "error: /usr/local/bin/cloudflared sha256 $cloudflared_sha256 is not the pinned official $TIER3_CLOUDFLARED_VERSION asset" >&2
+    exit 1
+}
+echo "cloudflared: $TIER3_CLOUDFLARED_VERSION (sha256 pinned)"
 
 # The unified_server and oramctl binaries must be built and present.
 [ -x "$BINARY" ] || {

--- a/scripts/tier3-uki-policy-contract.test.mjs
+++ b/scripts/tier3-uki-policy-contract.test.mjs
@@ -23,6 +23,12 @@ const runPath = resolve(
 const PAYMENT_RESIDUE = /BPIR_TIER3_SERVICE_POLICY|service-policy|service_policy|public-artifact-set|accounting-authorization|issuer-approval|class_digest|minimum_authorization_epoch/;
 
 function validateBuildContract(source) {
+  // The baked cloudflared is inside MEASUREMENT: the build must pin the exact
+  // official release by version and SHA-256 rather than take whatever the
+  // build host has installed.
+  assert.match(source, /^TIER3_CLOUDFLARED_VERSION=\d{4}\.\d+\.\d+$/m);
+  assert.match(source, /^TIER3_CLOUDFLARED_SHA256=[0-9a-f]{64}$/m);
+  assert.match(source, /"\$cloudflared_sha256" = "\$TIER3_CLOUDFLARED_SHA256"/);
   assert.match(source, /for input_name in KERNEL BINARY ORAMCTL BHTM_FROM_LEAF_PROOF OUT/);
   assert.match(
     source,
@@ -80,6 +86,16 @@ function validateMeasuredRunContract(source) {
 
 test("production Tier3 build takes exactly the runtime inputs and embeds no policy", () => {
   validateBuildContract(readFileSync(buildPath, "utf8"));
+});
+
+test("production Tier3 build pins the baked cloudflared release", () => {
+  const source = readFileSync(buildPath, "utf8");
+  assert.throws(() =>
+    validateBuildContract(source.replace(/^TIER3_CLOUDFLARED_SHA256=[0-9a-f]{64}$/m, "")),
+  );
+  assert.throws(() =>
+    validateBuildContract(source.replace(/^TIER3_CLOUDFLARED_VERSION=.*$/m, "TIER3_CLOUDFLARED_VERSION=latest")),
+  );
 });
 
 test("production Tier3 build rejects a policy or payment-artifact regression", () => {


### PR DESCRIPTION
Repo side of the pir2 cloudflared upgrade (todo added 2026-09-07). Live image 305 still bakes cloudflared `2026.3.0`; the binary is part of MEASUREMENT, so the upgrade goes into the **next** serving UKI (no UKI is cut for this alone).

## Change

- `scripts/build_uki_tier3.sh` pins the baked tunnel client: `TIER3_CLOUDFLARED_VERSION=2026.8.3` and the SHA-256 of the official static `cloudflared-linux-amd64` asset (digest taken from the GitHub release API, no download). The build refuses any other version or bytes on `/usr/local/bin/cloudflared`; `--dry-run` prints `cloudflared_pin=`. `2026.8.0`/`2026.8.1` are skipped on purpose (path-normalization regression, reverted in `2026.8.2`).
- `flake.nix` `cloudflaredStatic` moved to `2026.8.3` with the matching SRI hash (dev harness only).
- `scripts/tier3-uki-policy-contract.test.mjs`: the build contract now requires the pin lines and the sha256 comparison (+1 test).
- `docs/runbooks/uki-build.md` lists the build-host cloudflared as an input: place the pinned asset before building; after the build, extract `/usr/bin/cloudflared` from the candidate initrd and confirm it is the pinned bytes.

Untouched by design: `cloudflared-run.sh` (`TUNNEL_TOKEN` from `tunnel.env`, no `--token`), pir1's unit/binary (already `2026.8.3` via `.deb`), every `tunnel.env`, the attested-builder UKI.

## Campaign side (separate, needs the operator's go)

In the Flow F window before the next build: install the official static asset on the build host (`pir-server-vpsbg` stock root) at `/usr/local/bin/cloudflared`, check `ldd` reports a static executable, then build; the pin makes the build fail closed if that step was skipped.

## Tests

`node --test scripts/tier3-uki-policy-contract.test.mjs` (8 pass), `scripts/build_uki_tier3.sh --dry-run`, `bash -n`, `node scripts/github-workflow-supply-chain-gate.mjs` PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
