### PR TITLE
vpsbg-data-disk: one SSH connection per window (ControlMaster), torn down by open and close

### DIFF
--- a/docs/PRODUCTION_OPERATIONS.md
+++ b/docs/PRODUCTION_OPERATIONS.md
@@ -212,7 +212,12 @@ A data/proof-only rotation does not need a new UKI (Flow H).
 
 Use [`scripts/vpsbg-data-disk.sh`](../scripts/vpsbg-data-disk.sh).
 Never build a provisioner UKI. Detach body is
-`{"kernel_image_id":null}`. SSH only when `boot_mode=stock`.
+`{"kernel_image_id":null}`. SSH only when `boot_mode=stock`. The stock
+rootfs rate-limits new SSH connections (6 per 30 s per source); the wrapper
+therefore multiplexes every `put`/`get`/`ssh` of a window over one
+ControlMaster connection (socket under `VPSBG_SSH_CONTROL_DIR`, default
+`/tmp/bpir-vpsbg-ssh-<uid>`), torn down by `open` and `close`. Do not add
+your own `ssh`/`scp` calls beside it during a window.
 
 1. Read — Flow A. The `--image-id` passed to `open` and `close` is
    the UKI to reattach, usually the current live image.

--- a/docs/history/PIR2_DEPLOYMENT_PAIN_POINTS_2026-09.md
+++ b/docs/history/PIR2_DEPLOYMENT_PAIN_POINTS_2026-09.md
@@ -33,6 +33,10 @@ Each item: what hurt, evidence, proposed cleanup.
 5. UFW rate-limits SSH (6 conns/30 s); scripted campaigns that open one ssh per step
    get locked out. Fix: document; batch steps per session; consider a control
    socket (`ControlMaster`) in the wrapper.
+   **Fixed:** `scripts/vpsbg-data-disk.sh` multiplexes every ssh/scp of a window over a
+   ControlMaster socket (`ControlPersist=600`, private control directory), torn down
+   by `open` and `close` (tested in `scripts/vpsbg-data-disk.test.mjs`); the r7
+   campaign's per-step pacing is now a courtesy, not the mechanism.
 6. `cargo fmt --all` reformats `unified_server_pir2_sealed/mod.rs` on main (file is not
    rustfmt-clean); every PR touching the server has to revert it. Fix: format it once.
 7. Contract test regexes match comments (`--require-session-grant` mention failed the

--- a/scripts/pir2-sealed-campaign.sh
+++ b/scripts/pir2-sealed-campaign.sh
@@ -65,7 +65,7 @@ done < "$env_file"
 : "${OPERATOR_KEY:=$REPO/.keys/pir2-operator.key}"; : "${STABLE_SERVER_ID:=pir2-vpsbg-dpf-v1}"
 : "${VCPUS:=4}"; : "${VCPU_SIG_HEX:=00b10f10}"; : "${VMM_TYPE:=qemu}"; : "${GUEST_FEATURES_HEX:=1}"; : "${GUEST_POLICY_HEX:=30000}"
 : "${MIN_TCB_FMC:=1}"; : "${MIN_TCB_BOOTLOADER:=1}"; : "${MIN_TCB_TEE:=1}"; : "${MIN_TCB_SNP:=4}"; : "${MIN_TCB_MICROCODE:=88}"
-: "${SSH_PACE_SECONDS:=8}"; : "${READY_WAIT_SECONDS:=2400}"
+: "${SSH_PACE_SECONDS:=2}"; : "${READY_WAIT_SECONDS:=2400}"  # ssh/scp share one ControlMaster connection per window
 : "${TAG:=}"; : "${UKI_LOCAL_DIR:=$REPO/deploy/uki/$TAG}"; : "${HETZNER_ARCHIVE:=}"; : "${IMAGE:=}"; : "${ROLLBACK_LABEL:=}"
 
 need() { local k; for k in "$@"; do [[ -n "${!k:-}" ]] || { echo "env: $k is required for $action" >&2; exit 2; }; done; }

--- a/scripts/testdata/fake-vpsbg-curl.sh
+++ b/scripts/testdata/fake-vpsbg-curl.sh
@@ -24,9 +24,14 @@ echo "$url ${data:+POST}" >> "$S/log"
 case "$url" in
   *status.json*) echo "curl: (22) The requested URL returned error: 502" >&2; exit 22 ;;
   */servers/25285/measured-boot)
