### PR TITLE
unified_server: --help and --version answered before the parser (exit 0)

### DIFF
--- a/apps/server/src/bin/unified_server/cli.rs
+++ b/apps/server/src/bin/unified_server/cli.rs
@@ -302,6 +302,83 @@ pub(crate) fn fatal_cli(msg: impl AsRef<str>) -> ! {
     std::process::exit(2);
 }
 
+/// Flag reference printed by `--help`. Every `"--flag"` literal the parser
+/// accepts must appear here (enforced by a unit test), so the text cannot
+/// drift from the parser. Production values come from the reviewed run
+/// scripts and unit files, never from this text.
+pub(crate) const USAGE_V1: &str = "\
+unified_server - BitcoinPIR unified PIR server (DPF, OnionPIR, HarmonyPIR, Direct/Cuckoo ORAM)
+
+usage: unified_server [FLAGS]           production flags come from the reviewed run
+                                        scripts and unit files (docs/PRODUCTION_OPERATIONS.md)
+       unified_server --help | -h       print this text and exit
+       unified_server --version | -V    print crate version, git revision, binary sha256
+
+listener:      --bind-address ADDR  --port N  --role primary|secondary  --serve-hints
+               --serve-queries  --max-connections N  --connection-idle-timeout-ms MS
+               --websocket-handshake-timeout-ms MS
+databases:     --config databases.toml | --data-dir DIR  --checkpoint DIR HEIGHT
+               --delta DIR BASE TIP  --disable-onion
+attestation:   --vcek-dir DIR  --identity-key-path FILE  --identity-cert-path FILE
+               --identity-server-id ID
+admin:         --admin-pubkey-hex HEX
+session grants: --session-grant-pubkey FILE  --session-grant-hint-credits N
+               --require-session-grant
+hint pool:     --pool-size N  --pool-db-id ID  --pool-dir DIR  --harmony-pool-db ID=DIR
+direct oram:   --direct-oram-db ID=DIR  --direct-oram-dir DIR  --direct-oram-trusted-state-db ID=DIR
+               --direct-oram-drain-per-access N  --direct-oram-access-budget N
+               --direct-oram-cache-levels N  --direct-oram-encrypted  --direct-oram-key-hex HEX
+               --direct-oram-state-key-hex HEX  --direct-oram-auth-store  --direct-oram-no-save
+               --allow-direct-oram-trusted-state-outside-run-dev
+cuckoo oram:   --cuckoo-oram-db ID=DIR  --cuckoo-oram-dir DIR  --cuckoo-oram-drain-per-access N
+               --cuckoo-oram-cache-levels N  --cuckoo-oram-encrypted  --cuckoo-oram-key-hex HEX
+               --cuckoo-oram-state-key-hex HEX  --cuckoo-oram-auth-store  --cuckoo-oram-no-save
+               --cuckoo-oram-pack
+harmony oram:  --harmony-oram-db ID=DIR  --harmony-oram-dir DIR  --harmony-oram-drain-per-access N
+               --harmony-oram-cache-levels N  --harmony-oram-encrypted  --harmony-oram-key-hex HEX
+               --harmony-oram-state-key-hex HEX  --harmony-oram-auth-store  --harmony-oram-no-save
+               --harmony-oram-pack
+pir2 sealed:   --pir2-snp-sealed-release FILE  --pir2-snp-sealed-envelope FILE
+               --pir2-snp-sealed-receipt FILE  --pir2-snp-sealed-marker FILE
+               --pir2-snp-sealed-phase observe|enroll|probe|ready  --pir2-snp-sealed-ordinal N
+               --pir2-snp-sealed-verifier-nonce-hex HEX  --pir2-snp-sealed-current-boot-id-hex HEX
+               --pir2-snp-sealed-current-channel-pubkey-hex HEX  --pir2-snp-sealed-identity-cert FILE
+               --pir2-snp-sealed-preflight-only  --pir2-snp-sealed-require-ready
+development:   --unsafe-debug-query-logging (test-only-unsafe-query-logging builds only)
+";
+
+/// `--help`/`-h` and `--version`/`-V` as the only argument print and exit 0
+/// before anything else runs; any other argument list goes to the parser,
+/// which still rejects unknown flags. Returns the text to print.
+pub(crate) fn informational_argument_v1(args: &[String]) -> Option<String> {
+    if args.len() != 2 {
+        return None;
+    }
+    match args[1].as_str() {
+        "--help" | "-h" => Some(USAGE_V1.to_owned()),
+        "--version" | "-V" => Some(version_line_v1()),
+        _ => None,
+    }
+}
+
+/// One line: crate version, the git revision baked at build time, and the
+/// sha256 of the running executable (what the client pins), for install
+/// sanity checks.
+pub(crate) fn version_line_v1() -> String {
+    let digest = pir_runtime_core::attest::self_exe_sha256();
+    let binary = if digest == [0u8; 32] {
+        "unavailable".to_owned()
+    } else {
+        hex::encode(digest)
+    };
+    format!(
+        "unified_server {} git_rev={} binary_sha256={}\n",
+        env!("CARGO_PKG_VERSION"),
+        pir_runtime_core::attest::GIT_REV,
+        binary
+    )
+}
+
 pub(crate) fn parse_args() -> CliArgs {
     parse_args_from(std::env::args().collect())
 }

