### PR TITLE
web: credits wallet in the paid-access panel

### DIFF
--- a/docs/CREDITS.md
+++ b/docs/CREDITS.md
@@ -225,6 +225,32 @@ a private key: clients compare the issuer key and epoch against
 `/v2/info` and the SDK's pinned values. Query contents were never visible
 to anyone; PIR hides them regardless of payment.
 
+## Rollout
+
+In this order, each step reversible on its own; nothing charges a user
+until the last one. Steps marked Human are key generation or funds and
+are never run by an agent; the others are operator campaigns routed
+through [Production operations](PRODUCTION_OPERATIONS.md).
+
+1. Cashier (pir1, [runbook](runbooks/cashier-and-mint.md) "Credits (v2)"):
+   Human runs `bpir-cashier arc-seed`; upgrade the binary to a `main`
+   revision with `/v2/`; add `[gas]`, `operator_pubkeys`, `[arc]`; restart;
+   check `GET /v2/info`.
+2. pir1 (Flow D): rebuild `unified_server` from `main`, add
+   `--credit-issuer-url https://cashier.bitcoinpir.org` to the unit, restart;
+   the startup log must show `Credits: issuer=… accepted, not charged` and
+   the issuer parameters. Web (Flow C): deploy the page with the wallet.
+3. End-to-end check on pir1 only: buy one 100-credit pack in the browser,
+   query DPF, watch `bpir-cashier settlement` book the sat to pir1 and the
+   server's hourly `[meter]` lines; nothing is charged yet (frames are free
+   without `--require-credits`).
+4. pir2: set `PIR2_CREDIT_ISSUER_URL` in `unified-server-run.sh`, run the
+   sealed campaign (`scripts/pir2-sealed-campaign.sh`; a VPSBG image slot must
+   be freed first, Human), update the pins.
+5. Switch: `--require-credits` on pir1 (unit) and pir2 (image); the pricing
+   in `/v2/info` is what users then pay. Keep `--session-grant-pubkey` until
+   every stored grant has expired (30 days at most), then retire `0x0b`.
+
 ## Status
 
 | Step | Where | State |
@@ -237,5 +263,5 @@ to anyone; PIR hides them regardless of payment.
 | ARC client (`WasmArcCredentialRequest`, `WasmArcCredential`), `presentCredits` on every wasm client, `pir_sdk_client::credits` (presentation, gas card, connection meter), `web/src/credits.ts` (issuer v2 client, credential store, wallet, purchase flow) | `crates/sdk/wasm`, `crates/sdk/client`, `web/` | done (nothing calls it yet) |
 | Metering hooks: the credited transport in the SDK, `enableCredits` on the wasm clients, `creditProvider` in the web adapters and the OnionPIR web client, `"credits"` flags in `GET_INFO_JSON` | `crates/sdk/client`, `crates/sdk/wasm`, `web/`, `apps/server` | done (nothing supplies a provider yet) |
 | Wallet UI: the "Paid access" panel buys credit packs over Lightning (`purchaseCredential`, resumable), shows the balance and each connection's credits state, and hands `CreditWallet.present` to the four adapters as `creditProvider` | `web/index.html`, `web/src/sdk-bridge.ts` | done |
-| Rollout: issuer config (`[gas]`, `operator_pubkeys`, `[arc]`, `arc-seed`), `--credit-issuer-url` on pir1, the pir2 UKI script flags and a sealed campaign, `--require-credits` once clients carry wallets | `Bitcoin-PIR/cashier`, pir1, pir2 | next |
+| Rollout (see above) | `Bitcoin-PIR/cashier`, pir1, pir2 | next; pir2's `unified-server-run.sh` carries `PIR2_CREDIT_ISSUER_URL` |
 | Retire `0x0b` | protocol registry | after every client presents credits |

--- a/docs/CREDITS.md
+++ b/docs/CREDITS.md
@@ -236,5 +236,6 @@ to anyone; PIR hides them regardless of payment.
 | ARC issuance and verification (`/v2/credentials`, ARC items on `/v2/redeem`) | `Bitcoin-PIR/cashier` | after that |
 | ARC client (`WasmArcCredentialRequest`, `WasmArcCredential`), `presentCredits` on every wasm client, `pir_sdk_client::credits` (presentation, gas card, connection meter), `web/src/credits.ts` (issuer v2 client, credential store, wallet, purchase flow) | `crates/sdk/wasm`, `crates/sdk/client`, `web/` | done (nothing calls it yet) |
 | Metering hooks: the credited transport in the SDK, `enableCredits` on the wasm clients, `creditProvider` in the web adapters and the OnionPIR web client, `"credits"` flags in `GET_INFO_JSON` | `crates/sdk/client`, `crates/sdk/wasm`, `web/`, `apps/server` | done (nothing supplies a provider yet) |