-    # The detach changes the boot config at once (status reads stock) while
-    # the guest keeps running the old kernel until a power cycle.
-    echo stock > "$S/mode"; echo true > "$S/running"; echo 1 > "$S/detached"; reply 200 '{}' ;;
+    if [[ "$data" == *'"kernel_image_id":null'* ]]; then
+      # The detach changes the boot config at once (status reads stock) while
+      # the guest keeps running the old kernel until a power cycle.
+      echo stock > "$S/mode"; echo true > "$S/running"; echo 1 > "$S/detached"; reply 200 '{"id":25285}'
+    else
+      # A switch (close) reattaches an image and reboots the guest into it.
+      echo measured > "$S/mode"; echo true > "$S/running"; echo 0 > "$S/ssh"; reply 200 '{"id":25285}'
+    fi ;;
   */servers/25285/stop)
     code=$(rd stop_http)
     if [[ "$code" == 423-always ]]; then reply 423 '{}'; fi

--- a/scripts/vpsbg-data-disk.sh
+++ b/scripts/vpsbg-data-disk.sh
@@ -15,7 +15,10 @@ usage: scripts/vpsbg-data-disk.sh <open|put|get|ssh|close> [options]
 open detaches measured boot (kernel_image_id=null), then settles the guest
 by readback: a still-measured guest gets a stop request (HTTP 423 is retried,
 not fatal), a stock-but-off guest gets a start (at most 3), and open returns
-once boot_mode=stock and SSH answers. close switches back to the
+once boot_mode=stock and SSH answers. All SSH/SCP steps of a window share one
+connection (ControlMaster socket under VPSBG_SSH_CONTROL_DIR, default
+/tmp/bpir-vpsbg-ssh-<uid>, ControlPersist 600 s); open and close tear it
+down. close switches back to the
 caller-supplied image ID; it never remembers the previous image. put/get/ssh
 refuse to run unless the guest is already stock. There is no provisioner UKI
 path. Mutations default to a dry-run preview unless --apply is set.
@@ -130,28 +133,52 @@ ssh_opts() {
   [[ -r "$known_hosts" && -s "$known_hosts" ]] || { echo "VPSBG known_hosts is missing or empty: $known_hosts" >&2; exit 2; }
 }
 
