### PR TITLE
pir2-sealed-campaign: bundle the release commit through a temporary branch ref

### DIFF
--- a/scripts/pir2-sealed-campaign.sh
+++ b/scripts/pir2-sealed-campaign.sh
@@ -154,7 +154,13 @@ build)
   ((dry_run)) || mkdir -p "$UKI_LOCAL_DIR"
   bundle=$EVIDENCE_DIR/source-$TAG.bundle
   stage "source bundle for $REV"
-  run git -C "$REPO" bundle create "$bundle" "$REV"
+  # `git bundle create` refuses a bare commit id ("empty bundle"): it records
+  # refs. A temporary branch pointing at REV makes the bundle clonable on the
+  # build host, where build-runtime.sh checks out REV by id.
+  bundle_ref=refs/heads/bpir-campaign-$TAG
+  run git -C "$REPO" update-ref "$bundle_ref" "$REV"
+  run git -C "$REPO" bundle create "$bundle" "$bundle_ref"
+  run git -C "$REPO" update-ref -d "$bundle_ref"
   open_window "$ROLLBACK_IMAGE"
   stage "preserve the rollback set $ROLLBACK_LABEL (previous image's credentials + Ready startup)"
   put "$REPO/scripts/pir2-sealed-rollback-set.sh" "$BUILD_ROOT/pir2-sealed-rollback-set.sh"

--- a/scripts/pir2-sealed-campaign.test.mjs
+++ b/scripts/pir2-sealed-campaign.test.mjs
@@ -91,7 +91,9 @@ test("build --dry-run plans the whole first window in order without touching the
   assert.doesNotMatch(r.stderr, /NETWORK TOOL INVOKED/);
   const p = plans(r).join("\n");
   const order = [
-    /git -C .* bundle create .*source-r7-test\.bundle 6a407bdb/,
+    /git -C .* update-ref refs\/heads\/bpir-campaign-r7-test 6a407bdb/,
+    /git -C .* bundle create .*source-r7-test\.bundle refs\/heads\/bpir-campaign-r7-test/,
+    /git -C .* update-ref -d refs\/heads\/bpir-campaign-r7-test/,
     /vpsbg-data-disk\.sh open --server-id 25285 --image-id 305 --apply/,
     /pir2-sealed-rollback-set\.sh preserve --label image305-test/,
     /prep-inputs\.sh/, /build-runtime\.sh/, /build-uki\.sh/,


### PR DESCRIPTION
First live use of the campaign script (r8) hit `git bundle create FILE <sha>` → "Refusing to create empty bundle": bundles record refs, not bare commits. The build action now creates a temporary `refs/heads/bpir-campaign-<TAG>` at `REV`, bundles it, and deletes it; the build host still checks out `REV` by id. Dry-run test updated. Verified live: the r8 build window then ran end to end (image 309).

🤖 Generated with [Claude Code](https://claude.com/claude-code)