--- a/apps/server/src/bin/unified_server/main.rs
+++ b/apps/server/src/bin/unified_server/main.rs
@@ -6,10 +6,9 @@
 //!
 //! Uses pir-core's MappedDatabase for table loading instead of legacy CuckooTablePair.
 //!
-//! Usage:
-//!   unified_server --port 8091 [--data-dir /path/to/checkpoint] [--role primary|secondary]
-//!     [--checkpoint /path/to/checkpoint <height>]...
-//!     [--delta /path/to/delta <base_height> <tip_height>]...
+//! Usage: `unified_server --help` prints the flag reference (`cli::USAGE_V1`);
+//! `unified_server --version` prints the crate version, git revision, and
+//! binary sha256. Production flags come from the reviewed run scripts.
 
 mod cli;
 mod dispatch;
@@ -59,6 +58,10 @@ use std::sync::atomic::Ordering;
 
 #[tokio::main]
 async fn main() {
+    if let Some(text) = informational_argument_v1(&std::env::args().collect::<Vec<_>>()) {
+        print!("{text}");
+        return;
+    }
     let args = parse_args();
     #[cfg(any(test, feature = "test-only-unsafe-query-logging"))]
     {

--- a/apps/server/src/bin/unified_server/tests.rs
+++ b/apps/server/src/bin/unified_server/tests.rs
@@ -2118,3 +2118,61 @@ mod session_grant_gate {
         }
     }
 }
+
+mod cli_informational_tests {
+    //! `--help`/`--version` are answered before the parser runs, and the
+    //! usage text must name every flag the parser accepts.
+    use super::*;
+
+    fn argv(items: &[&str]) -> Vec<String> {
+        std::iter::once("unified_server")
+            .chain(items.iter().copied())
+            .map(str::to_owned)
+            .collect()
+    }
+
+    #[test]
+    fn usage_names_every_flag_the_parser_accepts() {
+        let source = include_str!("cli.rs");
+        let mut missing = Vec::new();
+        for (i, _) in source.match_indices("\"--") {
+            let rest = &source[i + 1..];
+            let end = rest.find('"').expect("closing quote");
+            let flag = &rest[..end];
+            let is_match_arm = rest[end + 1..].trim_start().starts_with("=>")
+                || rest[end + 1..].trim_start().starts_with('|');
+            if is_match_arm && !USAGE_V1.contains(flag) {
+                missing.push(flag.to_owned());
+            }
+        }
+        missing.sort();
+        missing.dedup();
+        assert!(
+            missing.is_empty(),
+            "flags missing from USAGE_V1: {missing:?}"
+        );
+    }
+
+    #[test]
+    fn help_and_version_are_answered_only_as_the_sole_argument() {
+        let help = informational_argument_v1(&argv(&["--help"])).expect("--help");
+        assert!(help.contains("--serve-queries") && help.contains("--pir2-snp-sealed-release"));
+        assert_eq!(
+            informational_argument_v1(&argv(&["-h"])),
+            Some(USAGE_V1.to_owned())
+        );
+        let version = informational_argument_v1(&argv(&["--version"])).expect("--version");
+        assert!(version.starts_with("unified_server "));
+        assert!(version.contains(" git_rev=") && version.contains(" binary_sha256="));
+        assert_eq!(
+            informational_argument_v1(&argv(&["-V"])),
+            Some(version_line_v1())
+        );
+        assert_eq!(informational_argument_v1(&argv(&[])), None);
+        assert_eq!(informational_argument_v1(&argv(&["--port", "8091"])), None);
+        assert_eq!(
+            informational_argument_v1(&argv(&["--help", "--port"])),
+            None
+        );
+    }
+}