-ssh_base() {
-  ssh_opts
-  SSH_BASE=(
-    ssh
+# One TCP connection per window. The stock rootfs rate-limits new SSH
+# connections (ufw limit: 6 per 30 s per source), so a scripted window that
+# opened one connection per put/get/ssh step locked itself out. With a
+# ControlMaster socket the first successful probe becomes the master and every
+# later step is a channel on it; the master is torn down at close (the guest
+# reboots) and before open (a stale master must not mask a dead guest).
+ssh_control_dir() {
+  local dir=${VPSBG_SSH_CONTROL_DIR:-/tmp/bpir-vpsbg-ssh-$(id -u)}
+  if [[ ! -d "$dir" ]]; then
+    mkdir -m 700 "$dir" || { echo "cannot create SSH control directory $dir" >&2; exit 2; }
+  fi
+  [[ -O "$dir" ]] || { echo "SSH control directory is not owned by this user: $dir" >&2; exit 2; }
+  chmod 700 "$dir"
+  printf '%s' "$dir"
+}
+
+ssh_common_opts() {
+  local dir; dir=$(ssh_control_dir)
+  SSH_COMMON=(
     -i "$ssh_key"
     -o IdentitiesOnly=yes
     -o UserKnownHostsFile="$known_hosts"
     -o StrictHostKeyChecking=yes
     -o ConnectTimeout=20
+    -o ControlMaster=auto
+    -o ControlPath="$dir/%C"
+    -o ControlPersist=600
   )
+}
+
+ssh_base() {
+  ssh_opts
+  ssh_common_opts
+  SSH_BASE=(ssh "${SSH_COMMON[@]}")
 }
 
 scp_base() {
   ssh_opts
-  SCP_BASE=(
-    scp
-    -i "$ssh_key"
-    -o IdentitiesOnly=yes
-    -o UserKnownHostsFile="$known_hosts"
-    -o StrictHostKeyChecking=yes
-    -o ConnectTimeout=20
-  )
+  ssh_common_opts
+  SCP_BASE=(scp "${SSH_COMMON[@]}")
+}
+
+# Best-effort teardown of a control master for the guest; silent when none.
+ssh_control_exit() {
+  ssh_base
+  "${SSH_BASE[@]}" -o BatchMode=yes -O exit "root@$VPSBG_HOST" >/dev/null 2>&1 || true
 }
 
 require_stock() {
@@ -294,6 +321,7 @@ case "$action" in
       echo "recorded close image $image_id does not match live image $live_image_id" >&2
       exit 2
     fi
+    ssh_control_exit
     if [[ "$live_boot_mode" != stock ]]; then
       echo '[stage] detach measured boot'
       api_post "/servers/$server_id/measured-boot" '{"kernel_image_id":null}' >/dev/null
@@ -314,6 +342,8 @@ case "$action" in
       echo 'NEXT_STEP=rerun with --apply to switch this exact image'
       exit 0
     fi
+    echo '[stage] close SSH control master'
+    ssh_control_exit
     echo '[stage] switch measured-boot image'
     "$root/scripts/vpsbg-measured-boot.sh" switch --server-id "$server_id" --image-id "$image_id" --apply
     echo 'PASS action=close'

--- a/scripts/vpsbg-data-disk.test.mjs
+++ b/scripts/vpsbg-data-disk.test.mjs
@@ -22,7 +22,7 @@ const wrapper = resolve(repository, "scripts/vpsbg-data-disk.sh");
 //   stop_http  status code the next POST /stop answers (423 or 200)
 //   log        appended request lines for assertions
 
-function runOpen(initial) {
+function harness(initial) {
   const dir = mkdtempSync(join(tmpdir(), "vpsbg-open-"));
   const bin = join(dir, "bin"); mkdirSync(bin);
   const state = join(dir, "state"); mkdirSync(state);
@@ -33,15 +33,20 @@ function runOpen(initial) {
   const token = join(dir, "token"); writeFileSync(token, "fake-token\n");
   const key = join(dir, "key"); writeFileSync(key, "fake-key\n");
   const hosts = join(dir, "known_hosts"); writeFileSync(hosts, "fake-hosts\n");
-  const result = spawnSync("bash", [wrapper, "open", "--server-id", "25285", "--image-id", "303", "--apply",
-    "--token-file", token, "--ssh-key", key, "--known-hosts", hosts], {
-    env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, FAKE_VPSBG_STATE: state,
-      VPSBG_API_TOKEN_FILE: token, VPSBG_DATA_DISK_POLL_SECONDS: "0", VPSBG_DATA_DISK_HARD_STOP_SECONDS: "20",
-      VPSBG_DATA_DISK_START_COOLDOWN_SECONDS: "0", VPSBG_DATA_DISK_STALL_SECONDS: "2" },
-    encoding: "utf8", timeout: 60_000,
-  });
-  return { ...result, log: readFileSync(join(state, "log"), "utf8") };
+  const control = join(dir, "cm"); mkdirSync(control, { mode: 0o700 });
+  const run = (action) => {
+    const result = spawnSync("bash", [wrapper, action, "--server-id", "25285", "--image-id", "303", "--apply",
+      "--token-file", token, "--ssh-key", key, "--known-hosts", hosts], {
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, FAKE_VPSBG_STATE: state,
+        VPSBG_API_TOKEN_FILE: token, VPSBG_SSH_CONTROL_DIR: control, VPSBG_DATA_DISK_POLL_SECONDS: "0",
+        VPSBG_DATA_DISK_HARD_STOP_SECONDS: "20", VPSBG_DATA_DISK_START_COOLDOWN_SECONDS: "0", VPSBG_DATA_DISK_STALL_SECONDS: "2" },
+      encoding: "utf8", timeout: 60_000,
+    });
+    return { ...result, log: readFileSync(join(state, "log"), "utf8"), control };
+  };
+  return { run };
 }
+const runOpen = (initial) => harness(initial).run("open");
 
 test("open survives the detach/stop race: 423 on stop, delayed stop lands, one start, then SSH", () => {
   // Detach flips the guest to stock+running immediately; the stop answers 423;
@@ -52,6 +57,30 @@ test("open survives the detach/stop race: 423 on stop, delayed stop lands, one s
   assert.match(r.stdout, /PASS action=open/);
   assert.equal((r.log.match(/\/servers\/25285\/start POST/g) || []).length, 1, r.log);
   assert.equal((r.log.match(/\/servers\/25285\/measured-boot POST/g) || []).length, 1, r.log);
+  // One connection per window: every ssh carries the ControlMaster options, and a stale
+  // master is torn down before the detach so it can never mask a dead guest.
+  const sshLines = r.log.split("\n").filter((l) => l.startsWith("ssh "));
+  assert.ok(sshLines.length >= 2, r.log);
+  for (const l of sshLines) {
+    assert.match(l, /-o ControlMaster=auto/);
+    assert.match(l, new RegExp(`-o ControlPath=${r.control.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/%C`));
+    assert.match(l, /-o ControlPersist=600/);
+  }
+  assert.match(sshLines[0], /-O exit root@/);
+  assert.ok(r.log.indexOf("-O exit") < r.log.indexOf("/servers/25285/measured-boot POST"), "teardown precedes the detach");
+});
+
+test("close tears the control master down, then switches the recorded image", () => {
+  const h = harness({ mode: "stock", running: "true", ssh: "1", stop_http: "200", script: "" });
+  const r = h.run("close");
+  assert.equal(r.status, 0, r.stdout + r.stderr);
+  assert.match(r.stdout, /^\[stage\] close SSH control master$/m);
+  assert.match(r.stdout, /^PASS action=switch server_id=25285 image_id=303$/m);
+  assert.match(r.stdout, /^PASS action=close$/m);
+  const sshLines = r.log.split("\n").filter((l) => l.startsWith("ssh "));
+  assert.equal(sshLines.length, 1, r.log);
+  assert.match(sshLines[0], /-o ControlMaster=auto .*-O exit root@/);
+  assert.ok(r.log.indexOf("-O exit") < r.log.indexOf("/servers/25285/measured-boot POST"), "teardown precedes the switch");
 });
 
 test("open stops a guest that stays on the old kernel: stall → stop (423 retried) → off → start → SSH", () => {


### PR DESCRIPTION
Pain point 5 (`docs/history/PIR2_DEPLOYMENT_PAIN_POINTS_2026-09.md`): the stock rootfs rate-limits new SSH connections (6 per 30 s), so every `put`/`get`/`ssh` of a window now shares one ControlMaster connection (`ControlPersist=600`, private control directory `VPSBG_SSH_CONTROL_DIR`, default `/tmp/bpir-vpsbg-ssh-<uid>`). `open` tears a stale master down before the detach, `close` before the switch. Offline simulations extended (open asserts the options and the teardown order; new close test with the fake control plane answering the switch). Flow F documents it; the campaign's pacing drops to 2 s; pain point marked fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)