-| Wallet UI: buy a credential, show the balance, hand `CreditWallet.present` to the adapters | `web/` | next |
+| Wallet UI: the "Paid access" panel buys credit packs over Lightning (`purchaseCredential`, resumable), shows the balance and each connection's credits state, and hands `CreditWallet.present` to the four adapters as `creditProvider` | `web/index.html`, `web/src/sdk-bridge.ts` | done |
+| Rollout: issuer config (`[gas]`, `operator_pubkeys`, `[arc]`, `arc-seed`), `--credit-issuer-url` on pir1, the pir2 UKI script flags and a sealed campaign, `--require-credits` once clients carry wallets | `Bitcoin-PIR/cashier`, pir1, pir2 | next |
 | Retire `0x0b` | protocol registry | after every client presents credits |

--- a/docs/runbooks/cashier-and-mint.md
+++ b/docs/runbooks/cashier-and-mint.md
@@ -36,6 +36,7 @@ mint.
 | `/etc/bitcoinpir/cashier/grant.key` | `bpir-cashier`, 0600 | 32-byte Ed25519 seed (`bpir-cashier keygen`) | rotate: new key, re-pin every server |
 | `/etc/bitcoinpir/cashier/wallet.seed` | `bpir-cashier`, 0600 | 64-byte Cashu wallet seed | the cashier's ecash claim on the mint is lost |
 | `/etc/bitcoinpir/cashier/grant.pub` | root, 0644 | 64 hex, the public key servers pin | regenerate with `bpir-cashier pubkey` |
+| `/etc/bitcoinpir/cashier/arc.seed` | `bpir-cashier`, 0600 | 32-byte ARC master seed (`bpir-cashier arc-seed`); every epoch's issuer keys derive from it | every issued credential becomes unspendable; buyers must be refunded out of band |
 
 `bpir-cashier keygen`, `wallet-seed`, and `mnemonic` never print the
 secret; `keygen` and `pubkey` print only the public key.
@@ -52,6 +53,16 @@ secret; `keygen` and `pubkey` print only the public key.
   key or price change is a new image (Flow E/G). An image built before the
   pin answers "session grants not enabled" and the client treats it as the
   free path.
+- Credits ([Credits and gas](../CREDITS.md)): a server that should verify
+  credits at the cashier passes `--credit-issuer-url
+  https://cashier.bitcoinpir.org` (pir1: the unit; pir2:
+  `PIR2_CREDIT_ISSUER_URL` in `unified-server-run.sh`, a new image). The
+  cashier's answers verify under the same `grant.pub` the server already
+  pins, and the server signs its redeem requests with its identity key, so
+  the cashier's `operator_pubkeys` must list the operator key that signed
+  that server's identity certificate. `--require-credits` closes the free
+  path; until then presentations are verified and booked but frames stay
+  free (the rollout state).
 - Gas meter: each server prints one `[meter op=0x.. db=N] last 3600s: n=…
   gas_mean=… cpu_mean_ms=… wall_mean_ms=… egress_mean_kib=… inflight_max=…`
   line per opcode and database per hour plus a `[meter] last 3600s: …`
@@ -104,6 +115,55 @@ Amboss Magma through its API (`liquidity.buy` with the node's
 in the graph). Keep the order id and session key with the operator's
 private records. Keep a small on-chain balance in CLN for anchor-channel
 fee bumping.
