### PR TITLE
pir2-post-switch-check: empty status arguments are valid under set -u on bash 3.2

### DIFF
--- a/docs/history/PIR2_DEPLOYMENT_PAIN_POINTS_2026-09.md
+++ b/docs/history/PIR2_DEPLOYMENT_PAIN_POINTS_2026-09.md
@@ -18,6 +18,9 @@ Each item: what hurt, evidence, proposed cleanup.
    offline simulation of the race in `scripts/vpsbg-data-disk.test.mjs`.
 2. `scripts/pir2-post-switch-check.sh`: `status_args[@]: unbound variable` when no
    `--server-id` is given (noted in the epoch-5 handoff, still unfixed).
+   **Fixed:** the empty array is expanded with the `${status_args[@]+"${status_args[@]}"}`
+   form (bash 3.2 under `set -u`); `scripts/ops-operator-scripts.test.sh` checks that no
+   unguarded expansion comes back.
 3. Hint-pool generation timing is compiled out in production
    (`test-only-unsafe-query-logging`); capacity planning needed /proc CPU sampling.
    Fix: a non-sensitive duration counter (no keys, no query data) in the info log.

--- a/scripts/ops-operator-scripts.test.sh
+++ b/scripts/ops-operator-scripts.test.sh
@@ -83,6 +83,13 @@ grep -qx 'PASS action=status dry_run=true' <<<"$status_token_preview"
 expect_fail 'status still rejects --image-id' \
   "$script_dir/vpsbg-measured-boot.sh" status --image-id 291 --dry-run
 check_preview=$("$script_dir/pir2-post-switch-check.sh" --dry-run)
+# Without --server-id the status arguments are an empty array; bash 3.2 under
+# set -u rejects "${status_args[@]}", so the script must use the guarded form
+# (docs/history/PIR2_DEPLOYMENT_PAIN_POINTS_2026-09.md #2).
+grep -q 'status_args\[@\]+"\${status_args\[@\]}"' "$script_dir/pir2-post-switch-check.sh" \
+  || { echo 'pir2-post-switch-check.sh must expand status_args with the empty-safe form' >&2; exit 1; }
+grep -q '"\${status_args\[@\]}"' <(grep -v 'status_args\[@\]+' "$script_dir/pir2-post-switch-check.sh") \
+  && { echo 'pir2-post-switch-check.sh still has an unguarded status_args expansion' >&2; exit 1; }
 grep -qx "pin_source=$repo/web/src/attest-pin.ts" <<<"$check_preview"
 grep -qx 'PASS action=post_switch_check dry_run=true' <<<"$check_preview"
 

--- a/scripts/pir2-post-switch-check.sh
+++ b/scripts/pir2-post-switch-check.sh
@@ -80,7 +80,7 @@ if ((dry_run)); then
   exit 0
 fi
 
-status_args=()
+status_args=()  # expanded as ${status_args[@]+"${status_args[@]}"}: empty is valid under set -u on bash 3.2
 [[ -z "$server_id" ]] || status_args+=(--server-id "$server_id")
 [[ -z "$status_url" ]] || status_args+=(--status-url "$status_url")
 
@@ -97,7 +97,7 @@ while :; do
     echo "hard stop: pir2 did not reach boot_mode=measured and running=true in ${HARD_STOP_SECONDS}s" >&2
     exit 1
   fi
-  snapshot=$("$root/scripts/vpsbg-production-status.sh" "${status_args[@]}")
+  snapshot=$("$root/scripts/vpsbg-production-status.sh" ${status_args[@]+"${status_args[@]}"})
   boot_mode=$(status_field boot_mode <<<"$snapshot")
   running=$(status_field control_plane_running <<<"$snapshot")
   image_id=$(status_field image_id <<<"$snapshot")


### PR DESCRIPTION
Pain point 2 (`docs/history/PIR2_DEPLOYMENT_PAIN_POINTS_2026-09.md`), which I had wrongly listed as already fixed: without `--server-id` the live path died with `status_args[@]: unbound variable` on macOS bash 3.2. Guarded expansion (`${status_args[@]+"${status_args[@]}"}`); `scripts/ops-operator-scripts.test.sh` asserts no unguarded expansion returns; item marked fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)