### PR TITLE
web: pin pir2 to VPSBG image 309 (r8: --help/--version, hourly hint-pool timing)

### DIFF
--- a/web/src/attest-pin.ts
+++ b/web/src/attest-pin.ts
@@ -126,21 +126,22 @@ export interface ServerAttestPin {
 }
 
 /**
- * weikeng2.bitcoinpir.org — VPSBG Tier 3 SNP-sealed UKI, pinned 2026-09-07
- * after the r7 rollout (Observe/Enroll/Probe/Ready on image 307, source
- * `6a407bdb`). Image 307 serves DPF, Harmony-query and TEE ORAM, meters session
- * grants (hint set = 150 credits), serves its own Ready receipts read-only
- * (REQ_PIR2_SEALED_RECEIPT_GET), and bakes cloudflared 2026.8.3.
+ * weikeng2.bitcoinpir.org — VPSBG Tier 3 SNP-sealed UKI, pinned 2026-09-08
+ * after the r8 rollout (Observe/Enroll/Probe/Ready on image 309, source
+ * `a77e4d52`, run by scripts/pir2-sealed-campaign.sh). Image 309 serves DPF,
+ * Harmony-query and TEE ORAM, meters session grants (hint set = 150 credits),
+ * serves its own Ready receipts read-only, answers --help/--version, logs an
+ * hourly hint-pool timing summary, and bakes cloudflared 2026.8.3.
  */
 export const PIR2_TIER3_PIN: ServerAttestPin = {
-  // Captured from live image 307 after AMD chain + REPORT_DATA verification
+  // Captured from live image 309 after AMD chain + REPORT_DATA verification
   // in scripts/pir2-post-switch-check.sh. binary_sha256 and MEASUREMENT
-  // mismatched the previous image-305 pin, as expected for this UKI.
+  // mismatched the previous image-307 pin, as expected for this UKI.
   measurementHex:
-    'de353c325cc59d6d45d5bc880086f846686161554dffc44a68dd941e9d99f354ba8db0c0131b8f7fdc7b033b2e9b3369',
+    'db2a43c3f2601a5f649c9b7ead7ad093d94f3d1a0e991035c86da92ccff1582ee6b390b4c16b33123ab5481cff696156',
   binarySha256Hex:
-    '0583bab081fa3c8ab523c44f028605d1b0693d43bf11e2e603aa2122ec73096f',
-  description: 'weikeng2.bitcoinpir.org (VPSBG image 307, SEV-SNP, sealed Tier 3 DPF + Harmony + Direct ORAM, session grants metered, Ready receipts over WS)',
+    '71796e85906c758cd00d2714bc570ce9af01401f6b4802f01fbe6a7151681813',
+  description: 'weikeng2.bitcoinpir.org (VPSBG image 309, SEV-SNP, sealed Tier 3 DPF + Harmony + Direct ORAM, session grants metered, Ready receipts over WS)',
 };
 
 /**


### PR DESCRIPTION
Repins `PIR2_TIER3_PIN` to VPSBG image 309 (r8, runtime `a77e4d52`), the first campaign run entirely through `scripts/pir2-sealed-campaign.sh`: Observe 61 → release generation 8 → Enroll 62 → Probe 63/64 (one identity) → Ready 65 serving. Live attestation (Observe-61 measurement, sidecar binary) passed at 08:17Z; post-switch check passes with this pin; both Ready receipts were fetched over the WebSocket and accepted offline. Rollback target: image 307 (rollback set `image307-20260908` on the data disk). Release record follows in a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)