+
+## Credits (v2): configuration and settlement
+
+The same `bpir-cashier` serves the session-grant contract under `/v1/` and
+the credits contract under `/v2/` ([Credits and gas](../CREDITS.md)).
+Everything credits need is in `config.toml`; an existing file keeps working
+without these tables, which leaves `POST /v2/redeem` refusing every server
+and `/v2/credentials` unsold.
+
+```toml
+[gas]                       # docs/CREDITS.md "Rate card"; defaults shown
+credit_sat = 10
+gas_per_credit = 72000
+base_gas_per_frame = 20
+egress_gas_per_mb = 1000
+
+# Operator identity keys (64 hex) whose certified servers may redeem: the
+# `operatorPubkey` values of PIR1_PROVIDER and PIR2_PROVIDER in
+# web/src/production-providers.ts (pir1 and pir2 are certified by
+# different operator keys; list both).
+operator_pubkeys = ["<pir1 operator pubkey hex>", "<pir2 operator pubkey hex>"]
+redeem_max_skew_secs = 300
+
+[arc]                       # Human: `bpir-cashier arc-seed --out /etc/bitcoinpir/cashier/arc.seed`
+seed_path = "/etc/bitcoinpir/cashier/arc.seed"
+epoch_secs = 7776000        # 90 days
+grace_secs = 2592000        # 30 days
+presentation_limit = 100
+[[arc.credential_offers]]   # credits must equal presentation_limit
+credits = 100
+sat = 1000
+```
+
+`chown bpir-cashier:bpir-cashier /etc/bitcoinpir/cashier/arc.seed && chmod
+0600 …`, then `systemctl restart bpir-cashier`; the startup log line says
+`arc=true` and `operator_keys=2`. `GET /v2/info` must then show the `arc`
+section and the pack.
+
+- Every redemption is appended to `/var/lib/bitcoinpir-cashier/redeem.jsonl`
+  (the replay index for `(server_id, nonce)` and the per-server ledger with
+  the ARC tags each epoch consumed). `bpir-cashier settlement --config
+  /etc/bitcoinpir/cashier/config.toml` prints redemptions, gas, and sat per
+  server: what each server earned.
+- `grants.jsonl` now also records `redeemed` (a token spent through a
+  server) and `credentialed` (a token that bought a credential) states, so
+  a token can never be used twice across the three paths.
+- Back up `arc.seed` with the other secrets; rotating it is a new epoch's
+  worth of refunds, not a key rotation (issued credentials are bound to the
+  seed's per-epoch keys).
 
 ## Change offers or TTL
 

--- a/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
+++ b/scripts/dracut/97bpir-tier3-init/unified-server-run.sh
@@ -60,6 +60,12 @@ PIR2_SEALED_IDENTITY_CERT_PATH="$PIR2_SEALED_ROOT/identity.cert"
 PIR2_SESSION_GRANT_PUBKEY_HEX=59392a0738106c4954c317f9bfae2e4918fe809fa0c49fdf23493ce709b9c6e0
 PIR2_SESSION_GRANT_PUBKEY_FILE=/run/bitcoinpir-session-grant.pub
 PIR2_SESSION_GRANT_HINT_CREDITS=150
+# Credits (docs/CREDITS.md): the issuer this guest forwards presentations
+# to. Its answers verify under the session-grant key above; the guest signs
+# redeem requests with its sealed identity. Presentations are accepted but
+# frames stay free until --require-credits is added, which is a new image
+# and an operator decision.
+PIR2_CREDIT_ISSUER_URL=https://cashier.bitcoinpir.org
 PIR2_SEALED_INERT_SUCCESS_EXIT_CODE=42
 # Inert Observe/Enroll/Probe runs leave no listener behind.  VPSBG currently
 # has no console or file-extraction API, so expose only the canonical receipt
@@ -1267,5 +1273,6 @@ exec "$UNIFIED_SERVER" \
     --pir2-snp-sealed-identity-cert "$PIR2_SEALED_IDENTITY_CERT_PATH" \
     --session-grant-pubkey "$PIR2_SESSION_GRANT_PUBKEY_FILE" \
     --session-grant-hint-credits "$PIR2_SESSION_GRANT_HINT_CREDITS" \
+    --credit-issuer-url "$PIR2_CREDIT_ISSUER_URL" \
     --connection-idle-timeout-ms 300000 \
     2>&1

--- a/scripts/tier3-uki-policy-contract.test.mjs
+++ b/scripts/tier3-uki-policy-contract.test.mjs
@@ -170,6 +170,13 @@ test("runtime UKI pins the cashier key and the hint-set price, never --require-s
   assert.doesNotMatch(withoutComments(source), /^\s*--require-session-grant\b/m);
 });
 