--- a/apps/server/tests/unified_server_cli.rs
+++ b/apps/server/tests/unified_server_cli.rs
@@ -1,0 +1,41 @@
+//! The production binary answers `--help` and `--version` (exit 0) and still
+//! rejects an unknown flag (exit 2), so install sanity checks can call it
+//! without starting a server (docs/history/PIR2_DEPLOYMENT_PAIN_POINTS_2026-09.md #10).
+
+use std::process::Command;
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_unified_server"))
+        .args(args)
+        .output()
+        .expect("spawn unified_server")
+}
+
+#[test]
+fn version_prints_one_line_and_exits_zero() {
+    let out = run(&["--version"]);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = String::from_utf8(out.stdout).unwrap();
+    assert_eq!(text.lines().count(), 1);
+    assert!(text.starts_with("unified_server "));
+    assert!(text.contains(" git_rev=") && text.contains(" binary_sha256="));
+}
+
+#[test]
+fn help_prints_the_flag_reference_and_exits_zero() {
+    let out = run(&["--help"]);
+    assert!(out.status.success());
+    let text = String::from_utf8(out.stdout).unwrap();
+    assert!(text.contains("--serve-queries") && text.contains("--session-grant-pubkey"));
+}
+
+#[test]
+fn unknown_flag_is_still_rejected() {
+    let out = run(&["--no-such-flag"]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&out.stderr).contains("unknown argument: --no-such-flag"));
+}

--- a/docs/PRODUCTION_OPERATIONS.md
+++ b/docs/PRODUCTION_OPERATIONS.md
@@ -169,6 +169,9 @@ contains a stale single-host caveat — ignore that; pir2 is VPSBG.
 2. Auth — on the host, fast-forward the reviewed commit, build the
    same command, restart `pir-primary`. Restart `cloudflared` only if
    the tunnel itself is broken. Build 2–5 min, hard stop 15 min.
+   `unified_server --version` prints the crate version, git revision,
+   and binary sha256 of an installed binary without starting a server;
+   `--help` prints the flag reference.
 3. Read — `scripts/production-status.sh` and confirm `:8091` /
    `pir-primary` are active. Do not treat `pir-secondary` as the
    public peer. This step is systemd/SSH health only; it does not

--- a/docs/history/PIR2_DEPLOYMENT_PAIN_POINTS_2026-09.md
+++ b/docs/history/PIR2_DEPLOYMENT_PAIN_POINTS_2026-09.md
@@ -62,6 +62,10 @@ Each item: what hurt, evidence, proposed cleanup.
    offline test of every plan; the runbook's "Campaign" section documents the env file.
 10. `unified_server` rejects `--help` (breaks install sanity checks); add `--help`/
     `--version`.
+    **Fixed:** `--help`/`-h` prints a flag reference that a unit test keeps in sync with
+    the parser; `--version`/`-V` prints crate version, git revision, and binary sha256;
+    both exit 0 as the sole argument and never start a server (integration test
+    `apps/server/tests/unified_server_cli.rs`, run by the runtime CI lane).
 11. `scripts/pir2-sealed-ceremony.sh` runs `cargo run --locked --offline -p bpir-admin`
     (debug profile) for `release`/`receipt`; after any runtime change the first call
     recompiles for >10 min in the middle of a ceremony window (observed 2026-09-07).

--- a/scripts/rust-ci-lane.sh
+++ b/scripts/rust-ci-lane.sh
@@ -27,7 +27,7 @@ case "$lane" in
     cargo clippy --timings --locked --offline --all-targets --no-deps -p pir-private-files -p pir-session-grant -p bpir-admin -- -D warnings
     ;;
   runtime-default-security)
-    cargo check --timings --locked --offline -p runtime --bin unified_server; cargo test --locked --offline -p runtime --lib hint_pool; cargo test --locked --offline -p runtime --bin unified_server
+    cargo check --timings --locked --offline -p runtime --bin unified_server; cargo test --locked --offline -p runtime --lib hint_pool; cargo test --locked --offline -p runtime --bin unified_server; cargo test --locked --offline -p runtime --test unified_server_cli
     cargo clippy --locked --offline -p runtime --bin unified_server --no-deps -- -D warnings
     cargo clippy --locked --offline -p runtime --features test-only-unsafe-query-logging --bin unified_server --no-deps -- -D warnings
     # The privacy-dangerous logging feature must never compile into a release


### PR DESCRIPTION
Pain point 10 (`docs/history/PIR2_DEPLOYMENT_PAIN_POINTS_2026-09.md`). `--help`/`-h` prints a grouped flag reference that a unit test keeps in sync with the parser's `"--flag"` arms; `--version`/`-V` prints crate version, git revision, and the running binary's sha256. Both only as the sole argument, before any server state is touched; unknown flags still exit 2. Integration test spawns the built binary (3 cases) and runs in the runtime-default-security lane. Flow D mentions the sanity-check use.

Takes effect on pir1 with its next rebuild and on pir2 with the next image; no run-script or flag change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)