+test("runtime UKI names the credit issuer and never --require-credits", () => {
+  const source = readFileSync(runPath, "utf8");
+  assert.match(source, /^PIR2_CREDIT_ISSUER_URL=https:\/\/[a-z0-9.-]+$/m);
+  assert.match(source, /--credit-issuer-url "\$PIR2_CREDIT_ISSUER_URL"/);
+  assert.doesNotMatch(withoutComments(source), /^\s*--require-credits\b/m);
+});
+
 test("a comment mentioning a retired flag or artifact does not fail any contract, a real line does", () => {
   const mention = "\n# historical note: --require-session-grant, server.key, BPIR_TIER3_SERVICE_POLICY, target/release/unified_server\n";
   validateBuildContract(readFileSync(buildPath, "utf8") + mention);

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-/Paty+iS6bicoLbE64G6aZ+fIna6CzE6h+WSpPokiYQ=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; object-src 'none'; frame-src 'none'; form-action 'none'; script-src 'self' 'wasm-unsafe-eval' 'sha256-msrSUUsiTWxtaUsGoA5LMsaQJU3M09isucBKw4ugbEw=' 'sha256-RWVm/OUC8vUEGlsjafPo+FBblnycISMLULzPhZl9R4E=' 'sha256-/trgIxztzvg7U4CrsWvgkl752ZxtSM4j5zr9O+sqhUI='; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' https: wss: ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; manifest-src 'self'">
     <title>Bitcoin PIR</title>
     <link rel="icon" href="/brand/bitcoinpir-mark.svg" type="image/svg+xml" />
     <style>
@@ -888,6 +888,27 @@
                             <button type="button" id="pa-redeemBtn" class="btn sm">Redeem token</button>
                         </div>
                     </details>
+                    <!-- Credits (docs/CREDITS.md): ARC credentials bought for
+                         ecash and spent per metered frame wherever a server
+                         requires credits. -->
+                    <div style="margin-top: 12px; border-top: 1px solid var(--line, #ddd); padding-top: 8px;">
+                        <p id="pa-credits" style="margin: 0 0 8px;">No credits stored.</p>
+                        <div id="pa-creditLegs" style="font-family: monospace; font-size: 12px; margin-bottom: 8px;"></div>
+                        <div style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;">
+                            <button type="button" id="pa-loadCreditOffersBtn" class="btn sm">Load credit packs</button>
+                            <button type="button" id="pa-resumeCredentialBtn" class="btn accent sm" hidden>Resume pending credit purchase</button>
+                            <button type="button" id="pa-forgetCredentialsBtn" class="btn ghost sm" disabled>Forget credits</button>
+                        </div>
+                        <div id="pa-creditOffers" style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px;"></div>
+                        <div id="pa-credInvoiceBox" hidden style="margin-top: 8px;">
+                            <div>Pay this Lightning invoice with any wallet. The page then mints the ecash, has the issuer sign a blinded credential, and stores it. Credits are spent per query frame; nothing links a query to this purchase.</div>
+                            <textarea id="pa-credInvoice" readonly rows="3" style="width: 100%; font-family: monospace; font-size: 11px; margin-top: 4px;"></textarea>
+                            <div style="display: flex; gap: 8px; margin-top: 4px;">
+                                <button type="button" id="pa-copyCredInvoiceBtn" class="btn sm">Copy invoice</button>
+                                <button type="button" id="pa-cancelCredentialBtn" class="btn ghost sm">Cancel</button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </section>
 
@@ -1610,6 +1631,7 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         import { BatchPirClientAdapter, OnionPirWebClient, HarmonyPirClientAdapter, OramPirClientAdapter, hexToBytes, bytesToHex, scriptHash, scriptPubKeyToAddress, addressToScriptPubKey, decompileScript, decodeDeltaData, computeSyncPlan, mergeDeltaIntoSnapshot, mergeDeltaIntoHarmonySnapshot, SyncController, describeStep, initSdkWasm, isSdkWasmReady, AMD_TURIN_ARK_FINGERPRINT, PIR1_PIN, PIR2_TIER3_PIN, PRODUCTION_DB_PROOF_PINS, PRODUCTION_ONION_DB_PROOF_V2_PINS, PRODUCTION_ORAM_DB_PROOF_V2_PINS, DELTA_940611_948454_DB_PROOF_PIN, databaseProofAnchorLabel, databaseProofAnchorPoints, mempoolSpaceBlockUrl, verifyProductionTrustChain, oramSourceProofManifestPathForDbId, verifyOramSourceProof, renderSecurityBadgeTextRowsV1, prepareQueryInspectorRenderDataV1, requireVerifiedQueryResultsV1 } from './src/index.ts';
         import { PIR1_PROVIDER, PIR2_PROVIDER } from './src/production-providers.js';
         import { CashierClient, SessionGrantStore, PendingPurchaseStore, requestLightningQuote, waitForQuotePayment, mintTokenForQuote, PRODUCTION_CASHIER_URL } from './src/index.ts';
+        import { IssuerClient, CreditStore, CreditWallet, purchaseCredential, cashuLightningRail, sdkArcFactories } from './src/index.ts';
         window.__bitcoinPirPrepareQueryInspectorRenderDataV1 = prepareQueryInspectorRenderDataV1;
         // Initialize SDK WASM (optional - falls back to TS if unavailable)
         initSdkWasm().then(ok => {
@@ -1708,7 +1730,9 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
         // credit per query-bearing frame from the stored grant (servers that do
         // not meter grants still answer on the free path).
         function queryButtonLabel() {
-            return sessionGrantStore.load() ? 'Run query (session grant)' : 'Run free query';
+            if (sessionGrantStore.load()) return 'Run query (session grant)';
+            if (creditStore.remainingCredits(nowUnix()) > 0) return 'Run query (credits)';
+            return 'Run free query';
         }
 
         function renderPaidAccess() {
@@ -1879,6 +1903,168 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             renderPaidAccess();
             paStatus('grant forgotten');
         });
+
+        // ─── Paid access: credits (docs/CREDITS.md) ────────────────────────
+        // ARC credentials bought from the issuer for ecash, spent one credit
+        // per presentation on whichever server requires credits. The wallet
+        // lives in localStorage; the wasm SDK does the cryptography.
+        const issuer = new IssuerClient(PRODUCTION_CASHIER_URL);
+        const creditStore = new CreditStore();
+        const creditLegs = new Map();
+        let creditWallet = null;
+        let issuerInfo = null;
+        let credentialAbort = null;
+
+        function nowUnix() {
+            return Math.floor(Date.now() / 1000);
+        }
+
+        function creditWalletReady() {
+            if (creditWallet) return creditWallet;
+            if (!isSdkWasmReady()) return null;
+            creditWallet = new CreditWallet(creditStore, sdkArcFactories().credential, nowUnix);
+            return creditWallet;
+        }
+
+        // Handed to every adapter as `creditProvider`: called from inside a
+        // query when a connection's balance runs short. The nonce is
+        // persisted before the payload leaves (a reused nonce is a double
+        // spend at the issuer).
+        function currentCreditProvider(credits) {
+            const wallet = creditWalletReady();
+            const presentation = wallet ? wallet.present(credits) : null;
+            renderCredits();
+            return presentation;
+        }
+
+        function noteCredits(key, status) {
+            creditLegs.set(key, status);
+            renderCredits();
+        }
+
+        function renderCredits() {
+            const remaining = creditStore.remainingCredits(nowUnix());
+            const credentials = creditStore.list();
+            const el = document.getElementById('pa-credits');
+            el.textContent = credentials.length
+                ? `${remaining} credit(s) left across ${credentials.length} credential(s) (${issuerInfo ? `1 credit = ${issuerInfo.gas.creditSat} sat` : 'spent per query frame'}).`
+                : 'No credits stored.';
+            document.getElementById('pa-forgetCredentialsBtn').disabled = credentials.length === 0;
+            document.getElementById('pa-resumeCredentialBtn').hidden = !creditStore.pending();
+            const legs = document.getElementById('pa-creditLegs');
+            legs.replaceChildren();
+            for (const [key, status] of creditLegs) {
+                const line = document.createElement('div');
+                line.textContent = status.state === 'required'
+                    ? `${key}: credits required — funded from the wallet per frame`
+                    : status.state === 'not-required'
+                        ? `${key}: credits accepted, not required yet`
+                        : status.state === 'not-enabled'
+                            ? `${key}: free path (credits not enabled)`
+                            : `${key}: credits could not be enabled — ${status.error}`;
+                legs.appendChild(line);
+            }
+            const queryButton = document.getElementById('queryBtn');
+            if (queryButton && !queryButton.disabled) queryButton.textContent = queryButtonLabel();
+        }
+
+        function renderCreditOffers() {
+            const offersEl = document.getElementById('pa-creditOffers');
+            offersEl.replaceChildren();
+            if (!issuerInfo) return;
+            if (!issuerInfo.arc) {
+                offersEl.textContent = 'This issuer sells no credentials yet.';
+                return;
+            }
+            issuerInfo.offers.forEach((offer) => {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = 'btn accent sm';
+                button.textContent = `Buy ${offer.credits} credits for ${offer.sat} sat (Lightning)`;
+                button.addEventListener('click', () => {
+                    paBuyCredential(offer).catch(e => paStatus(`credit purchase failed: ${e?.message || e}`, 'error'));
+                });
+                offersEl.appendChild(button);
+            });
+        }
+
+        async function paLoadCreditOffers() {
+            paStatus('loading credit packs…');
+            issuerInfo = await issuer.info();
+            renderCreditOffers();
+            renderCredits();
+            const card = issuerInfo.rateCard.map(e => `${e.flow.replace(/_/g, ' ')} ≈ ${e.credits}`).join(', ');
+            paStatus(`issuer ${issuerInfo.service}: ${issuerInfo.offers.length} pack(s), 1 credit = ${issuerInfo.gas.creditSat} sat${card ? `; ${card}` : ''}`, 'success');
+        }
+
+        function credentialHooks() {
+            return {
+                onInvoice: (invoice) => {
+                    document.getElementById('pa-credInvoice').value = invoice;
+                    document.getElementById('pa-credInvoiceBox').hidden = false;
+                },
+                onStatus: (state) => paStatus(`credential: ${state.replace(/-/g, ' ')}`),
+                signal: credentialAbort?.signal,
+            };
+        }
+
+        async function paBuyCredential(offer) {
+            if (!issuerInfo) throw new Error('load the credit packs first');
+            if (creditStore.pending()) throw new Error('finish or cancel the pending credit purchase first');
+            if (!(isSdkWasmReady() || await initSdkWasm())) throw new Error('SDK WASM failed to load; credentials need it');
+            credentialAbort?.abort();
+            credentialAbort = new AbortController();
+            const stored = await purchaseCredential(
+                issuer, creditStore, sdkArcFactories().request, cashuLightningRail(),
+                offer, issuerInfo.mints[0], credentialHooks(), nowUnix,
+            );
+            document.getElementById('pa-credInvoiceBox').hidden = true;
+            renderCredits();
+            paStatus(`credential stored: ${stored.presentationLimit} credits, epoch ${stored.epoch}, spendable until ${new Date(stored.validUntil * 1000).toLocaleDateString()}`, 'success');
+        }
+
+        async function paResumeCredential() {
+            const pending = creditStore.pending();
+            if (!pending) return;
+            if (!(isSdkWasmReady() || await initSdkWasm())) throw new Error('SDK WASM failed to load; credentials need it');
+            credentialAbort?.abort();
+            credentialAbort = new AbortController();
+            if (!pending.token && pending.invoice) {
+                document.getElementById('pa-credInvoice').value = pending.invoice;
+                document.getElementById('pa-credInvoiceBox').hidden = false;
+            }
+            const stored = await purchaseCredential(
+                issuer, creditStore, sdkArcFactories().request, cashuLightningRail(),
+                pending.offer, pending.mintUrl, credentialHooks(), nowUnix,
+            );
+            document.getElementById('pa-credInvoiceBox').hidden = true;
+            renderCredits();
+            paStatus(`credential stored: ${stored.presentationLimit} credits`, 'success');
+        }
+
+        paHandle('pa-loadCreditOffersBtn', paLoadCreditOffers);
+        paHandle('pa-resumeCredentialBtn', paResumeCredential);
+        paHandle('pa-copyCredInvoiceBtn', async () => {
+            await navigator.clipboard.writeText(document.getElementById('pa-credInvoice').value);
+            paStatus('invoice copied');
+        });
+        paHandle('pa-cancelCredentialBtn', async () => {
+            credentialAbort?.abort();
+            const pending = creditStore.pending();
+            if (pending?.token) throw new Error('a minted token is pending — resume to finish the credential; it is not lost');
+            creditStore.setPending(null);
+            document.getElementById('pa-credInvoiceBox').hidden = true;
+            renderCredits();
+            paStatus('credit purchase cancelled (an unpaid invoice can simply be ignored)');
+        });
+        paHandle('pa-forgetCredentialsBtn', async () => {
+            if (!window.confirm('Forget every stored credential? Unspent credits on them are lost.')) return;
+            for (const credential of creditStore.list()) creditStore.remove(credential.credentialHex);
+            creditLegs.clear();
+            renderCredits();
+            paStatus('credits forgotten');
+        });
+        renderCredits();
         renderPaidAccess();
 
         // ─── Free/open product connection ──────────────────────────────────
@@ -3059,6 +3245,8 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 if (!client) client = new BatchPirClientAdapter({
                     sessionGrant: currentSessionGrant,
                     onSessionGrant: (idx, info) => noteSessionGrant(`DPF server${idx}`, info),
+                    creditProvider: currentCreditProvider,
+                    onCredits: (idx, status) => noteCredits(`DPF server${idx}`, status),
                     server0Url: '',
                     server1Url: '',
                     strictVerification: true,
@@ -3935,6 +4123,8 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 candidate = new OnionPirWebClient({
                     sessionGrant: currentSessionGrant,
                     onSessionGrant: (info) => noteSessionGrant('OnionPIR', info),
+                    creditProvider: currentCreditProvider,
+                    onCredits: (status) => noteCredits('OnionPIR', status),
                     serverUrl,
                     strictVerification: true,
                     expectedArkFingerprint: provider.expectedArkFingerprint,
@@ -4517,6 +4707,15 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
             // hint server, so every fetch (first load, DB switch, refresh
             // after exhaustion) is an explicit, confirmed step.
             const paidGrant = sessionGrantStore.load();
+            const hintCredits = creditLegs.get('HarmonyPIR hint');
+            if (!paidGrant && hintCredits?.state === 'required') {
+                const fresh = issuerInfo?.rateCard.find(e => e.flow === 'harmony_fresh_client')?.credits;
+                const question = `Fetch a HarmonyPIR hint set? The hint server requires credits: a fresh hint load costs about ${fresh ?? 'four to five'} credit(s) from your wallet (${creditStore.remainingCredits(nowUnix())} left). A set serves a limited number of queries; the count is shown once it is loaded.`;
+                if (!window.confirm(question)) {
+                    offlineStatus.textContent = 'Not loaded';
+                    return false;
+                }
+            }
             if (paidGrant) {
                 const cost = await paHintSetCost();
                 const hintBalance = sessionGrantBalances.get('HarmonyPIR hint');
@@ -4608,6 +4807,8 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 if (providerIndex === 0) candidate = new HarmonyPirClientAdapter({
                     sessionGrant: currentSessionGrant,
                     onSessionGrant: (idx, info) => noteSessionGrant(idx === 0 ? 'HarmonyPIR hint' : 'HarmonyPIR query', info),
+                    creditProvider: currentCreditProvider,
+                    onCredits: (idx, status) => noteCredits(idx === 0 ? 'HarmonyPIR hint' : 'HarmonyPIR query', status),
                     hintServerUrl: '',
                     queryServerUrl: '',
                     prpBackend: hpCurrentPrp,
@@ -5515,6 +5716,8 @@ bc1q2292d7mz8txc7462hjy4prs2gtx727ut8mcanr</textarea>
                 oramClient = new OramPirClientAdapter({
                     sessionGrant: currentSessionGrant,
                     onSessionGrant: (info) => noteSessionGrant('ORAM TEE', info),
+                    creditProvider: currentCreditProvider,
+                    onCredits: (status) => noteCredits('ORAM TEE', status),
                     serverUrl,
                     strictVerification: true,
                     expectedArkFingerprint: provider.expectedArkFingerprint,

--- a/web/src/credits.ts
+++ b/web/src/credits.ts
@@ -22,6 +22,7 @@ import {
   RESP_CREDIT_OK,
 } from './constants.js';
 import type { StorageLike } from './session-grant.js';
+import { mintTokenForQuote, requestLightningQuote, waitForQuotePayment } from './cashu-purchase.js';
 
 const RESP_ERROR = 0xff;
 export const CREDITS_API_VERSION = 2;
@@ -930,6 +931,25 @@ export interface LightningRail {
   quote(mintUrl: string, amountSat: number, memo: string): Promise<{ quoteId: string; invoice: string; expiry: number | null }>;
   waitPaid(mintUrl: string, quoteId: string, signal?: AbortSignal): Promise<void>;
   mint(mintUrl: string, amountSat: number, quoteId: string): Promise<string>;
+}
+
+/**
+ * The Lightning → ecash rail of `cashu-purchase.ts` (cashu-ts loaded on
+ * demand) in the shape `purchaseCredential` takes.
+ */
+export function cashuLightningRail(): LightningRail {
+  const offer = (amountSat: number, credits = 0) => ({ credits, amount: amountSat, unit: 'sat' });
+  return {
+    quote: async (mintUrl, amountSat, memo) => {
+      const credits = Number(/(\d+) credits/.exec(memo)?.[1] ?? 0);
+      const quote = await requestLightningQuote(mintUrl, offer(amountSat, credits));
+      return { quoteId: quote.quoteId, invoice: quote.invoice, expiry: quote.expiry };
+    },
+    waitPaid: async (mintUrl, quoteId, signal) => {
+      await waitForQuotePayment(mintUrl, 'sat', quoteId, { signal });
+    },
+    mint: (mintUrl, amountSat, quoteId) => mintTokenForQuote(mintUrl, offer(amountSat), quoteId),
+  };
 }
 
 export interface PurchaseHooks {

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -118,6 +118,31 @@ export {
 } from './cashu-purchase.js';
 
 export {
+  CREDIT_PRESENT_KIND_ARC,
+  CREDIT_PRESENT_KIND_CASHU,
+  CreditStore,
+  CreditWallet,
+  CreditedChannel,
+  ConnectionCreditMeter,
+  IssuerClient,
+  IssuerError,
+  cashuLightningRail,
+  parseIssuerInfo,
+  purchaseCredential,
+  serverGasCardFromInfo,
+  type CreditEnablement,
+  type CreditOffer,
+  type CreditProvider,
+  type IssuedCredential,
+  type IssuerInfo,
+  type LightningRail,
+  type PendingCredential,
+  type Presentation,
+  type PurchaseHooks,
+  type StoredCredential,
+} from './credits.js';
+
+export {
   computeDataHash,
   computeParentN,
   computeBinLeafHash,
@@ -273,6 +298,9 @@ export {
 // SDK WASM bridge (optional - use pir-sdk-wasm for Rust-backed implementations)
 export {
   initSdkWasm,
+  sdkArcFactories,
+  type WasmArcCredential,
+  type WasmArcCredentialRequest,
   isSdkWasmReady,
   computeSyncPlanSdk,
   sdkSplitmix64,

--- a/web/src/sdk-bridge.ts
+++ b/web/src/sdk-bridge.ts
@@ -17,6 +17,14 @@ interface PirSdkWasm {
     new(): WasmDatabaseCatalog;
     fromJson(json: any): WasmDatabaseCatalog;
   };
+  /** ARC credentials for credits (`docs/CREDITS.md`); see `sdkArcFactories`. */
+  WasmArcCredentialRequest: {
+    new(epoch: number): WasmArcCredentialRequest;
+    fromBytes(epoch: number, secrets: Uint8Array, request: Uint8Array): WasmArcCredentialRequest;
+  };
+  WasmArcCredential: {
+    new(credential: Uint8Array, epoch: number, presentationLimit: number, nextNonce: number): WasmArcCredential;
+  };
   WasmSyncPlan: WasmSyncPlan;
   WasmQueryResult: {
     new(): WasmQueryResult;
@@ -885,6 +893,53 @@ export async function initSdkWasm(): Promise<boolean> {
  */
 export function isSdkWasmReady(): boolean {
   return sdkWasm !== null;
+}
+
+/** A blinded ARC credential request held in wasm (`WasmArcCredentialRequest`). */
+export interface WasmArcCredentialRequest {
+  epoch(): number;
+  requestBytes(): Uint8Array;
+  secretsBytes(): Uint8Array;
+  finalize(issuerPublicKeyHex: string, response: Uint8Array): Uint8Array;
+  free(): void;
+}
+
+/** A finished ARC credential with its presentation counter (`WasmArcCredential`). */
+export interface WasmArcCredential {
+  epoch(): number;
+  presentationLimit(): number;
+  nextNonce(): number;
+  remaining(): number;
+  present(count: number): Uint8Array;
+  free(): void;
+}
+
+/**
+ * The ARC factories `credits.ts` needs (`ArcRequestFactory` and
+ * `ArcCredentialFactory`), backed by the loaded wasm module. Throws when
+ * the module is not loaded: call `initSdkWasm()` first.
+ */
+export function sdkArcFactories(): {
+  request: {
+    create(epoch: number): WasmArcCredentialRequest;
+    restore(epoch: number, secrets: Uint8Array, request: Uint8Array): WasmArcCredentialRequest;
+  };
+  credential: {
+    open(credential: Uint8Array, epoch: number, presentationLimit: number, nextNonce: number): WasmArcCredential;
+  };
+} {
+  const mod = sdkWasm;
+  if (!mod) throw new Error('SDK WASM is not loaded; credentials need it');
+  return {
+    request: {
+      create: (epoch) => new mod.WasmArcCredentialRequest(epoch),
+      restore: (epoch, secrets, request) => mod.WasmArcCredentialRequest.fromBytes(epoch, secrets, request),
+    },
+    credential: {
+      open: (credential, epoch, presentationLimit, nextNonce) =>
+        new mod.WasmArcCredential(credential, epoch, presentationLimit, nextNonce),
+    },
+  };
 }
 
 // ─── Catalog Conversion ─────────────────────────────────────────────────────


### PR DESCRIPTION
Sixth step of the credits v2 path (`docs/CREDITS.md`): the browser gets a wallet, so a user can buy credits and every connection that requires them is funded automatically; plus the rollout runbook and the pir2 image's issuer flag. Production servers still run without `--require-credits`, so nothing changes for users until the rollout.

## What lands

- **`web/src/sdk-bridge.ts`**: `sdkArcFactories()` exposes the wasm `WasmArcCredentialRequest` / `WasmArcCredential` classes in the shape `credits.ts` takes; typed interfaces for both.
- **`web/src/credits.ts`**: `cashuLightningRail()` wraps the existing Lightning → ecash functions (`cashu-purchase.ts`, cashu-ts loaded on demand) as the `LightningRail` that `purchaseCredential` drives. `web/src/index.ts` exports the credits module.
- **`web/index.html`**, "Paid access" card: a credits block that loads the issuer's credit packs (`GET /v2/info`), buys one over Lightning (blinded ARC request persisted before the invoice; invoice shown and copyable; a reload resumes from the last completed step; cancel refuses to drop a minted token), shows the credits left across stored credentials and each connection's credits state, and forgets credentials on request. All four adapters receive `creditProvider` (`CreditWallet.present`, which persists the credential's nonce before the payload leaves) and `onCredits`; the query button reads "(credits)" when a wallet is stored; the HarmonyPIR hint fetch asks before spending credits on a hint set, quoting the issuer's rate card. Session grants keep working unchanged. The CSP pin of the changed inline module is updated (the `security-badge` test hashes every inline script; the vite `parse5` warning on `index.html` predates this change).
- **Rollout readiness** (second commit): `docs/runbooks/cashier-and-mint.md` "Credits (v2)" (config tables, the Human-generated `arc.seed`, `settlement`, the redeem log, server pins for `--credit-issuer-url` / `--require-credits`); `docs/CREDITS.md` "Rollout" (five ordered steps with the Human ones marked); `unified-server-run.sh` names the issuer (`PIR2_CREDIT_ISSUER_URL`, passed as `--credit-issuer-url`, never `--require-credits`) so the next pir2 image accepts presentations without charging, matching pir1's rollout state; the UKI policy contract test pins that.

## Verification

`cd web && npx tsc --noEmit && npm test` (383 tests) `&& npm run build-web` (vite build + `verify-csp.mjs`); `bash scripts/test-scripts.sh` (7 suites, the new contract test included); `bash -n` on the boot script.

Next: the rollout itself, per `docs/CREDITS.md` "Rollout" (cashier config with a Human-generated ARC seed, pir1 flag, end-to-end check, pir2 campaign, then `--require-credits`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
